### PR TITLE
fix: EnableFinegrainedQuotas should be set based on profile setting

### DIFF
--- a/assets/docs/QUOTA_MONITORING.md
+++ b/assets/docs/QUOTA_MONITORING.md
@@ -50,7 +50,7 @@ Deploy using `poetry run ccwb deploy` (deploys all enabled stacks) or `poetry ru
 | Critical Threshold      | 90% (202.5M)| Second alert level                             |
 | Check Frequency         | 15 minutes  | Lambda execution interval                      |
 | Alert Retention         | 60 days     | DynamoDB TTL for deduplication                 |
-| EnableFinegrainedQuotas | true        | Enable fine-grained policy support             |
+| EnableFinegrainedQuotas | false       | Enable fine-grained policy support             |
 
 To update limits: Re-run `ccwb init` and redeploy with `ccwb deploy quota`.
 

--- a/deployment/infrastructure/quota-monitoring.yaml
+++ b/deployment/infrastructure/quota-monitoring.yaml
@@ -52,7 +52,7 @@ Parameters:
 
   EnableFinegrainedQuotas:
     Type: String
-    Default: 'true'
+    Default: 'false'
     AllowedValues:
       - 'true'
       - 'false'

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -793,6 +793,10 @@ class DeployCommand(Command):
                     oidc_issuer_url = f"{oidc_issuer_url}/"
                 oidc_client_id = profile.client_id
 
+                # Pass explicitly so the profile is the source of truth; the CF template
+                # default is 'false' to match the opt-in intent of this field.
+                enable_finegrained_quotas = profile.enable_finegrained_quotas
+
                 params = [
                     f"MonthlyTokenLimit={monthly_limit}",
                     f"MetricsTableArn={dashboard_outputs['MetricsTableArn']}",
@@ -804,6 +808,7 @@ class DeployCommand(Command):
                     f"MonthlyEnforcementMode={monthly_enforcement}",
                     f"OidcIssuerUrl={oidc_issuer_url}",
                     f"OidcClientId={oidc_client_id}",
+                    f"EnableFinegrainedQuotas={str(enable_finegrained_quotas).lower()}",
                 ]
 
                 # Package the template using AWS CLI


### PR DESCRIPTION
The quota-monitoring CF template had Default: 'true' for EnableFinegrainedQuotas, and deploy.py never passed the parameter explicitly, so fine-grained quotas were unconditionally enabled.

Changed the template default to 'false' to keep the opt-in intent of profile.enable_finegrained_quotas and now pass the value explicitly so the profile is always the source of truth.

Closes: https://github.com/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock/issues/279


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
