### PR TITLE
fix: preserve sso_enabled when pre-populating existing profile in ccwb init

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -296,23 +296,27 @@ class InitCommand(Command):
             console.print("\n[bold blue]Step 1: Authentication Configuration[/bold blue]")
             console.print("─" * 40)
 
-            console.print("\n[bold]SSO Authentication[/bold]")
-            console.print("Enable Single Sign-On authentication via identity providers")
-            console.print("(Okta, Auth0, Azure AD, AWS Cognito)")
-            console.print("\nWhen disabled:")
-            console.print("  • Uses AWS IAM roles for access control")
-            console.print("  • Metrics will use anonymous tracking based on IAM identity")
-            console.print("  • No user authentication required\n")
+            # Skip the SSO toggle when updating an existing profile — preserve the saved value
+            if existing_config and "sso_enabled" in existing_config:
+                config["sso_enabled"] = existing_config["sso_enabled"]
+            else:
+                console.print("\n[bold]SSO Authentication[/bold]")
+                console.print("Enable Single Sign-On authentication via identity providers")
+                console.print("(Okta, Auth0, Azure AD, AWS Cognito)")
+                console.print("\nWhen disabled:")
+                console.print("  • Uses AWS IAM roles for access control")
+                console.print("  • Metrics will use anonymous tracking based on IAM identity")
+                console.print("  • No user authentication required\n")
 
-            sso_enabled = questionary.confirm(
-                "Enable SSO authentication?",
-                default=config.get("sso_enabled", True),
-            ).ask()
+                sso_enabled = questionary.confirm(
+                    "Enable SSO authentication?",
+                    default=config.get("sso_enabled", True),
+                ).ask()
 
-            if sso_enabled is None:
-                return None
+                if sso_enabled is None:
+                    return None
 
-            config["sso_enabled"] = sso_enabled
+                config["sso_enabled"] = sso_enabled
 
         # OIDC Provider Configuration
         if not skip_okta and config.get("sso_enabled", True):
@@ -1848,6 +1852,10 @@ class InitCommand(Command):
                     else None,
                 },
             }
+
+            # Preserve sso_enabled flag (added in PR #71; missing here caused it to always default to True)
+            if hasattr(profile, "sso_enabled"):
+                existing_config["sso_enabled"] = profile.sso_enabled
 
             # Add provider type if present (critical to preserve during updates)
             if hasattr(profile, "provider_type") and profile.provider_type:

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -317,23 +317,27 @@ class InitCommand(Command):
             console.print("\n[bold blue]Step 1: Authentication Configuration[/bold blue]")
             console.print("─" * 40)
 
-            console.print("\n[bold]SSO Authentication[/bold]")
-            console.print("Enable Single Sign-On authentication via identity providers")
-            console.print("(Okta, Auth0, Azure AD, AWS Cognito)")
-            console.print("\nWhen disabled:")
-            console.print("  • Uses AWS IAM roles for access control")
-            console.print("  • Metrics will use anonymous tracking based on IAM identity")
-            console.print("  • No user authentication required\n")
+            # Skip the SSO toggle when updating an existing profile — preserve the saved value
+            if existing_config and "sso_enabled" in existing_config:
+                config["sso_enabled"] = existing_config["sso_enabled"]
+            else:
+                console.print("\n[bold]SSO Authentication[/bold]")
+                console.print("Enable Single Sign-On authentication via identity providers")
+                console.print("(Okta, Auth0, Azure AD, AWS Cognito)")
+                console.print("\nWhen disabled:")
+                console.print("  • Uses AWS IAM roles for access control")
+                console.print("  • Metrics will use anonymous tracking based on IAM identity")
+                console.print("  • No user authentication required\n")
 
-            sso_enabled = questionary.confirm(
-                "Enable SSO authentication?",
-                default=config.get("sso_enabled", True),
-            ).ask()
+                sso_enabled = questionary.confirm(
+                    "Enable SSO authentication?",
+                    default=config.get("sso_enabled", True),
+                ).ask()
 
-            if sso_enabled is None:
-                return None
+                if sso_enabled is None:
+                    return None
 
-            config["sso_enabled"] = sso_enabled
+                config["sso_enabled"] = sso_enabled
 
         # OIDC Provider Configuration
         if not skip_okta and config.get("sso_enabled", True):
@@ -2307,6 +2311,10 @@ class InitCommand(Command):
                     else None,
                 },
             }
+
+            # Preserve sso_enabled flag (added in PR #71; missing here caused it to always default to True)
+            if hasattr(profile, "sso_enabled"):
+                existing_config["sso_enabled"] = profile.sso_enabled
 
             # Add provider type if present (critical to preserve during updates)
             if hasattr(profile, "provider_type") and profile.provider_type:

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -121,6 +121,12 @@ class Profile:
         if "credential_storage" not in data:
             data["credential_storage"] = "session"
 
+        # Infer sso_enabled for profiles saved before PR #71 introduced the field:
+        # if provider_domain is set to a real value, SSO was enabled.
+        if "sso_enabled" not in data:
+            domain = data.get("provider_domain", "none")
+            data["sso_enabled"] = bool(domain and domain != "none")
+
         # Auto-detect provider type if not set
         if "provider_type" not in data and "provider_domain" in data:
             domain = data["provider_domain"]

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -147,6 +147,12 @@ class Profile:
         if "credential_storage" not in data:
             data["credential_storage"] = "session"
 
+        # Infer sso_enabled for profiles saved before PR #71 introduced the field:
+        # if provider_domain is set to a real value, SSO was enabled.
+        if "sso_enabled" not in data:
+            domain = data.get("provider_domain", "none")
+            data["sso_enabled"] = bool(domain and domain != "none")
+
         # Auto-detect provider type if not set
         if "provider_type" not in data and "provider_domain" in data:
             domain = data["provider_domain"]


### PR DESCRIPTION
## Summary

- Fixes #283
- PR #71 (merged 2026-04-20) introduced `sso_enabled` but left three gaps, all fixed here:
  - `_check_existing_deployment()` never included `sso_enabled` in the returned dict, so the wizard always defaulted to `True` when pre-populating an existing profile
  - The SSO toggle prompt was shown even when updating an existing profile that already had SSO configured — it now skips the prompt and carries the saved value forward silently
  - Old profile files (saved before PR #71) don't have `sso_enabled`; `Profile.from_dict()` now infers it from `provider_domain` so legacy profiles load correctly

## Test plan

- [ ] Run `ccwb init` and update an existing Cognito profile — SSO prompt should not appear
- [ ] Run `ccwb init` and update an existing IAM-only profile (`sso_enabled: false`) — SSO prompt should not appear and SSO should remain disabled
- [ ] Run `ccwb init` on a legacy profile file without `sso_enabled` — should correctly infer `True` if provider domain is set
- [ ] Run `ccwb init` to create a brand new profile — SSO prompt should still appear