### PR TITLE
feat: Improve AWS profile display and enhance stack management

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -193,7 +193,9 @@ class PackageCommand(Command):
             embedded_config["identity_pool_id"] = identity_pool_id
 
         # Show what will be packaged using shared display utility
-        display_configuration_info(profile, identity_pool_id or federated_role_arn, format_type="simple")
+        display_configuration_info(
+            profile, identity_pool_id or federated_role_arn, format_type="simple", profile_name=profile_name
+        )
 
         # Build package
         console.print("\n[bold]Building package...[/bold]")
@@ -346,7 +348,7 @@ class PackageCommand(Command):
 
         # Create documentation
         console.print("[cyan]Creating documentation...[/cyan]")
-        self._create_documentation(output_dir, profile, timestamp)
+        self._create_documentation(output_dir, profile, timestamp, profile_name)
 
         # Always create Claude Code settings (required for Bedrock configuration)
         console.print("[cyan]Creating Claude Code settings...[/cyan]")
@@ -2111,7 +2113,7 @@ pause
         # Note: chmod not needed on Windows batch files
         return installer_path
 
-    def _create_documentation(self, output_dir: Path, profile, timestamp: str):
+    def _create_documentation(self, output_dir: Path, profile, timestamp: str, profile_name: str = "ClaudeCode"):
         """Create user documentation."""
         readme_content = f"""# Claude Code Authentication Setup
 
@@ -2132,7 +2134,7 @@ pause
 
 3. Use the AWS profile:
    ```bash
-   export AWS_PROFILE=ClaudeCode
+   export AWS_PROFILE={profile_name}
    aws sts get-caller-identity
    ```
 
@@ -2180,13 +2182,13 @@ install.bat
 The installer will:
 - Check for AWS CLI installation
 - Copy authentication tools to `%USERPROFILE%\\claude-code-with-bedrock`
-- Configure the AWS profile "ClaudeCode"
+- Configure the AWS profile "{profile_name}"
 - Test the authentication
 
 #### Step 4: Use Claude Code
 ```cmd
 # Set the AWS profile
-set AWS_PROFILE=ClaudeCode
+set AWS_PROFILE={profile_name}
 
 # Verify authentication works
 aws sts get-caller-identity
@@ -2196,7 +2198,7 @@ aws sts get-caller-identity
 
 For PowerShell users:
 ```powershell
-$env:AWS_PROFILE = "ClaudeCode"
+$env:AWS_PROFILE = "{profile_name}"
 aws sts get-caller-identity
 ```
 


### PR DESCRIPTION
## Summary

- Replace hardcoded "ClaudeCode" with actual profile name in CLI output
- Add support for destroying distribution, codebuild, and quota stacks
- Implement dependency-aware stack deletion order
- Add automatic skipping of non-enabled stacks in destroy command
- Show comprehensive stack status including new stack types
- Update CLI_REFERENCE.md to document profile naming and stack management

## Test plan

- [x] Code changes reviewed and verified
- [x] Documentation updated to match code changes
- [x] Changes are consistent across all affected files