### PR TITLE
fix: CloudFormation template bugs (ALB logs region, ECS DependsOn, CodeBuild SSL)

### DIFF
--- a/deployment/infrastructure/codebuild-windows.yaml
+++ b/deployment/infrastructure/codebuild-windows.yaml
@@ -142,7 +142,8 @@ Resources:
               commands:
                 - echo Installing build dependencies...
                 - C:\Python312\python.exe -m pip install --upgrade pip
-                - C:\Python312\python.exe -m pip install nuitka==2.7.12 ordered-set zstandard
+                - C:\Python312\python.exe -m pip install nuitka==2.7.12 ordered-set zstandard certifi
+                - Set-Content -Path 'C:\Python312\Lib\site-packages\sitecustomize.py' -Value 'import os; os.environ["SSL_CERT_FILE"]=r"C:\Python312\Lib\site-packages\certifi\cacert.pem"'
                 - echo Installing application dependencies...
                 - C:\Python312\python.exe -m pip install boto3 requests PyJWT cryptography
                 - C:\Python312\python.exe -m pip install keyring pywin32

--- a/deployment/infrastructure/landing-page-distribution.yaml
+++ b/deployment/infrastructure/landing-page-distribution.yaml
@@ -175,7 +175,7 @@ Resources:
           - Sid: AWSLogDeliveryWrite
             Effect: Allow
             Principal:
-              AWS: !Sub 'arn:aws:iam::127311923021:root'  # ELB service account for us-east-1
+              Service: logdelivery.elasticloadbalancing.amazonaws.com
             Action: s3:PutObject
             Resource: !Sub '${ALBLogsBucket.Arn}/*'
           - Sid: AWSLogDeliveryAclCheck

--- a/deployment/infrastructure/otel-collector.yaml
+++ b/deployment/infrastructure/otel-collector.yaml
@@ -459,6 +459,7 @@ Resources:
     Type: AWS::ECS::Service
     DependsOn:
       - HTTPListener
+      - HTTPSListener
     Properties:
       ServiceName: otel-collector-service
       Cluster: !Ref ECSCluster


### PR DESCRIPTION
## Description

Fixes three CloudFormation template bugs that block deployment in various configurations.

Partially addresses #118 (section 3c), fixes #122, fixes #121

> Note: PR #112 also addresses #121 with a different approach (pre-installing MinGW). This PR instead fixes the root cause - broken SSL certificates in the Windows CodeBuild container - by installing `certifi` and configuring `sitecustomize.py`. This covers Nuitka's MinGW download and any future HTTPS downloads.

### Changes

**landing-page-distribution.yaml:**
- ALB access logs S3 bucket policy now uses `logdelivery.elasticloadbalancing.amazonaws.com` service principal instead of hardcoded us-east-1 ELB account ID (`127311923021`). Per [AWS docs](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html). Note: #118 suggests a `Mappings`+`FindInMap` approach; this uses the service principal instead, which is simpler and requires no region mapping table.

**otel-collector.yaml:**
- Added `HTTPSListener` to ECSService `DependsOn`. When `HasCustomDomain` is true, the target group is associated via HTTPSListener, not HTTPListener. Without this, ECS service creation races ahead and fails.

**codebuild-windows.yaml:**
- Added `certifi` to pip install and wrote `sitecustomize.py` to set `SSL_CERT_FILE`. The Windows Server 2022 CodeBuild container has outdated CA certificates causing Nuitka's MinGW download to fail with `SSL: CERTIFICATE_VERIFY_FAILED`.

### Testing

- Deployed full stack in ap-southeast-1 with landing-page distribution, Entra ID, and monitoring enabled
- Verified ALB access logs write successfully
- Verified ECS service starts after HTTPS listener is ready
- Verified CodeBuild Windows build completes successfully

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.