### PR TITLE
Add model alias and opusplan support for ANTHROPIC_MODEL

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1276,6 +1276,34 @@ class InitCommand(Command):
             config["aws"]["selected_model"] = model_id
             config["aws"]["cross_region_profile"] = selected_profile
 
+            # For Opus models, ask whether to use opusplan or standard opus
+            if selected_model_key.startswith("opus"):
+                saved_alias = config.get("aws", {}).get("model_alias")
+                opus_alias = questionary.select(
+                    "How should Claude Code use this Opus model?",
+                    choices=[
+                        questionary.Choice(
+                            title="opusplan  Use Opus during plan mode, then switch to Sonnet for execution",
+                            value="opusplan",
+                        ),
+                        questionary.Choice(
+                            title="opus       Standard Opus for all interactions",
+                            value="opus",
+                        ),
+                    ],
+                    default=saved_alias if saved_alias in ("opusplan", "opus") else "opusplan",
+                    instruction="(Use arrow keys to select, Enter to confirm)",
+                ).ask()
+
+                if opus_alias is None:  # User cancelled
+                    return None
+
+                config["aws"]["model_alias"] = opus_alias
+                console.print(f"[green]✓[/green] Model alias: {opus_alias}")
+            else:
+                # For non-Opus models, alias is derived automatically from the tier
+                config["aws"].pop("model_alias", None)
+
             # Get destination regions for the model/profile combination
             destination_regions = get_destination_regions_for_model_profile(selected_model_key, selected_profile)
 
@@ -1618,6 +1646,7 @@ class InitCommand(Command):
             allowed_bedrock_regions=config_data["aws"]["allowed_bedrock_regions"],
             cross_region_profile=config_data["aws"].get("cross_region_profile", "us"),
             selected_model=config_data["aws"].get("selected_model"),
+            model_alias=config_data["aws"].get("model_alias"),
             selected_source_region=config_data["aws"].get("selected_source_region"),
             provider_type=config_data.get("provider_type"),
             cognito_user_pool_id=config_data.get("cognito_user_pool_id"),

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1525,6 +1525,34 @@ class InitCommand(Command):
             config["aws"]["selected_model"] = model_id
             config["aws"]["cross_region_profile"] = selected_profile
 
+            # For Opus models, ask whether to use opusplan or standard opus
+            if selected_model_key.startswith("opus"):
+                saved_alias = config.get("aws", {}).get("model_alias")
+                opus_alias = questionary.select(
+                    "How should Claude Code use this Opus model?",
+                    choices=[
+                        questionary.Choice(
+                            title="opusplan  Use Opus during plan mode, then switch to Sonnet for execution",
+                            value="opusplan",
+                        ),
+                        questionary.Choice(
+                            title="opus       Standard Opus for all interactions",
+                            value="opus",
+                        ),
+                    ],
+                    default=saved_alias if saved_alias in ("opusplan", "opus") else "opusplan",
+                    instruction="(Use arrow keys to select, Enter to confirm)",
+                ).ask()
+
+                if opus_alias is None:  # User cancelled
+                    return None
+
+                config["aws"]["model_alias"] = opus_alias
+                console.print(f"[green]✓[/green] Model alias: {opus_alias}")
+            else:
+                # For non-Opus models, alias is derived automatically from the tier
+                config["aws"].pop("model_alias", None)
+
             # Get destination regions for the model/profile combination
             destination_regions = get_destination_regions_for_model_profile(selected_model_key, selected_profile)
 
@@ -2009,6 +2037,7 @@ class InitCommand(Command):
             allowed_bedrock_regions=config_data["aws"]["allowed_bedrock_regions"],
             cross_region_profile=config_data["aws"].get("cross_region_profile", "us"),
             selected_model=config_data["aws"].get("selected_model"),
+            model_alias=config_data["aws"].get("model_alias"),
             selected_source_region=config_data["aws"].get("selected_source_region"),
             inference_profile_opus_arn=config_data["aws"].get("inference_profile_opus_arn"),
             inference_profile_sonnet_arn=config_data["aws"].get("inference_profile_sonnet_arn"),

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -2386,14 +2386,19 @@ Available metrics include:
 
             # Add selected model as environment variable if available
             if hasattr(profile, "selected_model") and profile.selected_model:
