### PR TITLE
fix: add two-layer caching to otel-helper to eliminate telemetry UI freezes

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -344,6 +344,17 @@ class PackageCommand(Command):
         console.print("[cyan]Creating installer script...[/cyan]")
         self._create_installer(output_dir, profile, built_executables, built_otel_helpers)
 
+        # Copy shell wrapper for OTEL helper (Layer 2 caching - avoids PyInstaller startup)
+        if built_otel_helpers:
+            import shutil as _shutil
+
+            shell_wrapper_src = Path(__file__).parent.parent.parent.parent / "otel_helper" / "otel-helper.sh"
+            if shell_wrapper_src.exists():
+                shell_wrapper_dst = output_dir / "otel-helper.sh"
+                _shutil.copy2(shell_wrapper_src, shell_wrapper_dst)
+                shell_wrapper_dst.chmod(0o755)
+                console.print("[green]✓ OTEL helper shell wrapper included[/green]")
+
         # Create documentation
         console.print("[cyan]Creating documentation...[/cyan]")
         self._create_documentation(output_dir, profile, timestamp)
@@ -1869,12 +1880,22 @@ if [ -d "claude-settings" ]; then
     fi
 fi
 
-# Copy OTEL helper executable if present
+# Copy OTEL helper executable and shell wrapper if present
 if [ -f "$OTEL_BINARY" ]; then
     echo
     echo "Installing OTEL helper..."
-    cp "$OTEL_BINARY" ~/claude-code-with-bedrock/otel-helper
-    chmod +x ~/claude-code-with-bedrock/otel-helper
+    # Install PyInstaller binary as otel-helper-bin (fallback for cache miss)
+    cp "$OTEL_BINARY" ~/claude-code-with-bedrock/otel-helper-bin
+    chmod +x ~/claude-code-with-bedrock/otel-helper-bin
+    # Install shell wrapper as otel-helper (fast cache check, avoids PyInstaller startup)
+    if [ -f "otel-helper.sh" ]; then
+        cp "otel-helper.sh" ~/claude-code-with-bedrock/otel-helper
+        chmod +x ~/claude-code-with-bedrock/otel-helper
+    else
+        # Fallback: if shell wrapper not in package, point directly to binary
+        cp "$OTEL_BINARY" ~/claude-code-with-bedrock/otel-helper
+        chmod +x ~/claude-code-with-bedrock/otel-helper
+    fi
     echo "✓ OTEL helper installed"
 fi
 
@@ -1882,7 +1903,7 @@ fi
 if [ -f ~/claude-code-with-bedrock/otel-helper ]; then
     echo "The OTEL helper will extract user attributes from authentication tokens"
     echo "and include them in metrics. To test the helper, run:"
-    echo "  ~/claude-code-with-bedrock/otel-helper --test"
+    echo "  ~/claude-code-with-bedrock/otel-helper-bin --test"
 fi
 
 # Update AWS config

--- a/source/otel_helper/__main__.py
+++ b/source/otel_helper/__main__.py
@@ -18,6 +18,8 @@ import logging
 import os
 import subprocess
 import sys
+import time
+from pathlib import Path
 
 # Configure debug mode if requested
 DEBUG_MODE = os.environ.get("DEBUG_MODE", "").lower() in ("true", "1", "yes", "y")
@@ -191,6 +193,66 @@ def format_as_headers_dict(attributes):
     return headers
 
 
