### PR TITLE
fix(quota): skip JWT authorizer and OIDC params when SSO disabled

### DIFF
--- a/deployment/infrastructure/quota-monitoring.yaml
+++ b/deployment/infrastructure/quota-monitoring.yaml
@@ -61,11 +61,17 @@ Parameters:
   # JWT Authentication Parameters for Quota Check API
   OidcIssuerUrl:
     Type: String
-    Description: OIDC provider issuer URL for JWT validation (e.g., https://company.okta.com)
+    Default: ''
+    Description: OIDC provider issuer URL for JWT validation (e.g., https://company.okta.com) - leave empty to disable JWT auth
 
   OidcClientId:
     Type: String
+    Default: ''
     Description: OIDC client ID (audience) for JWT validation
+
+Conditions:
+  HasJwtAuth: !Not [!Equals [!Ref OidcIssuerUrl, '']]
+  NoJwtAuth: !Equals [!Ref OidcIssuerUrl, '']
 
 Resources:
   # DynamoDB table for quota policies (user, group, default levels)
@@ -296,9 +302,10 @@ Resources:
           - Authorization
         MaxAge: 300
 
-  # JWT Authorizer for OIDC token validation
+  # JWT Authorizer for OIDC token validation (only when SSO is enabled)
   QuotaCheckAuthorizer:
     Type: AWS::ApiGatewayV2::Authorizer
+    Condition: HasJwtAuth
     Properties:
       ApiId: !Ref QuotaCheckApi
       AuthorizerType: JWT
@@ -319,15 +326,24 @@ Resources:
       IntegrationUri: !GetAtt QuotaCheckFunction.Arn
       PayloadFormatVersion: '2.0'
 
-  # Route for GET /check (JWT authenticated)
-  QuotaCheckRoute:
+  # Route for GET /check (JWT authenticated when SSO enabled, open when disabled)
+  QuotaCheckRouteWithAuth:
     Type: AWS::ApiGatewayV2::Route
+    Condition: HasJwtAuth
     Properties:
       ApiId: !Ref QuotaCheckApi
       RouteKey: 'GET /check'
       Target: !Sub 'integrations/${QuotaCheckIntegration}'
       AuthorizerId: !Ref QuotaCheckAuthorizer
       AuthorizationType: JWT
+
+  QuotaCheckRouteNoAuth:
+    Type: AWS::ApiGatewayV2::Route
+    Condition: NoJwtAuth
+    Properties:
+      ApiId: !Ref QuotaCheckApi
+      RouteKey: 'GET /check'
+      Target: !Sub 'integrations/${QuotaCheckIntegration}'
 
   # Default stage with auto-deploy
   QuotaCheckStage:

--- a/deployment/infrastructure/quota-monitoring.yaml
+++ b/deployment/infrastructure/quota-monitoring.yaml
@@ -53,11 +53,17 @@ Parameters:
   # JWT Authentication Parameters for Quota Check API
   OidcIssuerUrl:
     Type: String
-    Description: OIDC provider issuer URL for JWT validation (e.g., https://company.okta.com)
+    Default: ''
+    Description: OIDC provider issuer URL for JWT validation (e.g., https://company.okta.com) - leave empty to disable JWT auth
 
   OidcClientId:
     Type: String
+    Default: ''
     Description: OIDC client ID (audience) for JWT validation
+
+Conditions:
+  HasJwtAuth: !Not [!Equals [!Ref OidcIssuerUrl, '']]
+  NoJwtAuth: !Equals [!Ref OidcIssuerUrl, '']
 
 Resources:
   # DynamoDB table for quota policies (user, group, default levels)
@@ -293,9 +299,10 @@ Resources:
           - Authorization
         MaxAge: 300
 
-  # JWT Authorizer for OIDC token validation
+  # JWT Authorizer for OIDC token validation (only when SSO is enabled)
   QuotaCheckAuthorizer:
     Type: AWS::ApiGatewayV2::Authorizer
+    Condition: HasJwtAuth
     Properties:
       ApiId: !Ref QuotaCheckApi
       AuthorizerType: JWT
@@ -316,15 +323,24 @@ Resources:
       IntegrationUri: !GetAtt QuotaCheckFunction.Arn
       PayloadFormatVersion: '2.0'
 
-  # Route for GET /check (JWT authenticated)
-  QuotaCheckRoute:
+  # Route for GET /check (JWT authenticated when SSO enabled, open when disabled)
+  QuotaCheckRouteWithAuth:
     Type: AWS::ApiGatewayV2::Route
+    Condition: HasJwtAuth
     Properties:
       ApiId: !Ref QuotaCheckApi
       RouteKey: 'GET /check'
       Target: !Sub 'integrations/${QuotaCheckIntegration}'
       AuthorizerId: !Ref QuotaCheckAuthorizer
       AuthorizationType: JWT
+
+  QuotaCheckRouteNoAuth:
+    Type: AWS::ApiGatewayV2::Route
+    Condition: NoJwtAuth
+    Properties:
+      ApiId: !Ref QuotaCheckApi
+      RouteKey: 'GET /check'
+      Target: !Sub 'integrations/${QuotaCheckIntegration}'
 
   # Default stage with auto-deploy
   QuotaCheckStage:

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -803,27 +803,27 @@ class DeployCommand(Command):
                     "MetricsAggregatorRoleName", "claude-code-auth-dashboard-MetricsAggregatorRole-*"
                 )
 
-                # Get OIDC configuration for JWT authentication
-                if profile.provider_type == "cognito":
-                    # Cognito issuer uses cognito-idp endpoint, not the hosted UI domain
-                    pool_id = getattr(profile, "cognito_user_pool_id", "")
-                    if pool_id:
-                        pool_region = pool_id.split("_")[0] if "_" in pool_id else profile.aws_region
-                        oidc_issuer_url = f"https://cognito-idp.{pool_region}.amazonaws.com/{pool_id}"
+                # Get OIDC configuration for JWT authentication (only when SSO is enabled)
+                oidc_issuer_url = ""
+                oidc_client_id = ""
+                if getattr(profile, "sso_enabled", True):
+                    if profile.provider_type == "cognito":
+                        pool_id = getattr(profile, "cognito_user_pool_id", "")
+                        if pool_id:
+                            pool_region = pool_id.split("_")[0] if "_" in pool_id else profile.aws_region
+                            oidc_issuer_url = f"https://cognito-idp.{pool_region}.amazonaws.com/{pool_id}"
+                        else:
+                            raise ValueError(
+                                "Cognito User Pool ID is required for quota monitoring JWT authentication. "
+                                "Please set cognito_user_pool_id in your profile configuration."
+                            )
                     else:
-                        raise ValueError(
-                            "Cognito User Pool ID is required for quota monitoring JWT authentication. "
-                            "Please set cognito_user_pool_id in your profile configuration."
-                        )
-                else:
-                    oidc_issuer_url = profile.provider_domain
-                    # Ensure issuer URL has https:// prefix
-                    if oidc_issuer_url and not oidc_issuer_url.startswith(("http://", "https://")):
-                        oidc_issuer_url = f"https://{oidc_issuer_url}"
-                # Auth0 tokens include trailing slash in iss claim, so authorizer must match
-                if profile.provider_type == "auth0" and oidc_issuer_url and not oidc_issuer_url.endswith("/"):
-                    oidc_issuer_url = f"{oidc_issuer_url}/"
-                oidc_client_id = profile.client_id
+                        oidc_issuer_url = profile.provider_domain
+                        if oidc_issuer_url and not oidc_issuer_url.startswith(("http://", "https://")):
+                            oidc_issuer_url = f"https://{oidc_issuer_url}"
+                    if profile.provider_type == "auth0" and oidc_issuer_url and not oidc_issuer_url.endswith("/"):
+                        oidc_issuer_url = f"{oidc_issuer_url}/"
+                    oidc_client_id = profile.client_id
 
                 # Pass explicitly so the profile is the source of truth; the CF template
                 # default is 'false' to match the opt-in intent of this field.

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -789,24 +789,27 @@ class DeployCommand(Command):
                 warning_80 = getattr(profile, "warning_threshold_80", int(monthly_limit * 0.8))
                 warning_90 = getattr(profile, "warning_threshold_90", int(monthly_limit * 0.9))
 
-                # Get OIDC configuration for JWT authentication
-                if profile.provider_type == "cognito":
-                    pool_id = getattr(profile, "cognito_user_pool_id", "")
-                    if pool_id:
-                        pool_region = pool_id.split("_")[0] if "_" in pool_id else profile.aws_region
-                        oidc_issuer_url = f"https://cognito-idp.{pool_region}.amazonaws.com/{pool_id}"
+                # Get OIDC configuration for JWT authentication (only when SSO is enabled)
+                oidc_issuer_url = ""
+                oidc_client_id = ""
+                if getattr(profile, "sso_enabled", True):
+                    if profile.provider_type == "cognito":
+                        pool_id = getattr(profile, "cognito_user_pool_id", "")
+                        if pool_id:
+                            pool_region = pool_id.split("_")[0] if "_" in pool_id else profile.aws_region
+                            oidc_issuer_url = f"https://cognito-idp.{pool_region}.amazonaws.com/{pool_id}"
+                        else:
+                            raise ValueError(
+                                "Cognito User Pool ID is required for quota monitoring JWT authentication. "
+                                "Please set cognito_user_pool_id in your profile configuration."
+                            )
                     else:
-                        raise ValueError(
-                            "Cognito User Pool ID is required for quota monitoring JWT authentication. "
-                            "Please set cognito_user_pool_id in your profile configuration."
-                        )
-                else:
-                    oidc_issuer_url = profile.provider_domain
-                    if oidc_issuer_url and not oidc_issuer_url.startswith(("http://", "https://")):
-                        oidc_issuer_url = f"https://{oidc_issuer_url}"
-                if profile.provider_type == "auth0" and oidc_issuer_url and not oidc_issuer_url.endswith("/"):
-                    oidc_issuer_url = f"{oidc_issuer_url}/"
-                oidc_client_id = profile.client_id
+                        oidc_issuer_url = profile.provider_domain
+                        if oidc_issuer_url and not oidc_issuer_url.startswith(("http://", "https://")):
+                            oidc_issuer_url = f"https://{oidc_issuer_url}"
+                    if profile.provider_type == "auth0" and oidc_issuer_url and not oidc_issuer_url.endswith("/"):
+                        oidc_issuer_url = f"{oidc_issuer_url}/"
+                    oidc_client_id = profile.client_id
 
                 # Pass explicitly so the profile is the source of truth; the CF template
                 # default is 'false' to match the opt-in intent of this field.

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -790,26 +790,7 @@ class DeployCommand(Command):
                 warning_90 = getattr(profile, "warning_threshold_90", int(monthly_limit * 0.9))
 
                 # Get OIDC configuration for JWT authentication (only when SSO is enabled)
-                oidc_issuer_url = ""
-                oidc_client_id = ""
-                if getattr(profile, "sso_enabled", True):
-                    if profile.provider_type == "cognito":
-                        pool_id = getattr(profile, "cognito_user_pool_id", "")
-                        if pool_id:
-                            pool_region = pool_id.split("_")[0] if "_" in pool_id else profile.aws_region
-                            oidc_issuer_url = f"https://cognito-idp.{pool_region}.amazonaws.com/{pool_id}"
-                        else:
-                            raise ValueError(
-                                "Cognito User Pool ID is required for quota monitoring JWT authentication. "
-                                "Please set cognito_user_pool_id in your profile configuration."
-                            )
-                    else:
-                        oidc_issuer_url = profile.provider_domain
-                        if oidc_issuer_url and not oidc_issuer_url.startswith(("http://", "https://")):
-                            oidc_issuer_url = f"https://{oidc_issuer_url}"
-                    if profile.provider_type == "auth0" and oidc_issuer_url and not oidc_issuer_url.endswith("/"):
-                        oidc_issuer_url = f"{oidc_issuer_url}/"
-                    oidc_client_id = profile.client_id
+                oidc_issuer_url, oidc_client_id = self._resolve_oidc_config(profile)
 
                 # Pass explicitly so the profile is the source of truth; the CF template
                 # default is 'false' to match the opt-in intent of this field.
@@ -1312,3 +1293,32 @@ class DeployCommand(Command):
             console.print(f"[yellow]Warning: Could not verify ECS service linked role: {str(e)}[/yellow]")
             console.print("[dim]If deployment fails, manually create the role with:[/dim]")
             console.print("[dim]aws iam create-service-linked-role --aws-service-name ecs.amazonaws.com[/dim]")
+
+    def _resolve_oidc_config(self, profile) -> tuple:
+        """Resolve OIDC issuer URL and client ID for quota JWT authentication.
+
+        Returns ("", "") when SSO is disabled — the CF template's HasJwtAuth
+        condition will disable the JWT authorizer and use an open route instead.
+        """
+        if not getattr(profile, "sso_enabled", True):
+            return "", ""
+
+        if profile.provider_type == "cognito":
+            pool_id = getattr(profile, "cognito_user_pool_id", "")
+            if not pool_id:
+                raise ValueError(
+                    "Cognito User Pool ID is required for quota monitoring JWT authentication. "
+                    "Please set cognito_user_pool_id in your profile configuration."
+                )
+            pool_region = pool_id.split("_")[0] if "_" in pool_id else profile.aws_region
+            issuer_url = f"https://cognito-idp.{pool_region}.amazonaws.com/{pool_id}"
+        else:
+            issuer_url = profile.provider_domain
+            if issuer_url and not issuer_url.startswith(("http://", "https://")):
+                issuer_url = f"https://{issuer_url}"
+
+        # Auth0 tokens include trailing slash in iss claim, so authorizer must match
+        if profile.provider_type == "auth0" and issuer_url and not issuer_url.endswith("/"):
+            issuer_url += "/"
+
+        return issuer_url, profile.client_id

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1313,15 +1313,18 @@ class InitCommand(Command):
         table.add_column("Setting", style="white", no_wrap=True)
         table.add_column("Value", style="green")
 
-        table.add_row("OIDC Provider", config["okta"]["domain"])
-        table.add_row(
-            "OIDC Client ID",
-            (
-                config["okta"]["client_id"][:20] + "..."
-                if len(config["okta"]["client_id"]) > 20
-                else config["okta"]["client_id"]
-            ),
-        )
+        if config.get("sso_enabled", True) and "okta" in config:
+            table.add_row("OIDC Provider", config["okta"]["domain"])
+            table.add_row(
+                "OIDC Client ID",
+                (
+                    config["okta"]["client_id"][:20] + "..."
+                    if len(config["okta"]["client_id"]) > 20
+                    else config["okta"]["client_id"]
+                ),
+            )
+        else:
+            table.add_row("Authentication", "AWS SSO / IAM Identity Center (no OIDC)")
         table.add_row(
             "Credential Storage",
             (
@@ -1936,13 +1939,14 @@ class InitCommand(Command):
         """Show summary of existing deployment."""
         console = Console()
 
-        console.print(f"• OIDC Provider: [cyan]{config['okta']['domain']}[/cyan]")
-
-        # Show Cognito-specific fields if using Cognito User Pool
-        if "cognito_user_pool_id" in config:
-            console.print(f"• Cognito User Pool ID: [cyan]{config['cognito_user_pool_id']}[/cyan]")
-        if "okta" in config and "client_id" in config["okta"]:
-            console.print(f"• Client ID: [cyan]{config['okta']['client_id']}[/cyan]")
+        if config.get("sso_enabled", True) and "okta" in config:
+            console.print(f"• OIDC Provider: [cyan]{config['okta']['domain']}[/cyan]")
+            if "cognito_user_pool_id" in config:
+                console.print(f"• Cognito User Pool ID: [cyan]{config['cognito_user_pool_id']}[/cyan]")
+            if "client_id" in config["okta"]:
+                console.print(f"• Client ID: [cyan]{config['okta']['client_id']}[/cyan]")
+        else:
+            console.print("• Authentication: [cyan]AWS SSO / IAM Identity Center (no OIDC)[/cyan]")
 
         cred_storage = "Keyring" if config.get("credential_storage") == "keyring" else "Session Files"
         console.print(f"• Credential Storage: [cyan]{cred_storage}[/cyan]")

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1762,17 +1762,16 @@ class InitCommand(Command):
                     else (okta_client_id or "—")
                 ),
             )
-
-            table.add_row(
-                "Credential Storage",
-                (
-                    "Keyring (OS secure storage)"
-                    if config.get("credential_storage") == "keyring"
-                    else "Session Files (temporary)"
-                ),
-            )
         else:
-            table.add_row("SSO Authentication", "Disabled (IAM credentials used)")
+            table.add_row("Authentication", "AWS SSO / IAM Identity Center (no OIDC)")
+        table.add_row(
+            "Credential Storage",
+            (
+                "Keyring (OS secure storage)"
+                if config.get("credential_storage") == "keyring"
+                else "Session Files (temporary)"
+            ),
+        )
         table.add_row("Infrastructure Region", f"{config['aws']['region']} (Cognito, IAM, Monitoring)")
         table.add_row("Identity Pool", config["aws"]["identity_pool_name"])
         table.add_row("Monitoring", "✓ Enabled" if config["monitoring"]["enabled"] else "✗ Disabled")
@@ -2481,7 +2480,7 @@ class InitCommand(Command):
         if config.get("sso_enabled", True) and "okta" in config and "domain" in config["okta"]:
             console.print(f"• OIDC Provider: [cyan]{config['okta']['domain']}[/cyan]")
         else:
-            console.print("• SSO Authentication: [cyan]Disabled (IAM credentials used)[/cyan]")
+            console.print("• Authentication: [cyan]AWS SSO / IAM Identity Center (no OIDC)[/cyan]")
 
         # Show Cognito-specific fields if using Cognito User Pool
         if "cognito_user_pool_id" in config:

--- a/source/claude_code_with_bedrock/cli/commands/status.py
+++ b/source/claude_code_with_bedrock/cli/commands/status.py
@@ -174,10 +174,11 @@ class StatusCommand(Command):
         """Get status of all stacks."""
         stacks = {}
 
-        # Check auth stack
-        auth_stack = profile.stack_names.get("auth", f"{profile.identity_pool_name}-stack")
-        auth_status = self._check_stack(auth_stack, profile.aws_region)
-        stacks["auth"] = auth_status
+        # Check auth stack (only when SSO is enabled)
+        if getattr(profile, "sso_enabled", True):
+            auth_stack = profile.stack_names.get("auth", f"{profile.identity_pool_name}-stack")
+            auth_status = self._check_stack(auth_stack, profile.aws_region)
+            stacks["auth"] = auth_status
 
         if profile.monitoring_enabled:
             # Check monitoring stack
@@ -218,15 +219,15 @@ class StatusCommand(Command):
         """Get all relevant endpoints."""
         endpoints = {}
 
-        # Get auth stack outputs
-        auth_stack = profile.stack_names.get("auth", f"{profile.identity_pool_name}-stack")
-        auth_outputs = get_stack_outputs(auth_stack, profile.aws_region)
+        # Get auth stack outputs (only when SSO is enabled)
+        if getattr(profile, "sso_enabled", True):
+            auth_stack = profile.stack_names.get("auth", f"{profile.identity_pool_name}-stack")
+            auth_outputs = get_stack_outputs(auth_stack, profile.aws_region)
 
-        if auth_outputs:
-            endpoints["identity_pool_id"] = auth_outputs.get("IdentityPoolId")
-            # Try FederatedRoleArn first (new templates), fallback to BedrockRoleArn (old template)
-            endpoints["role_arn"] = auth_outputs.get("FederatedRoleArn") or auth_outputs.get("BedrockRoleArn")
-            endpoints["oidc_provider"] = auth_outputs.get("OIDCProviderArn")
+            if auth_outputs:
+                endpoints["identity_pool_id"] = auth_outputs.get("IdentityPoolId")
+                endpoints["role_arn"] = auth_outputs.get("FederatedRoleArn") or auth_outputs.get("BedrockRoleArn")
+                endpoints["oidc_provider"] = auth_outputs.get("OIDCProviderArn")
 
         if profile.monitoring_enabled:
             # Get monitoring endpoint

--- a/source/claude_code_with_bedrock/cli/commands/status.py
+++ b/source/claude_code_with_bedrock/cli/commands/status.py
@@ -174,10 +174,11 @@ class StatusCommand(Command):
         """Get status of all stacks."""
         stacks = {}
 
-        # Check auth stack
-        auth_stack = profile.stack_names.get("auth", f"{profile.identity_pool_name}-stack")
-        auth_status = self._check_stack(auth_stack, profile.aws_region)
-        stacks["auth"] = auth_status
+        # Check auth stack (only when SSO is enabled)
+        if getattr(profile, "sso_enabled", True):
+            auth_stack = profile.stack_names.get("auth", f"{profile.identity_pool_name}-stack")
+            auth_status = self._check_stack(auth_stack, profile.aws_region)
+            stacks["auth"] = auth_status
 
         if profile.monitoring_enabled:
             monitoring_mode = getattr(profile, "monitoring_mode", "central")
@@ -223,15 +224,15 @@ class StatusCommand(Command):
         """Get all relevant endpoints."""
         endpoints = {}
 
-        # Get auth stack outputs
-        auth_stack = profile.stack_names.get("auth", f"{profile.identity_pool_name}-stack")
-        auth_outputs = get_stack_outputs(auth_stack, profile.aws_region)
+        # Get auth stack outputs (only when SSO is enabled)
+        if getattr(profile, "sso_enabled", True):
+            auth_stack = profile.stack_names.get("auth", f"{profile.identity_pool_name}-stack")
+            auth_outputs = get_stack_outputs(auth_stack, profile.aws_region)
 
-        if auth_outputs:
-            endpoints["identity_pool_id"] = auth_outputs.get("IdentityPoolId")
-            # Try FederatedRoleArn first (new templates), fallback to BedrockRoleArn (old template)
-            endpoints["role_arn"] = auth_outputs.get("FederatedRoleArn") or auth_outputs.get("BedrockRoleArn")
-            endpoints["oidc_provider"] = auth_outputs.get("OIDCProviderArn")
+            if auth_outputs:
+                endpoints["identity_pool_id"] = auth_outputs.get("IdentityPoolId")
+                endpoints["role_arn"] = auth_outputs.get("FederatedRoleArn") or auth_outputs.get("BedrockRoleArn")
+                endpoints["oidc_provider"] = auth_outputs.get("OIDCProviderArn")
 
         if profile.monitoring_enabled:
             monitoring_mode = getattr(profile, "monitoring_mode", "central")

--- a/source/claude_code_with_bedrock/cli/commands/test.py
+++ b/source/claude_code_with_bedrock/cli/commands/test.py
@@ -974,6 +974,10 @@ class TestCommand(Command):
     def _get_expected_account(self, config_profile) -> str:
         """Get the expected AWS account ID from the deployed stack."""
         try:
+            # Skip auth stack lookup when SSO is disabled
+            if not getattr(config_profile, "sso_enabled", True):
+                return None
+
             # Try to get account ID from the auth stack
             stack_name = config_profile.stack_names.get("auth", f"{config_profile.identity_pool_name}-stack")
 

--- a/source/claude_code_with_bedrock/cli/commands/test.py
+++ b/source/claude_code_with_bedrock/cli/commands/test.py
@@ -1030,6 +1030,10 @@ class TestCommand(Command):
     def _get_expected_account(self, config_profile) -> str:
         """Get the expected AWS account ID from the deployed stack."""
         try:
+            # Skip auth stack lookup when SSO is disabled
+            if not getattr(config_profile, "sso_enabled", True):
+                return None
+
             # Try to get account ID from the auth stack
             stack_name = config_profile.stack_names.get("auth", f"{config_profile.identity_pool_name}-stack")
 

--- a/source/tests/cli/commands/test_deploy_quota.py
+++ b/source/tests/cli/commands/test_deploy_quota.py
@@ -101,3 +101,77 @@ class TestDeployQuotaCommand:
             key, value = param.split("=")
             assert key in ["MonthlyTokenLimit", "WarningThreshold80", "WarningThreshold90"]
             assert int(value) > 0
+
+
+class TestResolveOidcConfig:
+    """Regression tests for OIDC config resolution with SSO disabled.
+
+    Prevents issue #287: quota deploy crash when sso_enabled=False
+    because no valid JWT issuer URL exists.
+    """
+
+    @pytest.fixture
+    def command(self):
+        return DeployCommand()
+
+    def test_sso_disabled_returns_empty_strings(self, command):
+        """When SSO is disabled, OIDC config must return empty strings (no crash)."""
+        profile = Mock()
+        profile.sso_enabled = False
+        issuer, client_id = command._resolve_oidc_config(profile)
+        assert issuer == ""
+        assert client_id == ""
+
+    def test_sso_enabled_okta_returns_valid_issuer(self, command):
+        """Okta provider returns https:// prefixed domain."""
+        profile = Mock()
+        profile.sso_enabled = True
+        profile.provider_type = "okta"
+        profile.provider_domain = "company.okta.com"
+        profile.client_id = "abc123"
+        issuer, client_id = command._resolve_oidc_config(profile)
+        assert issuer == "https://company.okta.com"
+        assert client_id == "abc123"
+
+    def test_sso_enabled_cognito_returns_pool_url(self, command):
+        """Cognito provider returns cognito-idp issuer URL."""
+        profile = Mock()
+        profile.sso_enabled = True
+        profile.provider_type = "cognito"
+        profile.cognito_user_pool_id = "us-east-1_abc123"
+        profile.aws_region = "us-east-1"
+        profile.client_id = "cogclient"
+        issuer, client_id = command._resolve_oidc_config(profile)
+        assert issuer == "https://cognito-idp.us-east-1.amazonaws.com/us-east-1_abc123"
+        assert client_id == "cogclient"
+
+    def test_sso_enabled_cognito_no_pool_id_raises(self, command):
+        """Cognito without pool_id must raise ValueError (not crash with None)."""
+        profile = Mock()
+        profile.sso_enabled = True
+        profile.provider_type = "cognito"
+        profile.cognito_user_pool_id = ""
+        with pytest.raises(ValueError, match="Cognito User Pool ID is required"):
+            command._resolve_oidc_config(profile)
+
+    def test_sso_enabled_auth0_appends_slash(self, command):
+        """Auth0 issuer URL must end with trailing slash (matches iss claim)."""
+        profile = Mock()
+        profile.sso_enabled = True
+        profile.provider_type = "auth0"
+        profile.provider_domain = "company.auth0.com"
+        profile.client_id = "auth0client"
+        issuer, client_id = command._resolve_oidc_config(profile)
+        assert issuer == "https://company.auth0.com/"
+        assert client_id == "auth0client"
+
+    def test_sso_enabled_azure_no_trailing_slash(self, command):
+        """Azure issuer URL must NOT have trailing slash."""
+        profile = Mock()
+        profile.sso_enabled = True
+        profile.provider_type = "azure"
+        profile.provider_domain = "login.microsoftonline.com/tenant-id/v2.0"
+        profile.client_id = "azureclient"
+        issuer, client_id = command._resolve_oidc_config(profile)
+        assert issuer == "https://login.microsoftonline.com/tenant-id/v2.0"
+        assert not issuer.endswith("/")

--- a/source/tests/e2e/test_cross_platform.py
+++ b/source/tests/e2e/test_cross_platform.py
@@ -582,3 +582,36 @@ class TestCfnTemplateValidation:
                     f"{tmpl.name} defines 'IsGovCloud' condition but never references it. "
                     f"Remove unused conditions to fix cfn-lint W8001."
                 )
+
+
+class TestSsoEnabledConsistency:
+    """Static analysis guards for sso_enabled checks.
+
+    All getattr/get calls for sso_enabled must default to True for backward
+    compatibility. A single False default could break existing SSO deployments.
+    """
+
+    def test_no_sso_enabled_default_false_in_source(self):
+        """No source file should use sso_enabled with a False default."""
+        import re
+
+        # Patterns that would indicate wrong default
+        bad_patterns = [
+            re.compile(r'getattr\([^,]+,\s*["\']sso_enabled["\'],\s*False\)'),
+            re.compile(r'\.get\(["\']sso_enabled["\'],\s*False\)'),
+        ]
+
+        source_files = list(CLI_DIR.rglob("*.py"))
+        violations = []
+
+        for src in source_files:
+            content = src.read_text(encoding="utf-8")
+            for pattern in bad_patterns:
+                matches = pattern.findall(content)
+                if matches:
+                    violations.append(f"{src.name}: {matches}")
+
+        assert not violations, (
+            f"Found sso_enabled with default=False (must be True for backward compat):\n"
+            + "\n".join(violations)
+        )


### PR DESCRIPTION
## Summary

Closes #287

Quota monitoring stack deployment fails when `sso_enabled: false` with:

```
Invalid issuer: Issuer is not a valid URL for JWT Authorizer
```

### Root Cause

Two problems combined to produce this failure:

1. **`deploy.py`** was unconditionally passing `provider_domain` (the literal string `"none"` when SSO is disabled) as the `OidcIssuerUrl` CloudFormation parameter. API Gateway rejects this with a `BadRequestException 400` — not a valid JWT issuer URL.

2. **`quota-monitoring.yaml`** created the `QuotaCheckAuthorizer` Lambda authorizer resource and its authenticated route unconditionally, meaning any deployment — SSO-enabled or not — required a valid issuer URL to exist at stack-creation time.

Together these mean: if you set `sso_enabled: false`, the quota stack simply cannot be deployed.

### Fix

- **`deploy.py`** now passes empty strings for `OidcIssuerUrl` and `OidcClientId` when `sso_enabled=false`, preventing the bad value from reaching API Gateway.
- **`quota-monitoring.yaml`** gains `HasJwtAuth` / `NoJwtAuth` conditions. The JWT authorizer and its route are created only when a non-empty issuer URL is provided. When SSO is disabled, an unauthenticated fallback route is used instead.
- **`init.py`, `status.py`, `test.py`** — auth stack lookups are now guarded behind `sso_enabled` so they don't fail when the auth stack doesn't exist.

### How to Test

**SSO disabled (reproduces the original bug):**

1. Set `sso_enabled: false` in your config.
2. Run `ccwb deploy quota-monitoring` — should complete without a `BadRequestException`.
3. Confirm `QuotaCheckAuthorizer` is absent from the deployed stack and the quota endpoint is accessible without a JWT.

**SSO enabled (regression check):**

1. Set `sso_enabled: true` in your config.
2. Run `ccwb deploy quota-monitoring` — the JWT authorizer should be created and the endpoint should require a valid token.
3. Confirm `ccwb init`, `ccwb status`, and `ccwb test` still resolve auth stack outputs correctly.