-                settings["env"]["ANTHROPIC_MODEL"] = profile.selected_model
+                from claude_code_with_bedrock.models import get_claude_code_alias, resolve_model_for_tier
+
+                # Use a Claude Code alias (sonnet/opus/opusplan/haiku) so ANTHROPIC_MODEL
+                # feeds through the DEFAULT_*_MODEL resolution chain for CRIS-aware routing.
+                # model_alias is set during ccwb init (e.g. opus vs opusplan for Opus models).
+                alias = getattr(profile, "model_alias", None) or get_claude_code_alias(profile.selected_model)
+                settings["env"]["ANTHROPIC_MODEL"] = alias or profile.selected_model
 
                 # Set all model tier env vars using the CRIS prefix from init.
                 # Claude Code uses these to resolve the correct CRIS-prefixed
                 # models for each tier (small/fast, default sonnet/opus/haiku).
                 # This ensures all tiers respect the admin's routing geography
                 # choice and works correctly with model aliases like 'opusplan'.
-                from claude_code_with_bedrock.models import resolve_model_for_tier
                 cris_prefix = getattr(profile, "cross_region_profile", None) or "us"
 
                 haiku_model = resolve_model_for_tier("haiku", cris_prefix)

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -2842,14 +2842,19 @@ Available metrics include:
 
             # Add ANTHROPIC_MODEL if user selected a model during init
             if hasattr(profile, "selected_model") and profile.selected_model:
-                settings["env"]["ANTHROPIC_MODEL"] = profile.selected_model
+                from claude_code_with_bedrock.models import get_claude_code_alias, resolve_model_for_tier
+
+                # Use a Claude Code alias (sonnet/opus/opusplan/haiku) so ANTHROPIC_MODEL
+                # feeds through the DEFAULT_*_MODEL resolution chain for CRIS-aware routing.
+                # model_alias is set during ccwb init (e.g. opus vs opusplan for Opus models).
+                alias = getattr(profile, "model_alias", None) or get_claude_code_alias(profile.selected_model)
+                settings["env"]["ANTHROPIC_MODEL"] = alias or profile.selected_model
 
                 # Set all model tier env vars using the CRIS prefix from init.
                 # Claude Code uses these to resolve the correct CRIS-prefixed
                 # models for each tier (small/fast, default sonnet/opus/haiku).
                 # This ensures all tiers respect the admin's routing geography
-                # choice and works correctly with model aliases like 'opusplan'.
-                from claude_code_with_bedrock.models import resolve_model_for_tier
+                # choice and works correctly with model aliases like 'opus', 'sonnet', 'haiku', 'opusplan'.
                 cris_prefix = getattr(profile, "cross_region_profile", None) or "us"
 
                 haiku_model = resolve_model_for_tier("haiku", cris_prefix)

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -32,6 +32,7 @@ class Profile:
     allowed_bedrock_regions: list[str] = field(default_factory=list)
     cross_region_profile: str | None = None  # Cross-region profile: "us", "europe", "apac"
     selected_model: str | None = None  # Selected Claude model ID (e.g., "us.anthropic.claude-3-7-sonnet-20250805-v1:0")
+    model_alias: str | None = None  # Claude Code alias for ANTHROPIC_MODEL: "sonnet", "opus", "opusplan", "haiku"
     selected_source_region: str | None = None  # User-selected source region for AWS config and Claude Code settings
     created_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
     updated_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -33,6 +33,7 @@ class Profile:
     allowed_bedrock_regions: list[str] = field(default_factory=list)
     cross_region_profile: str | None = None  # Cross-region profile: "us", "europe", "apac"
     selected_model: str | None = None  # Selected Claude model ID (e.g., "us.anthropic.claude-3-7-sonnet-20250805-v1:0")
+    model_alias: str | None = None  # Claude Code alias for ANTHROPIC_MODEL: "sonnet", "opus", "opusplan", "haiku"
     selected_source_region: str | None = None  # User-selected source region for AWS config and Claude Code settings
     created_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
     updated_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())