+def get_cache_path():
+    """Get the path to the OTEL headers cache file."""
+    cache_dir = Path.home() / ".claude-code-session"
+    cache_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    profile = os.environ.get("AWS_PROFILE", "ClaudeCode")
+    return cache_dir / f"{profile}-otel-headers.json"
+
+
+def read_cached_headers():
+    """Read cached OTEL headers if they exist and the token hasn't expired."""
+    try:
+        cache_path = get_cache_path()
+        if not cache_path.exists():
+            return None
+        with open(cache_path) as f:
+            cached = json.load(f)
+        # Check if token expires in more than 10 minutes
+        now = int(time.time())
+        if cached.get("token_exp", 0) - now > 600:
+            logger.debug("Using cached OTEL headers (token still valid)")
+            return cached["headers"]
+        logger.debug("Cached OTEL headers expired or expiring soon")
+        return None
+    except Exception as e:
+        logger.debug(f"Failed to read cached headers: {e}")
+        return None
+
+
+def write_cached_headers(headers, token_exp):
+    """Write OTEL headers to cache file and a companion raw headers file."""
+    try:
+        cache_path = get_cache_path()
+        import tempfile
+
+        # Write main cache file atomically (prevents shell wrapper reading partial JSON)
+        fd, tmp_path = tempfile.mkstemp(dir=cache_path.parent, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump({"headers": headers, "token_exp": token_exp, "cached_at": int(time.time())}, f)
+            os.chmod(tmp_path, 0o600)
+            os.rename(tmp_path, str(cache_path))
+        except Exception:
+            os.unlink(tmp_path)
+            raise
+
+        # Write companion file with just the raw headers JSON for the shell wrapper to cat
+        raw_path = cache_path.with_suffix(".raw")
+        fd, tmp_path = tempfile.mkstemp(dir=cache_path.parent, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(headers, f)
+            os.chmod(tmp_path, 0o600)
+            os.rename(tmp_path, str(raw_path))
+        except Exception:
+            os.unlink(tmp_path)
+            raise
+    except Exception as e:
+        logger.debug(f"Failed to write cached headers: {e}")
+
+
 def get_token_via_credential_process():
     """Get monitoring token via credential-process to avoid direct keychain access"""
     logger.info("Getting token via credential-process...")
@@ -219,7 +281,7 @@ def get_token_via_credential_process():
             [credential_process, "--profile", profile, "--get-monitoring-token"],
             capture_output=True,
             text=True,
-            timeout=300,  # 5 minute timeout for auth if needed
+            timeout=30,  # Reduced from 300s - fail open if auth can't complete quickly
         )
 
         if result.returncode == 0 and result.stdout.strip():
@@ -240,6 +302,13 @@ def get_token_via_credential_process():
 def main():
     """Main function to generate OTEL headers"""
     parse_args()
+
+    # Layer 1: Check file cache first (avoids credential-process entirely)
+    if not TEST_MODE:
+        cached_headers = read_cached_headers()
+        if cached_headers:
+            print(json.dumps(cached_headers))
+            return 0
 
     # Try to get token from environment first (fastest, set by credential_provider/__main__.py)
     token = os.environ.get("CLAUDE_CODE_MONITORING_TOKEN")
@@ -299,6 +368,12 @@ def main():
             print("\n========================")
         else:
             # Normal mode: Output as JSON (flat object with string values)
+            # Cache headers for future calls (avoids credential-process on next invocation)
+            token_exp = payload.get("exp")
+            if token_exp:
+                write_cached_headers(headers_dict, token_exp)
+            else:
+                logger.debug("JWT has no exp claim, skipping cache write")
             print(json.dumps(headers_dict))
 
         if DEBUG_MODE or TEST_MODE:

--- a/source/otel_helper/otel-helper.sh
+++ b/source/otel_helper/otel-helper.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# ABOUTME: Lightweight shell wrapper for otel-helper that checks file cache first
+# ABOUTME: Avoids PyInstaller binary startup (~6s) on cache hit, falls back to full binary on miss
+PROFILE="${AWS_PROFILE:-ClaudeCode}"
+CACHE_DIR="$HOME/.claude-code-session"
+CACHE_FILE="$CACHE_DIR/${PROFILE}-otel-headers.json"
+RAW_FILE="$CACHE_DIR/${PROFILE}-otel-headers.raw"
+
+if [ -f "$CACHE_FILE" ] && [ -f "$RAW_FILE" ]; then
+    # Extract token_exp from metadata cache (date +%s is GNU/BSD, works on macOS and Linux)
+    TOKEN_EXP=$(grep -o '"token_exp": *[0-9]*' "$CACHE_FILE" | grep -o '[0-9]*')
+    NOW=$(date +%s)
+    if [ -n "$TOKEN_EXP" ] && [ "$((TOKEN_EXP - NOW))" -gt 600 ]; then
+        # Serve raw headers directly — no JSON parsing needed
+        cat "$RAW_FILE"
+        exit 0
+    fi
+fi
+
+# Cache miss - fall back to full PyInstaller binary (which writes the cache)
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec "$SCRIPT_DIR/otel-helper-bin" "$@"


### PR DESCRIPTION
## Summary

When `CLAUDE_CODE_ENABLE_TELEMETRY=1`, the `otel-helper` is called synchronously on every metric export, spawning two chained PyInstaller binaries (`otel-helper` → `credential-process`) taking ~10-20 seconds each time. This caused periodic UI freezes in Claude Code.

This PR adds a two-layer caching strategy that eliminates the freeze after the first call:

- **Layer 1 (Python):** File-based header cache (`~/.claude-code-session/{profile}-otel-headers.json`) that stores headers + real JWT expiry. On cache hit, skips `credential-process` entirely. Uses atomic writes (tempfile + rename) to prevent partial reads.
- **Layer 2 (Shell):** Lightweight bash wrapper installed as the `otel-helper` entry point. Reads a companion `.raw` cache file directly (~0.04s) and only falls back to the PyInstaller binary on cache miss.
- **Timeout reduction:** `credential-process` subprocess timeout reduced from 300s to 30s to fail open quickly rather than freezing the UI.

### Measured results

| Scenario | Before | After |
|----------|--------|-------|
| Every metric export | ~10-20s | **0.04s** (cache hit) |
| First call / cache expired | ~10-20s | ~10-20s (then cached) |
| credential-process hang | up to 300s | max 30s |

### Files changed

- `source/otel_helper/__main__.py` — caching functions, reduced timeout, cache-first main() flow
- `source/otel_helper/otel-helper.sh` — **new** shell wrapper (Layer 2)
- `source/claude_code_with_bedrock/cli/commands/package.py` — installer deploys shell wrapper as `otel-helper`, renames binary to `otel-helper-bin`

Resolves #158

## Test Plan

- [x] Cold cache: binary runs, writes cache with real JWT exp, outputs headers
- [x] Warm cache: shell wrapper serves from `.raw` file in ~0.04s
- [x] Cache expiry: expired `token_exp` triggers fallback to binary, re-caches
- [x] File permissions: cache files created with 0o600
- [x] Atomic writes: no partial JSON reads under concurrent access
- [x] Test mode (`--test`): bypasses cache, shows full diagnostic output
- [x] Missing JWT `exp` claim: skips cache write, logs at debug level
- [x] Live testing with `CLAUDE_CODE_ENABLE_TELEMETRY=1`: no UI freezes observed