### PR TITLE
fix: relax CognitoUserPoolClientId AllowedPattern to match AWS docs (1-128 chars)

### DIFF
--- a/deployment/infrastructure/bedrock-auth-cognito-pool.yaml
+++ b/deployment/infrastructure/bedrock-auth-cognito-pool.yaml
@@ -19,7 +19,7 @@ Parameters:
   CognitoUserPoolClientId:
     Type: String
     Description: Cognito User Pool App Client ID
-    AllowedPattern: '^[a-z0-9]{26}$'
+    AllowedPattern: '^[a-z0-9]{1,128}$'
     ConstraintDescription: Must be a valid Cognito User Pool Client ID
 
   CognitoUserPoolDomain:


### PR DESCRIPTION
## Summary

- Fix `CognitoUserPoolClientId` `AllowedPattern` in `bedrock-auth-cognito-pool.yaml` to match the AWS documented constraints

## Problem

The current `AllowedPattern` only allows exactly 26 characters:

```yaml
AllowedPattern: '^[a-z0-9]{26}$'
```

This causes `ccwb deploy` to fail when the Cognito App Client ID is not exactly 26 characters (e.g., 25 characters), with the following error:

```
CloudFormation error: Template validation failed: Parameter CognitoUserPoolClientId failed to satisfy constraint: Must be a valid Cognito User Pool Client ID
```

## Fix

According to the [AWS documentation](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_UserPoolClientType.html#CognitoUserPools-Type-UserPoolClientType-ClientId), `ClientId` has:

> Length Constraints: Minimum length of 1. Maximum length of 128.

Updated the pattern to:

```yaml
AllowedPattern: '^[a-z0-9]{1,128}$'
```

## Related Issue

Closes #141