### PR TITLE
fix: OTEL collector deploy fails when HTTPS is not enabled

### DIFF
--- a/deployment/infrastructure/otel-collector.yaml
+++ b/deployment/infrastructure/otel-collector.yaml
@@ -492,7 +492,6 @@ Resources:
     Type: AWS::ECS::Service
     DependsOn:
       - HTTPListener
-      - HTTPSListener
     Properties:
       ServiceName: otel-collector-service
       Cluster: !Ref ECSCluster


### PR DESCRIPTION
## Problem

When the admin answers **No** to "Enable HTTPS with custom domain?" during `ccwb init`, the `HasCustomDomain` condition is `false` and `HTTPSListener` is never created. However, `ECSService` unconditionally lists `HTTPSListener` in its `DependsOn`, causing CloudFormation to fail at deploy time:

```
Template format error: Unresolved resource dependencies [HTTPSListener] in the Resources block of the template
```

## Fix

Remove `HTTPSListener` from `ECSService.DependsOn`. The `HTTPListener` (which always exists) is sufficient — both listeners attach to the same ALB, so the service does not need an explicit dependency on the conditional HTTPS listener.

One line removed from `otel-collector.yaml`.