### PR TITLE
Fix Auth0 Direct IAM federation and dashboard region issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,49 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.4] - 2025-11-04
+
+### Fixed
+
+- **Auth0 OIDC provider URL format**: Fixed issuer validation failures during token exchange
+  - Added trailing slash to Auth0 OIDC provider URL (`https://${Auth0Domain}/`)
+  - Auth0's OIDC issuer includes trailing slash per OAuth 2.0 spec
+  - Prevents "issuer mismatch" errors during Direct IAM federation
+  - Updated CloudFormation template parameter documentation with supported domain formats
+
+- **Auth0 session name sanitization**: Fixed AssumeRoleWithWebIdentity errors for Auth0 users
+  - Auth0 uses pipe-delimited format in sub claims (e.g., `auth0|12345`)
+  - AWS RoleSessionName regex `[\w+=,.@-]*` doesn't allow pipe characters
+  - Automatically sanitize invalid characters to hyphens in session names
+  - Prevents "Member must satisfy regular expression pattern" validation errors
+
+- **Bedrock list permissions**: Fixed permission errors for model listing operations
+  - Changed Resource from specific ARNs to `'*'` for list operations
+  - Affects `ListFoundationModels`, `GetFoundationModel`, `GetFoundationModelAvailability`, `ListInferenceProfiles`, `GetInferenceProfile`
+  - AWS Bedrock list operations require `Resource: '*'` per AWS IAM documentation
+  - Applied fix to all provider templates (Auth0, Azure AD, Okta, Cognito User Pool)
+
+- **Dashboard region configuration**: Fixed monitoring dashboards for multi-region deployments
+  - Replaced hardcoded `us-east-1` with `${MetricsRegion}` parameter in log widgets
+  - Deploy command now passes `MetricsRegion` parameter from `profile.aws_region`
+  - Prevents `ResourceNotFoundException` for deployments outside us-east-1
+  - Affects CloudWatch Logs Insights widgets in monitoring dashboard
+
+### Changed
+
+- **Code quality improvements**:
+  - Moved `subprocess` import to module level in `deploy.py`
+  - Fixed variable shadowing: `platform_choice` → `platform_name` in `package.py`
+
+### Documentation
+
+- Enhanced Auth0 setup documentation
+  - Added comprehensive table of supported Auth0 domain formats (standard and regional)
+  - Added troubleshooting section for AssumeRoleWithWebIdentity validation errors
+  - Documented automatic handling of Auth0 pipe character issue
+  - Added examples of valid and invalid domain formats
+  - Clarified that https:// prefix and trailing slash are added automatically
+
 ## [1.1.3] - 2025-11-03
 
 ### Fixed

--- a/assets/docs/providers/auth0-setup.md
+++ b/assets/docs/providers/auth0-setup.md
@@ -157,6 +157,23 @@ You now have everything needed for deployment:
 | **Auth0Domain**   | Your Auth0 domain | `your-name.auth0.com`              |
 | **Auth0ClientId** | Your Client ID    | `aBcDeFgHiJkLmNoPqRsTuVwXyZ123456` |
 
+### Supported Provider Domain Formats
+
+The CLI accepts multiple formats for the Auth0 provider domain:
+
+| Format | Example | Notes |
+|--------|---------|-------|
+| **Standard domain** | `company.auth0.com` | **Recommended** - Standard Auth0 domain |
+| **Regional domain (US)** | `company.us.auth0.com` | US-based Auth0 tenant |
+| **Regional domain (EU)** | `company.eu.auth0.com` | European Auth0 tenant |
+| **Regional domain (AU)** | `company.au.auth0.com` | Australia Auth0 tenant |
+| **Regional domain (JP)** | `company.jp.auth0.com` | Japan Auth0 tenant |
+
+**Important**:
+- Do NOT include `https://` prefix - the system adds this automatically
+- Do NOT include trailing slash - the OIDC provider URL is constructed automatically
+- Just provide the domain name (e.g., `company.auth0.com`)
+
 ### Use the values with ccwb init
 
 When running `poetry run ccwb init`, you'll be prompted for these values:
