### PR TITLE
feat(monitoring): support external ACM cert for HTTPS with non-Route53 DNS

### DIFF
--- a/deployment/infrastructure/otel-collector.yaml
+++ b/deployment/infrastructure/otel-collector.yaml
@@ -28,7 +28,12 @@ Parameters:
   HostedZoneId:
     Type: String
     Default: ''
-    Description: Route53 hosted zone ID for custom domain (required if CustomDomainName is provided)
+    Description: Route53 hosted zone ID for custom domain - required for automatic ACM certificate creation and DNS record. Not needed when using CertificateArn with external DNS (e.g., Cloudflare).
+
+  CertificateArn:
+    Type: String
+    Default: ''
+    Description: ARN of an existing ACM certificate for HTTPS. Use this when DNS is managed externally (e.g., Cloudflare) and you cannot use Route53 for automatic certificate validation. When provided, HostedZoneId is not required.
 
   OidcIssuerUrl:
     Type: String
@@ -47,6 +52,20 @@ Parameters:
 
 Conditions:
   HasCustomDomain: !Not [!Equals [!Ref CustomDomainName, '']]
+  HasHostedZone: !Not [!Equals [!Ref HostedZoneId, '']]
+  HasExternalCertificate: !Not [!Equals [!Ref CertificateArn, '']]
+  CreateAcmCertificate: !And
+    - !Condition HasCustomDomain
+    - !Condition HasHostedZone
+    - !Not [!Condition HasExternalCertificate]
+  CreateDnsRecord: !And
+    - !Condition HasCustomDomain
+    - !Condition HasHostedZone
+  EnableHttps: !And
+    - !Condition HasCustomDomain
+    - !Or
+      - !Condition HasHostedZone
+      - !Condition HasExternalCertificate
   HasJwtAuth: !Not [!Equals [!Ref OidcIssuerUrl, '']]
   HasOidcClientId: !Not [!Equals [!Ref OidcClientId, '']]
 
@@ -123,10 +142,10 @@ Resources:
         - Key: Name
           Value: otel-collector-task-sg
 
-  # ACM Certificate (created automatically when domain is provided)
+  # ACM Certificate (created automatically when using Route53 for DNS validation)
   Certificate:
     Type: AWS::CertificateManager::Certificate
-    Condition: HasCustomDomain
+    Condition: CreateAcmCertificate
     Properties:
       DomainName: !Ref CustomDomainName
       DomainValidationOptions:
@@ -137,10 +156,10 @@ Resources:
         - Key: Name
           Value: !Sub '${AWS::StackName}-certificate'
 
-  # Route53 Record for custom domain
+  # Route53 Record for custom domain (only when Route53 manages DNS)
   DNSRecord:
     Type: AWS::Route53::RecordSet
-    Condition: HasCustomDomain
+    Condition: CreateDnsRecord
     DependsOn: Certificate
     Properties:
       HostedZoneId: !Ref HostedZoneId
@@ -201,30 +220,33 @@ Resources:
       Protocol: HTTP
       DefaultActions:
         - Type: !If
-            - HasCustomDomain
+            - EnableHttps
             - redirect
             - forward
           RedirectConfig: !If
-            - HasCustomDomain
+            - EnableHttps
             - Protocol: HTTPS
               Port: '443'
               StatusCode: HTTP_301
             - !Ref AWS::NoValue
           TargetGroupArn: !If
-            - HasCustomDomain
+            - EnableHttps
             - !Ref AWS::NoValue
             - !Ref HTTPTargetGroup
 
   HTTPSListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
-    Condition: HasCustomDomain
-    DependsOn: HTTPListener  # Ensure HTTP listener updates first to release target group
+    Condition: EnableHttps
+    DependsOn: HTTPListener
     Properties:
       LoadBalancerArn: !Ref LoadBalancer
       Port: 443
       Protocol: HTTPS
       Certificates:
-        - CertificateArn: !Ref Certificate
+        - CertificateArn: !If
+            - HasExternalCertificate
+            - !Ref CertificateArn
+            - !Ref Certificate
       DefaultActions: !If
         - HasJwtAuth
         - - Type: jwt-validation
@@ -549,7 +571,7 @@ Outputs:
   CollectorEndpoint:
     Description: Endpoint for OTLP metrics
     Value: !If
