### PR TITLE
feat: Add no-browser mode for device code flow authentication

### DIFF
--- a/assets/docs/CLI_REFERENCE.md
+++ b/assets/docs/CLI_REFERENCE.md
@@ -95,6 +95,14 @@ poetry run ccwb init [options]
 - Prompts for Windows build support via AWS CodeBuild (optional)
 - Saves configuration to `.ccwb-config/config.json` in the project directory
 
+**Additional Configuration Options:**
+
+After running `init`, you can manually edit the configuration to enable additional features:
+
+- `no_browser_mode`: Set to `true` to use device code flow (RFC 8628) instead of browser-based authentication. Useful for headless servers or SSH sessions. Users can also override this per-invocation using `--no-browser` flag.
+  - Supported providers: Okta, Azure AD, Auth0
+  - Not supported: Cognito User Pools
+
 **Note:** This command only creates configuration. Use `deploy` to create AWS resources.
 
 ### `deploy` - Deploy Infrastructure

--- a/assets/docs/providers/auth0-setup.md
+++ b/assets/docs/providers/auth0-setup.md
@@ -91,6 +91,9 @@ After creation, you'll see:
 2. Ensure these are enabled:
    - ✅ **Authorization Code**
    - ✅ **Refresh Token**
+   - ✅ **Device Code** (optional, for no-browser mode support)
+
+> **Note**: Enable **Device Code** if you want to support headless servers or SSH sessions using device code flow (`--no-browser` flag).
 
 ### Step 4.5: Save Changes
 

--- a/assets/docs/providers/microsoft-entra-id-setup.md
+++ b/assets/docs/providers/microsoft-entra-id-setup.md
@@ -86,6 +86,8 @@ After registration, save these values:
 2. Toggle **Allow public client flows** to **Yes**
 3. Click **Save**
 
+> **Note**: Enabling **Allow public client flows** automatically enables device code flow, which allows users to authenticate from headless servers or SSH sessions using the `--no-browser` flag.
+
 ### Step 4.3: Verify API Permissions
 
 The default `User.Read` permission is sufficient. No changes needed.

--- a/assets/docs/providers/okta-setup.md
+++ b/assets/docs/providers/okta-setup.md
@@ -69,6 +69,9 @@ Make sure these are checked:
 - ✅ **Authorization Code**
 - ✅ **Refresh Token**
 - ✅ **Resource Owner Password** (optional, for testing)
+- ✅ **Device Authorization** (optional, for no-browser mode support)
+
+> **Note**: Enable **Device Authorization** if you want to support headless servers or SSH sessions using device code flow (`--no-browser` flag).
 
 #### Sign-in Redirect URIs
 

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -73,6 +73,9 @@ class Profile:
     # Claude Code settings configuration
     include_coauthored_by: bool = True  # Whether to include "co-authored-by Claude" in git commits
 
+    # Authentication mode configuration
+    no_browser_mode: bool = False  # Use device code flow instead of browser-based authentication
+
     # Legacy field support
     @property
     def okta_domain(self) -> str:


### PR DESCRIPTION
## Summary

 Implements device code flow (RFC 8628) as an alternative to browser-based authentication for headless servers, SSH sessions, and environments where opening a browser is not practical.

 ## Changes

 ### Implementation
 - Add `no_browser_mode` configuration field to Profile dataclass
 - Implement `authenticate_device_code()` method supporting Okta, Azure AD, Auth0
 - Add `--no-browser` CLI flag with config override support
 - Add device authorization endpoints for all supported providers
 - Update polling logic to comply with RFC 8628 best practices

 ### Documentation
 - Add no-browser mode section to LOCAL_TESTING.md
 - Add complete credential-process CLI reference with all options
 - Update CLI_REFERENCE.md with configuration instructions
 - Update provider setup guides (Okta, Azure AD, Auth0) with grant type requirements

 ## Provider Support

 - ✅ Okta - Full support
 - ✅ Azure AD (Microsoft Entra ID) - Full support
 - ✅ Auth0 - Full support
 - ❌ Cognito User Pools - Not supported (provider limitation)

 ## Usage

 ```bash
 # Command line flag (overrides config)
 credential-process --no-browser

 # Or set in config.json
 {
   "no_browser_mode": true
 }
 ```

 ## Testing

 Tested successfully with Azure AD device code flow:
 - Device code request and user code display
 - Polling with proper RFC 8628 compliance
 - Token exchange and AWS credential issuance
 - Cache and credential storage

 ## Files Changed

 - `source/claude_code_with_bedrock/config.py` - Add no_browser_mode field
 - `source/credential_provider/__main__.py` - Implement device code flow
 - `assets/docs/LOCAL_TESTING.md` - Add no-browser mode and CLI reference
 - `assets/docs/CLI_REFERENCE.md` - Document configuration
 - `assets/docs/providers/okta-setup.md` - Add Device Authorization grant
 - `assets/docs/providers/microsoft-entra-id-setup.md` - Document device flow support
 - `assets/docs/providers/auth0-setup.md` - Add Device Code grant

 ## References

 - RFC 8628: OAuth 2.0 Device Authorization Grant
 - MSAL Python device flow implementation
 - Okta Device Authorization documentation