### PR TITLE
fix: add encoding="utf-8" to all text-mode open() calls

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/builds.py
+++ b/source/claude_code_with_bedrock/cli/commands/builds.py
@@ -180,7 +180,7 @@ class BuildsCommand(Command):
                     console.print("[red]No recent builds found. Start a build with 'poetry run ccwb package'[/red]")
                     return 1
 
-                with open(build_info_file) as f:
+                with open(build_info_file, encoding="utf-8") as f:
                     build_info = json.load(f)
                     build_id = build_info["build_id"]
                     console.print(f"[dim]Checking latest build: {build_id}[/dim]")

--- a/source/claude_code_with_bedrock/cli/commands/cleanup.py
+++ b/source/claude_code_with_bedrock/cli/commands/cleanup.py
@@ -63,7 +63,7 @@ class CleanupCommand(Command):
         aws_config = Path.home() / ".aws" / "config"
         has_profile = False
         if aws_config.exists():
-            with open(aws_config) as f:
+            with open(aws_config, encoding="utf-8") as f:
                 if f"[profile {profile_name}]" in f.read():
                     has_profile = True
                     items_to_remove.append(("AWS Profile", profile_name, f"In {aws_config}"))
@@ -104,7 +104,7 @@ class CleanupCommand(Command):
         if has_profile and aws_config.exists():
             try:
                 # Read the config file
-                with open(aws_config) as f:
+                with open(aws_config, encoding="utf-8") as f:
                     lines = f.readlines()
 
                 # Find and remove the profile section
@@ -129,7 +129,7 @@ class CleanupCommand(Command):
                         new_lines.append(line)
 
                 # Write back the cleaned config
-                with open(aws_config, "w") as f:
+                with open(aws_config, "w", encoding="utf-8") as f:
                     f.writelines(new_lines)
 
                 console.print(f"✓ Removed AWS profile '{profile_name}'")

--- a/source/claude_code_with_bedrock/cli/commands/context.py
+++ b/source/claude_code_with_bedrock/cli/commands/context.py
@@ -478,7 +478,7 @@ class ConfigImportCommand(Command):
                 console.print(f"\n[red]Error: File not found: {file_path}[/red]\n")
                 return 1
 
-            with open(file_path_obj) as f:
+            with open(file_path_obj, encoding="utf-8") as f:
                 profile_data = json.load(f)
 
             # Use provided name or name from file

--- a/source/claude_code_with_bedrock/cli/commands/distribute.py
+++ b/source/claude_code_with_bedrock/cli/commands/distribute.py
@@ -770,7 +770,7 @@ class DistributeCommand(Command):
             if not windows_downloaded:
                 build_info_file = Path.home() / ".claude-code" / "latest-build.json"
                 if build_info_file.exists():
-                    with open(build_info_file) as f:
+                    with open(build_info_file, encoding="utf-8") as f:
                         build_info = json.load(f)
 
                     # Check build status

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1559,7 +1559,7 @@ class InitCommand(Command):
         """Update the CloudFormation parameters file with our configuration."""
         # Load existing parameters
         if params_file.exists():
-            with open(params_file) as f:
+            with open(params_file, encoding="utf-8") as f:
                 params = json.load(f)
         else:
             params = []
@@ -1597,7 +1597,7 @@ class InitCommand(Command):
 
         # Save updated parameters
         params_file.parent.mkdir(parents=True, exist_ok=True)
-        with open(params_file, "w") as f:
+        with open(params_file, "w", encoding="utf-8") as f:
             json.dump(params, f, indent=2)
 
     def _deploy_stack(self, stack_name: str, template_file: Path, params_file: Path, region: str) -> bool:

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -420,7 +420,7 @@ class PackageCommand(Command):
                     console.print("[red]No recent builds found. Start a build with 'poetry run ccwb package'[/red]")
                     return 1
 
-                with open(build_info_file) as f:
+                with open(build_info_file, encoding="utf-8") as f:
                     build_info = json.load(f)
                     build_id = build_info["build_id"]
                     console.print(f"[dim]Checking latest build: {build_id}[/dim]")
@@ -1340,7 +1340,7 @@ RUN pyinstaller \
 
             build_info_file = Path.home() / ".claude-code" / "latest-build.json"
             build_info_file.parent.mkdir(exist_ok=True)
