### PR TITLE
Fix port 8400 conflict by auto-selecting available port

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -291,6 +291,17 @@ Force re-authentication:
 ~/claude-code-with-bedrock/credential-process --clear-cache
 ```
 
+### Port Conflicts
+
+The credential provider uses port 8400 by default for OAuth callbacks.
+If this port is in use by another application, authentication will automatically use an available port.
+
+To manually specify a different port, set the `REDIRECT_PORT` environment variable:
+
+```bash
+export REDIRECT_PORT=8401
+```
+
 ### Build Failures
 
 Check Windows build status:

--- a/source/credential_provider/__main__.py
+++ b/source/credential_provider/__main__.py
@@ -95,9 +95,10 @@ class MultiProviderAuth:
             )
         self.provider_config = PROVIDER_CONFIGS[self.provider_type]
 
-        # OAuth configuration
-        self.redirect_port = int(os.getenv("REDIRECT_PORT", "8400"))
-        self.redirect_uri = f"http://localhost:{self.redirect_port}/callback"
+        # OAuth configuration - port selection deferred until authentication
+        self.preferred_port = int(os.getenv("REDIRECT_PORT", "8400"))
+        self.redirect_port = None
+        self.redirect_uri = None
 
         # Initialize credential storage
         self._init_credential_storage()
@@ -106,6 +107,31 @@ class MultiProviderAuth:
         """Print debug message only if debug mode is enabled"""
         if self.debug:
             print(f"Debug: {message}", file=sys.stderr)
+
+    def _get_available_port(self):
+        """Find an available port for OAuth callback, preferring the configured port."""
+        if self.redirect_port is not None:
+            return self.redirect_port
+
+        test_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            test_socket.bind(("127.0.0.1", self.preferred_port))
+            test_socket.close()
+            self.redirect_port = self.preferred_port
+        except OSError as e:
+            test_socket.close()
+            if e.errno == errno.EADDRINUSE:
+                self._debug_print(f"Port {self.preferred_port} in use, selecting available port")
+                auto_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                auto_socket.bind(("127.0.0.1", 0))
+                self.redirect_port = auto_socket.getsockname()[1]
+                auto_socket.close()
+                self._debug_print(f"Using port {self.redirect_port} for OAuth callback")
+            else:
+                raise
+
+        self.redirect_uri = f"http://localhost:{self.redirect_port}/callback"
+        return self.redirect_port
 
     def _auto_detect_profile(self):
         """Auto-detect profile name from config.json when only one profile exists."""
@@ -823,6 +849,8 @@ class MultiProviderAuth:
 
     def authenticate_oidc(self):
         """Perform OIDC authentication with PKCE"""
+        self._get_available_port()
+
         state = secrets.token_urlsafe(16)
         nonce = secrets.token_urlsafe(16)
 
@@ -1261,69 +1289,11 @@ class MultiProviderAuth:
                 ) from e
             raise Exception(f"Failed to get AWS credentials: {str(e)}") from None
 
-    def _wait_for_auth_completion(self, timeout=60):
-        """Wait for another process to complete authentication using port-based detection"""
-        start_time = time.time()
-
-        while time.time() - start_time < timeout:
-            # Check if port is still in use (another auth in progress)
-            test_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            try:
-                test_socket.bind(("127.0.0.1", self.redirect_port))
-                test_socket.close()
-                # Port is free, auth must have completed or failed
-                # Check for cached credentials
-                cached = self.get_cached_credentials()
-                if cached:
-                    return cached
-                else:
-                    # Auth failed or was cancelled
-                    return None
-            except OSError as e:
-                if e.errno == errno.EADDRINUSE:
-                    # Port still in use, auth still in progress
-                    time.sleep(0.5)
-                else:
-                    # Other error
-                    raise
-            finally:
-                try:
-                    test_socket.close()
-                except Exception:
-                    pass
-
-        return None
-
     def authenticate_for_monitoring(self):
         """Authenticate specifically for monitoring token (no AWS credential output)"""
         try:
-            # Try to acquire port lock by testing if we can bind to it
-            test_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            try:
-                test_socket.bind(("127.0.0.1", self.redirect_port))
-                test_socket.close()
-                # We got the port, we can proceed with authentication
-                self._debug_print("Port available, proceeding with monitoring authentication")
-            except OSError as e:
-                if e.errno == errno.EADDRINUSE:
-                    # Port in use, another auth is in progress
-                    self._debug_print("Another authentication is in progress, waiting...")
-                    test_socket.close()
-
-                    # Wait for the other process to complete
-                    # After waiting, check if we now have a monitoring token
-                    self._wait_for_auth_completion()
-                    token = self.get_monitoring_token()
-                    if token:
-                        return token
-                    else:
-                        self._debug_print("Authentication timeout or failed in another process")
-                        return None
-                else:
-                    test_socket.close()
-                    raise
-
             # Authenticate with OIDC provider
+            # Note: Port selection is handled dynamically in authenticate_oidc()
             self._debug_print(f"Authenticating with {self.provider_config['name']} for monitoring token...")
             id_token, token_claims = self.authenticate_oidc()
 
@@ -1792,7 +1762,7 @@ class MultiProviderAuth:
                     pass  # Suppress logs
 
             # Use a different port for quota page (8401) to avoid conflict with auth
-            quota_port = self.redirect_port + 1
+            quota_port = self.preferred_port + 1
             try:
                 server = HTTPServer(("127.0.0.1", quota_port), QuotaPageHandler)
                 server.timeout = 5  # 5 second timeout
@@ -1891,39 +1861,6 @@ class MultiProviderAuth:
                     else:
                         self._debug_print("No cached token for quota re-check, skipping")
 
-                # Output cached credentials (intended behavior for AWS CLI)
-                print(json.dumps(cached))  # noqa: S105
-                return 0
-
-            # Try to acquire port lock by testing if we can bind to it
-            test_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            try:
-                test_socket.bind(("127.0.0.1", self.redirect_port))
-                test_socket.close()
-                # We got the port, we can proceed with authentication
-                self._debug_print("Port available, proceeding with authentication")
-            except OSError as e:
-                if e.errno == errno.EADDRINUSE:
-                    # Port in use, another auth is in progress
-                    self._debug_print("Another authentication is in progress, waiting...")
-                    test_socket.close()
-
-                    # Wait for the other process to complete
-                    cached = self._wait_for_auth_completion()
-                    if cached:
-                        print(json.dumps(cached))
-                        return 0
-                    else:
-                        # Only print error to stderr for actual failures
-                        self._debug_print("Authentication timeout or failed in another process")
-                        return 1
-                else:
-                    test_socket.close()
-                    raise
-
-            # Check cache again (another process might have just finished)
-            cached = self.get_cached_credentials()
-            if cached:
                 # Output cached credentials (intended behavior for AWS CLI)
                 print(json.dumps(cached))  # noqa: S105
                 return 0


### PR DESCRIPTION
## Summary

- Fixes authentication hang when port 8400 is in use by another application
- Adds `_get_available_port()` method that tries the preferred port first, then auto-selects an available port
- Fixes `quota_port` TypeError when `redirect_port` is `None`
- Documents the `REDIRECT_PORT` environment variable in QUICK_START.md

## Problem

When port 8400 is in use by another service (e.g., [Commvault uses port 8400](https://documentation.commvault.com/v11/software/port_requirements_for_commvault.html)), the credential-process hangs indefinitely. The code assumed that if port 8400 was busy, another credential-process was authenticating, and waited for it to finish. This assumption breaks when external services use port 8400.

## Solution

1. **Dynamic port selection**: Try the preferred port (8400 or `REDIRECT_PORT` env var) first. If unavailable, auto-select a free port using `socket.bind((host, 0))`.

2. **Simplified locking**: Removed the port-based locking mechanism from `run()` and `authenticate_for_monitoring()` since it conflicted with external services.

3. **Quota port fix**: Changed `quota_port = self.redirect_port + 1` to `self.preferred_port + 1` to avoid `TypeError` when `redirect_port` is `None` (before authentication has selected a port).

4. **Documentation**: Added troubleshooting section for port conflicts in QUICK_START.md.

## Impact of Removing Locking

The previous locking mechanism prevented multiple credential-process instances from authenticating simultaneously. Without it, if two processes need fresh credentials at the same time, both may open browser windows. Since users typically run many Claude Code instances, this could occur when credentials expire across multiple sessions. Cached credentials mitigate this in most cases, but a more robust locking mechanism (e.g., file-based) may be worth considering.

## Testing

- 199 passing tests (2 pre-existing failures on `main` unrelated to this change)
- Manual testing recommended:
  - Block port 8400 with `nc -l 8400`, verify auth works on auto-selected port
  - Verify auth still works on port 8400 when available

## Licensing

I confirm that this contribution is licensed under the MIT No Attribution license, consistent with the project's LICENSE file.