### PR TITLE
fix(deploy): move distribution stack after networking in deploy order

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -157,11 +157,11 @@ class DeployCommand(Command):
             # Deploy all configured stacks in dependency order
             stacks_to_deploy.append(("auth", "Authentication Stack (Cognito + IAM)"))
 
-            # Deploy distribution after networking if it's landing-page type
-            if profile.enable_distribution:
+            # Deploy presigned-s3 distribution early (no networking dependency)
+            if profile.enable_distribution and getattr(profile, "distribution_type", "") != "landing-page":
                 stacks_to_deploy.append(("distribution", "Distribution infrastructure (S3 + IAM)"))
 
-            # Deploy remaining monitoring stacks
+            # Deploy monitoring stacks
             if profile.monitoring_enabled:
                 vpc_config = profile.monitoring_config or {}
                 if vpc_config.get("create_vpc", True):
@@ -175,6 +175,18 @@ class DeployCommand(Command):
                 # Check if quota monitoring is enabled
                 if getattr(profile, "quota_monitoring_enabled", False):
                     stacks_to_deploy.append(("quota", "Quota Monitoring (Per-User Token Limits)"))
+
+            # Deploy landing-page distribution after networking (requires VPC outputs)
+            if profile.enable_distribution and getattr(profile, "distribution_type", "") == "landing-page":
+                if not profile.monitoring_enabled:
+                    console.print(
+                        "[red]Error: Landing-page distribution requires monitoring to be enabled "
+                        "(provides the VPC/networking stack).[/red]"
+                    )
+                    console.print("[dim]Run 'ccwb init' and enable monitoring, or use presigned-s3 distribution instead.[/dim]")
+                    return 1
+                stacks_to_deploy.append(("distribution", "Distribution infrastructure (Landing Page)"))
+
             # Check if CodeBuild is enabled
             if getattr(profile, "enable_codebuild", False):
                 stacks_to_deploy.append(("codebuild", "CodeBuild for Windows binary builds"))

--- a/source/claude_code_with_bedrock/validators.py
+++ b/source/claude_code_with_bedrock/validators.py
@@ -159,6 +159,16 @@ class ProfileValidator:
 
             # Landing page requires additional fields
             if distribution_type == "landing-page":
+                # Landing-page distribution depends on VPC outputs from the networking stack,
+                # which is only deployed when monitoring is enabled (see deploy.py)
+                monitoring_enabled = profile_data.get("monitoring_enabled", True)
+                if not monitoring_enabled:
+                    errors.append(
+                        "landing-page distribution requires monitoring to be enabled "
+                        "(provides the VPC/networking stack). Enable monitoring or use "
+                        "presigned-s3 distribution instead."
+                    )
+
                 dist_provider = profile_data.get("distribution_idp_provider")
                 if not dist_provider:
                     errors.append("distribution_idp_provider is required for landing-page distribution")


### PR DESCRIPTION
Fixes #214

The landing-page distribution stack requires VPC outputs from the networking stack (`get_stack_outputs(networking_stack_name)` at line 449), but was queued **before** networking in the deploy-all sequence. This caused `ccwb deploy` to fail on fresh environments.

### Fix

Move the distribution block after the monitoring block (which contains networking). One block moved, no conditional logic.

**Before:** `auth → distribution → networking → monitoring → ...`
**After:** `auth → networking → monitoring → ... → distribution → codebuild`

1 file, +6/-5. Backward compatible — same stacks, just reordered.