### PR TITLE
Fix: Use 'ClaudeCode' as default AWS profile name instead of 'default'

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -71,8 +71,8 @@ class PackageCommand(Command):
 
         # Load configuration first (needed to check CodeBuild status)
         config = Config.load()
-        # Use specified profile or default to active profile
-        profile_name = self.option("profile") or config.active_profile
+        # Use specified profile or default to active profile, or fall back to "ClaudeCode"
+        profile_name = self.option("profile") or config.active_profile or "ClaudeCode"
         profile = config.get_profile(profile_name)
 
         if not profile:

--- a/source/claude_code_with_bedrock/migration.py
+++ b/source/claude_code_with_bedrock/migration.py
@@ -41,7 +41,7 @@ def migrate_legacy_config() -> bool:
 
         # Extract profiles and default profile
         legacy_profiles = legacy_data.get("profiles", {})
-        active_profile_name = legacy_data.get("default_profile")
+        active_profile_name = legacy_data.get("default_profile") or "ClaudeCode"
 
         if not legacy_profiles:
             print("⚠️  Warning: No profiles found in legacy config")

--- a/source/credential_provider/__main__.py
+++ b/source/credential_provider/__main__.py
@@ -75,7 +75,7 @@ PROVIDER_CONFIGS = {
 class MultiProviderAuth:
     def __init__(self, profile=None):
         # Load configuration from environment or config file
-        self.profile = profile or "default"
+        self.profile = profile or "ClaudeCode"
 
         # Debug mode - set before loading config since _load_config may use _debug_print
         self.debug = os.getenv("COGNITO_AUTH_DEBUG", "").lower() in ("1", "true", "yes")


### PR DESCRIPTION
## Summary
Fixes an issue where the system was using "default" as the AWS profile name fallback, which conflicts with existing company AWS profiles.

Changes the fallback AWS profile name from "default" to "ClaudeCode" across:
- Migration code (when migrating from v1.x with missing default_profile)
- Package command (when no active profile is set)
- Credential provider (when no profile argument is passed)

## Problem
Users migrating from v1.x or with missing profile configurations would end up with a "default" AWS profile in `~/.aws/config`, which often conflicts with company-standard AWS profiles named "default".

## Solution
Use "ClaudeCode" as the consistent fallback profile name throughout the codebase, aligning with:
- Existing documentation examples
- Codebase naming conventions
- CloudWatch namespace naming
- User expectations

## Files Changed
- `source/claude_code_with_bedrock/migration.py` - Add "ClaudeCode" fallback for migration
- `source/claude_code_with_bedrock/cli/commands/package.py` - Add "ClaudeCode" final fallback
- `source/credential_provider/__main__.py` - Change default from "default" to "ClaudeCode"

## Impact
- ✅ New installations will use "ClaudeCode" consistently
- ✅ Migrations from v1.x will default to "ClaudeCode"
- ✅ No conflicts with company AWS "default" profiles
- ✅ Aligns with existing documentation

## Testing
- Pre-commit hooks passed (Ruff linting and formatting)
- Changes are minimal and targeted

## Type
Patch release (v2.0.1)