### PR TITLE
feat: add Application Inference Profile and support 3-Tier Model Pinning

### DIFF
--- a/deployment/infrastructure/bedrock-auth-auth0.yaml
+++ b/deployment/infrastructure/bedrock-auth-auth0.yaml
@@ -112,6 +112,7 @@ Resources:
             Resource:
               - !Sub 'arn:${AWS::Partition}:bedrock:*::foundation-model/*'
               - !Sub 'arn:${AWS::Partition}:bedrock:*:*:inference-profile/*'
+              - !Sub 'arn:${AWS::Partition}:bedrock:*:*:application-inference-profile/*'
             Condition:
               StringEquals:
                 'aws:RequestedRegion': !Ref AllowedBedrockRegions

--- a/deployment/infrastructure/bedrock-auth-azure.yaml
+++ b/deployment/infrastructure/bedrock-auth-azure.yaml
@@ -104,6 +104,7 @@ Resources:
             Resource:
               - !Sub 'arn:${AWS::Partition}:bedrock:*::foundation-model/*'
               - !Sub 'arn:${AWS::Partition}:bedrock:*:*:inference-profile/*'
+              - !Sub 'arn:${AWS::Partition}:bedrock:*:*:application-inference-profile/*'
             Condition:
               StringEquals:
                 'aws:RequestedRegion': !Ref AllowedBedrockRegions

--- a/deployment/infrastructure/bedrock-auth-cognito-pool.yaml
+++ b/deployment/infrastructure/bedrock-auth-cognito-pool.yaml
@@ -110,6 +110,7 @@ Resources:
             Resource:
               - !Sub 'arn:${AWS::Partition}:bedrock:*::foundation-model/*'
               - !Sub 'arn:${AWS::Partition}:bedrock:*:*:inference-profile/*'
+              - !Sub 'arn:${AWS::Partition}:bedrock:*:*:application-inference-profile/*'
             Condition:
               StringEquals:
                 'aws:RequestedRegion': !Ref AllowedBedrockRegions

--- a/deployment/infrastructure/bedrock-auth-okta.yaml
+++ b/deployment/infrastructure/bedrock-auth-okta.yaml
@@ -103,6 +103,7 @@ Resources:
             Resource:
               - !Sub 'arn:${AWS::Partition}:bedrock:*::foundation-model/*'
               - !Sub 'arn:${AWS::Partition}:bedrock:*:*:inference-profile/*'
+              - !Sub 'arn:${AWS::Partition}:bedrock:*:*:application-inference-profile/*'
             Condition:
               StringEquals:
                 'aws:RequestedRegion': !Ref AllowedBedrockRegions

--- a/deployment/infrastructure/cognito-identity-pool.yaml
+++ b/deployment/infrastructure/cognito-identity-pool.yaml
@@ -143,6 +143,7 @@ Resources:
             Resource:
               - !Sub 'arn:${AWS::Partition}:bedrock:*::foundation-model/*'
               - !Sub 'arn:${AWS::Partition}:bedrock:*:*:inference-profile/*'
+              - !Sub 'arn:${AWS::Partition}:bedrock:*:*:application-inference-profile/*'
             Condition:
               StringEquals:
                 'aws:RequestedRegion': !Ref AllowedBedrockRegions

--- a/source/claude_code_with_bedrock/cli/commands/context.py
+++ b/source/claude_code_with_bedrock/cli/commands/context.py
@@ -199,6 +199,10 @@ class ContextShowCommand(Command):
             console.print("\n[bold cyan]Bedrock Configuration:[/bold cyan]")
             if profile.selected_model:
                 console.print(f"  Selected Model:       {profile.selected_model}")
+            for tier, attr in [("Opus", "inference_profile_opus_arn"), ("Sonnet", "inference_profile_sonnet_arn"), ("Haiku", "inference_profile_haiku_arn")]:
+                arn = getattr(profile, attr, None)
+                if arn:
+                    console.print(f"  {tier} Inference Profile: {arn}")
             if profile.selected_source_region:
                 console.print(f"  Source Region:        {profile.selected_source_region}")
             if profile.cross_region_profile:

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1343,6 +1343,54 @@ class InitCommand(Command):
                 f"Cross-Region ({profile_description})"
             )
 