@@ -228,6 +245,39 @@ Should return a JSON response with OIDC endpoints.
 - Ensure Authorization Code grant type is enabled
 - Check that PKCE is not explicitly disabled
 - Verify refresh token settings
+
+### "AssumeRoleWithWebIdentity" Validation Error
+
+If you encounter errors like:
+```
+Member must satisfy regular expression pattern: [\w+=,.@-]*
+```
+
+This is automatically handled by the credential provider. Auth0 commonly uses pipe-delimited format in user IDs (e.g., `auth0|12345`), which AWS doesn't allow in session names. The credential provider sanitizes these characters automatically by replacing them with hyphens.
+
+**What this means for you:**
+- This is a known Auth0 characteristic and is handled automatically
+- No configuration changes needed
+- Session names are automatically sanitized to meet AWS requirements
+- User authentication will work seamlessly
+
+### "Parameter Auth0Domain failed to satisfy constraint" Error
+
+If you encounter deployment errors related to the Auth0Domain parameter:
+
+**Cause**: The Auth0 domain format doesn't match the expected pattern.
+
+**Solution**:
+1. Ensure you're using just the domain name: `company.auth0.com`
+2. Don't include `https://` or trailing slash
+3. Verify the regional suffix if using a regional tenant (`.us`, `.eu`, `.au`, `.jp`)
+4. The domain must be a valid Auth0 domain
+
+**Valid examples:**
+- ✅ `company.auth0.com`
+- ✅ `company.us.auth0.com`
+- ❌ `https://company.auth0.com`
+- ❌ `company.auth0.com/`
 
 ---
 

--- a/deployment/infrastructure/bedrock-auth-auth0.yaml
+++ b/deployment/infrastructure/bedrock-auth-auth0.yaml
@@ -12,9 +12,17 @@ Parameters:
 
   Auth0Domain:
     Type: String
-    Description: Your Auth0 domain (e.g., company.auth0.com or company.us.auth0.com)
+    Description: |
+      Your Auth0 domain (e.g., company.auth0.com or company.us.auth0.com).
+      Supported formats:
+        - company.auth0.com (standard domain)
+        - company.us.auth0.com (region-specific domain)
+        - company.eu.auth0.com (European region)
+        - company.au.auth0.com (Australia region)
+        - company.jp.auth0.com (Japan region)
+      Note: Do NOT include 'https://' prefix or trailing slash - these are added automatically.
     AllowedPattern: '^[a-zA-Z0-9][a-zA-Z0-9-]*\.(us|eu|au|jp)?\.?auth0\.com$'
-    ConstraintDescription: Must be a valid Auth0 domain
+    ConstraintDescription: Must be a valid Auth0 domain without https:// prefix or trailing slash
 
   Auth0ClientId:
     Type: String
@@ -62,7 +70,7 @@ Resources:
   Auth0OIDCProvider:
     Type: AWS::IAM::OIDCProvider
     Properties:
-      Url: !Sub 'https://${Auth0Domain}'
+      Url: !Sub 'https://${Auth0Domain}/'
       ClientIdList:
         - !Ref Auth0ClientId
       ThumbprintList:
@@ -119,9 +127,7 @@ Resources:
               - 'bedrock:GetFoundationModelAvailability'
               - 'bedrock:ListInferenceProfiles'
               - 'bedrock:GetInferenceProfile'
-            Resource:
-              - 'arn:aws:bedrock:*::foundation-model/*'
-              - 'arn:aws:bedrock:*:*:inference-profile/*'
+            Resource: '*'
             Condition:
               StringEquals:
                 'aws:RequestedRegion': !Ref AllowedBedrockRegions
@@ -133,8 +139,7 @@ Resources:
               - 'bedrock:GetFoundationModelAvailability'
               - 'bedrock:ListInferenceProfiles'
               - 'bedrock:GetInferenceProfile'
-            Resource:
-              - 'arn:aws:bedrock:::foundation-model/*'
+            Resource: '*'
           - !If
             - MonitoringEnabled
             - Sid: AllowCloudWatchMetrics

