### PR TITLE
fix: remove hard AWS CLI dependency from installer

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -1807,10 +1807,10 @@ echo
 # Check prerequisites
 echo "Checking prerequisites..."
 
-if ! command -v aws &> /dev/null; then
-    echo "❌ AWS CLI is not installed"
-    echo "   Please install from https://aws.amazon.com/cli/"
-    exit 1
+if command -v aws &> /dev/null; then
+    echo "✓ AWS CLI found (optional)"
+else
+    echo "ℹ  AWS CLI not found — not required. The credential process binary handles authentication directly."
 fi
 
 echo "✓ Prerequisites found"
@@ -2038,10 +2038,9 @@ echo Checking prerequisites...
 
 where aws >nul 2>&1
 if %errorlevel% neq 0 (
-    echo ERROR: AWS CLI is not installed
-    echo        Please install from https://aws.amazon.com/cli/
-    pause
-    exit /b 1
+    echo INFO: AWS CLI not found -- not required. The credential process binary handles authentication directly.
+) else (
+    echo OK AWS CLI found [optional]
 )
 
 echo OK Prerequisites found
@@ -2352,6 +2351,11 @@ Available metrics include:
                     "CLAUDE_CODE_USE_BEDROCK": "1",
                     # AWS_PROFILE is used by both AWS SDK and otel-helper
                     "AWS_PROFILE": profile_name,
+                    # AWS_CREDENTIAL_PROCESS allows the AWS SDK to obtain credentials
+                    # directly without requiring the AWS CLI or ~/.aws/config.
+                    # The __CREDENTIAL_PROCESS_PATH__ placeholder is replaced by
+                    # install.sh/install.bat with the actual binary path at install time.
+                    "AWS_CREDENTIAL_PROCESS": f"__CREDENTIAL_PROCESS_PATH__ --profile {profile_name}",
                 }
             }
 


### PR DESCRIPTION
Closes #217

## Problem

The installer exits with an error if the AWS CLI is not installed. For organisations with large developer populations (e.g. embedded systems engineers), requiring the AWS CLI purely for an AI coding assistant creates unnecessary friction.

## Fix

One file changed (`package.py`), three targeted edits:

1. **install.sh** — AWS CLI check becomes informational instead of `exit 1`
2. **install.bat** — same for Windows
3. **settings.json** — adds `AWS_CREDENTIAL_PROCESS` env var pointing to the credential binary

## How it works

The credential-process binary calls AWS APIs directly via its bundled SDK — it never needed the AWS CLI. Adding `AWS_CREDENTIAL_PROCESS` to `settings.json` gives the AWS SDK for JavaScript (used by Claude Code) a direct path to invoke the binary, without needing `~/.aws/config` or the CLI.

## Backwards compatible

- Existing installs with AWS CLI: **no change** — `AWS_PROFILE` + `~/.aws/config` still works as before
- The installer still writes `~/.aws/config` (via `cat >>`, not `aws configure`) for users with other AWS tooling
- `AWS_CREDENTIAL_PROCESS` is additive — if `AWS_PROFILE` resolves first, the SDK uses that

Based on the customer-submitted patch attached to #217.