### PR TITLE
fix: use correct OIDC issuer URL for Cognito in quota monitoring stack

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -736,13 +736,21 @@ class DeployCommand(Command):
                 )
 
                 # Get OIDC configuration for JWT authentication
-                oidc_issuer_url = profile.provider_domain
-                # Ensure issuer URL has https:// prefix
-                if oidc_issuer_url and not oidc_issuer_url.startswith(("http://", "https://")):
-                    oidc_issuer_url = f"https://{oidc_issuer_url}"
-                # Auth0 tokens include trailing slash in iss claim, so authorizer must match
-                if profile.provider_type == "auth0" and oidc_issuer_url and not oidc_issuer_url.endswith("/"):
-                    oidc_issuer_url = f"{oidc_issuer_url}/"
+                # For Cognito User Pools, use the cognito-idp issuer format required by API Gateway
+                if profile.provider_type == "cognito":
+                    cognito_user_pool_id = getattr(profile, "cognito_user_pool_id", None)
+                    if cognito_user_pool_id:
+                        oidc_issuer_url = f"https://cognito-idp.{profile.aws_region}.amazonaws.com/{cognito_user_pool_id}"
+                    else:
+                        raise ValueError("Cognito User Pool ID is required for quota monitoring with Cognito")
+                else:
+                    oidc_issuer_url = profile.provider_domain
+                    # Ensure issuer URL has https:// prefix
+                    if oidc_issuer_url and not oidc_issuer_url.startswith(("http://", "https://")):
+                        oidc_issuer_url = f"https://{oidc_issuer_url}"
+                    # Auth0 tokens include trailing slash in iss claim, so authorizer must match
+                    if profile.provider_type == "auth0" and oidc_issuer_url and not oidc_issuer_url.endswith("/"):
+                        oidc_issuer_url = f"{oidc_issuer_url}/"
                 oidc_client_id = profile.client_id
 
                 params = [


### PR DESCRIPTION
## Summary

- Fix quota monitoring stack deployment failure when using Cognito User Pools as OIDC provider
- API Gateway JWT authorizers require the issuer URL in `https://cognito-idp.{region}.amazonaws.com/{user-pool-id}` format, not the hosted UI domain (`my-app.auth.{region}.amazoncognito.com`)
- The hosted UI domain does not expose a `.well-known/openid-configuration` endpoint, causing a `BadRequestException` during CloudFormation deployment of the `QuotaCheckAuthorizer`

## Test plan

- [x] Deployed full ccwb stack with Cognito User Pool provider — quota stack now deploys successfully
- [ ] Verify Okta/Azure AD/Auth0 providers are unaffected (existing code path preserved in `else` branch)