### PR TITLE
feat: hub-and-spoke multi-account support for StackSet deployments

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -34,7 +34,7 @@ class DeployCommand(Command):
     arguments = [
         argument(
             "stack",
-            description="Specific stack to deploy (auth/networking/monitoring/dashboard/analytics/quota)",
+            description="Specific stack to deploy (auth/networking/monitoring/dashboard/analytics/quota/hub/spoke-stackset)",
             optional=True,
         )
     ]
@@ -145,10 +145,42 @@ class DeployCommand(Command):
                 else:
                     console.print("[yellow]CodeBuild is not enabled in your configuration.[/yellow]")
                     return 1
+            elif stack_arg == "hub":
+                if profile.deployment_mode != "hub":
+                    console.print("[yellow]Profile is not configured for hub mode.[/yellow]")
+                    console.print("Run 'poetry run ccwb init' and select 'Hub' deployment mode.")
+                    return 1
+                # Hub deploys monitoring/dashboard/analytics/quota to the central account (skips auth)
+                if profile.monitoring_enabled:
+                    vpc_config = profile.monitoring_config or {}
+                    if vpc_config.get("create_vpc", True):
+                        stacks_to_deploy.append(("networking", "VPC Networking for OTEL Collector"))
+                    stacks_to_deploy.append(("s3bucket", "S3 Bucket"))
+                    stacks_to_deploy.append(("monitoring", "OpenTelemetry Collector"))
+                    stacks_to_deploy.append(("dashboard", "CloudWatch Dashboard"))
+                    if getattr(profile, "analytics_enabled", True):
+                        stacks_to_deploy.append(("analytics", "Analytics Pipeline (Kinesis Firehose + Athena)"))
+                    if getattr(profile, "quota_monitoring_enabled", False):
+                        stacks_to_deploy.append(("quota", "Quota Monitoring (Per-User Token Limits)"))
+                else:
+                    console.print("[yellow]No monitoring stacks to deploy. Enable monitoring in your configuration.[/yellow]")
+                    return 1
+            elif stack_arg == "spoke-stackset":
+                if profile.deployment_mode != "hub":
+                    console.print("[yellow]Profile is not configured for hub mode.[/yellow]")
+                    console.print("Run 'poetry run ccwb init' and select 'Hub' deployment mode.")
+                    return 1
+                if not profile.spoke_ou_id and not profile.spoke_account_ids:
+                    console.print("[red]No spoke OU ID or account IDs configured.[/red]")
+                    console.print("Run 'poetry run ccwb init' to configure spoke targets.")
+                    return 1
+                # spoke-stackset is handled directly, not via the standard stack loop
+                return self._deploy_spoke_stackset(profile, console, config, dry_run)
             else:
                 console.print(f"[red]Unknown stack: {stack_arg}[/red]")
                 console.print(
-                    "Valid stacks: auth, distribution, networking, monitoring, dashboard, analytics, quota, codebuild\n"
+                    "Valid stacks: auth, distribution, networking, monitoring, dashboard, "
+                    "analytics, quota, codebuild, hub, spoke-stackset\n"
                 )
                 console.print("[dim]Tip: Use 'ccwb deploy' without arguments to deploy all enabled stacks.[/dim]")
                 console.print("[dim]Use 'ccwb deploy quota' for quota-specific updates or late enablement.[/dim]")
@@ -1031,3 +1063,208 @@ class DeployCommand(Command):
             console.print(f"[yellow]Warning: Could not verify ECS service linked role: {str(e)}[/yellow]")
             console.print("[dim]If deployment fails, manually create the role with:[/dim]")
             console.print("[dim]aws iam create-service-linked-role --aws-service-name ecs.amazonaws.com[/dim]")
