### PR TITLE
fix: sync pyproject.toml version (1.1.4 → 2.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2026-03-20
+
+### Fixed
+
+- **Version sync**: Bumped `source/pyproject.toml` from 1.1.4 to 2.1.0 to match project release version
+  - The v2.0.0 release updated CHANGELOG but never bumped pyproject.toml
+  - Users installing the package saw version 1.1.4 instead of 2.0.x
+
+### Changed
+
+- **PR checklist**: Added version bump reminder to CONTRIBUTING.md to prevent future version drift
+
 ## [2.0.0] - 2025-11-17
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,9 +32,10 @@ To send us a pull request, please:
 1. Fork the repository.
 2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
 3. Ensure local tests pass.
-4. Commit to your fork using clear commit messages.
-5. Send us a pull request, answering any default questions in the pull request interface.
-6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
+4. If your change warrants a version bump, update **both** `source/pyproject.toml` and `CHANGELOG.md` in the same PR.
+5. Commit to your fork using clear commit messages.
+6. Send us a pull request, answering any default questions in the pull request interface.
+7. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 
 GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).

--- a/source/pyproject.toml
+++ b/source/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "claude-code-with-bedrock"
-version = "1.1.4"
+version = "2.1.0"
 description = "Deploy and manage Claude Code on Amazon Bedrock"
 authors = ["Claude Code Team <claude-code@example.com>"]
 readme = "../README.md"


### PR DESCRIPTION
## Summary

- **Bumps `source/pyproject.toml`** from `1.1.4` to `2.1.0` — the v2.0.0 release (commit 3ab4dd4, 2025-11-17) updated CHANGELOG.md but never bumped pyproject.toml, so users installing the package saw version 1.1.4
- **Adds CHANGELOG entry** for v2.1.0 documenting the fix
- **Adds version bump reminder** to the PR checklist in CONTRIBUTING.md to prevent future drift

## Files changed

| File | Change |
|------|--------|
| `source/pyproject.toml` | `version = "1.1.4"` → `version = "2.1.0"` |
| `CHANGELOG.md` | New `[2.1.0]` entry |
| `CONTRIBUTING.md` | Added step 4: update both pyproject.toml and CHANGELOG.md |

## Test plan

- [ ] Verify `source/pyproject.toml` shows `version = "2.1.0"`
- [ ] Verify CHANGELOG.md has correct `[2.1.0]` entry above `[2.0.0]`
- [ ] Verify CONTRIBUTING.md PR checklist includes version bump reminder