### PR TITLE
fix: add trailing slash to Auth0 issuer URL for quota API JWT authorizer

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -740,6 +740,9 @@ class DeployCommand(Command):
                 # Ensure issuer URL has https:// prefix
                 if oidc_issuer_url and not oidc_issuer_url.startswith(("http://", "https://")):
                     oidc_issuer_url = f"https://{oidc_issuer_url}"
+                # Auth0 tokens include trailing slash in iss claim, so authorizer must match
+                if profile.provider_type == "auth0" and oidc_issuer_url and not oidc_issuer_url.endswith("/"):
+                    oidc_issuer_url = f"{oidc_issuer_url}/"
                 oidc_client_id = profile.client_id
 
                 params = [


### PR DESCRIPTION
## Summary

Auth0 tokens include a trailing slash in the `iss` claim (e.g., `https://tenant.auth0.com/`) but users typically enter the domain without it. API Gateway JWT authorizer performs exact string matching, causing 401 Unauthorized errors when calling the quota check API.

## Changes

Added logic in `deploy.py` to append a trailing slash to the `OidcIssuerUrl` parameter when the provider type is Auth0.

## Testing

- Deployed quota-monitoring stack with Auth0 provider
- Verified JWT token validation now succeeds on `/check` endpoint
- `ccwb test` quota monitoring test passes

Fixes #97