### PR TITLE
chore: Remove duplicate commented-out Security Groups section

### DIFF
--- a/deployment/infrastructure/otel-collector.yaml
+++ b/deployment/infrastructure/otel-collector.yaml
@@ -70,7 +70,6 @@ Resources:
           Value: !Ref AWS::StackName
 
   # Security Groups
-  # Security Groups
   ALBSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:


### PR DESCRIPTION
*Issue #, if available:* No

*Description of changes:* I happened to see it, so I removed the duplicated comment
