### PR TITLE
fix: relax Cognito client ID validation and correct OIDC issuer URL f…

### DIFF
--- a/deployment/infrastructure/bedrock-auth-cognito-pool.yaml
+++ b/deployment/infrastructure/bedrock-auth-cognito-pool.yaml
@@ -19,7 +19,7 @@ Parameters:
   CognitoUserPoolClientId:
     Type: String
     Description: Cognito User Pool App Client ID
-    AllowedPattern: '^[a-z0-9]{26}$'
+    AllowedPattern: '^[a-zA-Z0-9_+]{1,128}$'
     ConstraintDescription: Must be a valid Cognito User Pool Client ID
 
   CognitoUserPoolDomain:

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -773,6 +773,12 @@ class DeployCommand(Command):
 
                 # Get OIDC configuration for JWT authentication
                 oidc_issuer_url = profile.provider_domain
+                if profile.provider_type == "cognito":
+                    # Cognito OIDC issuer is cognito-idp URL, not the hosted UI domain
+                    pool_id = getattr(profile, "cognito_user_pool_id", None)
+                    if pool_id:
+                        pool_region = pool_id.split("_")[0] if "_" in pool_id else profile.aws_region
+                        oidc_issuer_url = f"https://cognito-idp.{pool_region}.amazonaws.com/{pool_id}"
                 # Ensure issuer URL has https:// prefix
                 if oidc_issuer_url and not oidc_issuer_url.startswith(("http://", "https://")):
                     oidc_issuer_url = f"https://{oidc_issuer_url}"


### PR DESCRIPTION
…or Cognito

- Update CognitoUserPoolClientId AllowedPattern to match AWS API constraints (1-128 chars, word chars + plus sign)
- Construct proper cognito-idp OIDC issuer URL instead of using hosted UI domain

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