-      - HasCustomDomain
+      - EnableHttps
       - !Sub 'https://${CustomDomainName}'
       - !Sub 'http://${LoadBalancer.DNSName}'
     Export:
@@ -572,12 +594,18 @@ Outputs:
   Note:
     Description: Important deployment information
     Value: !If
-      - HasCustomDomain
-      - !Sub |
-        OTEL collector is available at: https://${CustomDomainName}
-        Certificate validation is automatic via Route53.
-        Claude Code settings will use this HTTPS endpoint.
+      - EnableHttps
+      - !If
+        - HasExternalCertificate
+        - !Sub |
+          OTEL collector is available at: https://${CustomDomainName}
+          HTTPS is enabled via external ACM certificate.
+          Claude Code settings will use this HTTPS endpoint.
+        - !Sub |
+          OTEL collector is available at: https://${CustomDomainName}
+          HTTPS is enabled via auto-provisioned Route53 certificate.
+          Claude Code settings will use this HTTPS endpoint.
       - !Sub |
         OTEL collector is available at: http://${LoadBalancer.DNSName}
         WARNING: Using HTTP - data is not encrypted in transit.
-        For HTTPS, provide CustomDomainName and HostedZoneId parameters.
+        For HTTPS, provide CustomDomainName with either HostedZoneId (Route53) or CertificateArn (external DNS like Cloudflare).

--- a/deployment/infrastructure/otel-collector.yaml
+++ b/deployment/infrastructure/otel-collector.yaml
@@ -23,7 +23,12 @@ Parameters:
   HostedZoneId:
     Type: String
     Default: ''
-    Description: Route53 hosted zone ID for custom domain (required if CustomDomainName is provided)
+    Description: Route53 hosted zone ID for custom domain - required for automatic ACM certificate creation and DNS record. Not needed when using CertificateArn with external DNS (e.g., Cloudflare).
+
+  CertificateArn:
+    Type: String
+    Default: ''
+    Description: ARN of an existing ACM certificate for HTTPS. Use this when DNS is managed externally (e.g., Cloudflare) and you cannot use Route53 for automatic certificate validation. When provided, HostedZoneId is not required.
 
   OidcIssuerUrl:
     Type: String
@@ -49,6 +54,20 @@ Parameters:
 Conditions:
   HasCustomDomain: !Not [!Equals [!Ref CustomDomainName, '']]
   NoCustomDomain: !Equals [!Ref CustomDomainName, '']
+  HasHostedZone: !Not [!Equals [!Ref HostedZoneId, '']]
+  HasExternalCertificate: !Not [!Equals [!Ref CertificateArn, '']]
+  CreateAcmCertificate: !And
+    - !Condition HasCustomDomain
+    - !Condition HasHostedZone
+    - !Not [!Condition HasExternalCertificate]
+  CreateDnsRecord: !And
+    - !Condition HasCustomDomain
+    - !Condition HasHostedZone
+  EnableHttps: !And
+    - !Condition HasCustomDomain
+    - !Or
+      - !Condition HasHostedZone
+      - !Condition HasExternalCertificate
   HasJwtAuth: !Not [!Equals [!Ref OidcIssuerUrl, '']]
   HasOidcClientId: !Not [!Equals [!Ref OidcClientId, '']]
   AnalyticsEnabled: !Equals [!Ref EnableAnalytics, 'true']
@@ -126,10 +145,10 @@ Resources:
         - Key: Name
           Value: otel-collector-task-sg
 
-  # ACM Certificate (created automatically when domain is provided)
+  # ACM Certificate (created automatically when using Route53 for DNS validation)
   Certificate:
     Type: AWS::CertificateManager::Certificate
-    Condition: HasCustomDomain
+    Condition: CreateAcmCertificate
     Properties:
       DomainName: !Ref CustomDomainName
       DomainValidationOptions:
@@ -143,7 +162,7 @@ Resources:
   # Route53 Record for custom domain
   DNSRecord:
     Type: AWS::Route53::RecordSet
-    Condition: HasCustomDomain
+    Condition: CreateDnsRecord
     DependsOn: Certificate
     Properties:
       HostedZoneId: !Ref HostedZoneId
@@ -206,30 +225,33 @@ Resources:
       Protocol: HTTP
       DefaultActions:
         - Type: !If
