### PR TITLE
fix: Malformed Windows install.bat

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -2033,11 +2033,7 @@ if exist "claude-settings" (
 
         if not "%SKIP_SETTINGS%"=="true" (
             REM Use PowerShell to replace placeholder
-            powershell -Command "$path = '%USERPROFILE%\\claude-code-with-bedrock\\otel-helper.exe'
-            powershell -Command "
-            $path = '%USERPROFILE%\\\\claude-code-with-bedrock\\\\otel-helper.exe' -replace '\\\\\\\\', '/';
-            (Get-Content 'claude-settings\\\\settings.json') -replace '__OTEL_HELPER_PATH__', $path |
-            Set-Content '%USERPROFILE%\\\\.claude\\\\settings.json'"
+            powershell -Command "$path = $env:USERPROFILE + '\\claude-code-with-bedrock\\otel-helper.exe' -replace '\\\\', '/'; (Get-Content 'claude-settings\\settings.json') -replace '__OTEL_HELPER_PATH__', $path | Set-Content (Join-Path $env:USERPROFILE '.claude\\settings.json')"
             echo OK Claude Code settings configured
         )
     )
@@ -2048,21 +2044,20 @@ echo.
 echo Configuring AWS profiles...
 
 REM Read profiles from config.json using PowerShell
