### PR TITLE
fix(package): include quota fields in config export

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -1708,6 +1708,12 @@ RUN pyinstaller \
         if hasattr(profile, "selected_model") and profile.selected_model:
             config[profile_name]["selected_model"] = profile.selected_model
 
+        # Add quota fields if configured
+        if getattr(profile, "quota_api_endpoint", None):
+            config[profile_name]["quota_api_endpoint"] = profile.quota_api_endpoint
+            config[profile_name]["quota_check_interval"] = profile.quota_check_interval
+            config[profile_name]["quota_fail_mode"] = profile.quota_fail_mode
+
         # Add confidential client fields for Azure AD if present.
         # client_secret is never written to config.json — it lives in the OS keyring.
         # End users set it with: credential-process --set-client-secret --profile <profile>


### PR DESCRIPTION
## Summary

Fixes #131

Quota profile fields (`quota_api_endpoint`, `quota_check_interval`, `quota_fail_mode`) were defined and loaded correctly but never written during `package export`, causing them to be silently dropped from the generated `config.json`.

All three fields are gated on `quota_api_endpoint` being set, since it is the field that activates the feature and the other two have non-falsy defaults.

## Test plan

- [x] Configure a profile with `quota_api_endpoint`, `quota_check_interval`, and `quota_fail_mode` set
- [x] Run `package export` and inspect the generated `config.json`
- [x] Confirm all three quota fields are present in the output
- [x] Confirm profiles without `quota_api_endpoint` are unaffected