+
+    def _deploy_spoke_stackset(self, profile, console: Console, config: Config, dry_run: bool) -> int:
+        """Deploy auth infrastructure to spoke accounts via CloudFormation StackSet."""
+        import boto3
+        import time
+
+        project_root = Path(__file__).parents[4]
+
+        # Select template based on provider type (same logic as auth deploy)
+        provider_type = profile.provider_type or "okta"
+        template_map = {
+            "okta": "bedrock-auth-okta.yaml",
+            "auth0": "bedrock-auth-auth0.yaml",
+            "azure": "bedrock-auth-azure.yaml",
+            "cognito": "bedrock-auth-cognito-pool.yaml",
+        }
+
+        template_file = template_map.get(provider_type, "bedrock-auth-okta.yaml")
+        template_path = project_root / "deployment" / "infrastructure" / template_file
+
+        if not template_path.exists():
+            console.print(f"[red]Error: Template not found: {template_file}[/red]")
+            return 1
+
+        with open(template_path) as f:
+            template_body = f.read()
+
+        # Build parameters — force FederationType=direct for spoke accounts
+        params = [{"ParameterKey": "FederationType", "ParameterValue": "direct"}]
+
+        if provider_type == "okta":
+            params.extend([
+                {"ParameterKey": "OktaDomain", "ParameterValue": profile.provider_domain},
+                {"ParameterKey": "OktaClientId", "ParameterValue": profile.client_id},
+            ])
+        elif provider_type == "auth0":
+            params.extend([
+                {"ParameterKey": "Auth0Domain", "ParameterValue": profile.provider_domain},
+                {"ParameterKey": "Auth0ClientId", "ParameterValue": profile.client_id},
+            ])
+        elif provider_type == "azure":
+            guid_pattern = r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+            match = re.search(guid_pattern, profile.provider_domain)
+            tenant_id = match.group(0) if match else profile.provider_domain
+            params.extend([
+                {"ParameterKey": "AzureTenantId", "ParameterValue": tenant_id},
+                {"ParameterKey": "AzureClientId", "ParameterValue": profile.client_id},
+            ])
+        elif provider_type == "cognito":
+            cognito_domain = (
+                profile.provider_domain.split(".")[0]
+                if "." in profile.provider_domain
+                else profile.provider_domain
+            )
+            params.extend([
+                {"ParameterKey": "CognitoUserPoolId", "ParameterValue": profile.cognito_user_pool_id or ""},
+                {"ParameterKey": "CognitoUserPoolClientId", "ParameterValue": profile.client_id},
+                {"ParameterKey": "CognitoUserPoolDomain", "ParameterValue": cognito_domain},
+            ])
+
+        params.extend([
+            {"ParameterKey": "IdentityPoolName", "ParameterValue": profile.identity_pool_name},
+            {"ParameterKey": "AllowedBedrockRegions", "ParameterValue": ",".join(profile.allowed_bedrock_regions)},
+            {"ParameterKey": "EnableMonitoring", "ParameterValue": "false"},
+        ])
+
+        stackset_name = profile.stackset_name or f"{profile.identity_pool_name}-spoke-auth"
+
+        console.print(f"\n[bold]Spoke StackSet Deployment[/bold]")
+        console.print(f"• StackSet Name: [cyan]{stackset_name}[/cyan]")
+        console.print(f"• Template: [cyan]{template_file}[/cyan]")
+        console.print(f"• Federation Type: [cyan]direct[/cyan]")
+        if profile.spoke_ou_id:
+            console.print(f"• Target OU: [cyan]{profile.spoke_ou_id}[/cyan]")
+        if profile.spoke_account_ids:
+            console.print(f"• Target Accounts: [cyan]{len(profile.spoke_account_ids)} accounts[/cyan]")
+
+        if dry_run:
+            console.print("\n[yellow]Dry run mode - no changes will be made[/yellow]")
+            return 0
+
+        cf_client = boto3.client("cloudformation", region_name=profile.aws_region)
+
+        with Progress(
+            SpinnerColumn(), TextColumn("[progress.description]{task.description}"), console=console
+        ) as progress:
+            task = progress.add_task("Creating/updating StackSet...", total=None)
+
+            try:
+                # Check if StackSet already exists
+                stackset_exists = False
+                try:
+                    cf_client.describe_stack_set(StackSetName=stackset_name, CallAs="SELF")
+                    stackset_exists = True
+                except cf_client.exceptions.StackSetNotFoundException:
+                    pass
+
+                if stackset_exists:
+                    progress.update(task, description="Updating existing StackSet...")
+                    cf_client.update_stack_set(
+                        StackSetName=stackset_name,
+                        TemplateBody=template_body,
+                        Parameters=params,
+                        Capabilities=["CAPABILITY_NAMED_IAM"],
+                    )
+                    console.print("[green]✓ StackSet updated[/green]")
+                else:
+                    progress.update(task, description="Creating new StackSet...")
+
+                    stackset_kwargs = {
+                        "StackSetName": stackset_name,
+                        "TemplateBody": template_body,
+                        "Parameters": params,
+                        "Capabilities": ["CAPABILITY_NAMED_IAM"],
+                    }
+
+                    if profile.spoke_ou_id:
+                        # Service-managed permissions for OU-based targeting
+                        stackset_kwargs["PermissionModel"] = "SERVICE_MANAGED"
+                        stackset_kwargs["AutoDeployment"] = {
+                            "Enabled": True,
+                            "RetainStacksOnAccountRemoval": False,
+                        }
+                    else:
+                        # Self-managed for explicit account list
+                        stackset_kwargs["PermissionModel"] = "SELF_MANAGED"
+
+                    cf_client.create_stack_set(**stackset_kwargs)
+                    console.print("[green]✓ StackSet created[/green]")
+
+                # Create stack instances
+                progress.update(task, description="Deploying stack instances to spoke accounts...")
+
+                instance_kwargs = {
+                    "StackSetName": stackset_name,
+                    "Regions": [profile.aws_region],
+                    "OperationPreferences": {
+                        "MaxConcurrentPercentage": 100,
+                        "FailureTolerancePercentage": 10,
+                    },
+                }
+
+                if profile.spoke_ou_id:
+                    instance_kwargs["DeploymentTargets"] = {
+                        "OrganizationalUnitIds": [profile.spoke_ou_id],
+                    }
+                    instance_kwargs["CallAs"] = "DELEGATED_ADMIN"
+                else:
+                    instance_kwargs["DeploymentTargets"] = {
+                        "Accounts": profile.spoke_account_ids,
+                    }
+
+                operation = cf_client.create_stack_instances(**instance_kwargs)
+                operation_id = operation["OperationId"]
+
+                # Poll for completion
+                progress.update(task, description=f"Deploying to spoke accounts (operation: {operation_id[:8]}...)...")
+
+                while True:
+                    op_result = cf_client.describe_stack_set_operation(
+                        StackSetName=stackset_name,
+                        OperationId=operation_id,
+                    )
+                    status = op_result["StackSetOperation"]["Status"]
+
+                    if status == "SUCCEEDED":
+                        progress.update(task, description="StackSet deployment succeeded", completed=True)
+                        break
+                    elif status in ("FAILED", "STOPPED"):
+                        progress.update(task, description=f"StackSet deployment {status}", completed=True)
+                        console.print(f"[red]StackSet operation {status}[/red]")
+
+                        # Show failure details
+                        try:
+                            results = cf_client.list_stack_set_operation_results(
+                                StackSetName=stackset_name,
+                                OperationId=operation_id,
+                            )
+                            for result in results.get("Summaries", [])[:5]:
+                                account = result.get("Account", "N/A")
+                                reason = result.get("StatusReason", "Unknown")
+                                console.print(f"  • Account {account}: {reason}")
+                        except Exception:
+                            pass
+
+                        return 1
+                    else:
+                        progress.update(task, description=f"Deploying to spoke accounts ({status})...")
+                        time.sleep(10)
+
+                # Save stackset name to profile
+                profile.stackset_name = stackset_name
+                config.save_profile(profile)
+
+                console.print(f"\n[bold green]Spoke StackSet deployment complete![/bold green]")
+                console.print(f"• StackSet: [cyan]{stackset_name}[/cyan]")
+                console.print("\nNext steps:")
+                console.print("• Check status: [cyan]ccwb status[/cyan]")
+                console.print("• Generate per-account configs: [cyan]ccwb package[/cyan]")
+                return 0
+
+            except Exception as e:
+                progress.update(task, completed=True)
+                console.print(f"[red]Error deploying spoke StackSet: {str(e)}[/red]")
+                return 1

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -448,6 +448,76 @@ class InitCommand(Command):
             config["federation_type"] = federation_type
             config["max_session_duration"] = 43200 if federation_type == "direct" else 28800
 