-for /f %%p in ('powershell -Command "$config = Get-Content config.json | ConvertFrom-Json; \
-$config.PSObject.Properties.Name"') do (
+for /f %%p in ('powershell -Command "& {{$c=Get-Content config.json|ConvertFrom-Json;$c.PSObject.Properties.Name}}"') do (
     echo Configuring AWS profile: %%p
 
     REM Get profile-specific region
-    for /f %%r in ('powershell -Command "$config = Get-Content config.json | ConvertFrom-Json;
-    $config.'%%p'.aws_region"') do set PROFILE_REGION=%%r
+    for /f %%r in ('powershell -Command "& {{$c=Get-Content config.json|ConvertFrom-Json;$c.'%%p'.aws_region}}"') do set PROFILE_REGION=%%r
+
 
     REM Set credential process with --profile flag (cross-platform, no wrapper needed)
-    aws configure set credential_process "\"%USERPROFILE%\\claude-code-with-bedrock\\credential-process.exe\"
-    --profile %%p" --profile %%p
+    aws configure set credential_process "%USERPROFILE%\\claude-code-with-bedrock\\credential-process.exe --profile %%p" --profile %%p
+
 
     REM Set region
     if defined PROFILE_REGION (
-        aws configure set region %PROFILE_REGION% --profile %%p
+        aws configure set region !PROFILE_REGION! --profile %%p
     ) else (
         aws configure set region {profile.aws_region} --profile %%p
     )
@@ -2076,8 +2071,7 @@ echo Installation complete!
 echo ======================================
 echo.
 echo Available profiles:
-for /f %%p in ('powershell -Command "$config = Get-Content config.json | ConvertFrom-Json; \
-$config.PSObject.Properties.Name"') do (
+for /f %%p in ('powershell -Command "$config = Get-Content config.json | ConvertFrom-Json; $config.PSObject.Properties.Name"') do (
     echo   - %%p
 )
 echo.
@@ -2086,8 +2080,7 @@ echo   set AWS_PROFILE=^<profile-name^>
 echo   aws sts get-caller-identity
 echo.
 echo Example:
-for /f %%p in ('powershell -Command "$config = Get-Content config.json | ConvertFrom-Json; \
-$config.PSObject.Properties.Name | Select-Object -First 1"') do (
+for /f %%p in ('powershell -Command "$config = Get-Content config.json | ConvertFrom-Json; $config.PSObject.Properties.Name | Select-Object -First 1"') do (
     echo   set AWS_PROFILE=%%p
     echo   aws sts get-caller-identity
 )


### PR DESCRIPTION
# Pull Request: Fix PowerShell syntax errors and path formatting issues in Windows installer

## Description
This PR fixes critical issues in the Windows install.bat script that prevented it from running correctly:

1. **Fixed broken PowerShell command syntax** - Removed malformed multi-line commands that caused script failure
2. **Fixed OTEL helper path formatting** - Ensured paths use consistent forward slashes for cross-platform compatibility
3. **Fixed credential_process configuration** - Corrected spacing and quoting issues in AWS CLI commands
4. **Fixed PowerShell variable escaping** - Removed unnecessary backslash escapes that broke command execution

## Changes Made

### 1. Fixed OTEL Helper Path Configuration (Line 68)

**Problem:** The original script had malformed PowerShell syntax with duplicate command declarations and an incomplete first command, causing the script to fail. Additionally, the path handling mixed Windows backslashes with Unix forward slashes inconsistently.

**Before:**
```batch
powershell -Command "$path = '%USERPROFILE%\claude-code-with-bedrock\otel-helper.exe'
powershell -Command "$path = '%USERPROFILE%\\claude-code-with-bedrock\\otel-helper.exe' -replace '\\\\', '/';
(Get-Content 'claude-settings\\settings.json') -replace '__OTEL_HELPER_PATH__', $path |
Set-Content '%USERPROFILE%\\.claude\\settings.json'"
```

**After:**
```batch
powershell -Command "$path = $env:USERPROFILE + '\claude-code-with-bedrock\otel-helper.exe' -replace '\\', '/'; (Get-Content 'claude-settings\settings.json') -replace '__OTEL_HELPER_PATH__', $path | Set-Content (Join-Path $env:USERPROFILE '.claude\settings.json')"
```

**Rationale:** 
- Uses `$env:USERPROFILE` for proper PowerShell variable handling instead of batch-style variables
- Ensures all path separators are converted to forward slashes with correct regex escaping
- Single-line command eliminates syntax errors from multi-line breaks
- `Join-Path` ensures proper path construction for the output file

### 2. Fixed AWS Credential Process Configuration (Line 91)

**Problem:** Extra quotes and missing space between executable path and `--profile` flag caused AWS CLI configuration errors.

**Before:**
```batch
aws configure set credential_process "\"%USERPROFILE%\\claude-code-with-bedrock\\credential-process.exe\"--profile %%p" --profile %%p
```

**After:**
```batch
aws configure set credential_process "%USERPROFILE%\\claude-code-with-bedrock\\credential-process.exe --profile %%p" --profile %%p
```

**Rationale:** 
- Removed unnecessary escaped quotes that broke the command path
- Added proper space between executable and `--profile` flag
- Simplified quoting for better readability and correctness

### 3. Updated PowerShell Profile Reading Commands (Lines 82, 86, 104, 112)

**Problem:** Unnecessary backslash escaping of PowerShell variables caused command failures.

**Before:**
```batch
for /f %%p in ('powershell -Command "$config = Get-Content config.json | ConvertFrom-Json; \$config.PSObject.Properties.Name"') do (
```

**After:**
```batch
for /f %%p in ('powershell -Command "& {$c=Get-Content config.json|ConvertFrom-Json;$c.PSObject.Properties.Name}"') do (
```

**Rationale:** 
- Removed unnecessary backslash escapes before `$` that broke PowerShell variable references
- Used script block syntax with `& {}` for better command encapsulation
- Shortened variable names and removed unnecessary spaces for cleaner syntax

### 4. Fixed Region Variable Expansion (Line 95)

**Problem:** Missing delayed expansion for batch variables.

**Before:**
```batch
if defined PROFILE_REGION (
    aws configure set region %PROFILE_REGION% --profile %%p
```

**After:**
```batch
if defined PROFILE_REGION (
    aws configure set region !PROFILE_REGION! --profile %%p
```

**Rationale:** Uses `!PROFILE_REGION!` for proper delayed expansion within the for loop context

## Files Changed
- `source/claude_code_with_bedrock/cli/commands/package.py` - Fixed Windows install.bat template generation