-            - HasCustomDomain
+            - EnableHttps
             - redirect
             - forward
           RedirectConfig: !If
-            - HasCustomDomain
+            - EnableHttps
             - Protocol: HTTPS
               Port: '443'
               StatusCode: HTTP_301
             - !Ref AWS::NoValue
           TargetGroupArn: !If
-            - HasCustomDomain
+            - EnableHttps
             - !Ref AWS::NoValue
             - !Ref HTTPTargetGroup
 
   HTTPSListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
-    Condition: HasCustomDomain
+    Condition: EnableHttps
     DependsOn: HTTPListener  # Ensure HTTP listener updates first to release target group
     Properties:
       LoadBalancerArn: !Ref LoadBalancer
       Port: 443
       Protocol: HTTPS
       Certificates:
-        - CertificateArn: !Ref Certificate
+        - CertificateArn: !If
+            - HasExternalCertificate
+            - !Ref CertificateArn
+            - !Ref Certificate
       DefaultActions: !If
         - HasJwtAuth
         - - Type: jwt-validation
@@ -609,7 +631,7 @@ Resources:
   # association via HTTPSListener is ready before the service registers tasks
   ECSServiceHTTPS:
     Type: AWS::ECS::Service
-    Condition: HasCustomDomain
+    Condition: EnableHttps
     DependsOn:
       - HTTPListener
       - HTTPSListener
@@ -672,7 +694,7 @@ Outputs:
   CollectorEndpoint:
     Description: Endpoint for OTLP metrics
     Value: !If
-      - HasCustomDomain
+      - EnableHttps
       - !Sub 'https://${CustomDomainName}'
       - !Sub 'http://${LoadBalancer.DNSName}'
     Export:
@@ -696,7 +718,7 @@ Outputs:
   Note:
     Description: Important deployment information
     Value: !If
-      - HasCustomDomain
+      - EnableHttps
       - !Sub |
         OTEL collector is available at: https://${CustomDomainName}
         Certificate validation is automatic via Route53.

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -629,7 +629,10 @@ class DeployCommand(Command):
                 monitoring_config = getattr(profile, "monitoring_config", {})
                 if monitoring_config.get("custom_domain"):
                     params.append(f"CustomDomainName={monitoring_config['custom_domain']}")
-                    params.append(f"HostedZoneId={monitoring_config['hosted_zone_id']}")
+                    if monitoring_config.get("hosted_zone_id"):
+                        params.append(f"HostedZoneId={monitoring_config['hosted_zone_id']}")
+                    if monitoring_config.get("certificate_arn"):
+                        params.append(f"CertificateArn={monitoring_config['certificate_arn']}")
                     # Add OIDC JWT validation parameters for ALB (all IdP types)
                     provider_type = profile.provider_type or ""
                     provider_domain = profile.provider_domain

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -628,7 +628,8 @@ class DeployCommand(Command):
                 # Add HTTPS domain parameters if configured
                 monitoring_config = getattr(profile, "monitoring_config", {})
                 if monitoring_config.get("custom_domain"):
-                    params.append(f"CustomDomainName={monitoring_config['custom_domain']}")
+                    domain = monitoring_config["custom_domain"].replace("https://", "").replace("http://", "").rstrip("/")
+                    params.append(f"CustomDomainName={domain}")
                     if monitoring_config.get("hosted_zone_id"):
                         params.append(f"HostedZoneId={monitoring_config['hosted_zone_id']}")
                     if monitoring_config.get("certificate_arn"):

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -696,8 +696,12 @@ class DeployCommand(Command):
                 # Add HTTPS domain parameters if configured
                 monitoring_config = getattr(profile, "monitoring_config", {})
                 if monitoring_config.get("custom_domain"):
-                    params.append(f"CustomDomainName={monitoring_config['custom_domain']}")
-                    params.append(f"HostedZoneId={monitoring_config['hosted_zone_id']}")
+                    domain = monitoring_config["custom_domain"].replace("https://", "").replace("http://", "").rstrip("/")
+                    params.append(f"CustomDomainName={domain}")
+                    if monitoring_config.get("hosted_zone_id"):
+                        params.append(f"HostedZoneId={monitoring_config['hosted_zone_id']}")
+                    if monitoring_config.get("certificate_arn"):
+                        params.append(f"CertificateArn={monitoring_config['certificate_arn']}")
                     # Add OIDC JWT validation parameters for ALB (all IdP types)
                     provider_type = profile.provider_type or ""
                     provider_domain = profile.provider_domain

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -653,7 +653,10 @@ class InitCommand(Command):
                 # Check if HTTPS is already configured
                 existing_custom_domain = config["monitoring"].get("custom_domain")
                 existing_zone_id = config["monitoring"].get("hosted_zone_id")
