### PR TITLE
Fix: Add client secret support and Cognito User Pool ID prompt

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -293,9 +293,10 @@ class InitCommand(Command):
                         provider_type = "cognito"
             except Exception:
                 pass  # Continue to manual selection if parsing fails
-                # For Cognito, we must ask for the User Pool ID
-                # Cannot reliably extract from domain due to case sensitivity
-
+                
+            # For Cognito, we must ask for the User Pool ID
+            # Cannot reliably extract from domain due to case sensitivity
+            if provider_type == "cognito":
                 # Try to detect region from domain
                 region_match = re.search(r"\.auth\.([^.]+)\.amazoncognito\.com", provider_domain)
                 if not region_match:


### PR DESCRIPTION
## Description
Fixes the init command to only prompt for Cognito User Pool ID when using Cognito as the provider.

## Problem
The init command was unconditionally asking for User Pool ID for all providers (Okta, Auth0, Azure AD, Cognito), and when skipped, it would set `cognito_user_pool_id` to `null` in the config for non-Cognito providers.

## Changes
- Modified `claude_code_with_bedrock/cli/commands/init.py` to conditionally ask for User Pool ID only when `provider_type == "cognito"`
- Prevents setting `cognito_user_pool_id` to null for non-Cognito providers

## Testing
- Tested with Cognito provider - correctly prompts for User Pool ID
- Verified non-Cognito providers skip the User Pool ID prompt
