### PR TITLE
fix: Enable Cognito Hosted UI password reset via email

### DIFF
--- a/deployment/infrastructure/cognito-user-pool-setup.yaml
+++ b/deployment/infrastructure/cognito-user-pool-setup.yaml
@@ -80,10 +80,17 @@ Resources:
           AttributeDataType: String
           Required: false
           Mutable: true
-      # Message configuration - don't automatically send messages
-      AutoVerifiedAttributes: []
+      # Message configuration - enable email for password reset
+      AutoVerifiedAttributes:
+        - email
       EmailConfiguration:
         EmailSendingAccount: COGNITO_DEFAULT
+      AccountRecoverySetting:
+        RecoveryMechanisms:
+          - Name: verified_email
+            Priority: 1
+      AdminCreateUserConfig:
+        AllowAdminCreateUserOnly: true
       # Disable self-registration as required
       Policies:
         PasswordPolicy:


### PR DESCRIPTION
## Summary

- Set `AutoVerifiedAttributes` to `[email]` to allow Cognito to send password reset codes via email
- Add `AccountRecoverySetting` with `verified_email` as the recovery mechanism
- Explicitly set `AdminCreateUserConfig.AllowAdminCreateUserOnly: true`

## Background

The "Forgot your password?" link in Cognito Hosted UI was not functional because `AutoVerifiedAttributes` was set to an empty list, preventing Cognito from sending password reset emails.

## Test plan

- [x] Deploy the updated CloudFormation stack (`cognito-user-pool-setup.yaml`)
- [x] Open Cognito Hosted UI and click "Forgot your password?"
- [x] Enter a registered email address and confirm the reset code is received
- [x] Enter the code and new password to complete the reset flow
- [x] Verify existing users are unaffected

Closes #143