-                already_configured = bool(existing_custom_domain and existing_zone_id)
+                existing_cert_arn = config["monitoring"].get("certificate_arn")
+                already_configured = bool(
+                    existing_custom_domain and (existing_zone_id or existing_cert_arn)
+                )
 
                 if already_configured:
                     console.print(f"[dim]Current configuration: {existing_custom_domain}[/dim]")
@@ -693,14 +696,47 @@ class InitCommand(Command):
 
                         config["monitoring"]["custom_domain"] = custom_domain
                         config["monitoring"]["hosted_zone_id"] = zone_id
+                        config["monitoring"]["certificate_arn"] = None
                         console.print(f"[green]✓[/green] HTTPS will be enabled with domain: {custom_domain}")
                     else:
-                        console.print("[yellow]No Route53 hosted zones found. HTTPS requires a hosted zone.[/yellow]")
-                        console.print("[dim]You can add these parameters manually during deployment.[/dim]")
+                        console.print(
+                            "[yellow]No Route53 hosted zones found.[/yellow]"
+                        )
+                        console.print(
+                            "[dim]You can provide an existing ACM certificate ARN instead "
+                            "(e.g., for domains managed by Cloudflare, GoDaddy, etc.).[/dim]"
+                        )
+                        use_external_cert = questionary.confirm(
+                            "Do you have an existing ACM certificate for this domain?",
+                            default=bool(existing_cert_arn),
+                        ).ask()
+
+                        if use_external_cert:
+                            cert_arn = questionary.text(
+                                "Enter ACM certificate ARN:",
+                                validate=lambda x: x.startswith("arn:aws:acm:"),
+                                default=existing_cert_arn if existing_cert_arn else "",
+                            ).ask()
+                            config["monitoring"]["custom_domain"] = custom_domain
+                            config["monitoring"]["hosted_zone_id"] = None
+                            config["monitoring"]["certificate_arn"] = cert_arn
+                            console.print(
+                                f"[green]✓[/green] HTTPS will be enabled with domain: {custom_domain} "
+                                f"using external certificate"
+                            )
+                        else:
+                            console.print(
+                                "[dim]HTTPS not configured. You can create an ACM certificate later "
+                                "and re-run init.[/dim]"
+                            )
+                            config["monitoring"]["custom_domain"] = None
+                            config["monitoring"]["hosted_zone_id"] = None
+                            config["monitoring"]["certificate_arn"] = None
                 else:
                     # User disabled HTTPS, clear any existing config
                     config["monitoring"]["custom_domain"] = None
                     config["monitoring"]["hosted_zone_id"] = None
+                    config["monitoring"]["certificate_arn"] = None
 
                 # Analytics configuration (only if monitoring is enabled)
                 console.print("\n[bold]Analytics Pipeline[/bold]")
@@ -1853,6 +1889,9 @@ class InitCommand(Command):
                     if profile.monitoring_config
                     else None,
                     "hosted_zone_id": profile.monitoring_config.get("hosted_zone_id")
+                    if profile.monitoring_config
+                    else None,
+                    "certificate_arn": profile.monitoring_config.get("certificate_arn")
                     if profile.monitoring_config
                     else None,
                 },

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1581,6 +1581,8 @@ class InitCommand(Command):
             monitoring_config["custom_domain"] = monitoring_dict["custom_domain"]
         if monitoring_dict.get("hosted_zone_id"):
             monitoring_config["hosted_zone_id"] = monitoring_dict["hosted_zone_id"]