--- a/deployment/infrastructure/bedrock-auth-azure.yaml
+++ b/deployment/infrastructure/bedrock-auth-azure.yaml
@@ -119,9 +119,7 @@ Resources:
               - 'bedrock:GetFoundationModelAvailability'
               - 'bedrock:ListInferenceProfiles'
               - 'bedrock:GetInferenceProfile'
-            Resource:
-              - 'arn:aws:bedrock:*::foundation-model/*'
-              - 'arn:aws:bedrock:*:*:inference-profile/*'
+            Resource: '*'
             Condition:
               StringEquals:
                 'aws:RequestedRegion': !Ref AllowedBedrockRegions
@@ -133,8 +131,7 @@ Resources:
               - 'bedrock:GetFoundationModelAvailability'
               - 'bedrock:ListInferenceProfiles'
               - 'bedrock:GetInferenceProfile'
-            Resource:
-              - 'arn:aws:bedrock:::foundation-model/*'
+            Resource: '*'
           - !If
             - MonitoringEnabled
             - Sid: AllowCloudWatchMetrics

--- a/deployment/infrastructure/bedrock-auth-cognito-pool.yaml
+++ b/deployment/infrastructure/bedrock-auth-cognito-pool.yaml
@@ -125,9 +125,7 @@ Resources:
               - 'bedrock:GetFoundationModelAvailability'
               - 'bedrock:ListInferenceProfiles'
               - 'bedrock:GetInferenceProfile'
-            Resource:
-              - 'arn:aws:bedrock:*::foundation-model/*'
-              - 'arn:aws:bedrock:*:*:inference-profile/*'
+            Resource: '*'
             Condition:
               StringEquals:
                 'aws:RequestedRegion': !Ref AllowedBedrockRegions
@@ -139,8 +137,7 @@ Resources:
               - 'bedrock:GetFoundationModelAvailability'
               - 'bedrock:ListInferenceProfiles'
               - 'bedrock:GetInferenceProfile'
-            Resource:
-              - 'arn:aws:bedrock:::foundation-model/*'
+            Resource: '*'
           - !If
             - MonitoringEnabled
             - Sid: AllowCloudWatchMetrics

--- a/deployment/infrastructure/bedrock-auth-okta.yaml
+++ b/deployment/infrastructure/bedrock-auth-okta.yaml
@@ -118,9 +118,7 @@ Resources:
               - 'bedrock:GetFoundationModelAvailability'
               - 'bedrock:ListInferenceProfiles'
               - 'bedrock:GetInferenceProfile'
-            Resource:
-              - 'arn:aws:bedrock:*::foundation-model/*'
-              - 'arn:aws:bedrock:*:*:inference-profile/*'
+            Resource: '*'
             Condition:
               StringEquals:
                 'aws:RequestedRegion': !Ref AllowedBedrockRegions
@@ -132,8 +130,7 @@ Resources:
               - 'bedrock:GetFoundationModelAvailability'
               - 'bedrock:ListInferenceProfiles'
               - 'bedrock:GetInferenceProfile'
-            Resource:
-              - 'arn:aws:bedrock:::foundation-model/*'
+            Resource: '*'
           - !If
             - MonitoringEnabled
             - Sid: AllowCloudWatchMetrics

