### PR TITLE
fix: Quota enforcement

### DIFF
--- a/deployment/infrastructure/lambda-functions/quota_check/index.py
+++ b/deployment/infrastructure/lambda-functions/quota_check/index.py
@@ -20,6 +20,14 @@ POLICIES_TABLE = os.environ.get("POLICIES_TABLE", "QuotaPolicies")
 MISSING_EMAIL_ENFORCEMENT = os.environ.get("MISSING_EMAIL_ENFORCEMENT", "block")
 ERROR_HANDLING_MODE = os.environ.get("ERROR_HANDLING_MODE", "fail_closed")
 
+# Default limits from environment (used when fine-grained quotas are disabled)
+ENABLE_FINEGRAINED_QUOTAS = os.environ.get("ENABLE_FINEGRAINED_QUOTAS", "false").lower() == "true"
+MONTHLY_TOKEN_LIMIT = int(os.environ.get("MONTHLY_TOKEN_LIMIT", "0"))
+DAILY_TOKEN_LIMIT = int(os.environ.get("DAILY_TOKEN_LIMIT", "0"))
+MONTHLY_ENFORCEMENT_MODE = os.environ.get("MONTHLY_ENFORCEMENT_MODE", "block")
+WARNING_THRESHOLD_80 = int(os.environ.get("WARNING_THRESHOLD_80", "240000000"))
+WARNING_THRESHOLD_90 = int(os.environ.get("WARNING_THRESHOLD_90", "270000000"))
+
 # DynamoDB tables
 quota_table = dynamodb.Table(QUOTA_TABLE)
 policies_table = dynamodb.Table(POLICIES_TABLE)
@@ -255,6 +263,19 @@ def resolve_quota_for_user(email: str, groups: list) -> dict | None:
     Returns:
         Policy dict or None if no policy applies (unlimited).
     """
+    if not ENABLE_FINEGRAINED_QUOTAS and MONTHLY_TOKEN_LIMIT > 0:
+        # Return default limits from environment
+        return {
+            "policy_type": "default",
+            "identifier": "environment",
+            "monthly_token_limit": MONTHLY_TOKEN_LIMIT,
+            "daily_token_limit": DAILY_TOKEN_LIMIT if DAILY_TOKEN_LIMIT > 0 else None,
+            "warning_threshold_80": WARNING_THRESHOLD_80,
+            "warning_threshold_90": WARNING_THRESHOLD_90,
+            "enforcement_mode": MONTHLY_ENFORCEMENT_MODE,
+            "enabled": True,
+        }
+
     # 1. Check for user-specific policy
     user_policy = get_policy("user", email)
     if user_policy and user_policy.get("enabled", True):

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -1731,6 +1731,12 @@ RUN pyinstaller \
                 console.print("[dim]  AZURE_CLIENT_CERTIFICATE_PATH=<path/to/cert.pem>[/dim]")
                 console.print("[dim]  AZURE_CLIENT_CERTIFICATE_KEY_PATH=<path/to/key.pem>[/dim]\n")
 
+        # Add quota settings so the credential provider can enforce limits
+        if getattr(profile, "quota_api_endpoint", None):
+            config[profile_name]["quota_api_endpoint"] = profile.quota_api_endpoint
+            config[profile_name]["quota_fail_mode"] = getattr(profile, "quota_fail_mode", "open")
+            config[profile_name]["quota_check_interval"] = getattr(profile, "quota_check_interval", 30)
+
         config_path = output_dir / "config.json"
         with open(config_path, "w") as f:
             json.dump(config, f, indent=2)

--- a/source/credential_provider/__main__.py
+++ b/source/credential_provider/__main__.py
@@ -991,7 +991,7 @@ class MultiProviderAuth:
 
             def _send_response(self, code, message):
                 self.send_response(code)
-                self.send_header("Content-type", "text/html")
+                self.send_header("Content-type", "text/html; charset=utf-8")
                 self.end_headers()
                 html = f"""
                 <html>
@@ -1797,7 +1797,7 @@ class MultiProviderAuth:
             class QuotaPageHandler(BaseHTTPRequestHandler):
                 def do_GET(self):
                     self.send_response(200)
-                    self.send_header("Content-type", "text/html")
+                    self.send_header("Content-type", "text/html; charset=utf-8")
                     self.end_headers()
                     self.wfile.write(html.encode())
                     page_served["done"] = True


### PR DESCRIPTION
**This PR includes 2 commits that fixes quota enforcement**

**Server side change:**
The quota_check Lambda resolves enforcement limits exclusively from the QuotaPolicies DynamoDB table. However, nothing in the deployment pipeline seeds that table — ccwb deploy passes limits as CloudFormation parameters that become Lambda env vars (MONTHLY_TOKEN_LIMIT, MONTHLY_ENFORCEMENT_MODE, etc.), but the Lambda never reads them.

The result is that resolve_quota_for_user() always returns None (no policy), and every request gets {"allowed": true, "reason": "no_policy"} — unlimited access even when the operator configured enforcement_mode: block.

The similar quota_monitor Lambda already handles this correctly: when ENABLE_FINEGRAINED_QUOTAS is false it short-circuits with env var defaults instead of querying DynamoDB. (https://github.com/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock/blob/main/deployment/infrastructure/lambda-functions/quota_monitor/index.py#L292-L303)

This commit adds a similar pattern to quota_check.

**Client side change:**
This change ensures that the distributed `config.json` includes `quota_api_endpoint`, `quota_fail_mode`, and `quota_check_interval` so the credential provider on users' machines knows where to call quota enforcement. Without that the quotas aren't being properly enforced and Claude Code allows going past the allowances.


-- 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