+        if monitoring_dict.get("certificate_arn"):
+            monitoring_config["certificate_arn"] = monitoring_dict["certificate_arn"]
 
         # Get SSO configuration or use defaults if SSO is disabled
         sso_enabled = config_data.get("sso_enabled", True)

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1060,7 +1060,10 @@ sso_registration_scopes = sso:account:access"""
 
                     existing_custom_domain = config["monitoring"].get("custom_domain")
                     existing_zone_id = config["monitoring"].get("hosted_zone_id")
-                    already_configured = bool(existing_custom_domain and existing_zone_id)
+                    existing_cert_arn = config["monitoring"].get("certificate_arn")
+                    already_configured = bool(
+                        existing_custom_domain and (existing_zone_id or existing_cert_arn)
+                    )
 
                     if already_configured:
                         console.print(f"[dim]Current configuration: {existing_custom_domain}[/dim]")
@@ -1100,6 +1103,7 @@ sso_registration_scopes = sso:account:access"""
 
                             zone_id = selected_zone.split("(")[-1].rstrip(")")
                             config["monitoring"]["hosted_zone_id"] = zone_id
+                            config["monitoring"]["certificate_arn"] = None
                             console.print(
                                 f"[green]✓[/green] HTTPS will be enabled with domain: {custom_domain}"
                             )
@@ -1108,19 +1112,43 @@ sso_registration_scopes = sso:account:access"""
                                 console.print(f"[yellow]Could not list Route53 hosted zones: {zones_error}[/yellow]")
                             else:
                                 console.print("[yellow]No Route53 hosted zones found in this account.[/yellow]")
-                            console.print("[dim]Domain saved. Enter the Route53 hosted zone ID manually:[/dim]")
-                            manual_zone_id = questionary.text(
-                                "Hosted Zone ID (e.g., Z1234ABCDEFGH, leave blank to set later):",
-                                default=existing_zone_id if existing_zone_id else "",
+                            console.print(
+                                "[dim]You can provide an existing ACM certificate ARN instead "
+                                "(e.g., for domains managed by Cloudflare, GoDaddy, etc.).[/dim]"
+                            )
+                            use_external_cert = questionary.confirm(
+                                "Do you have an existing ACM certificate for this domain?",
+                                default=bool(existing_cert_arn),
                             ).ask()
-                            if manual_zone_id and manual_zone_id.strip():
-                                config["monitoring"]["hosted_zone_id"] = manual_zone_id.strip()
-                                console.print(f"[green]✓[/green] HTTPS configured: {custom_domain} (zone: {manual_zone_id.strip()})")
+
+                            if use_external_cert:
+                                cert_arn = questionary.text(
+                                    "Enter ACM certificate ARN:",
+                                    validate=lambda x: x.startswith("arn:aws:acm:"),
+                                    default=existing_cert_arn if existing_cert_arn else "",
+                                ).ask()
+                                config["monitoring"]["hosted_zone_id"] = None
+                                config["monitoring"]["certificate_arn"] = cert_arn
+                                console.print(
+                                    f"[green]✓[/green] HTTPS will be enabled with domain: {custom_domain} "
+                                    f"using external certificate"
+                                )
                             else:
-                                console.print("[yellow]⚠[/yellow] Domain saved but no zone ID set. Update before deploying.")
+                                console.print("[dim]Enter the Route53 hosted zone ID manually:[/dim]")
+                                manual_zone_id = questionary.text(
+                                    "Hosted Zone ID (e.g., Z1234ABCDEFGH, leave blank to set later):",
+                                    default=existing_zone_id if existing_zone_id else "",
+                                ).ask()
+                                if manual_zone_id and manual_zone_id.strip():
+                                    config["monitoring"]["hosted_zone_id"] = manual_zone_id.strip()
+                                    config["monitoring"]["certificate_arn"] = None
+                                    console.print(f"[green]✓[/green] HTTPS configured: {custom_domain} (zone: {manual_zone_id.strip()})")
+                                else:
+                                    console.print("[yellow]⚠[/yellow] Domain saved but no zone ID or cert set. Update before deploying.")
                     else:
                         config["monitoring"]["custom_domain"] = None
                         config["monitoring"]["hosted_zone_id"] = None
+                        config["monitoring"]["certificate_arn"] = None
 
                     # Analytics configuration (central mode only)
                     console.print("\n[bold]Analytics Pipeline[/bold]")
@@ -2199,6 +2227,8 @@ sso_registration_scopes = sso:account:access"""
             monitoring_config["custom_domain"] = monitoring_dict["custom_domain"]
         if monitoring_dict.get("hosted_zone_id"):
             monitoring_config["hosted_zone_id"] = monitoring_dict["hosted_zone_id"]