--- a/deployment/infrastructure/claude-code-dashboard.yaml
+++ b/deployment/infrastructure/claude-code-dashboard.yaml
@@ -618,7 +618,7 @@ Resources:
               "height": 6,
               "properties": {
                 "query": "SOURCE '/aws/claude-code/metrics' | fields @timestamp, @message | filter @message like /claude_code.token.usage/ | parse @message /\"claude_code.token.usage\":(?<tokens>[0-9.]+)/ | stats sum(tokens) as total_tokens by bin(5m)",
-                "region": "us-east-1",
+                "region": "${MetricsRegion}",
                 "title": "Token Usage Over Time",
                 "queryLanguage": "cwli",
                 "view": "timeSeries"
@@ -632,7 +632,7 @@ Resources:
               "height": 6,
               "properties": {
                 "query": "SOURCE '/aws/claude-code/metrics' | filter @message like /claude_code.token.usage/ | parse @message /\"model\":\"(?<model>[^\"]*)\"/  | parse @message /\"claude_code.token.usage\":(?<tokens>[0-9.]+)/ | fields bin(5m) as time, if(model like /opus-4-1/, tokens, 0) as opus_4_1, if(model like /opus-4-0|opus-4-[^1]/, tokens, 0) as opus_4, if(model like /sonnet-4-5/, tokens, 0) as sonnet_4_5, if(model like /sonnet-4-[^5]|sonnet-4-20250514/, tokens, 0) as sonnet_4, if(model like /3[-.]7.*sonnet/, tokens, 0) as sonnet_3_7, if(model like /3[-.]5.*haiku/, tokens, 0) as haiku_3_5 | stats sum(opus_4_1) as Opus_4_1, sum(opus_4) as Opus_4, sum(sonnet_4_5) as Sonnet_4_5, sum(sonnet_4) as Sonnet_4, sum(sonnet_3_7) as Sonnet_3_7, sum(haiku_3_5) as Haiku_3_5 by time",
-                "region": "us-east-1",
+                "region": "${MetricsRegion}",
                 "title": "Token Usage by Model Over Time",
                 "queryLanguage": "cwli",
                 "view": "timeSeries",

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -5,6 +5,7 @@
 
 import os
 import re
+import subprocess
 import tempfile
 from pathlib import Path
 
@@ -337,7 +338,7 @@ class DeployCommand(Command):
                     # - https://login.microsoftonline.com/{tenant-id}/v2.0
 
                     # Extract GUID using regex pattern matching
-                    guid_pattern = r'[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
+                    guid_pattern = r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
                     match = re.search(guid_pattern, profile.provider_domain)
 
                     if match:
@@ -462,8 +463,6 @@ class DeployCommand(Command):
                 task = progress.add_task("Packaging dashboard Lambda functions...", total=None)
 
                 try:
-                    import subprocess
-
                     # Create temp file for packaged template
                     with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
                         packaged_template_path = f.name
@@ -495,9 +494,10 @@ class DeployCommand(Command):
                         task, description="Dashboard Lambda functions packaged successfully", completed=True
                     )
 
-                    # Deploy the packaged template
+                    # Deploy the packaged template with MetricsRegion parameter
+                    params = [f"MetricsRegion={profile.aws_region}"]
                     return deploy_with_cf(
-                        packaged_template_path, stack_name, [], task_description="Deploying monitoring dashboard..."
+                        packaged_template_path, stack_name, params, task_description="Deploying monitoring dashboard..."
                     )
 
                 finally:

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -112,10 +112,10 @@ class PackageCommand(Command):
         # Validate platform
         valid_platforms = ["macos", "macos-arm64", "macos-intel", "linux", "linux-x64", "linux-arm64", "windows", "all"]
         if isinstance(target_platform, list):
-            for platform_choice in target_platform:
-                if platform_choice not in valid_platforms:
+            for platform_name in target_platform:
+                if platform_name not in valid_platforms:
                     console.print(
-                        f"[red]Invalid platform: {platform_choice}. Valid options: {', '.join(valid_platforms)}[/red]"
+                        f"[red]Invalid platform: {platform_name}. Valid options: {', '.join(valid_platforms)}[/red]"
                     )
                     return 1
         elif target_platform not in valid_platforms:

--- a/source/pyproject.toml
+++ b/source/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "claude-code-with-bedrock"
-version = "1.1.3"
+version = "1.1.4"
 description = "Deploy and manage Claude Code on Amazon Bedrock"
 authors = ["Claude Code Team <claude-code@example.com>"]
 readme = "../README.md"


### PR DESCRIPTION
*Description of changes:*
- Add trailing slash to Auth0 OIDC provider URL to fix issuer mismatch
- Sanitize Auth0 session names to handle pipe characters in sub claims
- Fix Bedrock list permissions to use Resource: '*' (was using specific ARNs)
- Fix dashboard to use MetricsRegion parameter instead of hardcoded us-east-1
- Move imports to module level in deploy.py and fix variable shadowing in package.py

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
