### PR TITLE
feat: implement --output/-o flag for ccwb config export

### DIFF
--- a/assets/docs/CLI_REFERENCE.md
+++ b/assets/docs/CLI_REFERENCE.md
@@ -1013,7 +1013,7 @@ poetry run ccwb config export [profile-name] [options]
 
 **Options:**
 
-- `--output <file>` - Output file path (default: `<profile-name>.json`)
+- `--output, -o <file>` - Write output to a file instead of stdout (uses UTF-8 encoding)
 - `--include-secrets` - Include sensitive values (not recommended)
 
 **What it does:**
@@ -1025,10 +1025,13 @@ poetry run ccwb config export [profile-name] [options]
 **Examples:**
 
 ```bash
-# Export active profile (secrets removed)
+# Export active profile to stdout (secrets removed)
 poetry run ccwb config export
 
-# Export specific profile to custom path
+# Export active profile to a file (cross-platform, UTF-8 safe)
+poetry run ccwb config export --output prod-config.json
+
+# Export specific profile to a file
 poetry run ccwb config export production --output prod-config.json
 
 # Export with secrets (use caution)

--- a/source/claude_code_with_bedrock/cli/commands/context.py
+++ b/source/claude_code_with_bedrock/cli/commands/context.py
@@ -4,7 +4,7 @@
 """Context command - Manage deployment profile contexts."""
 
 from cleo.commands.command import Command
-from cleo.helpers import argument
+from cleo.helpers import argument, option
 from rich import box
 from rich.console import Console
 from rich.panel import Panel
@@ -356,14 +356,21 @@ class ConfigExportCommand(Command):
             optional=True,
         )
     ]
+    options = [
+        option("output", "o", description="Write output to a file instead of stdout", flag=False, default=None),
+        option("include-secrets", description="Include sensitive values (not recommended)", flag=True),
+    ]
 
     def handle(self) -> int:
         """Execute the config export command."""
+        import json
         import sys
 
         Console()
         console_err = Console(file=sys.stderr)
         profile_name = self.argument("profile")
+        output_path = self.option("output")
+        include_secrets = self.option("include-secrets")
 
         try:
             config = Config.load()
@@ -384,18 +391,21 @@ class ConfigExportCommand(Command):
                 console_err.print("\nUse [cyan]ccwb context list[/cyan] to see all profiles.\n")
                 return 1
 
-            # Sanitize profile (remove secrets)
+            # Sanitize profile (remove secrets) unless --include-secrets is set
             profile_dict = profile.to_dict()
-            sanitized = self._sanitize_profile(profile_dict)
+            exported = profile_dict if include_secrets else self._sanitize_profile(profile_dict)
+            json_output = json.dumps(exported, indent=2)
 
-            # Output JSON to stdout
-            import json
+            if output_path:
+                with open(output_path, "w", encoding="utf-8") as f:
+                    f.write(json_output + "\n")
+                console_err.print(f"\n[green]✓ Exported profile:[/green] {profile_name} → {output_path}")
+            else:
+                print(json_output)
+                console_err.print(f"\n[green]✓ Exported profile:[/green] {profile_name} (sanitized)")
 
-            print(json.dumps(sanitized, indent=2))
-
-            # Log to stderr
-            console_err.print(f"\n[green]✓ Exported profile:[/green] {profile_name} (sanitized)")
-            console_err.print("[dim]Secrets have been removed for safe sharing.[/dim]\n")
+            if not include_secrets:
+                console_err.print("[dim]Secrets have been removed for safe sharing.[/dim]\n")
 
             return 0
 


### PR DESCRIPTION
## Summary

- Implements the `--output/-o` flag for `ccwb config export`, which was documented in `CLI_REFERENCE.md` since v2.0.0 but never wired up in code
- Also wires up `--include-secrets` which was doc-only too
- Fixes the docs to clarify that the default behavior is stdout (not `<profile-name>.json` as previously stated)

Closes #253

## Test plan

- [x] `ccwb config export` — JSON to stdout, status to stderr (unchanged behavior)
- [x] `ccwb config export --output prod-config.json` — creates UTF-8 file, nothing on stdout
- [x] `ccwb config export -o prod-config.json` — shorthand works
- [x] `ccwb config export --include-secrets` — secrets not redacted in output
- [x] `ccwb config export --help` — both flags appear in help text