### PR TITLE
fix: remove macOS quarantine flag on installed binaries

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -1838,8 +1838,11 @@ cp "$CREDENTIAL_BINARY" ~/claude-code-with-bedrock/credential-process
 cp config.json ~/claude-code-with-bedrock/
 chmod +x ~/claude-code-with-bedrock/credential-process
 
-# macOS Keychain Notice
+# macOS Gatekeeper + Keychain notices
 if [[ "$OSTYPE" == "darwin"* ]]; then
+    # Remove quarantine flag added by macOS when downloading unsigned binaries.
+    # Without this, Gatekeeper blocks execution with "Apple could not verify..." dialog.
+    xattr -d com.apple.quarantine ~/claude-code-with-bedrock/credential-process 2>/dev/null || true
     echo
     echo "⚠️  macOS Keychain Access:"
     echo "   On first use, macOS will ask for permission to access the keychain."
@@ -1887,6 +1890,7 @@ if [ -f "$OTEL_BINARY" ]; then
     # Install PyInstaller binary as otel-helper-bin (fallback for cache miss)
     cp "$OTEL_BINARY" ~/claude-code-with-bedrock/otel-helper-bin
     chmod +x ~/claude-code-with-bedrock/otel-helper-bin
+    xattr -d com.apple.quarantine ~/claude-code-with-bedrock/otel-helper-bin 2>/dev/null || true
     # Install shell wrapper as otel-helper (fast cache check, avoids PyInstaller startup)
     if [ -f "otel-helper.sh" ]; then
         cp "otel-helper.sh" ~/claude-code-with-bedrock/otel-helper


### PR DESCRIPTION
## Summary

- Adds `xattr -d com.apple.quarantine` after installing `credential-process` and `otel-helper-bin` on macOS
- Applied in both the installer template (`package.py`) and the pre-generated `source/dist/install.sh`

## Why

macOS Gatekeeper attaches a `com.apple.quarantine` extended attribute to binaries downloaded from the internet. Since the binaries are not signed with an Apple Developer ID (open-source project), Gatekeeper blocks execution with *"Apple could not verify this app is free from malware"*. Removing the quarantine flag after install resolves this silently and safely — the user has already made a trust decision by running the install script.

The `2>/dev/null || true` ensures the command is a no-op when the attribute is not present (e.g. when testing locally where the binary was never downloaded).

Note: `xattr` operates on standard POSIX file permissions — no admin rights are required to remove extended attributes from files owned by the current user. This fix works for non-admin users as well.

Closes #27
Closes #237

## Test plan

- [ ] Download and run `install.sh` on macOS — verify no Gatekeeper dialog appears for `credential-process` or `otel-helper`
- [ ] Run install locally (binary not quarantined) — verify script completes without error