### PR TITLE
fix: Resolve Cognito authentication issues for CLI credential process

### DIFF
--- a/deployment/infrastructure/cognito-user-pool-setup.yaml
+++ b/deployment/infrastructure/cognito-user-pool-setup.yaml
@@ -108,6 +108,8 @@ Resources:
     Properties:
       ClientName: !Sub '${UserPoolName}-client'
       UserPoolId: !Ref UserPool
+      # Public client for CLI apps (no client secret, uses PKCE)
+      GenerateSecret: false
       # OAuth2 configuration
       AllowedOAuthFlows:
         - code

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -1861,7 +1861,8 @@ if [ -d "claude-settings" ]; then
 
         if [ "$SKIP_SETTINGS" != "true" ]; then
             # Replace placeholders and write settings
-            sed -e 's|__OTEL_HELPER_PATH__|~/claude-code-with-bedrock/otel-helper|g' \
+            sed -e "s|__OTEL_HELPER_PATH__|$HOME/claude-code-with-bedrock/otel-helper|g" \
+                -e "s|__CREDENTIAL_PROCESS_PATH__|$HOME/claude-code-with-bedrock/credential-process|g" \
                 "claude-settings/settings.json" > ~/.claude/settings.json
             echo "✓ Claude Code settings configured"
         fi
@@ -2032,11 +2033,11 @@ if exist "claude-settings" (
         )
 
         if not "%SKIP_SETTINGS%"=="true" (
-            REM Use PowerShell to replace placeholder
-            powershell -Command "$path = '%USERPROFILE%\\claude-code-with-bedrock\\otel-helper.exe'
+            REM Use PowerShell to replace placeholders
             powershell -Command "
-            $path = '%USERPROFILE%\\\\claude-code-with-bedrock\\\\otel-helper.exe' -replace '\\\\\\\\', '/';
-            (Get-Content 'claude-settings\\\\settings.json') -replace '__OTEL_HELPER_PATH__', $path |
+            $otelPath = '%USERPROFILE%\\\\claude-code-with-bedrock\\\\otel-helper.exe' -replace '\\\\\\\\', '/';
+            $credPath = '%USERPROFILE%\\\\claude-code-with-bedrock\\\\credential-process.exe' -replace '\\\\\\\\', '/';
+            (Get-Content 'claude-settings\\\\settings.json') -replace '__OTEL_HELPER_PATH__', $otelPath -replace '__CREDENTIAL_PROCESS_PATH__', $credPath |
             Set-Content '%USERPROFILE%\\\\.claude\\\\settings.json'"
             echo OK Claude Code settings configured
         )
@@ -2300,7 +2301,7 @@ Available metrics include:
 
             # Add awsAuthRefresh for session-based credential storage
             if profile.credential_storage == "session":
-                settings["awsAuthRefresh"] = f"~/claude-code-with-bedrock/credential-process --profile {profile_name}"
+                settings["awsAuthRefresh"] = f"__CREDENTIAL_PROCESS_PATH__ --profile {profile_name}"
 
             # Add selected model as environment variable if available
             if hasattr(profile, "selected_model") and profile.selected_model:

--- a/source/credential_provider/__main__.py
+++ b/source/credential_provider/__main__.py
@@ -888,6 +888,14 @@ class MultiProviderAuth:
         """Direct STS federation without Cognito Identity Pool - provides 12 hour sessions"""
         self._debug_print("Using Direct STS federation (AssumeRoleWithWebIdentity)")
 
+        # Clear any AWS credentials to prevent recursive calls
+        env_vars_to_clear = ["AWS_PROFILE", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"]
+        saved_env = {}
+        for var in env_vars_to_clear:
+            if var in os.environ:
+                saved_env[var] = os.environ[var]
+                del os.environ[var]
+
         try:
             # Get the federated role ARN from config
             federated_role_arn = self.config.get("federated_role_arn")
@@ -989,6 +997,10 @@ class MultiProviderAuth:
                     f"Original error: {error_str}"
                 ) from e
             raise Exception(f"Failed to get AWS credentials via Direct STS: {str(e)}") from None
