### PR TITLE
fix: add IAM policy for dashboard viewers to invoke custom widget Lambda

### DIFF
--- a/deployment/infrastructure/claude-code-dashboard.yaml
+++ b/deployment/infrastructure/claude-code-dashboard.yaml
@@ -869,6 +869,36 @@ Resources:
           ]
         }
 
+  # IAM Managed Policy for dashboard viewers to invoke custom widget Lambdas
+  DashboardViewerPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: !Sub '${AWS::StackName}-DashboardViewerPolicy'
+      Description: >-
+        Grants lambda:InvokeFunction on CloudWatch dashboard custom widget
+        Lambda functions. Attach this policy to read-only IAM roles that
+        need to view the dashboard.
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - lambda:InvokeFunction
+            Resource:
+              - !GetAtt TotalTokensWidget.Arn
+              - !GetAtt OperationsCountWidget.Arn
+              - !GetAtt ActiveUsersWidget.Arn
+              - !GetAtt TokenByModelWidget.Arn
+              - !GetAtt CacheEfficiencyWidget.Arn
+              - !GetAtt TopUsersWidget.Arn
+              - !GetAtt OperationsByTypeWidget.Arn
+              - !GetAtt TokenUsageByTypeWidget.Arn
+              - !GetAtt CodeGenerationByLanguageWidget.Arn
+              - !GetAtt LinesOfCodeWidget.Arn
+              - !GetAtt CommitsWidget.Arn
+              - !GetAtt CodeAcceptanceWidget.Arn
+              - !GetAtt ActiveHoursWidget.Arn
+
 Outputs:
   DashboardURL:
     Description: Direct URL to the CloudWatch dashboard
@@ -889,3 +919,11 @@ Outputs:
     Value: !Ref MetricsAggregatorRole
     Export:
       Name: !Sub '${AWS::StackName}-MetricsAggregatorRoleName'
+
+  DashboardViewerPolicyArn:
+    Description: >-
+      ARN of the IAM managed policy that grants lambda:InvokeFunction on
+      dashboard widget Lambdas. Attach to read-only roles for dashboard access.
+    Value: !Ref DashboardViewerPolicy
+    Export:
+      Name: !Sub '${AWS::StackName}-DashboardViewerPolicyArn'

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -709,7 +709,9 @@ class DeployCommand(Command):
                     # Deploy the packaged template with MetricsRegion parameter
                     params = [f"MetricsRegion={profile.aws_region}"]
                     return deploy_with_cf(
-                        packaged_template_path, stack_name, params, task_description="Deploying monitoring dashboard..."
+                        packaged_template_path, stack_name, params,
+                        capabilities=["CAPABILITY_NAMED_IAM"],
+                        task_description="Deploying monitoring dashboard...",
                     )
 
                 finally:


### PR DESCRIPTION
## fix: Read-only IAM roles cannot invoke CloudWatch Dashboard Lambda widgets

Closes #150

### Problem

The CloudWatch dashboard stack deploys 13 Lambda-backed custom widgets. CloudWatch requires the **viewing user's** IAM role to have `lambda:InvokeFunction` on the widget Lambda ARNs to render them. The stack had no such policy, so any customer following least-privilege IAM patterns saw empty/broken widgets.

### Changes

| File | Change |
|------|--------|
| `deployment/infrastructure/claude-code-dashboard.yaml` | Added `DashboardViewerPolicy` (managed IAM policy) granting `lambda:InvokeFunction` on all 13 widget Lambdas. Added `DashboardViewerPolicyArn` stack output/export. |
| `source/claude_code_with_bedrock/cli/commands/deploy.py` | Updated dashboard deploy to pass `CAPABILITY_NAMED_IAM` (required because the policy uses a custom name). |

### Usage

After deploying, attach the exported policy to any read-only role that needs dashboard access:

```bash
aws iam attach-role-policy \
  --role-name <viewer-role> \
  --policy-arn $(aws cloudformation describe-stacks \
    --stack-name <dashboard-stack> \
    --query "Stacks[0].Outputs[?OutputKey=='DashboardViewerPolicyArn'].OutputValue" \
    --output text)
```

