### PR TITLE
fix: Cognito schema, quota JWT issuer, Okta preview domains, and Windows packaging

### DIFF
--- a/assets/docs/WINDOWS_BUILD_SYSTEM.md
+++ b/assets/docs/WINDOWS_BUILD_SYSTEM.md
@@ -7,10 +7,11 @@
 3. [Prerequisites](#prerequisites)
 4. [Initial Setup](#initial-setup)
 5. [Build Process](#build-process)
-6. [CLI Commands](#cli-commands)
-7. [Distribution](#distribution)
-8. [Troubleshooting](#troubleshooting)
-9. [Technical Details](#technical-details)
+6. [Building from a Windows Machine](#building-from-a-windows-machine)
+7. [CLI Commands](#cli-commands)
+8. [Distribution](#distribution)
+9. [Troubleshooting](#troubleshooting)
+10. [Technical Details](#technical-details)
 
 ## Overview
 
@@ -270,6 +271,94 @@ Output:
 │ ghi11111 │ ✗ Failed       │ 2024-08-24 08:00 │ 2 min    │ BUILD     │
 └──────────┴────────────────┴──────────────────┴──────────┴───────────┘
 ```
+
+## Building from a Windows Machine
+
+If you are deploying from a Windows machine rather than macOS/Linux, you can build Windows binaries natively using Nuitka without CodeBuild. macOS and Linux binaries require their respective platforms or Docker.
+
+### Prerequisites
+
+- Python 3.10, 3.11, or 3.12 (not 3.13+)
+- Poetry package manager
+- Nuitka and its dependencies (see below)
+- (Optional) Docker Desktop for Windows — required for Linux binary builds
+
+### Install Nuitka
+
+```powershell
+poetry add --group dev nuitka ordered-set zstandard
+```
+
+### Build Windows Binaries
+
+```powershell
+poetry run ccwb package --target-platform windows
+```
+
+This builds both `credential-process-windows.exe` and `otel-helper-windows.exe` (if monitoring is enabled) using Nuitka native compilation. Build time is approximately 10-15 minutes.
+
+Output directory: `source/dist/<profile-name>/<timestamp>/`
+
+### Cross-Platform Build Matrix
+
+When building from Windows, not all platforms are available:
+
+| Target Platform | Method | Available from Windows? |
+|----------------|--------|------------------------|
+| **Windows** | Nuitka (native) | Yes |
+| **Linux x64** | Docker (PyInstaller) | Yes, if Docker Desktop is installed |
+| **Linux arm64** | Docker (PyInstaller) | Yes, if Docker Desktop is installed |
+| **macOS arm64** | PyInstaller (native) | No — must build on a Mac |
+| **macOS Intel** | PyInstaller (native) | No — must build on a Mac |
+
+### Building All Available Platforms
+
+To build everything possible from Windows:
+
+```powershell
+# Windows only (always works)
+poetry run ccwb package --target-platform windows
+
+# All available (Windows native + Linux via Docker if installed)
+poetry run ccwb package
+```
+
+> **Note:** If Docker is not installed, Linux builds will be skipped with a warning. macOS builds will fail — this is expected. Use `--target-platform windows` to avoid these errors.
+
+### Multi-Platform Distribution Strategy
+
+If your organization needs packages for all platforms:
+
+1. **Windows** — Build natively on the Windows machine
+2. **Linux** — Either install Docker Desktop on Windows, or build from a Linux machine
+3. **macOS** — Must be built on a Mac (`poetry run ccwb package --target-platform macos`)
+
+Combine the binaries from each platform into a single `dist/` folder before running `poetry run ccwb distribute`.
+
+### Troubleshooting Windows Native Builds
+
+#### Python version not supported
+
+```
+The currently activated Python version 3.13.x is not supported by the project (>=3.10,<3.13).
+```
+
+Install Python 3.12 from [python.org](https://www.python.org/downloads/) and run:
+
+```powershell
+poetry env use py -3.12
+poetry install
+```
+
+#### Nuitka not found
+
+If you get "Nuitka not found" after installing it, verify the installation:
+
+```powershell
+poetry run python -m nuitka --version
+```
+
+If this works but the package command still fails, ensure you are running the latest version of `package.py` which uses a cross-platform Nuitka detection method.
 
 ## CLI Commands
 

--- a/assets/docs/providers/cognito-user-pool-setup.md
+++ b/assets/docs/providers/cognito-user-pool-setup.md
@@ -101,7 +101,7 @@ The template creates a User Pool with the following settings:
 ### Sign-in Options
 - Username with email alias
 - Email as required attribute
-- preferred_username as required attribute
+- preferred_username as optional attribute (used as sign-in alias)
 
 ### Security Settings
 - Self-registration disabled

--- a/deployment/infrastructure/bedrock-auth-okta.yaml
+++ b/deployment/infrastructure/bedrock-auth-okta.yaml
@@ -12,9 +12,9 @@ Parameters:
 
   OktaDomain:
     Type: String
-    Description: Your Okta domain (e.g., company.okta.com)
-    AllowedPattern: '^[a-zA-Z0-9][a-zA-Z0-9-]*\.okta(-emea)?\.com$'
-    ConstraintDescription: Must be a valid Okta domain
+    Description: Your Okta domain (e.g., company.okta.com or dev-123456.oktapreview.com)
+    AllowedPattern: '^[a-zA-Z0-9][a-zA-Z0-9-]*\.okta(preview|-emea)?\.com$'
+    ConstraintDescription: Must be a valid Okta domain (okta.com, oktapreview.com, or okta-emea.com)
 
   OktaClientId:
     Type: String

--- a/deployment/infrastructure/cognito-user-pool-setup.yaml
+++ b/deployment/infrastructure/cognito-user-pool-setup.yaml
@@ -70,7 +70,7 @@ Resources:
           Mutable: true
         - Name: preferred_username
           AttributeDataType: String
-          Required: true
+          Required: false
           Mutable: true
         - Name: given_name
           AttributeDataType: String

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -736,13 +736,18 @@ class DeployCommand(Command):
                 )
 
                 # Get OIDC configuration for JWT authentication
-                oidc_issuer_url = profile.provider_domain
-                # Ensure issuer URL has https:// prefix
-                if oidc_issuer_url and not oidc_issuer_url.startswith(("http://", "https://")):
-                    oidc_issuer_url = f"https://{oidc_issuer_url}"
-                # Auth0 tokens include trailing slash in iss claim, so authorizer must match
-                if profile.provider_type == "auth0" and oidc_issuer_url and not oidc_issuer_url.endswith("/"):
-                    oidc_issuer_url = f"{oidc_issuer_url}/"
+                # Cognito issuer URL uses cognito-idp endpoint, not the hosted UI domain
+                if profile.provider_type == "cognito" and profile.cognito_user_pool_id:
+                    region = profile.cognito_user_pool_id.split("_")[0]
+                    oidc_issuer_url = f"https://cognito-idp.{region}.amazonaws.com/{profile.cognito_user_pool_id}"
+                else:
+                    oidc_issuer_url = profile.provider_domain
+                    # Ensure issuer URL has https:// prefix
+                    if oidc_issuer_url and not oidc_issuer_url.startswith(("http://", "https://")):
+                        oidc_issuer_url = f"https://{oidc_issuer_url}"
+                    # Auth0 tokens include trailing slash in iss claim, so authorizer must match
+                    if profile.provider_type == "auth0" and oidc_issuer_url and not oidc_issuer_url.endswith("/"):
+                        oidc_issuer_url = f"{oidc_issuer_url}/"
                 oidc_client_id = profile.client_id
 
                 params = [

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -562,7 +562,7 @@ class PackageCommand(Command):
             binary_name = "credential-process-linux"
         elif target_platform == "windows":
             platform_variant = "x86_64"
-            # binary_name already set above
+            binary_name = "credential-process-windows.exe"
         else:
             raise ValueError(f"Unsupported target platform: {target_platform}")
 
@@ -598,7 +598,7 @@ class PackageCommand(Command):
         # Check if Nuitka is available (through Poetry)
         source_dir = Path(__file__).parent.parent.parent.parent
         nuitka_check = subprocess.run(
-            ["poetry", "run", "which", "nuitka"], capture_output=True, text=True, cwd=source_dir
+            ["poetry", "run", "python", "-m", "nuitka", "--version"], capture_output=True, text=True, cwd=source_dir
         )
         if nuitka_check.returncode != 0:
             raise RuntimeError(

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -1403,14 +1403,18 @@ RUN pyinstaller \
 
     def _build_otel_helper(self, output_dir: Path, target_platform: str) -> Path:
         """Build executable for OTEL helper script."""
-        # Windows uses Nuitka via CodeBuild
+        import platform as platform_mod
+
+        # Windows builds
         if target_platform == "windows":
-            # Check if the Windows binary already exists (built by _build_executable)
+            if platform_mod.system().lower() == "windows":
+                # Native Windows build with Nuitka
+                return self._build_native_otel_helper(output_dir, "windows")
+            # Check if the Windows binary already exists (built via CodeBuild)
             windows_binary = output_dir / "otel-helper-windows.exe"
             if windows_binary.exists():
                 return windows_binary
             else:
-                # If not, we need to build via CodeBuild (but this should have been done already)
                 raise RuntimeError("Windows otel-helper should have been built with credential-process")
 
         # macOS builds use PyInstaller
@@ -1573,6 +1577,9 @@ RUN pyinstaller \
         elif target_platform == "linux":
             platform_variant = "x86_64"
             binary_name = "otel-helper-linux"
+        elif target_platform == "windows":
+            platform_variant = "x86_64"
+            binary_name = "otel-helper-windows.exe"
         else:
             raise ValueError(f"Unsupported target platform: {target_platform}")
 
@@ -1581,6 +1588,8 @@ RUN pyinstaller \
             raise RuntimeError(f"Cannot build macOS binary on {current_system}. Nuitka requires native builds.")
         elif target_platform == "linux" and current_system != "linux":
             raise RuntimeError(f"Cannot build Linux binary on {current_system}. Nuitka requires native builds.")
+        elif target_platform == "windows" and current_system != "windows":
+            raise RuntimeError(f"Cannot build Windows binary on {current_system}. Nuitka requires native builds.")
 
         # Find the source file
         src_file = Path(__file__).parent.parent.parent.parent / "otel_helper" / "__main__.py"

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -1962,7 +1962,7 @@ echo
 """
 
         installer_path = output_dir / "install.sh"
-        with open(installer_path, "w") as f:
+        with open(installer_path, "w", encoding="utf-8") as f:
             f.write(installer_content)
         installer_path.chmod(0o755)
 
@@ -2284,7 +2284,7 @@ Available metrics include:
 
         readme_content += "\n" ""
 
-        with open(output_dir / "README.md", "w") as f:
+        with open(output_dir / "README.md", "w", encoding="utf-8") as f:
             f.write(readme_content)
 
     def _create_claude_settings(


### PR DESCRIPTION
## Summary

Multiple bug fixes found during Cognito and Okta deployments, plus Windows native packaging fixes and documentation:

### Bug Fixes

1. **Cognito `preferred_username` schema conflict** — `Required: true` conflicts with `AliasAttributes`, preventing users from logging in via Hosted UI. Changed to `Required: false`.

2. **Quota JWT authorizer issuer mismatch** — For Cognito, the quota API Gateway JWT authorizer receives the hosted UI domain, but Cognito tokens use `https://cognito-idp.<region>.amazonaws.com/<pool-id>` as the `iss` claim. All quota API requests are rejected.

3. **Okta preview domains rejected** — The `OktaDomain` CloudFormation parameter regex only accepts `.okta.com` and `.okta-emea.com`, rejecting `.oktapreview.com` (Okta sandbox/test environments).

4. **Windows native package build broken** — Three issues:
   - `binary_name` variable never set for Windows target, causing `cannot access local variable` error
   - Nuitka availability check uses `which` (Unix-only), fails on Windows
   - OTEL helper has no native Windows build path — always errors when monitoring is enabled

### Documentation

5. Updated `cognito-user-pool-setup.md` to reflect `preferred_username` as optional.

6. Added **"Building from a Windows Machine"** section to `WINDOWS_BUILD_SYSTEM.md` — covers native Windows builds with Nuitka, cross-platform build matrix, multi-platform distribution strategy, and troubleshooting. The existing docs only covered building via CodeBuild from macOS/Linux.

## Files Changed

| File | Change |
|------|--------|
| `deployment/infrastructure/cognito-user-pool-setup.yaml` | `preferred_username` Required: false |
| `assets/docs/providers/cognito-user-pool-setup.md` | Docs: preferred_username is optional |
| `source/claude_code_with_bedrock/cli/commands/deploy.py` | Cognito issuer URL for quota stack |
| `deployment/infrastructure/bedrock-auth-okta.yaml` | Accept `.oktapreview.com` domains |
| `source/claude_code_with_bedrock/cli/commands/package.py` | Windows binary_name, Nuitka check, native OTEL helper |
| `assets/docs/WINDOWS_BUILD_SYSTEM.md` | New section: Building from a Windows Machine |

## Test plan

- [x] Deployed Cognito User Pool with `preferred_username Required: false`
- [x] Verified users can log in via Hosted UI
- [x] Deployed quota stack with correct `cognito-idp` issuer URL
- [x] Verified quota API accepts Cognito JWT tokens
- [x] Deployed auth stack with `.oktapreview.com` domain
- [x] Built Windows package natively with Nuitka after fixes
- [x] Verified OTEL helper builds natively on Windows with Nuitka