-            with open(build_info_file, "w") as f:
+            with open(build_info_file, "w", encoding="utf-8") as f:
                 json.dump(
                     {
                         "build_id": build_id,
@@ -1708,7 +1708,7 @@ RUN pyinstaller \
             config[profile_name]["selected_model"] = profile.selected_model
 
         config_path = output_dir / "config.json"
-        with open(config_path, "w") as f:
+        with open(config_path, "w", encoding="utf-8") as f:
             json.dump(config, f, indent=2)
         return config_path
 
@@ -1974,7 +1974,7 @@ echo
 """
 
         installer_path = output_dir / "install.sh"
-        with open(installer_path, "w") as f:
+        with open(installer_path, "w", encoding="utf-8") as f:
             f.write(installer_content)
         installer_path.chmod(0o755)
 
@@ -2296,7 +2296,7 @@ Available metrics include:
 
         readme_content += "\n" ""
 
-        with open(output_dir / "README.md", "w") as f:
+        with open(output_dir / "README.md", "w", encoding="utf-8") as f:
             f.write(readme_content)
 
     def _create_claude_settings(
@@ -2404,7 +2404,7 @@ Available metrics include:
 
             # Save settings.json
             settings_path = claude_dir / "settings.json"
-            with open(settings_path, "w") as f:
+            with open(settings_path, "w", encoding="utf-8") as f:
                 json.dump(settings, f, indent=2)
 
             console.print("[dim]Created Claude Code settings for Bedrock configuration[/dim]")

--- a/source/claude_code_with_bedrock/cli/commands/quota.py
+++ b/source/claude_code_with_bedrock/cli/commands/quota.py
@@ -1048,7 +1048,7 @@ class QuotaExportCommand(Command):
             if to_stdout:
                 print(output)
             else:
-                with open(file_path, "w") as f:
+                with open(file_path, "w", encoding="utf-8") as f:
                     f.write(output)
                 console.print(f"[green]Exported {len(policies)} policies to {file_path}[/green]")
 
@@ -1201,7 +1201,7 @@ class QuotaImportCommand(Command):
         """
         file_ext = Path(file_path).suffix.lower()
 
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             if file_ext == ".csv":
                 reader = csv.DictReader(f)
                 return list(reader)

--- a/source/claude_code_with_bedrock/cli/commands/test.py
+++ b/source/claude_code_with_bedrock/cli/commands/test.py
@@ -171,7 +171,7 @@ class TestCommand(Command):
         console.print("✓ Found config.json")
 
         # Read and display config details
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             pkg_config = json.load(f)
             # Try to read from the specified profile name, fall back to "ClaudeCode" for backward compatibility
             profile_config = pkg_config.get(test_profile_name) or pkg_config.get("ClaudeCode", {})
@@ -472,7 +472,7 @@ class TestCommand(Command):
             if not aws_config_file.exists():
                 return {"status": "✗", "details": "AWS config file not found"}
 
-            with open(aws_config_file) as f:
+            with open(aws_config_file, encoding="utf-8") as f:
                 content = f.read()
                 if f"[profile {profile_name}]" in content:
                     return {"status": "✓", "details": f"Profile '{profile_name}' found"}
@@ -794,7 +794,7 @@ class TestCommand(Command):
         if not config_file.exists():
             return None
         try:
-            with open(config_file) as f:
+            with open(config_file, encoding="utf-8") as f:
                 config = json.load(f)
             # config.json has profile names as top-level keys
             # Return the first (usually only) profile
@@ -917,7 +917,7 @@ class TestCommand(Command):
             if result.returncode == 0:
                 # Check if we got a response
                 try:
-                    with open("/tmp/bedrock-test-output.json") as f:
+                    with open("/tmp/bedrock-test-output.json", encoding="utf-8") as f:
                         response = json.load(f)
                         if "content" in response and len(response["content"]) > 0:
                             text = response["content"][0].get("text", "").strip()

--- a/source/claude_code_with_bedrock/cli/utils/cloudformation.py
+++ b/source/claude_code_with_bedrock/cli/utils/cloudformation.py
@@ -299,7 +299,7 @@ class CloudFormationManager:
         template_path = Path(template_path)
 
         # Read template
-        with open(template_path) as f:
+        with open(template_path, encoding="utf-8") as f:
             template_body = f.read()
 
         # Parse template using cfn-flip for CloudFormation compatibility
@@ -454,7 +454,7 @@ class CloudFormationManager:
     def _read_template(self, template_path: str | Path) -> str:
         """Read and return template content."""
         template_path = Path(template_path)
-        with open(template_path) as f:
+        with open(template_path, encoding="utf-8") as f:
             content = f.read()
         return content
 

--- a/source/claude_code_with_bedrock/cli/utils/progress.py
+++ b/source/claude_code_with_bedrock/cli/utils/progress.py
@@ -28,7 +28,7 @@ class WizardProgress:
         """Load existing progress if available."""
         if self.progress_file.exists():
             try:
-                with open(self.progress_file) as f:
+                with open(self.progress_file, encoding="utf-8") as f:
                     data = json.load(f)
                     # Check if progress is recent (within 24 hours)
                     saved_time = datetime.fromisoformat(data.get("timestamp", ""))
@@ -44,7 +44,7 @@ class WizardProgress:
         self.data["data"].update(step_data)
         self.data["timestamp"] = datetime.now().isoformat()
 
-        with open(self.progress_file, "w") as f:
+        with open(self.progress_file, "w", encoding="utf-8") as f:
             json.dump(self.data, f, indent=2)
 
     def get_saved_data(self) -> dict[str, Any]:

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -193,7 +193,7 @@ class Config:
         # Load global config
         if cls.CONFIG_FILE.exists():
             try:
-                with open(cls.CONFIG_FILE) as f:
+                with open(cls.CONFIG_FILE, encoding="utf-8") as f:
                     data = json.load(f)
 
                 return cls(
@@ -215,7 +215,7 @@ class Config:
             "profiles_dir": str(self.PROFILES_DIR),
         }
 
-        with open(self.CONFIG_FILE, "w") as f:
+        with open(self.CONFIG_FILE, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2)
 
     def load_profile(self, name: str | None = None) -> Profile:
@@ -242,7 +242,7 @@ class Config:
             raise FileNotFoundError(f"Profile not found: {profile_name}")
 
         try:
-            with open(profile_path) as f:
+            with open(profile_path, encoding="utf-8") as f:
                 data = json.load(f)
 
             return Profile.from_dict(data)
@@ -272,7 +272,7 @@ class Config:
         # Save to file
         profile_path = self.PROFILES_DIR / f"{profile.name}.json"
 
-        with open(profile_path, "w") as f:
+        with open(profile_path, "w", encoding="utf-8") as f:
             json.dump(profile.to_dict(), f, indent=2)
 
         # Set as active if it's the first profile

--- a/source/claude_code_with_bedrock/migration.py
+++ b/source/claude_code_with_bedrock/migration.py
@@ -36,7 +36,7 @@ def migrate_legacy_config() -> bool:
 
     try:
         # Load legacy config
-        with open(legacy_config_file) as f:
+        with open(legacy_config_file, encoding="utf-8") as f:
             legacy_data = json.load(f)
 
         # Extract profiles and default profile
@@ -64,7 +64,7 @@ def migrate_legacy_config() -> bool:
 
                 # Save to individual file
                 profile_path = new_profiles_dir / f"{profile_name}.json"
-                with open(profile_path, "w") as f:
+                with open(profile_path, "w", encoding="utf-8") as f:
                     json.dump(profile.to_dict(), f, indent=2)
 
                 print(f"   ✓ Migrated profile: {profile_name}")
@@ -84,7 +84,7 @@ def migrate_legacy_config() -> bool:
             "profiles_dir": str(new_profiles_dir),
         }
 
-        with open(Config.CONFIG_FILE, "w") as f:
+        with open(Config.CONFIG_FILE, "w", encoding="utf-8") as f:
             json.dump(new_config_data, f, indent=2)
 
         print(f"   ✓ Created global config with active profile: {active_profile_name}")

--- a/source/credential_provider/__main__.py
+++ b/source/credential_provider/__main__.py
@@ -121,7 +121,7 @@ class MultiProviderAuth:
             if not config_path.exists():
                 return None
 
-            with open(config_path) as f:
+            with open(config_path, encoding="utf-8") as f:
                 file_config = json.load(f)
 
             # New format with "profiles" key
@@ -162,7 +162,7 @@ class MultiProviderAuth:
                 f"Configuration file not found in {binary_dir} or {Path.home() / 'claude-code-with-bedrock'}"
             )
 