+        finally:
+            # Restore environment variables
+            for var, value in saved_env.items():
+                os.environ[var] = value
 
     def get_aws_credentials_cognito(self, id_token, token_claims):
         """Exchange OIDC token for AWS credentials via Cognito Identity Pool"""


### PR DESCRIPTION
This PR fixes three critical authentication issues that prevented successful CLI authentication when using Cognito User Pools with Direct STS federation.

  Problems Fixed

  1. Cognito User Pool Client Secret Issue

  Symptom: Token exchange failed with error:
  Error: Token exchange failed: {"error":"invalid_client","error_description":"invalid_client_secret"}

  Root Cause: CloudFormation template created Cognito client with a client secret by default. CLI applications are public clients and must use PKCE (Proof Key for Code
  Exchange) instead of client secrets.

  Fix: Added GenerateSecret: false to cognito-user-pool-setup.yaml UserPoolClient resource.

  2. Path Expansion in Claude Code Settings

  Symptom: Claude Code failed to start with error:
  error: otelHeadersHelper did not return a valid value

  Root Cause: The install scripts used ~ for helper paths, but Claude Code doesn't expand ~ for the otelHeadersHelper setting (though it does for awsAuthRefresh).

  Fix:
  - Changed install scripts to use $HOME instead of ~ so shell expands to absolute path
  - Added __CREDENTIAL_PROCESS_PATH__ placeholder for consistency with __OTEL_HELPER_PATH__
  - Both helper paths now resolve to absolute paths during installation

  3. Credential Process Infinite Recursion

  Symptom: Authentication hung with recursive error:
  Error: Failed to get AWS credentials via Direct STS: Error when retrieving credentials from custom-process:

  Root Cause: When using Direct STS federation, the credential-process created an STS client without clearing the AWS_PROFILE environment variable. Boto3 saw the profile,
  which pointed back to the credential-process, causing infinite recursion.

  Fix: Added environment variable clearing logic to get_aws_credentials_direct() method, matching the pattern already used in get_aws_credentials_cognito().

  Changes Made

  Files Modified

  1. deployment/infrastructure/cognito-user-pool-setup.yaml
    - Added GenerateSecret: false to UserPoolClient
  2. source/claude_code_with_bedrock/cli/commands/package.py
    - Changed ~ to $HOME in install.sh sed command
    - Changed ~ to $HOME in install.bat PowerShell command
    - Added __CREDENTIAL_PROCESS_PATH__ placeholder
    - Updated placeholder replacement logic for both helpers
  3. source/credential_provider/__main__.py
    - Added environment variable clearing before STS client creation
    - Added finally block to restore environment variables
    - Matches existing pattern in Cognito Identity Pool path

  Testing

  Before these fixes:
  - ❌ Browser authentication opened but token exchange failed
  - ❌ Claude Code failed to start with OTEL helper error
  - ❌ Credential process hung in infinite loop

  After these fixes:
  - ✅ Browser authentication completes successfully
  - ✅ Token exchange with PKCE works correctly
  - ✅ Claude Code starts and can authenticate
  - ✅ AWS CLI with AWS_PROFILE=ClaudeCode works correctly
  - ✅ 12-hour sessions with Direct STS federation

  Test Steps:
  # 1. Deploy fresh Cognito User Pool (creates public client)
  cd source && poetry run ccwb init
  poetry run ccwb deploy

  # 2. Package and install
  poetry run ccwb package
  cd dist && ./install.sh

  # 3. Test authentication
  AWS_PROFILE=ClaudeCode aws sts get-caller-identity
  # Should show assumed-role/BedrockCognitoFederatedRole

  # 4. Test Claude Code integration
  claude
  # Should start successfully and authenticate

  Impact

  - Critical fix for all users deploying with Cognito User Pools
  - Required for CLI authentication to work at all
  - No breaking changes - fixes broken functionality

  Related Issues

  Discovered during GovCloud partition support testing (#PR_NUMBER).