+            # Deployment mode selection
+            console.print("\n[cyan]Deployment Mode[/cyan]")
+            console.print("Choose how this profile will be used:")
+            console.print("  • [cyan]Standalone[/cyan]: Single-account deployment (default)")
+            console.print("  • [cyan]Hub[/cyan]: Central account for multi-account hub-and-spoke deployment\n")
+
+            existing_deployment_mode = config.get("deployment_mode", "standalone")
+
+            deployment_mode = questionary.select(
+                "Deployment mode:",
+                choices=[
+                    questionary.Choice("Standalone (single account)", value="standalone"),
+                    questionary.Choice("Hub (multi-account, deploy auth to spoke accounts via StackSets)", value="hub"),
+                ],
+                default=existing_deployment_mode,
+            ).ask()
+
+            if not deployment_mode:
+                return None
+
+            config["deployment_mode"] = deployment_mode
+
+            if deployment_mode == "hub":
+                console.print("\n[yellow]Hub Mode Configuration[/yellow]")
+                console.print("Specify which spoke accounts should receive auth infrastructure.")
+                console.print("You can target an Organizational Unit (OU) or provide explicit account IDs.\n")
+
+                target_method = questionary.select(
+                    "How should spoke accounts be targeted?",
+                    choices=[
+                        questionary.Choice("Organizational Unit (OU ID)", value="ou"),
+                        questionary.Choice("Explicit account IDs", value="accounts"),
+                    ],
+                    default="ou" if config.get("spoke_ou_id") else ("accounts" if config.get("spoke_account_ids") else "ou"),
+                ).ask()
+
+                if not target_method:
+                    return None
+
+                if target_method == "ou":
+                    spoke_ou_id = questionary.text(
+                        "Enter the OU ID for spoke accounts:",
+                        default=config.get("spoke_ou_id", ""),
+                        validate=lambda x: bool(re.match(r"^ou-[a-z0-9]{4,32}-[a-z0-9]{8,32}$", x))
+                        or "Invalid OU ID format (e.g., ou-xxxx-xxxxxxxx)",
+                        instruction="(e.g., ou-xxxx-xxxxxxxx)",
+                    ).ask()
+
+                    if not spoke_ou_id:
+                        return None
+
+                    config["spoke_ou_id"] = spoke_ou_id
+                    config["spoke_account_ids"] = []
+                else:
+                    account_ids_str = questionary.text(
+                        "Enter spoke account IDs (comma-separated):",
+                        default=",".join(config.get("spoke_account_ids", [])),
+                        validate=lambda x: all(
+                            re.match(r"^\d{12}$", aid.strip()) for aid in x.split(",") if aid.strip()
+                        ) or "Each account ID must be exactly 12 digits",
+                    ).ask()
+
+                    if not account_ids_str:
+                        return None
+
+                    config["spoke_account_ids"] = [aid.strip() for aid in account_ids_str.split(",") if aid.strip()]
+                    config["spoke_ou_id"] = None
+
+                console.print(f"[green]✓[/green] Hub mode configured")
+
             # Save progress
             progress.save_step("oidc_complete", config)
 