-        with open(config_path) as f:
+        with open(config_path, encoding="utf-8") as f:
             file_config = json.load(f)
 
         # Handle new config format with profiles
@@ -539,7 +539,7 @@ class MultiProviderAuth:
                 # Use simple session file per profile
                 token_file = session_dir / f"{self.profile}-monitoring.json"
 
-                with open(token_file, "w") as f:
+                with open(token_file, "w", encoding="utf-8") as f:
                     json.dump(token_data, f)
                 token_file.chmod(0o600)
 
@@ -577,7 +577,7 @@ class MultiProviderAuth:
                 if not token_file.exists():
                     return None
 
-                with open(token_file) as f:
+                with open(token_file, encoding="utf-8") as f:
                     token_data = json.load(f)
 
             # Check expiration
@@ -638,7 +638,7 @@ class MultiProviderAuth:
             temp_fd, temp_path = tempfile.mkstemp(dir=credentials_path.parent, prefix=".credentials.", suffix=".tmp")
 
             try:
-                with os.fdopen(temp_fd, "w") as f:
+                with os.fdopen(temp_fd, "w", encoding="utf-8") as f:
                     config.write(f)
 
                 # Set restrictive permissions on temp file
@@ -1304,7 +1304,7 @@ class MultiProviderAuth:
                 session_dir = Path.home() / ".claude-code-session"
                 timestamp_file = session_dir / f"{self.profile}-quota-check.json"
                 if timestamp_file.exists():
