### PR TITLE
fix: strip macOS quarantine attribute from otel-helper shell wrapper

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -1919,10 +1919,12 @@ if [ -f "$OTEL_BINARY" ]; then
     if [ -f "otel-helper.sh" ]; then
         cp "otel-helper.sh" ~/claude-code-with-bedrock/otel-helper
         chmod +x ~/claude-code-with-bedrock/otel-helper
+        xattr -d com.apple.quarantine ~/claude-code-with-bedrock/otel-helper 2>/dev/null || true
     else
         # Fallback: if shell wrapper not in package, point directly to binary
         cp "$OTEL_BINARY" ~/claude-code-with-bedrock/otel-helper
         chmod +x ~/claude-code-with-bedrock/otel-helper
+        xattr -d com.apple.quarantine ~/claude-code-with-bedrock/otel-helper 2>/dev/null || true
     fi
     echo "✓ OTEL helper installed"
 fi


### PR DESCRIPTION
xattr -d com.apple.quarantine was only applied to otel-helper-bin but not to the otel-helper shell wrapper copied alongside it. macOS propagates the quarantine flag to all downloaded files, causing the "Apple could not verify" Gatekeeper warning when otel-helper is invoked.

This is a follow up from the previous PR: https://github.com/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock/pull/235

Tested on macOS successfully


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