@@ -1489,6 +1559,9 @@ class InitCommand(Command):
             daily_enforcement_mode=config_data.get("quota", {}).get("daily_enforcement_mode", "alert"),
             monthly_enforcement_mode=config_data.get("quota", {}).get("monthly_enforcement_mode", "block"),
             quota_check_interval=config_data.get("quota", {}).get("check_interval", 30),
+            deployment_mode=config_data.get("deployment_mode", "standalone"),
+            spoke_ou_id=config_data.get("spoke_ou_id"),
+            spoke_account_ids=config_data.get("spoke_account_ids", []),
         )
 
         config.add_profile(profile)

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -127,35 +127,50 @@ class PackageCommand(Command):
             )
             return 1
 
-        # Get actual Identity Pool ID or Role ARN from stack outputs
-        console.print("[yellow]Fetching deployment information...[/yellow]")
-        stack_outputs = get_stack_outputs(
-            profile.stack_names.get("auth", f"{profile.identity_pool_name}-stack"), profile.aws_region
+        # Hub mode with StackSet: generate per-account configs instead of single config
+        is_hub_with_stackset = (
+            getattr(profile, "deployment_mode", "standalone") == "hub"
+            and getattr(profile, "stackset_name", None)
         )
 
-        if not stack_outputs:
-            console.print("[red]Could not fetch stack outputs. Is the stack deployed?[/red]")
-            return 1
+        # Get actual Identity Pool ID or Role ARN from stack outputs
+        console.print("[yellow]Fetching deployment information...[/yellow]")
 
-        # Check federation type and get appropriate identifier
-        federation_type = stack_outputs.get("FederationType", profile.federation_type)
-        identity_pool_id = None
-        federated_role_arn = None
-
-        if federation_type == "direct":
-            # Try DirectSTSRoleArn first (both old and new templates have this for direct mode)
-            # Then fallback to FederatedRoleArn (new templates)
-            federated_role_arn = stack_outputs.get("DirectSTSRoleArn")
-            if not federated_role_arn or federated_role_arn == "N/A":
-                federated_role_arn = stack_outputs.get("FederatedRoleArn")
-            if not federated_role_arn or federated_role_arn == "N/A":
-                console.print("[red]Direct STS Role ARN not found in stack outputs.[/red]")
-                return 1
+        if is_hub_with_stackset:
+            # In hub mode, auth is deployed to spoke accounts via StackSet
+            # We'll generate per-account configs after building binaries
+            federation_type = "direct"
+            identity_pool_id = None
+            federated_role_arn = None  # Will be constructed per-account
+            console.print(f"[dim]Hub mode: auth deployed via StackSet '{profile.stackset_name}'[/dim]")
         else:
-            identity_pool_id = stack_outputs.get("IdentityPoolId")
-            if not identity_pool_id:
-                console.print("[red]Identity Pool ID not found in stack outputs.[/red]")
+            stack_outputs = get_stack_outputs(
+                profile.stack_names.get("auth", f"{profile.identity_pool_name}-stack"), profile.aws_region
+            )
+
+            if not stack_outputs:
+                console.print("[red]Could not fetch stack outputs. Is the stack deployed?[/red]")
                 return 1
+
+            # Check federation type and get appropriate identifier
+            federation_type = stack_outputs.get("FederationType", profile.federation_type)
+            identity_pool_id = None
+            federated_role_arn = None
+
+            if federation_type == "direct":
+                # Try DirectSTSRoleArn first (both old and new templates have this for direct mode)
+                # Then fallback to FederatedRoleArn (new templates)
+                federated_role_arn = stack_outputs.get("DirectSTSRoleArn")
+                if not federated_role_arn or federated_role_arn == "N/A":
+                    federated_role_arn = stack_outputs.get("FederatedRoleArn")
+                if not federated_role_arn or federated_role_arn == "N/A":
+                    console.print("[red]Direct STS Role ARN not found in stack outputs.[/red]")
+                    return 1
+            else:
+                identity_pool_id = stack_outputs.get("IdentityPoolId")
+                if not identity_pool_id:
+                    console.print("[red]Identity Pool ID not found in stack outputs.[/red]")
+                    return 1
 
         # Welcome
         console.print(
@@ -336,9 +351,16 @@ class PackageCommand(Command):
 
         # Create configuration
         console.print("\n[cyan]Creating configuration...[/cyan]")
-        # Pass the appropriate identifier based on federation type
-        federation_identifier = federated_role_arn if federation_type == "direct" else identity_pool_id
-        self._create_config(output_dir, profile, federation_identifier, federation_type, profile_name)
+        if is_hub_with_stackset:
+            # Generate per-account config files for spoke accounts
+            spoke_configs_dir = self._create_multi_account_configs(output_dir, profile, profile_name, console)
+            if not spoke_configs_dir:
+                console.print("[red]Failed to generate spoke account configurations.[/red]")
+                return 1
+        else:
+            # Pass the appropriate identifier based on federation type
+            federation_identifier = federated_role_arn if federation_type == "direct" else identity_pool_id
+            self._create_config(output_dir, profile, federation_identifier, federation_type, profile_name)
 
         # Create installer
         console.print("[cyan]Creating installer script...[/cyan]")
@@ -1700,6 +1722,90 @@ RUN pyinstaller \
         with open(config_path, "w") as f:
             json.dump(config, f, indent=2)
         return config_path
+
+    def _create_multi_account_configs(
+        self,
+        output_dir: Path,
+        profile,
+        profile_name: str,
+        console,
+    ) -> Path | None:
+        """Generate per-account config files for hub-and-spoke deployments.
+
+        Queries the StackSet for all spoke account IDs, constructs the
+        federated_role_arn for each account, and generates a config.json
+        per account in spoke-configs/.
+
+        Returns:
+            Path to spoke-configs directory, or None on failure.
+        """
+        import boto3
+
+        try:
+            cf_client = boto3.client("cloudformation", region_name=profile.aws_region)
+
+            # Get all stack instances from the StackSet
+            spoke_accounts = []
+            paginator = cf_client.get_paginator("list_stack_instances")
+            for page in paginator.paginate(StackSetName=profile.stackset_name):
+                for instance in page.get("Summaries", []):
+                    if instance.get("Status") == "CURRENT":
+                        spoke_accounts.append(instance["Account"])
+
+            if not spoke_accounts:
+                console.print("[yellow]No CURRENT spoke account instances found in StackSet.[/yellow]")
+                return None
+
+            console.print(f"[dim]Found {len(spoke_accounts)} spoke accounts in StackSet[/dim]")
+
+            # Determine the role name from the stack. The auth templates create a role
+            # with a predictable name based on the stack name. We can get this from any
+            # stack instance, or construct it from the template's output pattern.
+            # The role name in the auth templates follows: {IdentityPoolName}-BedrockAccessRole
+            role_name = f"{profile.identity_pool_name}-BedrockAccessRole"
+
+            # Create spoke-configs directory
+            spoke_configs_dir = output_dir / "spoke-configs"
+            spoke_configs_dir.mkdir(parents=True, exist_ok=True)
+
+            for account_id in spoke_accounts:
+                # Construct the role ARN for this spoke account
+                role_arn = f"arn:aws:iam::{account_id}:role/{role_name}"
+
+                config = {
+                    profile_name: {
+                        "provider_domain": profile.provider_domain,
+                        "client_id": profile.client_id,
+                        "aws_region": profile.aws_region,
+                        "provider_type": profile.provider_type or self._detect_provider_type(profile.provider_domain),
+                        "credential_storage": profile.credential_storage,
+                        "cross_region_profile": profile.cross_region_profile or "us",
+                        "federation_type": "direct",
+                        "federated_role_arn": role_arn,
+                        "max_session_duration": profile.max_session_duration,
+                    }
+                }
+
+                # Add cognito_user_pool_id if applicable
+                if profile.provider_type == "cognito" and profile.cognito_user_pool_id:
+                    config[profile_name]["cognito_user_pool_id"] = profile.cognito_user_pool_id
+
+                # Add selected_model if available
+                if hasattr(profile, "selected_model") and profile.selected_model:
+                    config[profile_name]["selected_model"] = profile.selected_model
+
+                config_path = spoke_configs_dir / f"config-{account_id}.json"
+                with open(config_path, "w") as f:
+                    json.dump(config, f, indent=2)
+
+            console.print(
+                f"[green]✓ Generated {len(spoke_accounts)} spoke account configs in {spoke_configs_dir}[/green]"
+            )
+            return spoke_configs_dir
+
+        except Exception as e:
+            console.print(f"[red]Error generating multi-account configs: {e}[/red]")
+            return None
 
     def _get_bedrock_region_for_profile(self, profile) -> str:
         """Get the correct AWS region for Bedrock API calls based on user-selected source region."""

--- a/source/claude_code_with_bedrock/cli/commands/status.py
+++ b/source/claude_code_with_bedrock/cli/commands/status.py
@@ -124,6 +124,23 @@ class StatusCommand(Command):
         if endpoints.get("dashboard_url"):
             console.print(f"\n• CloudWatch Dashboard: [cyan]{endpoints['dashboard_url']}[/cyan]")
 
+        # StackSet status for hub mode
+        if getattr(profile, "deployment_mode", "standalone") == "hub" and getattr(profile, "stackset_name", None):
+            console.print("\n[bold]Spoke StackSet[/bold]")
+            stackset_info = self._get_stackset_status(profile)
+            if stackset_info:
+                status_color = "green" if stackset_info["status"] == "ACTIVE" else "yellow"
+                console.print(f"• StackSet: [cyan]{profile.stackset_name}[/cyan]")
+                console.print(f"• Status: [{status_color}]{stackset_info['status']}[/{status_color}]")
+                console.print(
+                    f"• Spoke Accounts: [cyan]{stackset_info['total']}[/cyan] total, "
+                    f"[green]{stackset_info['current']}[/green] current, "
+                    f"[red]{stackset_info['failed']}[/red] failed"
+                )
+            else:
+                console.print(f"• StackSet: [cyan]{profile.stackset_name}[/cyan]")
+                console.print("• Status: [yellow]Could not retrieve status[/yellow]")
+
         # Package info
         dist_dir = Path.home() / "claude-code-with-bedrock" / "dist"
         if dist_dir.exists():
@@ -166,6 +183,15 @@ class StatusCommand(Command):
             "stacks": self._get_stack_status(profile),
             "endpoints": endpoints,
         }
+
+        # Add stackset info for hub mode
+        if getattr(profile, "deployment_mode", "standalone") == "hub" and getattr(profile, "stackset_name", None):
+            stackset_info = self._get_stackset_status(profile)
+            if stackset_info:
+                status["stackset"] = {
+                    "name": profile.stackset_name,
+                    **stackset_info,
+                }
 
         console.print(json.dumps(status, indent=2))
         return 0
@@ -213,6 +239,38 @@ class StatusCommand(Command):
             pass
 
         return {"status": "NOT_FOUND", "last_updated": None}
+
+    def _get_stackset_status(self, profile) -> dict[str, Any] | None:
+        """Get StackSet status for hub mode profiles."""
+        try:
+            import boto3
+
+            cf_client = boto3.client("cloudformation", region_name=profile.aws_region)
+            response = cf_client.describe_stack_set(
+                StackSetName=profile.stackset_name,
+                CallAs="SELF",
+            )
+            stackset = response["StackSet"]
+
+            # Get instance counts
+            summary = cf_client.list_stack_instances(
+                StackSetName=profile.stackset_name,
+            )
+            instances = summary.get("Summaries", [])
+
+            total = len(instances)
+            current = sum(1 for i in instances if i.get("StackInstanceStatus", {}).get("DetailedStatus") == "SUCCEEDED"
+                          or i.get("Status") == "CURRENT")
+            failed = sum(1 for i in instances if i.get("Status") in ("INOPERABLE", "OUTDATED"))
+
+            return {
+                "status": stackset.get("Status", "UNKNOWN"),
+                "total": total,
+                "current": current,
+                "failed": failed,
+            }
+        except Exception:
+            return None
 
     def _get_endpoints(self, profile) -> dict[str, Any]:
         """Get all relevant endpoints."""

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -70,6 +70,12 @@ class Profile:
     federated_role_arn: str | None = None  # ARN for Direct STS federation
     max_session_duration: int = 28800  # 8 hours default, 43200 (12 hours) for Direct STS
 
+    # Hub-and-spoke multi-account configuration
+    deployment_mode: str = "standalone"  # "standalone" or "hub"
+    spoke_ou_id: str | None = None  # OU ID for StackSet targeting (e.g., ou-xxxx-xxxxxxxx)
+    spoke_account_ids: list[str] = field(default_factory=list)  # Explicit account list (alternative to OU)
+    stackset_name: str | None = None  # StackSet name (set after deploy)
+
     # Claude Code settings configuration
     include_coauthored_by: bool = True  # Whether to include "co-authored-by Claude" in git commits
 
@@ -146,6 +152,10 @@ class Profile:
             # If distribution was enabled but no type specified, default to presigned-s3
             if "distribution_type" not in data or data["distribution_type"] is None:
                 data["distribution_type"] = "presigned-s3"
+
+        # Default deployment_mode to standalone for existing profiles
+        if "deployment_mode" not in data:
+            data["deployment_mode"] = "standalone"
 
         # Set default cross-region profile if not present
         if "cross_region_profile" not in data:


### PR DESCRIPTION
## Summary

- Add hub-and-spoke deployment mode to scale from single-account to multi-account (1,500+ developers) via CloudFormation StackSets
- Hub account centralizes monitoring/dashboards/quota while spoke accounts receive auth infrastructure (IAM OIDC Provider + IAM Role) via StackSets
- No changes to credential provider or CloudFormation templates — existing `FederationType=direct` templates deploy as-is via StackSet

## Changes

- **config.py**: Add `deployment_mode`, `spoke_ou_id`, `spoke_account_ids`, `stackset_name` fields to Profile
- **deploy.py**: Add `hub` target (monitoring stacks only) and `spoke-stackset` target (auth via StackSet with OU or explicit account targeting)
- **init.py**: Add hub mode wizard flow with OU ID or account list collection
- **package.py**: Add per-account config generation (`spoke-configs/config-{account_id}.json`) for hub deployments
- **status.py**: Add StackSet status display (name, status, spoke account counts)

## Test plan

- [ ] Run `ccwb init` — verify hub mode wizard collects OU ID and saves to profile JSON
- [ ] Run `ccwb deploy hub` — verify monitoring stacks deploy to hub (skip auth)
- [ ] Run `ccwb deploy spoke-stackset` — verify StackSet created, stack instances deployed to test accounts
- [ ] Run `ccwb status` — verify StackSet status shows in output
- [ ] Run `ccwb package` — verify per-account config files generated in `dist/spoke-configs/`
- [ ] Test end-to-end: developer installs package with spoke config, authenticates via IdP, gets Bedrock access in their own account

🤖 Generated with [Claude Code](https://claude.com/claude-code)