### PR TITLE
fix: s3bucket deploy uses wrong stack_names key

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -594,7 +594,7 @@ class DeployCommand(Command):
 
             elif stack_type == "s3bucket":
                 template = project_root / "deployment" / "infrastructure" / "s3bucket.yaml"
-                stack_name = profile.stack_names.get("networking", f"{profile.identity_pool_name}-s3bucket")
+                stack_name = profile.stack_names.get("s3", f"{profile.identity_pool_name}-s3bucket")
                 params = []
                 return deploy_with_cf(template, stack_name, params, task_description="Deploying S3 Bucket...")
             elif stack_type == "monitoring":

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -637,7 +637,7 @@ class DeployCommand(Command):
 
             elif stack_type == "s3bucket":
                 template = project_root / "deployment" / "infrastructure" / "s3bucket.yaml"
-                stack_name = profile.stack_names.get("networking", f"{profile.identity_pool_name}-s3bucket")
+                stack_name = profile.stack_names.get("s3", f"{profile.identity_pool_name}-s3bucket")
                 params = []
                 return deploy_with_cf(template, stack_name, params, task_description="Deploying S3 Bucket...")
             elif stack_type == "monitoring":
@@ -982,7 +982,7 @@ class DeployCommand(Command):
 
         elif stack_type == "s3bucket":
             template = project_root / "deployment" / "infrastructure" / "s3bucket.yaml"
-            stack_name = profile.stack_names.get("networking", f"{profile.identity_pool_name}-s3bucket")
+            stack_name = profile.stack_names.get("s3", f"{profile.identity_pool_name}-s3bucket")
             print_deploy_cmd(template, stack_name, [])
 
         elif stack_type == "monitoring":


### PR DESCRIPTION
Fixes #313

One-line fix: the s3bucket deploy path used `profile.stack_names.get("networking", ...)` instead of `profile.stack_names.get("s3", ...)`.

```diff
- stack_name = profile.stack_names.get("networking", f"{profile.identity_pool_name}-s3bucket")
+ stack_name = profile.stack_names.get("s3", f"{profile.identity_pool_name}-s3bucket")
```

Consistent with all other s3bucket references in the same file (lines 680, 783).