### PR TITLE
fix(otel): remove unconditional HTTPSListener DependsOn

### DIFF
--- a/deployment/infrastructure/otel-collector.yaml
+++ b/deployment/infrastructure/otel-collector.yaml
@@ -492,7 +492,6 @@ Resources:
     Type: AWS::ECS::Service
     DependsOn:
       - HTTPListener
-      - HTTPSListener
     Properties:
       ServiceName: otel-collector-service
       Cluster: !Ref ECSCluster


### PR DESCRIPTION
## Problem

Deploying the monitoring stack **without a custom domain** fails CloudFormation template validation with:

```
Template format error: Unresolved resource dependencies [HTTPSListener] in the Resources block of the template
```

### Root cause

`ECSService` had an unconditional `DependsOn` block that included `HTTPSListener`:

```yaml
DependsOn:
  - HTTPListener
  - HTTPSListener   # <-- problem
```

`HTTPSListener` carries `Condition: HasCustomDomain`, so CloudFormation only creates it when a custom domain is configured. When no custom domain is provided, the resource does not exist but the `DependsOn` reference still resolves — causing a hard validation failure before any stack operation begins.

## Fix

Removed `HTTPSListener` from the `ECSService` `DependsOn` list. `HTTPListener` alone is sufficient to correctly order ECS service creation relative to the load balancer listeners.

## Testing

1. Deploy the monitoring/OTEL stack **without** setting a custom domain.
2. Confirm CloudFormation template validation passes and the stack reaches `CREATE_COMPLETE` (previously it would fail at the validation stage with the unresolved dependency error).
3. Optionally re-deploy **with** a custom domain to confirm the HTTPS path is unaffected.

Closes #286