### PR TITLE
[bug] Fix analytics-pipeline.yaml to correct RoleARN instead of RoleArn

### DIFF
--- a/deployment/infrastructure/analytics-pipeline.yaml
+++ b/deployment/infrastructure/analytics-pipeline.yaml
@@ -398,7 +398,7 @@ Resources:
           SchemaConfiguration:
             DatabaseName: !Ref GlueDatabase
             TableName: !Ref GlueTable
-            RoleArn: !GetAtt FirehoseDeliveryRole.Arn
+            RoleARN: !GetAtt FirehoseDeliveryRole.Arn
         ProcessingConfiguration:
           Enabled: true
           Processors:


### PR DESCRIPTION
Based on the doc, it should be RoleARN instead of RoleArn: 

https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-properties-kinesisfirehose-deliverystream-schemaconfiguration.html#cfn-kinesisfirehose-deliverystream-schemaconfiguration-rolearn

I ran into the error: 
Resource template validation failed for resource MetricsFirehose as the template has invalid properties. Please refer to the resource documentation to fix the template.  Properties validation failed for resource MetricsFirehose with message: #/ExtendedS3DestinationConfiguration/DataFormatConversionConfiguration/SchemaConfiguration: extraneous key [RoleArn] is not permitted

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
