### PR TITLE
feat: Add profile support to builds command

### DIFF
--- a/assets/docs/CLI_REFERENCE.md
+++ b/assets/docs/CLI_REFERENCE.md
@@ -297,9 +297,11 @@ poetry run ccwb builds [options]
 
 **Options:**
 
+- `--profile <name>` - Configuration profile to use (defaults to active profile)
 - `--limit <n>` - Number of builds to show (default: "10")
 - `--project <name>` - CodeBuild project name (default: auto-detect)
 - `--status <id>` - Check status of a specific build by ID
+- `--download` - Download completed Windows artifacts to dist folder
 
 **What it does:**
 
@@ -307,8 +309,28 @@ poetry run ccwb builds [options]
 - Shows build status, duration, and completion time
 - Provides console links to view full build logs
 - Monitors in-progress builds
+- Uses active profile or specified profile for CodeBuild project detection
 
 **Note:** This command requires CodeBuild to be enabled during the `init` process. If CodeBuild was not enabled, you'll need to re-run `init` and enable Windows build support.
+
+**Examples:**
+
+```bash
+# List builds for active profile
+poetry run ccwb builds
+
+# List builds for specific profile
+poetry run ccwb builds --profile production
+
+# Check status of specific build
+poetry run ccwb builds --status abc12345
+
+# Check latest build status and download artifacts
+poetry run ccwb builds --status latest --download
+
+# List last 20 builds
+poetry run ccwb builds --limit 20
+```
 
 **Example output:**
 


### PR DESCRIPTION
## Summary

The `builds` command was hardcoded to use the "default" profile instead of respecting the `--profile` option or active profile like other commands (deploy, test, etc.). This PR adds proper profile support to maintain consistency across all CLI commands, along with bug fixes for build status display and path resolution.

## Changes

### Profile Support (Main Feature)
- ✅ Added `--profile` option to `builds` command
- ✅ Updated `handle()` method to load and use specified profile or active profile
- ✅ Updated `_check_build_status()` to use the same profile handling
- ✅ Removed duplicate config loading that was hardcoded to "default"
- ✅ Now respects active profile when no explicit profile is provided

### Documentation
- ✅ Updated `CLI_REFERENCE.md` with `--profile` option documentation
- ✅ Added comprehensive usage examples showing profile usage
- ✅ Documented the `--download` option that was previously undocumented

### Bug Fixes
- ✅ **Duration Display**: Fixed build duration showing as "Unknown" - now correctly calculates and displays actual build time from `startTime` and `endTime` (e.g., "22 minutes")
- ✅ **Path Resolution**: Fixed `ValueError` when displaying package directory paths - now uses correct source directory path structure

## Usage

```bash
# Uses active profile (default behavior)
poetry run ccwb builds

# Uses specific profile
poetry run ccwb builds --profile my-profile

# Check build status with specific profile
poetry run ccwb builds --status latest --profile my-profile

# Check latest build and download artifacts
poetry run ccwb builds --status latest --download

# List last 20 builds for specific profile
poetry run ccwb builds --limit 20 --profile production
```

## Testing

### Profile Management
- [x] Command works with active profile
- [x] Command works with explicit `--profile` option
- [x] Error handling for missing/invalid profiles
- [x] Consistent behavior with other CLI commands (deploy, test, etc.)

### Build Status & Download
- [x] Build duration displays correctly (calculated from startTime/endTime)
- [x] Package directory paths resolve correctly
- [x] Download functionality works with `--status latest --download`

## Impact

This change improves the CLI consistency and fixes several issues:
- **Consistency**: All commands now support the same profile management pattern
- **User Experience**: Users can seamlessly switch between profiles without confusion
- **Reliability**: Fixes critical bugs in build status reporting and artifact downloading
- **Documentation**: Complete documentation helps users understand all available options

## Related Issues

This fix ensures all commands in the CLI tool support the same profile management pattern, improving user experience when working with multiple profiles/environments (production, development, multi-region, etc.).