### PR TITLE
feat: add credential cache management with --clear-cache command

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,18 @@ The optional CloudWatch dashboard provides:
 - **Performance Metrics**: Response times and error rates
 - **User Activity**: Active users and authentication patterns
 
+## Troubleshooting
+
+### Clearing Cached Credentials
+
+To force re-authentication:
+
+```bash
+~/claude-code-with-bedrock/credential-process --clear-cache
+```
+
+Note: This replaces credentials with expired dummies rather than deleting them, which prevents macOS from repeatedly asking for keychain permissions.
+
 ## CLI Commands
 
 The guidance includes a comprehensive CLI tool (`ccwb`) for deployment and management:

--- a/assets/docs/LOCAL_TESTING.md
+++ b/assets/docs/LOCAL_TESTING.md
@@ -78,8 +78,8 @@ Understanding how authentication works helps you support users effectively. The 
 To force a fresh authentication and observe the complete flow:
 
 ```bash
-# Clear any cached credentials
-rm -rf ~/claude-code-with-bedrock/cache/*
+# Clear any cached credentials (this replaces them with expired dummies to preserve keychain permissions)
+~/claude-code-with-bedrock/credential-process --clear-cache
 
 # Trigger authentication
 aws sts get-caller-identity --profile ClaudeCode
@@ -167,3 +167,27 @@ claude
 ```
 
 Claude Code automatically uses the AWS profile for authentication. Behind the scenes, it calls the credential process whenever it needs to access Bedrock, with all authentication handled transparently.
+
+### Important: AWS Credential Precedence
+
+When testing, be aware that AWS CLI uses the following credential precedence order:
+
+1. **Environment variables** (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`) - highest priority
+2. Command line options
+3. Environment variable `AWS_PROFILE`
+4. Credential process from AWS config
+5. Config file credentials
+6. Instance metadata
+
+If you have AWS credentials in environment variables (e.g., from other tools like Isengard), they will override the ClaudeCode profile. To ensure you're using the Claude Code authentication:
+
+```bash
+# Clear any existing AWS credentials from environment
+unset AWS_ACCESS_KEY_ID
+unset AWS_SECRET_ACCESS_KEY
+unset AWS_SESSION_TOKEN
+
+# Then use the ClaudeCode profile
+export AWS_PROFILE=ClaudeCode
+aws sts get-caller-identity
+```

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -727,6 +727,8 @@ echo "To use Claude Code authentication:"
 echo "  export AWS_PROFILE=ClaudeCode"
 echo "  aws sts get-caller-identity"
 echo
+echo "Note: Authentication will automatically open your browser when needed."
+echo
 '''
         
         installer_path = output_dir / "install.sh"
@@ -775,6 +777,20 @@ If you encounter issues with authentication:
 - Ensure you're assigned to the Claude Code application in your identity provider
 - Check that port 8400 is available for the callback
 - Contact your IT administrator for help
+
+### Authentication Behavior
+
+The system handles authentication automatically:
+- Your browser will open when authentication is needed
+- Credentials are cached securely to avoid repeated logins
+- Bad credentials are automatically cleared and re-authenticated
+
+To manually clear cached credentials (if needed):
+```bash
+~/claude-code-with-bedrock/credential-process --clear-cache
+```
+
+This will force re-authentication on your next AWS command.
 
 ### Browser doesn't open
 Check that you're not in an SSH session. The browser needs to open on your local machine.


### PR DESCRIPTION
  ## Summary
  - Added credential cache management functionality to help users clear stored credentials
  - Introduced `--clear-cache` flag to credential-process for easy credential clearing
  - Fixed OTEL helper integration to prevent incorrect default user attributes in telemetry

  ## Key Features

  ### 1. Credential Cache Clearing
  - New `~/claude-code-with-bedrock/credential-process --clear-cache` command
  - Clears both AWS credentials and monitoring tokens from storage
  - Smart implementation replaces credentials with expired dummies instead of deleting
  - Prevents macOS from repeatedly asking for keychain "Always Allow" permissions

  ### 2. OTEL Helper Improvements
  - Refactored to use credential-process instead of direct keychain access
  - Fixed issue where telemetry showed "unknown@example.com" instead of actual user info
  - Proper error handling when authentication is unavailable

  ### 3. Auto-Recovery
  - Automatically detects and clears invalid/expired credentials
  - Provides helpful error messages to guide users through re-authentication
  - Seamless recovery from credential issues

  ## Documentation
  - Added troubleshooting section to README with clear-cache instructions
  - Updated LOCAL_TESTING.md with AWS credential precedence information
  - Added notes about the expired dummy credential approach
  
  Closes: https://github.com/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock/issues/8