-                    with open(timestamp_file) as f:
+                    with open(timestamp_file, encoding="utf-8") as f:
                         data = json.load(f)
                         return datetime.fromisoformat(data["last_check"])
             return None
@@ -1322,7 +1322,7 @@ class MultiProviderAuth:
                 session_dir = Path.home() / ".claude-code-session"
                 session_dir.mkdir(parents=True, exist_ok=True)
                 timestamp_file = session_dir / f"{self.profile}-quota-check.json"
-                with open(timestamp_file, "w") as f:
+                with open(timestamp_file, "w", encoding="utf-8") as f:
                     json.dump({"last_check": now}, f)
                 timestamp_file.chmod(0o600)
             self._debug_print("Saved quota check timestamp")
@@ -1341,7 +1341,7 @@ class MultiProviderAuth:
                 session_dir = Path.home() / ".claude-code-session"
                 token_file = session_dir / f"{self.profile}-monitoring.json"
                 if token_file.exists():
-                    with open(token_file) as f:
+                    with open(token_file, encoding="utf-8") as f:
                         token_data = json.load(f)
                         return {"email": token_data.get("email", "")}
             return None

--- a/source/otel_helper/__main__.py
+++ b/source/otel_helper/__main__.py
@@ -212,7 +212,7 @@ def read_cached_headers():
         cache_path = get_cache_path()
         if not cache_path.exists():
             return None
-        with open(cache_path) as f:
+        with open(cache_path, encoding="utf-8") as f:
             cached = json.load(f)
         headers = cached.get("headers")
         if not headers:
@@ -233,7 +233,7 @@ def write_cached_headers(headers, token_exp):
         # Write main cache file atomically (prevents shell wrapper reading partial JSON)
         fd, tmp_path = tempfile.mkstemp(dir=cache_path.parent, suffix=".tmp")
         try:
-            with os.fdopen(fd, "w") as f:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
                 json.dump({"headers": headers, "token_exp": token_exp, "cached_at": int(time.time())}, f)
             os.chmod(tmp_path, 0o600)
             os.rename(tmp_path, str(cache_path))
@@ -245,7 +245,7 @@ def write_cached_headers(headers, token_exp):
         raw_path = cache_path.with_suffix(".raw")
         fd, tmp_path = tempfile.mkstemp(dir=cache_path.parent, suffix=".tmp")
         try:
-            with os.fdopen(fd, "w") as f:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
                 json.dump(headers, f)
             os.chmod(tmp_path, 0o600)
             os.rename(tmp_path, str(raw_path))

--- a/source/tests/cli/commands/test_init.py
+++ b/source/tests/cli/commands/test_init.py
@@ -286,7 +286,7 @@ class TestInitCommandRegression:
             Path(__file__).parent.parent.parent.parent / "claude_code_with_bedrock" / "cli" / "commands" / "init.py"
         )
 
