### PR TITLE
docs: document Route53 same-account requirement for custom domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ This guidance uses Direct IAM OIDC federation as the recommended authentication 
   - (Optional) AWS CodeBuild
 - Amazon Bedrock activated in target regions
 
+**Custom Domain (Optional):**
+
+- Route53 hosted zone must be in the **same AWS account** as the deployment (ACM certificate validation creates DNS records directly). If your zone is in a separate account (e.g., Control Tower shared networking), migrate or delegate it to the deployment account first.
+
 **OIDC Provider Requirements:**
 
 - Existing OIDC identity provider (Okta, Azure AD, Auth0, etc.)


### PR DESCRIPTION
Fixes #216

ACM certificate validation requires the Route53 hosted zone to be in the same AWS account as the deployment. Cross-account hosted zones (e.g. shared networking account in Control Tower setups) cause deployment failures with no clear error.

Adds a "Custom Domain Requirements" section to the Prerequisites in README.md documenting this limitation and the workaround (migrate or delegate the zone).

1 file, +7 lines.