### PR TITLE
feat(iam): add Bedrock Application Inference Profile ARN to Bedrock access policy for cost tracking

### DIFF
--- a/deployment/infrastructure/bedrock-auth-auth0.yaml
+++ b/deployment/infrastructure/bedrock-auth-auth0.yaml
@@ -109,6 +109,7 @@ Resources:
             Resource:
               - !Sub 'arn:${AWS::Partition}:bedrock:*::foundation-model/*'
               - !Sub 'arn:${AWS::Partition}:bedrock:*:*:inference-profile/*'
+              - !Sub 'arn:${AWS::Partition}:bedrock:*:*:application-inference-profile/*'
             Condition:
               StringEquals:
                 'aws:RequestedRegion': !Ref AllowedBedrockRegions

--- a/deployment/infrastructure/bedrock-auth-azure.yaml
+++ b/deployment/infrastructure/bedrock-auth-azure.yaml
@@ -101,6 +101,7 @@ Resources:
             Resource:
               - !Sub 'arn:${AWS::Partition}:bedrock:*::foundation-model/*'
               - !Sub 'arn:${AWS::Partition}:bedrock:*:*:inference-profile/*'
+              - !Sub 'arn:${AWS::Partition}:bedrock:*:*:application-inference-profile/*'
             Condition:
               StringEquals:
                 'aws:RequestedRegion': !Ref AllowedBedrockRegions

--- a/deployment/infrastructure/bedrock-auth-cognito-pool.yaml
+++ b/deployment/infrastructure/bedrock-auth-cognito-pool.yaml
@@ -107,6 +107,7 @@ Resources:
             Resource:
               - !Sub 'arn:${AWS::Partition}:bedrock:*::foundation-model/*'
               - !Sub 'arn:${AWS::Partition}:bedrock:*:*:inference-profile/*'
+              - !Sub 'arn:${AWS::Partition}:bedrock:*:*:application-inference-profile/*'
             Condition:
               StringEquals:
                 'aws:RequestedRegion': !Ref AllowedBedrockRegions

--- a/deployment/infrastructure/bedrock-auth-okta.yaml
+++ b/deployment/infrastructure/bedrock-auth-okta.yaml
@@ -100,6 +100,7 @@ Resources:
             Resource:
               - !Sub 'arn:${AWS::Partition}:bedrock:*::foundation-model/*'
               - !Sub 'arn:${AWS::Partition}:bedrock:*:*:inference-profile/*'
+              - !Sub 'arn:${AWS::Partition}:bedrock:*:*:application-inference-profile/*'
             Condition:
               StringEquals:
                 'aws:RequestedRegion': !Ref AllowedBedrockRegions

--- a/deployment/infrastructure/cognito-identity-pool.yaml
+++ b/deployment/infrastructure/cognito-identity-pool.yaml
@@ -140,6 +140,7 @@ Resources:
             Resource:
               - !Sub 'arn:${AWS::Partition}:bedrock:*::foundation-model/*'
               - !Sub 'arn:${AWS::Partition}:bedrock:*:*:inference-profile/*'
+              - !Sub 'arn:${AWS::Partition}:bedrock:*:*:application-inference-profile/*'
             Condition:
               StringEquals:
                 'aws:RequestedRegion': !Ref AllowedBedrockRegions


### PR DESCRIPTION
…licies

The BedrockAccessPolicy in all auth CloudFormation templates only allowed `inference-profile/*` (system-defined cross-region inference profiles). This blocked API calls using Bedrock application inference profile ARNs (`arn:aws:bedrock:*:*:application-inference-profile/*`), which organizations use for custom throughput, routing, and cost controls.

Updated templates:
- bedrock-auth-okta.yaml
- bedrock-auth-azure.yaml
- bedrock-auth-auth0.yaml
- bedrock-auth-cognito-pool.yaml
- cognito-identity-pool.yaml

*Description of changes:*
Add a new resource to IAM policy: 
- !Sub 'arn:${AWS::Partition}:bedrock:*:*:application-inference-profile/*'

