### PR TITLE
fix: use correct Cognito OIDC issuer URL for quota monitoring stack

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -772,10 +772,22 @@ class DeployCommand(Command):
                 )
 
                 # Get OIDC configuration for JWT authentication
-                oidc_issuer_url = profile.provider_domain
-                # Ensure issuer URL has https:// prefix
-                if oidc_issuer_url and not oidc_issuer_url.startswith(("http://", "https://")):
-                    oidc_issuer_url = f"https://{oidc_issuer_url}"
+                if profile.provider_type == "cognito":
+                    # Cognito issuer uses cognito-idp endpoint, not the hosted UI domain
+                    pool_id = getattr(profile, "cognito_user_pool_id", "")
+                    if pool_id:
+                        pool_region = pool_id.split("_")[0] if "_" in pool_id else profile.aws_region
+                        oidc_issuer_url = f"https://cognito-idp.{pool_region}.amazonaws.com/{pool_id}"
+                    else:
+                        raise ValueError(
+                            "Cognito User Pool ID is required for quota monitoring JWT authentication. "
+                            "Please set cognito_user_pool_id in your profile configuration."
+                        )
+                else:
+                    oidc_issuer_url = profile.provider_domain
+                    # Ensure issuer URL has https:// prefix
+                    if oidc_issuer_url and not oidc_issuer_url.startswith(("http://", "https://")):
+                        oidc_issuer_url = f"https://{oidc_issuer_url}"
                 # Auth0 tokens include trailing slash in iss claim, so authorizer must match
                 if profile.provider_type == "auth0" and oidc_issuer_url and not oidc_issuer_url.endswith("/"):
                     oidc_issuer_url = f"{oidc_issuer_url}/"


### PR DESCRIPTION
## Summary

- Fixes quota monitoring stack deployment failure when using Cognito User Pools. The stack was passing the hosted UI domain (`https://cc-bedrock.auth.us-east-1.amazoncognito.com`) as the JWT issuer URL, but API Gateway JWT authorizers require the cognito-idp format (`https://cognito-idp.{region}.amazonaws.com/{pool_id}`) which serves the OIDC discovery endpoint.
- Mirrors the existing ALB deployment logic (lines 636-645) that already handles Cognito issuer URLs correctly.
- Raises a clear `ValueError` if `cognito_user_pool_id` is missing, rather than silently deploying a broken authorizer.

Closes #115
Related: #114, #140 — thanks to @windson and @schnetler for their PRs identifying this issue.

## Test plan

- [ ] Deploy quota monitoring stack with Cognito provider — verify CloudFormation succeeds and JWT authorizer uses `cognito-idp.{region}.amazonaws.com/{pool_id}` format
- [ ] Deploy with Auth0 provider — verify trailing slash normalization still applies
- [ ] Deploy with Okta/Azure provider — verify no regression
- [ ] Attempt deploy with Cognito but missing `cognito_user_pool_id` — verify clear error message