--- a/source/claude_code_with_bedrock/models.py
+++ b/source/claude_code_with_bedrock/models.py
@@ -1208,6 +1208,35 @@ PROFILE_KEY_ALIASES = {
 # These geographies have strict data residency requirements.
 DATA_RESIDENCY_PREFIXES = {"au", "jp", "eu"}
 
+# Auto-derived from MODEL_TIER_PREFERENCES: model_key → tier
+MODEL_KEY_TO_TIER: dict[str, str] = {
+    model_key: tier
+    for tier, model_keys in MODEL_TIER_PREFERENCES.items()
+    for model_key in model_keys
+}
+
+# Maps tier → Claude Code model alias used in ANTHROPIC_MODEL env var
+TIER_TO_CLAUDE_CODE_ALIAS: dict[str, str] = {
+    "sonnet": "sonnet",
+    "opus": "opus",
+    "haiku": "haiku",
+}
+
+
+def get_claude_code_alias(model_id: str) -> str | None:
+    """Given a full CRIS model ID, return the Claude Code tier alias.
+
+    Returns 'sonnet', 'opus', 'haiku', or None if model is unrecognised.
+    Callers may override the returned alias (e.g. replace 'opus' with
+    'opusplan') based on user preference stored in the profile.
+    """
+    for model_key, model_config in CLAUDE_MODELS.items():
+        for profile in model_config["profiles"].values():
+            if profile["model_id"] == model_id:
+                tier = MODEL_KEY_TO_TIER.get(model_key)
+                return TIER_TO_CLAUDE_CODE_ALIAS.get(tier) if tier else None
+    return None
+
 
 def resolve_model_for_tier(tier: str, cris_prefix: str) -> str | None:
     """Resolve the best available model ID for a tier and CRIS prefix.

--- a/source/tests/test_models.py
+++ b/source/tests/test_models.py
@@ -10,6 +10,7 @@ from claude_code_with_bedrock.models import (
     DEFAULT_REGIONS,
     get_all_model_display_names,
     get_available_profiles_for_model,
+    get_claude_code_alias,
     get_default_region_for_profile,
     get_destination_regions_for_model_profile,
     get_model_id_for_profile,
@@ -461,6 +462,24 @@ class TestResolveModelForTier:
 
         opus = resolve_model_for_tier("opus", "apac")
         assert opus is not None and "global." in opus
+
+    def test_get_claude_code_alias_sonnet(self):
+        """Sonnet CRIS model IDs resolve to 'sonnet' alias."""
+        assert get_claude_code_alias("us.anthropic.claude-sonnet-4-6") == "sonnet"
+        assert get_claude_code_alias("eu.anthropic.claude-sonnet-4-6") == "sonnet"
+
+    def test_get_claude_code_alias_opus(self):
+        """Opus CRIS model IDs resolve to 'opus' alias."""
+        assert get_claude_code_alias("us.anthropic.claude-opus-4-7") == "opus"
+        assert get_claude_code_alias("eu.anthropic.claude-opus-4-6-v1") == "opus"
+
+    def test_get_claude_code_alias_haiku(self):
+        """Haiku CRIS model IDs resolve to 'haiku' alias."""
+        assert get_claude_code_alias("us.anthropic.claude-haiku-4-5-20251001-v1:0") == "haiku"
+
+    def test_get_claude_code_alias_unknown(self):
+        """Unknown model IDs return None."""
+        assert get_claude_code_alias("us.anthropic.claude-unknown-99") is None
 
     def test_data_residency_prefixes_match_api(self):
         """Every prefix from the live API should resolve all available tiers."""


### PR DESCRIPTION
## Summary

Adds model alias support for `ANTHROPIC_MODEL` in managed_settings, replacing raw CRIS model IDs with Claude Code tier aliases (`sonnet`, `opus`, `opusplan`, `haiku`). This lets Claude Code use its built-in model resolution chain for CRIS-aware routing.

## Model options

| Alias | ANTHROPIC_MODEL value | Behavior |
|---|---|---|
| **sonnet** | `sonnet` | Standard Sonnet for all interactions |
| **opus** | `opus` | Standard Opus for all interactions |
| **opusplan** | `opusplan` | Opus during plan/thinking mode, then switches to Sonnet for execution (cost-optimized) |
| **haiku** | `haiku` | Haiku for all interactions |

### opusplan vs opus

- **`opus`** — every request uses Opus regardless of whether Claude is planning or executing
- **`opusplan`** — Claude Code's built-in mode that uses Opus for the planning/reasoning phase, then automatically switches to Sonnet for code execution. Gives Opus-quality thinking at Sonnet-level execution cost.

## How it works

1. During `ccwb init`, if admin selects an Opus model, they are prompted:
   ```
   How should Claude Code use this Opus model?
   > opusplan  Use Opus during plan mode, then switch to Sonnet for execution
     opus       Standard Opus for all interactions
   ```

2. `ccwb package` writes the alias to managed_settings:
   ```json
   { "env": { "ANTHROPIC_MODEL": "opusplan" } }
   ```
   Instead of the raw CRIS ID like `us.anthropic.claude-opus-4-7-v1:0`

3. Claude Code resolves the alias through its `DEFAULT_OPUS_MODEL` / `DEFAULT_SONNET_MODEL` chain, respecting the CRIS region prefix set in other env vars.

## Changes

| File | What |
|---|---|
| `models.py` | `MODEL_KEY_TO_TIER`, `TIER_TO_CLAUDE_CODE_ALIAS`, `get_claude_code_alias()` |
| `config.py` | `model_alias` field on Profile |
| `init.py` | Opus model prompt (opusplan vs opus choice) |
| `package.py` | Resolve ANTHROPIC_MODEL via alias with CRIS ID fallback |
| `test_models.py` | 4 tests for alias resolution (sonnet, opus, haiku, unknown) |

## Non-Opus models

For Sonnet/Haiku selections, the alias is auto-derived (no prompt needed). The admin just picks the model and the correct alias is written automatically.