### PR TITLE
feat: Add --skip-prompt to support unattended installs

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/distribute.py
+++ b/source/claude_code_with_bedrock/cli/commands/distribute.py
@@ -68,6 +68,7 @@ class DistributeCommand(Command):
         option("build-profile", description="Select build by profile name", flag=False),
         option("timestamp", description="Select build by timestamp (YYYY-MM-DD-HHMMSS)", flag=False),
         option("latest", description="Auto-select latest build without wizard", flag=True),
+        option("skip-prompt", description="Skip interactive prompts (auto-selects latest build, skips confirmations)", flag=True),
     ]
 
     def _check_old_flat_structure(self, dist_dir: Path) -> bool:
@@ -262,8 +263,8 @@ class DistributeCommand(Command):
                 console.print(f"[red]Build not found: {build_profile}/{timestamp}[/red]")
                 return 1
 
-        # Option 2: Latest flag (auto-select most recent)
-        elif self.option("latest"):
+        # Option 2: Latest flag or skip-prompt (auto-select most recent)
+        elif self.option("latest") or self.option("skip-prompt"):
             # Find most recent build across all profiles
             latest_build = None
             latest_timestamp = None
@@ -834,12 +835,13 @@ class DistributeCommand(Command):
 
         if "windows" not in found_platforms:
             console.print("\n[yellow]Warning: Windows support not included in this distribution[/yellow]")
-            from questionary import confirm
+            if not self.option("skip-prompt"):
+                from questionary import confirm
 
-            proceed = confirm("Continue without Windows support?", default=False).ask()
-            if not proceed:
-                console.print("Distribution cancelled.")
-                return 0
+                proceed = confirm("Continue without Windows support?", default=False).ask()
+                if not proceed:
+                    console.print("Distribution cancelled.")
+                    return 0
 
         console.print(f"\n[green]Ready to distribute for: {', '.join(found_platforms)}[/green]")
 

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -50,6 +50,9 @@ class PackageCommand(Command):
             default=None,
         ),
         option("build-verbose", description="Enable verbose logging for build processes", flag=True),
+        option(
+            "skip-prompt", description="Skip interactive prompts and use sensible defaults for CI", flag=True
+        ),
     ]
 
     def handle(self) -> int:
@@ -80,8 +83,13 @@ class PackageCommand(Command):
             return 1
 
         # Interactive prompts if not provided via CLI
+        skip_prompt = self.option("skip-prompt")
         target_platform = self.option("target-platform")
         if target_platform == "all":  # Default value, prompt user
+            if skip_prompt:
+                console.print("[red]--skip-prompt requires --target-platform to be set explicitly.[/red]")
+                return 1
+
             # Build list of available platform choices
             # Note: "macos" is omitted because it's just a smart alias for the current architecture
             # Users should explicitly choose macos-arm64 or macos-intel for clarity
@@ -107,10 +115,13 @@ class PackageCommand(Command):
             target_platform = selected_platforms if len(selected_platforms) > 1 else selected_platforms[0]
 
         # Prompt for co-authorship preference (default to No - opt-in approach)
-        include_coauthored_by = questionary.confirm(
-            "Include 'Co-Authored-By: Claude' in git commits?",
-            default=False,
-        ).ask()
+        if skip_prompt:
+            include_coauthored_by = profile.include_coauthored_by
+        else:
+            include_coauthored_by = questionary.confirm(
+                "Include 'Co-Authored-By: Claude' in git commits?",
+                default=False,
+            ).ask()
 
         # Validate platform
         valid_platforms = ["macos", "macos-arm64", "macos-intel", "linux", "linux-x64", "linux-arm64", "windows", "all"]


### PR DESCRIPTION
*Description of changes:*

## Summary

Adds a --skip-prompt flag to the package and distribute commands to support unattended/CI usage without interactive prompts.

### package --skip-prompt:
  - Skips the platform selection checkbox — requires --target-platform to be set explicitly when used
  - Skips the "Co-Authored-By: Claude" confirmation (defaults to false)

### distribute --skip-prompt:
  - Auto-selects the latest build (equivalent to --latest)
  - Skips the Windows support confirmation prompt


## Test

- [x]  Tested both ccwb package and ccwb distribute with and without the `--skip-prompt` flag

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
