### PR TITLE
fix: Windows install.bat fails with '-replace is incorrectly used' error

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -2034,6 +2034,7 @@ echo
         """Create Windows batch installer script."""
 
         installer_content = f"""@echo off
+SETLOCAL ENABLEDELAYEDEXPANSION
 REM Claude Code Authentication Installer for Windows
 REM Organization: {profile.provider_domain}
 REM Generated: {datetime.now().strftime("%Y-%m-%d %H:%M:%S")}
@@ -2088,28 +2089,20 @@ if exist "claude-settings" (
 
     REM Copy settings and replace placeholders
     if exist "claude-settings\\settings.json" (
-        set SKIP_SETTINGS=false
+        set "SKIP_SETTINGS=false"
         if exist "%USERPROFILE%\\.claude\\settings.json" (
             echo Existing Claude Code settings found
             set /p OVERWRITE="Overwrite with new settings? (y/n): "
-            if /i not "%OVERWRITE%"=="y" (
+            if /i not "!OVERWRITE!"=="y" (
                 echo Skipping Claude Code settings...
-                set SKIP_SETTINGS=true
+                set "SKIP_SETTINGS=true"
             )
         )
 
-        if not "%SKIP_SETTINGS%"=="true" (
-            REM Use PowerShell to replace placeholders
-            powershell -Command ^
-            "$otelPath = '%USERPROFILE%\\\\claude-code-with-bedrock\\\\otel-helper.exe' ^
-            -replace '\\\\\\\\', '/'; ^
-            $credPath = '%USERPROFILE%\\\\claude-code-with-bedrock\\\\credential-process.exe' ^
-            -replace '\\\\\\\\', '/'; ^
-            (Get-Content 'claude-settings\\\\settings.json') ^
-            -replace '__OTEL_HELPER_PATH__', $otelPath ^
-            -replace '__CREDENTIAL_PROCESS_PATH__', $credPath | ^
-            Set-Content '%USERPROFILE%\\\\.claude\\\\settings.json'"
-            echo OK Claude Code settings configured
+        if "!SKIP_SETTINGS!"=="false" (
+            REM Use PowerShell to replace placeholders (single-line, avoids ^ issues in quoted strings)
+            powershell -NoProfile -Command "$otel = ($env:USERPROFILE + '\\claude-code-with-bedrock\\otel-helper.exe').Replace('\\', '/'); $cred = ($env:USERPROFILE + '\\claude-code-with-bedrock\\credential-process.exe').Replace('\\', '/'); (Get-Content 'claude-settings\\settings.json') -replace '__OTEL_HELPER_PATH__', $otel -replace '__CREDENTIAL_PROCESS_PATH__', $cred | Set-Content ($env:USERPROFILE + '\\.claude\\settings.json')"
+            echo OK Claude settings configured
         )
     )
 )
@@ -2168,6 +2161,8 @@ echo.
 echo Note: Authentication will automatically open your browser when needed.
 echo.
 pause
+
+ENDLOCAL
 """
 
         installer_path = output_dir / "install.bat"


### PR DESCRIPTION
Fixes #226. Supersedes #139 (rebased on current main with same approach).

## Problem

The generated `install.bat` fails on Windows with:
```
-replace の使い方が誤っています。
```

**Root cause 1:** Multi-line PowerShell command uses `^` line continuation inside double-quoted strings. `cmd.exe` does not treat `^` as continuation inside quotes, so `-replace` is executed as a standalone command.

**Root cause 2:** `!PROFILE_REGION!` uses delayed expansion syntax without `SETLOCAL ENABLEDELAYEDEXPANSION`, so the region is set to the literal string.

## Fix

1. Add `SETLOCAL ENABLEDELAYEDEXPANSION` + `ENDLOCAL`
2. Replace multi-line PowerShell with single-line using `$env:USERPROFILE` and `.Replace()` 
3. Fix `SKIP_SETTINGS` and `OVERWRITE` to use `!var!` delayed expansion
4. Use `powershell -NoProfile` for faster execution

One file, +10/-15 lines.

## Credit

Based on the approach from PR #139 by @Oleh-Tkachuk-Nice, rebased on current main after recent changes (#291, #282, #299).

Co-authored-by: Oleh-Tkachuk-Nice <Oleh-Tkachuk-Nice@users.noreply.github.com>