+            # Optional: Application Inference Profiles
+            has_saved_arns = any(
+                config.get("aws", {}).get(k)
+                for k in ["inference_profile_opus_arn", "inference_profile_sonnet_arn", "inference_profile_haiku_arn"]
+            )
+            use_inference_profiles = questionary.confirm(
+                "Configure Application Inference Profiles?",
+                default=has_saved_arns,
+            ).ask()
+
+            if use_inference_profiles:
+                from claude_code_with_bedrock.validators import ProfileValidator
+
+                console.print("[dim]Provide an inference profile ARN for each model tier (press Enter to skip).[/dim]")
+
+                for tier_name, config_key in [
+                    ("Opus", "inference_profile_opus_arn"),
+                    ("Sonnet", "inference_profile_sonnet_arn"),
+                    ("Haiku", "inference_profile_haiku_arn"),
+                ]:
+                    saved_arn = config.get("aws", {}).get(config_key)
+                    while True:
+                        arn = questionary.text(
+                            f"  {tier_name} inference profile ARN:",
+                            default=saved_arn or "",
+                        ).ask()
+
+                        if arn is None:  # User cancelled
+                            config["aws"][config_key] = None
+                            break
+
+                        if not arn.strip():
+                            config["aws"][config_key] = None
+                            break
+
+                        error = ProfileValidator.validate_application_inference_profile_arn(arn)
+                        if error:
+                            console.print(f"[red]{error}[/red]")
+                            continue
+
+                        config["aws"][config_key] = arn.strip()
+                        console.print(f"[green]✓[/green] {tier_name} inference profile configured")
+                        break
+            else:
+                config["aws"]["inference_profile_opus_arn"] = None
+                config["aws"]["inference_profile_sonnet_arn"] = None
+                config["aws"]["inference_profile_haiku_arn"] = None
+
             # Save progress
             progress.save_step("bedrock_complete", config)
 
@@ -1418,6 +1466,12 @@ class InitCommand(Command):
         model_display = get_all_model_display_names()
         if selected_model:
             table.add_row("Claude Model", model_display.get(selected_model, selected_model))
+
+        # Show application inference profiles if configured
+        for tier, key in [("Opus", "inference_profile_opus_arn"), ("Sonnet", "inference_profile_sonnet_arn"), ("Haiku", "inference_profile_haiku_arn")]:
+            arn = config["aws"].get(key)
+            if arn:
+                table.add_row(f"{tier} Inference Profile", arn)
 
         # Show cross-region profile
         cross_region_profile = config["aws"].get("cross_region_profile", "us")
@@ -1626,6 +1680,9 @@ class InitCommand(Command):
             cross_region_profile=config_data["aws"].get("cross_region_profile", "us"),
             selected_model=config_data["aws"].get("selected_model"),
             selected_source_region=config_data["aws"].get("selected_source_region"),
+            inference_profile_opus_arn=config_data["aws"].get("inference_profile_opus_arn"),
+            inference_profile_sonnet_arn=config_data["aws"].get("inference_profile_sonnet_arn"),
+            inference_profile_haiku_arn=config_data["aws"].get("inference_profile_haiku_arn"),
             provider_type=config_data.get("provider_type"),
             cognito_user_pool_id=config_data.get("cognito_user_pool_id"),
             federation_type=config_data.get("federation_type", "cognito"),
@@ -1952,6 +2009,11 @@ class InitCommand(Command):
             if hasattr(profile, "cross_region_profile") and profile.cross_region_profile:
                 existing_config["aws"]["cross_region_profile"] = profile.cross_region_profile
 
+            # Add application inference profile ARNs if present
+            for arn_key in ["inference_profile_opus_arn", "inference_profile_sonnet_arn", "inference_profile_haiku_arn"]:
+                if getattr(profile, arn_key, None):
+                    existing_config["aws"][arn_key] = getattr(profile, arn_key)
+
             # Add CodeBuild configuration if present
             if hasattr(profile, "enable_codebuild"):
                 existing_config["codebuild"] = {"enabled": profile.enable_codebuild}
@@ -2025,6 +2087,12 @@ class InitCommand(Command):
             from claude_code_with_bedrock.models import get_all_model_display_names
             model_names = get_all_model_display_names()
             console.print(f"• Claude Model: [cyan]{model_names.get(selected_model, selected_model)}[/cyan]")
+
+        # Show application inference profiles if configured
+        for tier, key in [("Opus", "inference_profile_opus_arn"), ("Sonnet", "inference_profile_sonnet_arn"), ("Haiku", "inference_profile_haiku_arn")]:
+            arn = config["aws"].get(key)
+            if arn:
+                console.print(f"• {tier} Inference Profile: [cyan]{arn}[/cyan]")
 
         # Show cross-region profile
         cross_region_profile = config["aws"].get("cross_region_profile", "us")

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -2438,6 +2438,31 @@ Available metrics include:
                 if opus_model:
                     settings["env"]["ANTHROPIC_DEFAULT_OPUS_MODEL"] = opus_model
 
