### PR TITLE
feat: Add Claude Sonnet 4.5 tracking to CloudWatch dashboard

### DIFF
--- a/deployment/infrastructure/claude-code-dashboard.yaml
+++ b/deployment/infrastructure/claude-code-dashboard.yaml
@@ -631,7 +631,7 @@ Resources:
               "width": 12,
               "height": 6,
               "properties": {
-                "query": "SOURCE '/aws/claude-code/metrics' | filter @message like /claude_code.token.usage/ | parse @message /\"model\":\"(?<model>[^\"]*)\"/  | parse @message /\"claude_code.token.usage\":(?<tokens>[0-9.]+)/ | fields bin(5m) as time, if(model like /opus-4-1/, tokens, 0) as opus_4_1, if(model like /opus-4-0|opus-4-[^1]/, tokens, 0) as opus_4, if(model like /sonnet-4/, tokens, 0) as sonnet_4, if(model like /3[-.]7.*sonnet/, tokens, 0) as sonnet_3_7, if(model like /3[-.]5.*haiku/, tokens, 0) as haiku_3_5 | stats sum(opus_4_1) as Opus_4_1, sum(opus_4) as Opus_4, sum(sonnet_4) as Sonnet_4, sum(sonnet_3_7) as Sonnet_3_7, sum(haiku_3_5) as Haiku_3_5 by time",
+                "query": "SOURCE '/aws/claude-code/metrics' | filter @message like /claude_code.token.usage/ | parse @message /\"model\":\"(?<model>[^\"]*)\"/  | parse @message /\"claude_code.token.usage\":(?<tokens>[0-9.]+)/ | fields bin(5m) as time, if(model like /opus-4-1/, tokens, 0) as opus_4_1, if(model like /opus-4-0|opus-4-[^1]/, tokens, 0) as opus_4, if(model like /sonnet-4-5/, tokens, 0) as sonnet_4_5, if(model like /sonnet-4-[^5]|sonnet-4-20250514/, tokens, 0) as sonnet_4, if(model like /3[-.]7.*sonnet/, tokens, 0) as sonnet_3_7, if(model like /3[-.]5.*haiku/, tokens, 0) as haiku_3_5 | stats sum(opus_4_1) as Opus_4_1, sum(opus_4) as Opus_4, sum(sonnet_4_5) as Sonnet_4_5, sum(sonnet_4) as Sonnet_4, sum(sonnet_3_7) as Sonnet_3_7, sum(haiku_3_5) as Haiku_3_5 by time",
                 "region": "us-east-1",
                 "title": "Token Usage by Model Over Time",
                 "queryLanguage": "cwli",
@@ -836,6 +836,13 @@ Resources:
                   [ "AWS/Bedrock", "InvocationThrottles", "ModelId", "us.anthropic.claude-opus-4-1-20250805-v1:0", { "stat": "Sum", "label": "Opus 4.1 (us-east-1)", "region": "us-east-1" } ],
                   [ "AWS/Bedrock", "InvocationThrottles", "ModelId", "us.anthropic.claude-opus-4-1-20250805-v1:0", { "stat": "Sum", "label": "Opus 4.1 (us-west-2)", "region": "us-west-2" } ],
                   [ "AWS/Bedrock", "InvocationThrottles", "ModelId", "us.anthropic.claude-opus-4-20250514-v1:0", { "stat": "Sum", "label": "Opus 4 (us-east-1)", "region": "us-east-1" } ],
+                  [ "AWS/Bedrock", "InvocationThrottles", "ModelId", "global.anthropic.claude-sonnet-4-5-20250929-v1:0", { "stat": "Sum", "label": "Sonnet 4.5 (us-east-1)", "region": "us-east-1" } ],
+                  [ "AWS/Bedrock", "InvocationThrottles", "ModelId", "global.anthropic.claude-sonnet-4-5-20250929-v1:0", { "stat": "Sum", "label": "Sonnet 4.5 (us-west-2)", "region": "us-west-2" } ],
+                  [ "AWS/Bedrock", "InvocationThrottles", "ModelId", "global.anthropic.claude-sonnet-4-5-20250929-v1:0", { "stat": "Sum", "label": "Sonnet 4.5 (us-east-2)", "region": "us-east-2" } ],
+                  [ "AWS/Bedrock", "InvocationThrottles", "ModelId", "global.anthropic.claude-sonnet-4-5-20250929-v1:0", { "stat": "Sum", "label": "Sonnet 4.5 (eu-central-1)", "region": "eu-central-1" } ],
+                  [ "AWS/Bedrock", "InvocationThrottles", "ModelId", "global.anthropic.claude-sonnet-4-5-20250929-v1:0", { "stat": "Sum", "label": "Sonnet 4.5 (eu-west-1)", "region": "eu-west-1" } ],
+                  [ "AWS/Bedrock", "InvocationThrottles", "ModelId", "global.anthropic.claude-sonnet-4-5-20250929-v1:0", { "stat": "Sum", "label": "Sonnet 4.5 (ap-northeast-1)", "region": "ap-northeast-1" } ],
+                  [ "AWS/Bedrock", "InvocationThrottles", "ModelId", "global.anthropic.claude-sonnet-4-5-20250929-v1:0", { "stat": "Sum", "label": "Sonnet 4.5 (ap-southeast-1)", "region": "ap-southeast-1" } ],
                   [ "AWS/Bedrock", "InvocationThrottles", "ModelId", "us.anthropic.claude-sonnet-4-20250514-v1:0", { "stat": "Sum", "label": "Sonnet 4 (us-east-1)", "region": "us-east-1" } ],
                   [ "AWS/Bedrock", "InvocationThrottles", "ModelId", "us.anthropic.claude-3-7-sonnet-20250219-v1:0", { "stat": "Sum", "label": "Sonnet 3.7 (us-east-1)", "region": "us-east-1" } ],
                   [ "AWS/Bedrock", "InvocationThrottles", "ModelId", "anthropic.claude-3-5-haiku-20241022-v1:0", { "stat": "Sum", "label": "Haiku 3.5 (us-east-1)", "region": "us-east-1" } ]

--- a/deployment/infrastructure/lambda-functions/token_by_model/index.py
+++ b/deployment/infrastructure/lambda-functions/token_by_model/index.py
@@ -27,6 +27,8 @@ def get_model_display_name(model_id):
         return "Opus 4.1"
     elif "opus-4" in model_lower:
         return "Opus 4"
+    elif "sonnet-4-5" in model_lower or "sonnet-4.5" in model_lower:
+        return "Sonnet 4.5"
     elif "sonnet-4" in model_lower:
         return "Sonnet 4"
     elif "sonnet-3.7" in model_lower or "sonnet-3-7" in model_lower:
@@ -54,6 +56,7 @@ def get_model_color(model_name):
         "Opus 4.1": "#3b82f6",  # Blue
         "Opus 4": "#f97316",    # Orange
         "Opus": "#8b5cf6",      # Purple
+        "Sonnet 4.5": "#a855f7", # Purple variant
         "Sonnet 4": "#10b981",  # Green
         "Sonnet 3.7": "#ef4444", # Red
         "Sonnet 3.5": "#ec4899", # Pink


### PR DESCRIPTION
- Add Sonnet 4.5 detection to log query with pattern matching that distinguishes 4.5 from 4.0
- Update token_by_model widget to display Sonnet 4.5 separately with purple color
- Add comprehensive throttle tracking across 7 global regions (US, EU, APAC)
- Track global.anthropic.claude-sonnet-4-5-20250929-v1:0 model ID

This ensures Sonnet 4.5 is tracked as a distinct model with its unique capabilities, separate from Sonnet 4, across all dashboard widgets and metrics.
