### PR TITLE
fix: add IAM propagation delay after creating ECS service linked role

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -1056,6 +1056,10 @@ class DeployCommand(Command):
                 try:
                     iam_client.create_service_linked_role(AWSServiceName="ecs.amazonaws.com")
                     console.print("[green]✓ ECS service linked role created[/green]")
+                    # Wait for IAM propagation before proceeding with ECS cluster creation
+                    import time
+                    console.print("[dim]Waiting for IAM role propagation...[/dim]")
+                    time.sleep(10)
                 except iam_client.exceptions.InvalidInputException as e:
                     # Role might already exist (race condition)
                     if "has been taken in this account" in str(e):

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -1406,6 +1406,10 @@ class DeployCommand(Command):
                 try:
                     iam_client.create_service_linked_role(AWSServiceName="ecs.amazonaws.com")
                     console.print("[green]✓ ECS service linked role created[/green]")
+                    # Wait for IAM propagation before proceeding with ECS cluster creation
+                    import time
+                    console.print("[dim]Waiting for IAM role propagation...[/dim]")
+                    time.sleep(10)
                 except iam_client.exceptions.InvalidInputException as e:
                     # Role might already exist (race condition)
                     if "has been taken in this account" in str(e):


### PR DESCRIPTION
## Summary
- Fixes #236 (together with #247 which covers the standalone CloudFormation deploy path)
- After creating `AWSServiceRoleForECS`, IAM propagation takes several seconds before the role is globally consistent
- Without a delay, CloudFormation immediately attempts ECS cluster creation and fails with "Unable to assume the service linked role"
- Adds a 10-second wait only when the role is newly created (no delay if it already exists)

## Test plan
- [x] Deploy monitoring stack on an account where `AWSServiceRoleForECS` does not yet exist
- [x] Verify ECS cluster creation succeeds after the propagation wait
- [x] Verify no delay occurs when the role already exists