### PR TITLE
fix(cli): add bare namespace commands for quota, context, and config

### DIFF
--- a/source/claude_code_with_bedrock/cli/__init__.py
+++ b/source/claude_code_with_bedrock/cli/__init__.py
@@ -8,9 +8,11 @@ from cleo.application import Application
 from .commands.builds import BuildsCommand
 from .commands.cleanup import CleanupCommand
 from .commands.context import (
+    ConfigCommand,
     ConfigExportCommand,
     ConfigImportCommand,
     ConfigValidateCommand,
+    ContextCommand,
     ContextCurrentCommand,
     ContextListCommand,
     ContextShowCommand,
@@ -22,6 +24,7 @@ from .commands.distribute import DistributeCommand
 from .commands.init import InitCommand
 from .commands.package import PackageCommand
 from .commands.quota import (
+    QuotaCommand,
     QuotaDeleteCommand,
     QuotaExportCommand,
     QuotaImportCommand,
@@ -56,17 +59,20 @@ def create_application() -> Application:
     # application.add(TokenCommand())  # Temporarily disabled
 
     # Context management commands
+    application.add(ContextCommand())
     application.add(ContextListCommand())
     application.add(ContextCurrentCommand())
     application.add(ContextUseCommand())
     application.add(ContextShowCommand())
 
     # Config management commands
+    application.add(ConfigCommand())
     application.add(ConfigValidateCommand())
     application.add(ConfigExportCommand())
     application.add(ConfigImportCommand())
 
     # Quota management commands
+    application.add(QuotaCommand())
     application.add(QuotaSetUserCommand())
     application.add(QuotaSetGroupCommand())
     application.add(QuotaSetDefaultCommand())

--- a/source/claude_code_with_bedrock/cli/__init__.py
+++ b/source/claude_code_with_bedrock/cli/__init__.py
@@ -9,9 +9,11 @@ from .commands.builds import BuildsCommand
 from .commands.cleanup import CleanupCommand
 from .commands.cowork import CoworkGenerateCommand
 from .commands.context import (
+    ConfigCommand,
     ConfigExportCommand,
     ConfigImportCommand,
     ConfigValidateCommand,
+    ContextCommand,
     ContextCurrentCommand,
     ContextListCommand,
     ContextShowCommand,
@@ -24,6 +26,7 @@ from .commands.init import InitCommand
 from .commands.package import PackageCommand
 from .commands.package_cb import PackageCbCommand
 from .commands.quota import (
+    QuotaCommand,
     QuotaDeleteCommand,
     QuotaExportCommand,
     QuotaImportCommand,
@@ -60,17 +63,20 @@ def create_application() -> Application:
     # application.add(TokenCommand())  # Temporarily disabled
 
     # Context management commands
+    application.add(ContextCommand())
     application.add(ContextListCommand())
     application.add(ContextCurrentCommand())
     application.add(ContextUseCommand())
     application.add(ContextShowCommand())
 
     # Config management commands
+    application.add(ConfigCommand())
     application.add(ConfigValidateCommand())
     application.add(ConfigExportCommand())
     application.add(ConfigImportCommand())
 
     # Quota management commands
+    application.add(QuotaCommand())
     application.add(QuotaSetUserCommand())
     application.add(QuotaSetGroupCommand())
     application.add(QuotaSetDefaultCommand())

--- a/source/claude_code_with_bedrock/cli/commands/__init__.py
+++ b/source/claude_code_with_bedrock/cli/commands/__init__.py
@@ -8,6 +8,7 @@ from .deploy import DeployCommand
 from .destroy import DestroyCommand
 from .init import InitCommand
 from .package import PackageCommand
+from .quota import QuotaCommand
 from .status import StatusCommand
 from .test import TestCommand
 
@@ -19,4 +20,5 @@ __all__ = [
     "PackageCommand",
     "BuildsCommand",
     "DestroyCommand",
+    "QuotaCommand",
 ]

--- a/source/claude_code_with_bedrock/cli/commands/__init__.py
+++ b/source/claude_code_with_bedrock/cli/commands/__init__.py
@@ -9,6 +9,7 @@ from .deploy import DeployCommand
 from .destroy import DestroyCommand
 from .init import InitCommand
 from .package import PackageCommand
+from .quota import QuotaCommand
 from .status import StatusCommand
 from .test import TestCommand
 
@@ -21,4 +22,5 @@ __all__ = [
     "BuildsCommand",
     "DestroyCommand",
     "CoworkGenerateCommand",
+    "QuotaCommand",
 ]

--- a/source/claude_code_with_bedrock/cli/commands/context.py
+++ b/source/claude_code_with_bedrock/cli/commands/context.py
@@ -14,6 +14,28 @@ from claude_code_with_bedrock.config import Config
 from claude_code_with_bedrock.validators import ProfileValidator
 
 
+class ContextCommand(Command):
+    """Manage deployment profile contexts."""
+
+    name = "context"
+    description = "Manage deployment profile contexts (run 'ccwb context --help' for subcommands)"
+
+    def handle(self) -> int:
+        """Show available context subcommands."""
+        self.line("")
+        self.line("<info>Usage:</info>")
+        self.line("  context <subcommand> [options]")
+        self.line("")
+        self.line("<info>Available subcommands:</info>")
+        self.line("  <comment>context list</comment>     List all available deployment profiles")
+        self.line("  <comment>context current</comment>  Show the currently active deployment profile")
+        self.line("  <comment>context use</comment>      Switch to a different deployment profile")
+        self.line("  <comment>context show</comment>     Show detailed information about a deployment profile")
+        self.line("")
+        self.line("Run <comment>ccwb context <subcommand> --help</comment> for details on a subcommand.")
+        return 0
+
+
 class ContextListCommand(Command):
     """List all available profiles."""
 
@@ -237,6 +259,27 @@ class ContextShowCommand(Command):
         except Exception as e:
             console.print(f"\n[red]Error: {e}[/red]\n")
             return 1
+
+
+class ConfigCommand(Command):
+    """Manage profile configuration."""
+
+    name = "config"
+    description = "Manage profile configuration (run 'ccwb config --help' for subcommands)"
+
+    def handle(self) -> int:
+        """Show available config subcommands."""
+        self.line("")
+        self.line("<info>Usage:</info>")
+        self.line("  config <subcommand> [options]")
+        self.line("")
+        self.line("<info>Available subcommands:</info>")
+        self.line("  <comment>config validate</comment>  Validate profile configuration for errors")
+        self.line("  <comment>config export</comment>    Export profile configuration (sanitized for sharing)")
+        self.line("  <comment>config import</comment>    Import profile configuration from file")
+        self.line("")
+        self.line("Run <comment>ccwb config <subcommand> --help</comment> for details on a subcommand.")
+        return 0
 
 
 class ConfigValidateCommand(Command):

--- a/source/claude_code_with_bedrock/cli/commands/context.py
+++ b/source/claude_code_with_bedrock/cli/commands/context.py
@@ -14,6 +14,28 @@ from claude_code_with_bedrock.config import Config
 from claude_code_with_bedrock.validators import ProfileValidator
 
 
+class ContextCommand(Command):
+    """Manage deployment profile contexts."""
+
+    name = "context"
+    description = "Manage deployment profile contexts (run 'ccwb context --help' for subcommands)"
+
+    def handle(self) -> int:
+        """Show available context subcommands."""
+        self.line("")
+        self.line("<info>Usage:</info>")
+        self.line("  context <subcommand> [options]")
+        self.line("")
+        self.line("<info>Available subcommands:</info>")
+        self.line("  <comment>context list</comment>     List all available deployment profiles")
+        self.line("  <comment>context current</comment>  Show the currently active deployment profile")
+        self.line("  <comment>context use</comment>      Switch to a different deployment profile")
+        self.line("  <comment>context show</comment>     Show detailed information about a deployment profile")
+        self.line("")
+        self.line("Run <comment>ccwb context <subcommand> --help</comment> for details on a subcommand.")
+        return 0
+
+
 class ContextListCommand(Command):
     """List all available profiles."""
 
@@ -241,6 +263,27 @@ class ContextShowCommand(Command):
         except Exception as e:
             console.print(f"\n[red]Error: {e}[/red]\n")
             return 1
+
+
+class ConfigCommand(Command):
+    """Manage profile configuration."""
+
+    name = "config"
+    description = "Manage profile configuration (run 'ccwb config --help' for subcommands)"
+
+    def handle(self) -> int:
+        """Show available config subcommands."""
+        self.line("")
+        self.line("<info>Usage:</info>")
+        self.line("  config <subcommand> [options]")
+        self.line("")
+        self.line("<info>Available subcommands:</info>")
+        self.line("  <comment>config validate</comment>  Validate profile configuration for errors")
+        self.line("  <comment>config export</comment>    Export profile configuration (sanitized for sharing)")
+        self.line("  <comment>config import</comment>    Import profile configuration from file")
+        self.line("")
+        self.line("Run <comment>ccwb config <subcommand> --help</comment> for details on a subcommand.")
+        return 0
 
 
 class ConfigValidateCommand(Command):

--- a/source/claude_code_with_bedrock/cli/commands/quota.py
+++ b/source/claude_code_with_bedrock/cli/commands/quota.py
@@ -127,6 +127,34 @@ def _parse_tokens(value: str) -> int:
     return int(value)
 
 
+class QuotaCommand(Command):
+    """Manage quota policies."""
+
+    name = "quota"
+    description = "Manage quota policies (run 'ccwb quota --help' for subcommands)"
+
+    def handle(self) -> int:
+        """Show available quota subcommands."""
+        self.line("")
+        self.line("<info>Usage:</info>")
+        self.line("  quota <subcommand> [options]")
+        self.line("")
+        self.line("<info>Available subcommands:</info>")
+        self.line("  <comment>quota set-user</comment>     Set quota policy for a specific user")
+        self.line("  <comment>quota set-group</comment>    Set quota policy for a group")
+        self.line("  <comment>quota set-default</comment>  Set the default quota policy")
+        self.line("  <comment>quota list</comment>         List all quota policies")
+        self.line("  <comment>quota show</comment>         Show quota for a specific user or group")
+        self.line("  <comment>quota usage</comment>        Show quota usage and consumption")
+        self.line("  <comment>quota delete</comment>       Delete a quota policy")
+        self.line("  <comment>quota unblock</comment>      Temporarily unblock a quota-exceeded user")
+        self.line("  <comment>quota export</comment>       Export quota policies to a file")
+        self.line("  <comment>quota import</comment>       Import quota policies from a file")
+        self.line("")
+        self.line("Run <comment>ccwb quota <subcommand> --help</comment> for details on a subcommand.")
+        return 0
+
+
 class QuotaSetUserCommand(Command):
     """Set quota policy for a specific user."""
 

--- a/source/tests/cli/commands/test_namespace_commands.py
+++ b/source/tests/cli/commands/test_namespace_commands.py
@@ -1,0 +1,48 @@
+# ABOUTME: Tests for bare namespace CLI commands (quota, config, context)
+# ABOUTME: Ensures running 'ccwb <namespace>' without subcommand shows help, not errors
+
+"""Tests for bare namespace commands.
+
+Prevents issue #264: running 'ccwb quota', 'ccwb config', or 'ccwb context'
+without a subcommand returned 'command does not exist' instead of showing
+available subcommands.
+"""
+
+import pytest
+from cleo.testers.application_tester import ApplicationTester
+
+from claude_code_with_bedrock.cli import create_application
+
+
+class TestBareNamespaceCommands:
+    """Bare namespace commands must print help, not crash or error."""
+
+    @pytest.fixture
+    def app_tester(self):
+        app = create_application()
+        return ApplicationTester(app)
+
+    @pytest.mark.parametrize("namespace", ["quota", "config", "context"])
+    def test_bare_namespace_does_not_error(self, app_tester, namespace):
+        """Running 'ccwb <namespace>' must exit 0 and not say 'does not exist'."""
+        app_tester.execute(namespace)
+        output = app_tester.io.fetch_output()
+        assert "does not exist" not in output
+        assert app_tester.status_code == 0
+
+    @pytest.mark.parametrize("namespace", ["quota", "config", "context"])
+    def test_bare_namespace_shows_subcommands(self, app_tester, namespace):
+        """Running 'ccwb <namespace>' must list available subcommands."""
+        app_tester.execute(namespace)
+        output = app_tester.io.fetch_output()
+        # Should mention at least one subcommand
+        assert "subcommand" in output.lower() or namespace in output.lower()
+
+    def test_all_registered_commands_have_handle(self):
+        """Every command in the application must have a handle() method."""
+        app = create_application()
+        for name in app._commands:
+            cmd = app._commands[name]
+            assert hasattr(cmd, 'handle'), (
+                f"Command '{name}' is registered but has no handle() method"
+            )


### PR DESCRIPTION
## Summary

Fixes #264

- Running `ccwb quota`, `ccwb context`, or `ccwb config` without a subcommand previously failed with `The command "X" does not exist.`
- Added bare `QuotaCommand`, `ContextCommand`, and `ConfigCommand` that display available subcommands and usage help
- All existing subcommands are unaffected (verified via full test suite — 192 passing, 4 pre-existing failures unrelated to this change)

## Test plan

- [ ] `ccwb quota` prints subcommand list instead of erroring
- [ ] `ccwb context` prints subcommand list instead of erroring
- [ ] `ccwb config` prints subcommand list instead of erroring
- [ ] `ccwb quota list`, `ccwb context list`, `ccwb config validate` still work as before