### PR TITLE
fix: remove hardcoded OTEL attributes

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -2409,9 +2409,6 @@ Available metrics include:
                                 "OTEL_LOGS_EXPORTER": "otlp",
                                 "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
                                 "OTEL_EXPORTER_OTLP_ENDPOINT": endpoint,
-                                # Add basic OTEL resource attributes for multi-team support
-                                "OTEL_RESOURCE_ATTRIBUTES": "department=engineering,team.id=default, \
-                                cost_center=default,organization=default",
                             }
                         )
 


### PR DESCRIPTION
*Issue #, if available:*  #192
*Description of changes:*

Removes hardcoded `OTEL_RESOURCE_ATTRIBUTES` from the default `.claude/settings.json`.

Hardcoded attributes override the extracted headers from otel-helper.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