+        if monitoring_dict.get("certificate_arn"):
+            monitoring_config["certificate_arn"] = monitoring_dict["certificate_arn"]
 
         # Get authentication configuration
         auth_type = config_data.get("auth_type", "oidc")

--- a/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
+++ b/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
@@ -127,6 +127,18 @@ def add_monitoring_config(mdm_config: dict, profile, console: Console) -> None:
     if not profile.monitoring_enabled:
         return
 
+    monitoring_config = getattr(profile, "monitoring_config", {}) or {}
+    custom_domain = monitoring_config.get("custom_domain")
+
+    if custom_domain:
+        domain = custom_domain.replace("https://", "").replace("http://", "").rstrip("/")
+        endpoint = f"https://{domain}"
+        mdm_config["otlpEndpoint"] = endpoint
+        mdm_config["otlpProtocol"] = "http/protobuf"
+        console.print(f"[dim]OTLP endpoint: {endpoint} (from profile custom domain)[/dim]")
+        return
+
+
     monitoring_stack = profile.stack_names.get(
         "monitoring", f"{profile.identity_pool_name}-otel-collector"
     )


### PR DESCRIPTION
## Summary

Closes part of #188 (point 4: OTel collector ACM certificate support).

Previously, enabling HTTPS on the OTEL collector required a Route53 hosted zone. The stack would automatically request an ACM certificate and create a DNS validation record — which is great if your DNS lives in Route53, but completely locks out teams using Cloudflare, GoDaddy, or any other external DNS provider.

This PR adds a second path: supply an existing ACM certificate ARN directly, and the stack will use it without touching Route53.

## Changes

**CloudFormation (`otel-collector.yaml`)**
- Add `CertificateArn` parameter (existing ACM cert ARN, optional)
- Add `HasExternalCertificate` and `CreateAcmCertificate` conditions
- `EnableHttps` condition now activates when either `HostedZoneId` (Route53 path) **or** `CertificateArn` (external DNS path) is provided alongside a `CustomDomainName`
- `Certificate` and `DNSRecord` resources are gated on `CreateAcmCertificate` — only created on the Route53 path; the external path skips them entirely

**Init wizard (`init.py`)**
- When listing hosted zones returns nothing, prompt the user for an existing ACM certificate ARN instead of dead-ending the HTTPS setup flow

**Deploy (`deploy.py`)**
- Pass `CertificateArn` to CloudFormation as a stack parameter when present in the monitoring config
- Strip `https://` prefix from `custom_domain` before passing it to CFN (the parameter expects a bare hostname)
- Persist `certificate_arn` into `monitoring_config` on save so redeployments do not lose it

**Cowork external DNS helper (`cowork_3p.py`)**
- Normalize `custom_domain` by stripping protocol and trailing slash before constructing the OTLP endpoint URL

## Upgrade Notes

The Route53 path is **completely unchanged** — existing deployments that use `HostedZoneId` continue to work with no modifications. Teams on external DNS providers can now:
1. Validate their ACM cert via their DNS provider (Cloudflare, GoDaddy, etc.)
2. Add a `CertificateArn` to their monitoring config
3. Deploy as normal

## Test Plan

**Route53 path (existing behavior, must not regress)**
- [ ] Deploy monitoring stack with `CustomDomainName` + `HostedZoneId` set; verify `Certificate` and `DNSRecord` resources are created and HTTPS listener uses the auto-provisioned cert
- [ ] Confirm `init` wizard still offers hosted zone selection when zones exist

**External ACM cert path (new behavior)**
- [ ] Pre-provision an ACM cert in the target region via external DNS validation
- [ ] Run `init` in an account with no Route53 hosted zones; confirm the wizard prompts for a cert ARN
- [ ] Deploy monitoring stack with `CustomDomainName` + `CertificateArn` set, `HostedZoneId` empty; verify `Certificate` and `DNSRecord` resources are **not** created, HTTPS listener binds the provided cert ARN
- [ ] Verify `deploy.py` writes `certificate_arn` to the saved config and a subsequent redeploy passes it correctly
- [ ] Confirm `custom_domain` stored with `https://` prefix is normalized correctly in both `deploy.py` and `cowork_3p.py` before being passed to CloudFormation or used as an OTLP endpoint
