### PR TITLE
fix(credential_provider): Increase RoleSessionName truncation limit to preserve full UUIDs

### DIFF
--- a/source/credential_provider/__main__.py
+++ b/source/credential_provider/__main__.py
@@ -965,12 +965,14 @@ class MultiProviderAuth:
             # Sanitize to replace invalid characters with hyphens
             session_name = "claude-code"
             if "sub" in token_claims:
-                # Use first 32 chars of sub for uniqueness, sanitized for AWS
-                sub_sanitized = re.sub(r"[^\w+=,.@-]", "-", str(token_claims["sub"])[:32])
+                # Use first 52 chars of sub for uniqueness, sanitized for AWS
+                # AWS RoleSessionName limit is 64 chars; prefix "claude-code-" is 12 chars
+                # 52 chars accommodates standard UUIDs (36 chars) and longer identifiers
+                sub_sanitized = re.sub(r"[^\w+=,.@-]", "-", str(token_claims["sub"])[:52])
                 session_name = f"claude-code-{sub_sanitized}"
             elif "email" in token_claims:
                 # Use email username part, sanitized
-                email_part = token_claims["email"].split("@")[0][:32]
+                email_part = token_claims["email"].split("@")[0][:52]
                 email_sanitized = re.sub(r"[^\w+=,.@-]", "-", email_part)
                 session_name = f"claude-code-{email_sanitized}"
 


### PR DESCRIPTION
Summary

  - Increase RoleSessionName identifier truncation from 32 to 52 characters for both sub and email paths
  - Fixes UUID-based IdP user IDs being cut off in CloudTrail/CloudWatch identity fields
  - The 52-char limit (+ 12-char prefix = 64) matches the AWS RoleSessionName maximum

  Test plan

  - Verify with a UUID-format sub claim (36 chars) that the full ID appears in the session name
  - Verify with a long email prefix (>32 chars) that truncation still works correctly
  - Confirm total RoleSessionName length does not exceed 64 characters

Closes #204