### PR TITLE
feat: Add ml-training plugin with GRPO fine-tuning skill

### DIFF
--- a/assets/claude-code-plugins/plugins/ml-training/.claude-plugin/plugin.json
+++ b/assets/claude-code-plugins/plugins/ml-training/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "ml-training",
+  "version": "1.0.0",
+  "description": "Machine learning training skills for GRPO fine-tuning and vision-language models",
+  "author": {
+    "name": "Michael Walker",
+    "email": "michael@example.com"
+  }
+}


### PR DESCRIPTION
## Summary

Adds a new `ml-training` plugin with a skill for GRPO (Group Relative Policy Optimization) fine-tuning workflows.

## What's Included

- **GRPO Fine-Tuning Skill** (`ml-training/skills/grpo-finetuning/SKILL.md`)
  - When to use GRPO vs traditional SFT
  - Reward function implementation patterns
  - Training configuration for vision-language models
  - AWS SageMaker infrastructure setup
  - Common issues and troubleshooting

## Use Case

GRPO is particularly effective for:
- Small datasets (<1000 examples)
- Tasks with clear correctness criteria (JSON validation, format compliance)
- Vision-language model fine-tuning

## Testing

- Skill follows the existing plugin format in `assets/claude-code-plugins/plugins/`
- Markdown linting passes

---

This contribution is based on production experience fine-tuning VLMs for document extraction tasks on AWS.