-        with open(init_file_path) as f:
+        with open(init_file_path, encoding="utf-8") as f:
             content = f.read()
 
         # Count occurrences of 'import re'

--- a/source/tests/cli/commands/test_package.py
+++ b/source/tests/cli/commands/test_package.py
@@ -38,7 +38,7 @@ class TestPackageCommandCrossRegion:
             config_path = command._create_config(output_dir, profile, "test-identity-pool-id")
 
             # Read and verify the config
-            with open(config_path) as f:
+            with open(config_path, encoding="utf-8") as f:
                 config = json.load(f)
 
             assert "ClaudeCode" in config
@@ -77,7 +77,7 @@ class TestPackageCommandCrossRegion:
             config_path = command._create_config(output_dir, profile, "test-pool-id")
 
             # Read and verify
-            with open(config_path) as f:
+            with open(config_path, encoding="utf-8") as f:
                 config = json.load(f)
 
             # Should default to 'us'
@@ -108,7 +108,7 @@ class TestPackageCommandCrossRegion:
             )
 
             # Read installer and check region extraction
-            with open(installer_path) as f:
+            with open(installer_path, encoding="utf-8") as f:
                 installer_content = f.read()
 
             # Should extract region from Claude settings first, then fallback to profile region

--- a/source/tests/test_cloudformation.py
+++ b/source/tests/test_cloudformation.py
@@ -92,7 +92,7 @@ class TestCloudFormationCrossRegion:
         template_path = (
             Path(__file__).parent.parent.parent / "deployment" / "infrastructure" / "cognito-identity-pool.yaml"
         )
-        with open(template_path) as f:
+        with open(template_path, encoding="utf-8") as f:
             return yaml.load(f, Loader=CloudFormationLoader)
 
     def test_allowed_bedrock_regions_default(self):

--- a/source/tests/test_config.py
+++ b/source/tests/test_config.py
@@ -162,7 +162,7 @@ class TestConfigManager:
             # Write new-style config
             config_data = {"schema_version": "2.0", "active_profile": "default", "profiles_dir": str(profiles_dir)}
 
-            with open(config_file, "w") as f:
+            with open(config_file, "w", encoding="utf-8") as f:
                 json.dump(config_data, f)
 
             # Write profile without cross_region_profile (backward compatibility test)
@@ -180,7 +180,7 @@ class TestConfigManager:
                 "updated_at": "2024-01-01T00:00:00",
             }
 
-            with open(profiles_dir / "default.json", "w") as f:
+            with open(profiles_dir / "default.json", "w", encoding="utf-8") as f:
                 json.dump(profile_data, f)
 
             with patch.object(Config, "CONFIG_FILE", config_file):

--- a/source/tests/test_config_models.py
+++ b/source/tests/test_config_models.py
@@ -172,7 +172,7 @@ class TestConfigManagerWithModels:
             # Write new-style config
             config_data = {"schema_version": "2.0", "active_profile": "default", "profiles_dir": str(profiles_dir)}
 
-            with open(config_file, "w") as f:
+            with open(config_file, "w", encoding="utf-8") as f:
                 json.dump(config_data, f)
 
             # Write profile without selected_model (backward compatibility test)
@@ -190,7 +190,7 @@ class TestConfigManagerWithModels:
                 "updated_at": "2024-01-01T00:00:00",
             }
 
-            with open(profiles_dir / "default.json", "w") as f:
+            with open(profiles_dir / "default.json", "w", encoding="utf-8") as f:
                 json.dump(profile_data, f)
 
             with patch.object(Config, "CONFIG_FILE", config_file):


### PR DESCRIPTION
Fixes #209

Python defaults to the system encoding on Windows (often Windows-1252). Any file containing non-ASCII characters causes `UnicodeDecodeError: 'charmap' codec can't decode byte`. This affects CFN templates, installer scripts, and config files.

Adds explicit `encoding="utf-8"` to all 51 text-mode `open()` calls across 19 files. Binary-mode calls (`"rb"`, `"wb"`) are unchanged.

Note: [#146](https://github.com/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock/pull/146) fixes 2 of these in `package.py`. This PR covers the remaining 49 plus those 2 for completeness.