### PR TITLE
fix(deploy): add s3bucket to valid individual stack arguments

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -102,6 +102,12 @@ class DeployCommand(Command):
                 else:
                     console.print("[yellow]Monitoring is not enabled in your configuration.[/yellow]")
                     return 1
+            elif stack_arg == "s3bucket":
+                if profile.monitoring_enabled:
+                    stacks_to_deploy.append(("s3bucket", "S3 Bucket"))
+                else:
+                    console.print("[yellow]S3 bucket requires monitoring to be enabled in your configuration.[/yellow]")
+                    return 1
             elif stack_arg == "monitoring":
                 if profile.monitoring_enabled:
                     stacks_to_deploy.append(("monitoring", "OpenTelemetry Collector"))
@@ -148,7 +154,7 @@ class DeployCommand(Command):
             else:
                 console.print(f"[red]Unknown stack: {stack_arg}[/red]")
                 console.print(
-                    "Valid stacks: auth, distribution, networking, monitoring, dashboard, analytics, quota, codebuild\n"
+                    "Valid stacks: auth, networking, s3bucket, monitoring, dashboard, analytics, quota, distribution, codebuild\n"
                 )
                 console.print("[dim]Tip: Use 'ccwb deploy' without arguments to deploy all enabled stacks.[/dim]")
                 console.print("[dim]Use 'ccwb deploy quota' for quota-specific updates or late enablement.[/dim]")


### PR DESCRIPTION
Fixes #215

The `s3bucket` stack was deployable when running `ccwb deploy` (all stacks) and was handled in `_deploy_stack()`, but was missing from the individual stack argument router. This meant `ccwb deploy s3bucket` failed with `Unknown stack` — despite the codebase itself suggesting this command:

```
console.print("Run: [cyan]ccwb deploy s3bucket[/cyan]")  # line 757
```

### Changes (1 file, +7/-1)

- Add `s3bucket` to the `stack_arg` elif chain with `monitoring_enabled` guard (consistent with the deploy-all path at line 169)
- Update valid stacks help text to include `s3bucket`

### Testing

- Verified `s3bucket` is handled in `_deploy_stack()` (line 576)
- Verified deploy-all path includes `s3bucket` only when `monitoring_enabled` (line 169)
- Guard condition matches: s3bucket requires monitoring to be enabled