### PR TITLE
fix: resolve UnboundLocalError when storing EntraID client secret in keyring

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -104,7 +104,7 @@ class InitCommand(Command):
 
         # If user explicitly chose "Update existing profile", skip the second prompt
         if existing_config and user_action == "update":
-            config = self._gather_configuration(progress, existing_config)
+            config = self._gather_configuration(progress, existing_config, profile_name)
             if not config:
                 return 1
             if not self._review_configuration(config):
@@ -145,7 +145,7 @@ class InitCommand(Command):
                 self._review_configuration(existing_config)
                 return 0
             elif action == "Update configuration":
-                config = self._gather_configuration(progress, existing_config)
+                config = self._gather_configuration(progress, existing_config, profile_name)
                 if not config:
                     return 1
                 if not self._review_configuration(config):
@@ -196,7 +196,7 @@ class InitCommand(Command):
             return 1
 
         # Gather configuration
-        config = self._gather_configuration(progress)
+        config = self._gather_configuration(progress, profile_name=profile_name)
         if not config:
             return 1
         # Review and confirm
@@ -267,7 +267,7 @@ class InitCommand(Command):
         console.print("")
         return True
 
-    def _gather_configuration(self, progress: WizardProgress, existing_config: dict[str, Any] = None) -> dict[str, Any]:
+    def _gather_configuration(self, progress: WizardProgress, existing_config: dict[str, Any] = None, profile_name: str | None = None) -> dict[str, Any]:
         """Gather configuration from user."""
         console = Console()
         # Use existing config as base if provided, otherwise use saved progress
@@ -429,6 +429,8 @@ class InitCommand(Command):
                     ).ask()
                     if not client_secret:
                         return None
+                    if not profile_name:
+                        raise ValueError("profile_name is required to store client secret in keyring")
                     import keyring as _keyring
                     _keyring.set_password("claude-code-with-bedrock", f"{profile_name}-client-secret", client_secret)
                     console.print("[dim]  ✓ Client secret stored in OS secure storage (not written to config)[/dim]")
@@ -1163,8 +1165,8 @@ class InitCommand(Command):
             for profile_key in available_profiles:
                 # Get model-specific description
                 description = get_profile_description(selected_model_key, profile_key)
-                profile_name = profile_key.upper() if profile_key != "us" else "US"
-                choice_text = f"{profile_name} Cross-Region - {description}"
+                region_profile_label = profile_key.upper() if profile_key != "us" else "US"
+                choice_text = f"{region_profile_label} Cross-Region - {description}"
                 profile_choices.append(questionary.Choice(title=choice_text, value=profile_key))
 
             # Adjust the prompt based on number of options
@@ -1201,8 +1203,8 @@ class InitCommand(Command):
             config["aws"]["allowed_bedrock_regions"] = destination_regions
 
             # Step 3: Select source region for the selected model/profile combination
-            profile_name = selected_profile.upper() if selected_profile != "us" else "US"
-            console.print(f"\n[green]Selected:[/green] {profile_name} Cross-Region")
+            region_profile_label = selected_profile.upper() if selected_profile != "us" else "US"
+            console.print(f"\n[green]Selected:[/green] {region_profile_label} Cross-Region")
 
             # Get available source regions for this model/profile combination
             available_source_regions = get_source_regions_for_model_profile(selected_model_key, selected_profile)
@@ -1250,7 +1252,7 @@ class InitCommand(Command):
             profile_description = get_profile_description(selected_model_key, selected_profile)
 
             console.print(
-                f"\n[green]✓[/green] Configured {selected_model['name']} with {profile_name} "
+                f"\n[green]✓[/green] Configured {selected_model['name']} with {region_profile_label} "
                 f"Cross-Region ({profile_description})"
             )
 


### PR DESCRIPTION
## Summary

Fixes #249.

- `_gather_configuration` assigned `profile_name` as a display label for the cross-region inference profile (e.g. `"US"`, `"EUROPE"`) deep in the method
- Python's static scoping therefore treated `profile_name` as a local variable throughout the entire function
- Reading it earlier — to key the OS keyring entry for the client secret — raised `UnboundLocalError` for every user who selected "Confidential client — client secret"
- Renamed the display-only assignments to `region_profile_label` to eliminate the collision

## Test plan

- [x] Run `ccwb init` with an EntraID/Azure provider, select "Confidential client — client secret", enter a secret → confirm no `UnboundLocalError` and the keyring entry is created
- [x] Verify the cross-region inference profile selection UI still displays labels correctly (US / EUROPE / APAC)
- [x] Confirm the "Public client" and "certificate" paths are unaffected