+                # Override with Application Inference Profile ARNs when configured
+                opus_arn = getattr(profile, "inference_profile_opus_arn", None)
+                sonnet_arn = getattr(profile, "inference_profile_sonnet_arn", None)
+                haiku_arn = getattr(profile, "inference_profile_haiku_arn", None)
+
+                if opus_arn:
+                    settings["env"]["ANTHROPIC_DEFAULT_OPUS_MODEL"] = opus_arn
+                if sonnet_arn:
+                    settings["env"]["ANTHROPIC_DEFAULT_SONNET_MODEL"] = sonnet_arn
+                if haiku_arn:
+                    settings["env"]["ANTHROPIC_SMALL_FAST_MODEL"] = haiku_arn
+                    settings["env"]["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = haiku_arn
+
+                # Override ANTHROPIC_MODEL with the primary inference profile ARN
+                # so Claude Code uses the inference profile for all code paths.
+                # Only override if the matching tier has an ARN configured —
+                # otherwise ANTHROPIC_MODEL stays on the CRIS model ID.
+                model_id = profile.selected_model
+                if "opus" in model_id and opus_arn:
+                    settings["env"]["ANTHROPIC_MODEL"] = opus_arn
+                elif "sonnet" in model_id and sonnet_arn:
+                    settings["env"]["ANTHROPIC_MODEL"] = sonnet_arn
+                elif "haiku" in model_id and haiku_arn:
+                    settings["env"]["ANTHROPIC_MODEL"] = haiku_arn
+
             # If monitoring is enabled, add telemetry configuration
             if profile.monitoring_enabled:
                 # Get monitoring stack outputs

--- a/source/claude_code_with_bedrock/cli/utils/display.py
+++ b/source/claude_code_with_bedrock/cli/utils/display.py
@@ -68,6 +68,16 @@ def _display_table_format(console: Console, profile, identity_pool_id: str | Non
         model_names = get_all_model_display_names()
         config_table.add_row("Claude Model", model_names.get(selected_model, selected_model))
 
+    # Application inference profiles (if configured)
+    for tier, attr in [
+        ("Opus", "inference_profile_opus_arn"),
+        ("Sonnet", "inference_profile_sonnet_arn"),
+        ("Haiku", "inference_profile_haiku_arn"),
+    ]:
+        arn = getattr(profile, attr, None)
+        if arn:
+            config_table.add_row(f"{tier} Inference Profile", arn)
+
     # Source region
     source_region = getattr(profile, "selected_source_region", None)
     if source_region:
@@ -131,6 +141,16 @@ def _display_simple_format(console: Console, profile, identity_pool_id: str | No
         model_display = model_names.get(selected_model, selected_model)
         console.print(f"  Claude Model: [cyan]{model_display}[/cyan]")
 
+    # Application inference profiles (if configured)
+    for tier, attr in [
+        ("Opus", "inference_profile_opus_arn"),
+        ("Sonnet", "inference_profile_sonnet_arn"),
+        ("Haiku", "inference_profile_haiku_arn"),
+    ]:
+        arn = getattr(profile, attr, None)
+        if arn:
+            console.print(f"  {tier} Inference Profile: [cyan]{arn}[/cyan]")
+
     # Source region
     source_region = getattr(profile, "selected_source_region", None)
     if source_region:
@@ -174,6 +194,9 @@ def get_configuration_dict(profile, identity_pool_id: str | None = None) -> dict
         "cross_region_profile": getattr(profile, "cross_region_profile", None),
         "source_region": getattr(profile, "selected_source_region", None),
         "analytics_enabled": getattr(profile, "analytics_enabled", None),
+        "inference_profile_opus_arn": getattr(profile, "inference_profile_opus_arn", None),
+        "inference_profile_sonnet_arn": getattr(profile, "inference_profile_sonnet_arn", None),
+        "inference_profile_haiku_arn": getattr(profile, "inference_profile_haiku_arn", None),
     }
 
     if identity_pool_id:

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -82,6 +82,11 @@ class Profile:
     client_certificate_path: str | None = None  # Path to PEM certificate file
     client_certificate_key_path: str | None = None  # Path to PEM private key file
 
+    # Application Inference Profile support (per-tier ARNs)
+    inference_profile_opus_arn: str | None = None  # Optional inference profile ARN for Opus tier
+    inference_profile_sonnet_arn: str | None = None  # Optional inference profile ARN for Sonnet tier
+    inference_profile_haiku_arn: str | None = None  # Optional inference profile ARN for Haiku tier
+
     # Claude Code settings configuration
     include_coauthored_by: bool = True  # Whether to include "co-authored-by Claude" in git commits
 
@@ -169,6 +174,12 @@ class Profile:
                 regions = data["allowed_bedrock_regions"]
                 if any(r.startswith("us-") for r in regions):
                     data["cross_region_profile"] = "us"
+
+        # Filter out any keys not in the Profile dataclass to prevent TypeError
+        import dataclasses
+
+        valid_fields = {f.name for f in dataclasses.fields(cls)}
+        data = {k: v for k, v in data.items() if k in valid_fields}
 
         return cls(**data)
 

--- a/source/claude_code_with_bedrock/validators.py
+++ b/source/claude_code_with_bedrock/validators.py
@@ -326,6 +326,28 @@ class ProfileValidator:
         pool_pattern = r"^[a-z]{2}-[a-z]+-\d+_[a-zA-Z0-9]+$"
         return bool(re.match(pool_pattern, pool_id))
 
+    @staticmethod
+    def validate_application_inference_profile_arn(arn: str) -> str | None:
+        """Validate an Application Inference Profile ARN.
+
+        Args:
+            arn: ARN to validate, or empty string / None.
+
+        Returns:
+            None if valid (or empty/None), error message string if invalid.
+        """
+        if not arn or not arn.strip():
+            return None  # Empty is valid (means not configured)
+
+        arn = arn.strip()
+        pattern = r"^arn:(aws|aws-us-gov):bedrock:[a-z0-9-]+:\d{12}:application-inference-profile/[a-zA-Z0-9_-]+$"
+        if not re.match(pattern, arn):
+            return (
+                "Invalid Application Inference Profile ARN. Expected format: "
+                "arn:aws:bedrock:{region}:{account-id}:application-inference-profile/{profile-id}"
+            )
+        return None
+
 
 def validate_profile(profile_data: dict[str, Any]) -> ValidationResult:
     """Convenience function to validate a profile.


### PR DESCRIPTION
## Description

Adds support for [Application Inference Profiles](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-create.html) and migrates model configuration from the legacy `ANTHROPIC_MODEL` + deprecated `ANTHROPIC_SMALL_FAST_MODEL` to Anthropic's recommended three-tier model pinning.

Closes #151

## What changed

### Three-tier model pinning

The `ccwb package` command now outputs the recommended `ANTHROPIC_DEFAULT_OPUS_MODEL`, `ANTHROPIC_DEFAULT_SONNET_MODEL`, and `ANTHROPIC_DEFAULT_HAIKU_MODEL` environment variables in `settings.json`, replacing the legacy `ANTHROPIC_MODEL` + deprecated `ANTHROPIC_SMALL_FAST_MODEL`. All three tiers are auto-derived from the primary model selection:

| User picks | Opus tier | Sonnet tier | Haiku tier |
|---|---|---|---|
| Opus | selected CRIS ID | Sonnet 4.6 (same prefix) | Haiku 4.5 (same prefix) |
| Sonnet | (not set) | selected CRIS ID | Haiku 4.5 (same prefix) |
| Haiku/other | (not set) | (not set) | selected CRIS ID |

### Application Inference Profile support

Admins can optionally configure up to three Application Inference Profile ARNs (one per model tier) during `ccwb init`. When configured, the ARNs replace the CRIS model IDs in the corresponding `ANTHROPIC_DEFAULT_*_MODEL` environment variables.

### IAM policy update

All five auth CloudFormation templates now include `application-inference-profile/*` as an allowed resource for Bedrock invoke actions, alongside the existing `foundation-model/*` and `inference-profile/*` patterns.

### Backward compatibility fix

`Profile.from_dict()` now filters out unknown fields before constructing the dataclass, preventing `TypeError` when loading profiles that contain fields from other branches or older/newer versions.

## Files changed

- `config.py` — Three per-tier inference profile ARN fields on Profile, resilient `from_dict` field filtering
- `validators.py` — `validate_application_inference_profile_arn()` for aws + aws-us-gov partitions
- `package.py` — Three-tier `ANTHROPIC_DEFAULT_*_MODEL` env vars, inference profile ARN override logic
- `init.py` — Optional per-tier inference profile prompt after model selection, display in review/summary
- `context.py` — Display per-tier inference profile ARNs in `ccwb context show`
- `bedrock-auth-okta.yaml` — `application-inference-profile/*` in IAM policy
- `bedrock-auth-azure.yaml` — `application-inference-profile/*` in IAM policy
- `bedrock-auth-auth0.yaml` — `application-inference-profile/*` in IAM policy
- `bedrock-auth-cognito-pool.yaml` — `application-inference-profile/*` in IAM policy
- `cognito-identity-pool.yaml` — `application-inference-profile/*` in IAM policy

## Testing

- 192/196 unit tests pass (4 pre-existing failures unrelated to this change)
- Manually tested end-to-end: created Application Inference Profiles with tags in eu-central-1, configured via `ccwb init`, packaged, and verified Claude Code uses the inference profile ARNs for all three model tiers
- Verified backward compatibility with existing profiles that lack the new fields
- Verified ARN validation rejects invalid formats with helpful error messages
