### PR TITLE
fix: s3 stack output and IAM permission fix

### DIFF
--- a/deployment/infrastructure/bedrock-auth-auth0.yaml
+++ b/deployment/infrastructure/bedrock-auth-auth0.yaml
@@ -144,6 +144,12 @@ Resources:
               - 'bedrock:ListInferenceProfiles'
               - 'bedrock:GetInferenceProfile'
             Resource: '*'
+          - Sid: AllowMarketplaceAccess
+            Effect: Allow
+            Action:
+              - 'aws-marketplace:ViewSubscriptions'
+              - 'aws-marketplace:Subscribe'
+            Resource: '*'
           - !If
             - MonitoringEnabled
             - Sid: AllowCloudWatchMetrics

--- a/deployment/infrastructure/bedrock-auth-azure.yaml
+++ b/deployment/infrastructure/bedrock-auth-azure.yaml
@@ -136,6 +136,12 @@ Resources:
               - 'bedrock:ListInferenceProfiles'
               - 'bedrock:GetInferenceProfile'
             Resource: '*'
+          - Sid: AllowMarketplaceAccess
+            Effect: Allow
+            Action:
+              - 'aws-marketplace:ViewSubscriptions'
+              - 'aws-marketplace:Subscribe'
+            Resource: '*'
           - !If
             - MonitoringEnabled
             - Sid: AllowCloudWatchMetrics

--- a/deployment/infrastructure/bedrock-auth-cognito-pool.yaml
+++ b/deployment/infrastructure/bedrock-auth-cognito-pool.yaml
@@ -142,6 +142,12 @@ Resources:
               - 'bedrock:ListInferenceProfiles'
               - 'bedrock:GetInferenceProfile'
             Resource: '*'
+          - Sid: AllowMarketplaceAccess
+            Effect: Allow
+            Action:
+              - 'aws-marketplace:ViewSubscriptions'
+              - 'aws-marketplace:Subscribe'
+            Resource: '*'
           - !If
             - MonitoringEnabled
             - Sid: AllowCloudWatchMetrics

--- a/deployment/infrastructure/bedrock-auth-okta.yaml
+++ b/deployment/infrastructure/bedrock-auth-okta.yaml
@@ -135,6 +135,12 @@ Resources:
               - 'bedrock:ListInferenceProfiles'
               - 'bedrock:GetInferenceProfile'
             Resource: '*'
+          - Sid: AllowMarketplaceAccess
+            Effect: Allow
+            Action:
+              - 'aws-marketplace:ViewSubscriptions'
+              - 'aws-marketplace:Subscribe'
+            Resource: '*'
           - !If
             - MonitoringEnabled
             - Sid: AllowCloudWatchMetrics

--- a/deployment/infrastructure/cognito-identity-pool.yaml
+++ b/deployment/infrastructure/cognito-identity-pool.yaml
@@ -155,6 +155,12 @@ Resources:
             Condition:
               StringEquals:
                 'aws:RequestedRegion': !Ref AllowedBedrockRegions
+          - Sid: AllowMarketplaceAccess
+            Effect: Allow
+            Action:
+              - 'aws-marketplace:ViewSubscriptions'
+              - 'aws-marketplace:Subscribe'
+            Resource: '*'
           - !If
             - MonitoringEnabled
             - Sid: AllowCloudWatchOTLP

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -711,17 +711,17 @@ class DeployCommand(Command):
                     console.print("Run: [cyan]ccwb deploy dashboard[/cyan]")
                     return 1
 
-                # Get S3 bucket from networking stack for packaging
-                networking_stack = profile.stack_names.get("networking", f"{profile.identity_pool_name}-networking")
-                networking_outputs = get_stack_outputs(networking_stack, profile.aws_region)
+                # Get S3 bucket from s3bucket stack for packaging
+                s3_stack_name = profile.stack_names.get("s3", f"{profile.identity_pool_name}-s3bucket")
+                s3_outputs = get_stack_outputs(s3_stack_name, profile.aws_region)
 
-                if not networking_outputs or not networking_outputs.get("CfnArtifactsBucket"):
-                    console.print(f"[red]Could not get S3 bucket from networking stack {networking_stack}[/red]")
-                    console.print("[yellow]The networking stack must be deployed first.[/yellow]")
-                    console.print("Run: [cyan]ccwb deploy networking[/cyan]")
+                if not s3_outputs or not s3_outputs.get("CfnArtifactsBucket"):
+                    console.print(f"[red]Could not get S3 bucket from s3bucket stack {s3_stack_name}[/red]")
+                    console.print("[yellow]The s3bucket stack must be deployed first.[/yellow]")
+                    console.print("Run: [cyan]ccwb deploy s3bucket[/cyan]")
                     return 1
 
-                s3_bucket = networking_outputs["CfnArtifactsBucket"]
+                s3_bucket = s3_outputs["CfnArtifactsBucket"]
 
                 # Build parameters
                 monthly_limit = getattr(profile, "monthly_token_limit", 225000000)


### PR DESCRIPTION
  **Stack Output Fix**

  Fixed the deploy command to look for the S3 artifacts bucket in the correct stack. The command was incorrectly querying the networking stack instead of the s3bucket stack for CfnArtifactsBucket.

  Error:
  Could not get S3 bucket from networking stack {stack-name}
  The networking stack must be deployed first.

  File modified:
  - source/claude_code_with_bedrock/cli/commands/deploy.py

  **IAM Permissions Fix**

  Added AWS Marketplace access permissions to all authentication IAM policies to enable users to view and subscribe to marketplace models.

  Error:
  `403 Model access is denied due to IAM user or service role is not authorized to perform
  the required AWS Marketplace actions (aws-marketplace:ViewSubscriptions,
  aws-marketplace:Subscribe) to enable access to this model. Refer to the Amazon Bedrock
  documentation for further details. Your AWS Marketplace subscription for this model
  cannot be completed at this time. If you recently fixed this issue, try again after 5 minutes.`

  Files modified:
  - deployment/infrastructure/bedrock-auth-auth0.yaml
  - deployment/infrastructure/bedrock-auth-azure.yaml
  - deployment/infrastructure/bedrock-auth-cognito-pool.yaml
  - deployment/infrastructure/bedrock-auth-okta.yaml
  - deployment/infrastructure/cognito-identity-pool.yaml

  New permissions:
  - Sid: AllowMarketplaceAccess
    Effect: Allow
    Action:
      - 'aws-marketplace:ViewSubscriptions'
      - 'aws-marketplace:Subscribe'
    Resource: '*'