### PR TITLE
docs: Fix Quick Start install command to include marketplace reference

### DIFF
--- a/assets/claude-code-plugins/README.md
+++ b/assets/claude-code-plugins/README.md
@@ -12,7 +12,7 @@ Production-ready agents, hooks, and workflows for Claude Code - a comprehensive 
 /plugin marketplace add aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock
 
 # Install your first plugin (EPCC workflow recommended)
-/plugin install epcc-workflow
+/plugin install epcc-workflow@aws-claude-code-plugins
 
 # Browse all available plugins interactively
 /plugin


### PR DESCRIPTION
## Summary

Fix the Quick Start installation command that was missed in PR #48. The command at line 15 was missing the `@aws-claude-code-plugins` marketplace reference.

## Changes

**File**: `assets/claude-code-plugins/README.md` (line 15)

**Before:**
```bash
/plugin install epcc-workflow
```

**After:**
```bash
/plugin install epcc-workflow@aws-claude-code-plugins
```

## Context

This is the last remaining instance that was missed in PR #48, which fixed 112 other instances of the same issue. The Quick Start section is one of the most visible examples in the documentation, making this fix particularly important for users.

## Rationale

- Ensures the Quick Start command works as documented
- Matches the format used throughout the rest of the documentation
- Aligns with the marketplace name in `.claude-plugin/marketplace.json`
- Provides consistent user experience

## Impact

- Single line change to user-facing documentation
- No functional code changes
- Critical for first-time users following Quick Start guide

## Related

- Follows up on PR #48
- Completes the documentation consistency improvements