### PR TITLE
Add bedrock:CallWithBearerToken to IAM policies for Cowork credential-helper support

### DIFF
--- a/deployment/infrastructure/bedrock-auth-auth0.yaml
+++ b/deployment/infrastructure/bedrock-auth-auth0.yaml
@@ -102,6 +102,7 @@ Resources:
             Action:
               - 'bedrock:InvokeModel'
               - 'bedrock:InvokeModelWithResponseStream'
+              - 'bedrock:CallWithBearerToken'
               - 'bedrock:ListFoundationModels'
               - 'bedrock:ListInferenceProfiles'
               - 'bedrock-runtime:InvokeModel'
@@ -119,6 +120,7 @@ Resources:
             Action:
               - 'bedrock:InvokeModel'
               - 'bedrock:InvokeModelWithResponseStream'
+              - 'bedrock:CallWithBearerToken'
               - 'bedrock:ListFoundationModels'
               - 'bedrock:ListInferenceProfiles'
               - 'bedrock-runtime:InvokeModel'

--- a/deployment/infrastructure/bedrock-auth-azure.yaml
+++ b/deployment/infrastructure/bedrock-auth-azure.yaml
@@ -94,6 +94,7 @@ Resources:
             Action:
               - 'bedrock:InvokeModel'
               - 'bedrock:InvokeModelWithResponseStream'
+              - 'bedrock:CallWithBearerToken'
               - 'bedrock:ListFoundationModels'
               - 'bedrock:ListInferenceProfiles'
               - 'bedrock-runtime:InvokeModel'
@@ -111,6 +112,7 @@ Resources:
             Action:
               - 'bedrock:InvokeModel'
               - 'bedrock:InvokeModelWithResponseStream'
+              - 'bedrock:CallWithBearerToken'
               - 'bedrock:ListFoundationModels'
               - 'bedrock:ListInferenceProfiles'
               - 'bedrock-runtime:InvokeModel'

--- a/deployment/infrastructure/bedrock-auth-cognito-pool.yaml
+++ b/deployment/infrastructure/bedrock-auth-cognito-pool.yaml
@@ -100,6 +100,7 @@ Resources:
             Action:
               - 'bedrock:InvokeModel'
               - 'bedrock:InvokeModelWithResponseStream'
+              - 'bedrock:CallWithBearerToken'
               - 'bedrock:ListFoundationModels'
               - 'bedrock:ListInferenceProfiles'
               - 'bedrock-runtime:InvokeModel'
@@ -117,6 +118,7 @@ Resources:
             Action:
               - 'bedrock:InvokeModel'
               - 'bedrock:InvokeModelWithResponseStream'
+              - 'bedrock:CallWithBearerToken'
               - 'bedrock:ListFoundationModels'
               - 'bedrock:ListInferenceProfiles'
               - 'bedrock-runtime:InvokeModel'

--- a/deployment/infrastructure/bedrock-auth-okta.yaml
+++ b/deployment/infrastructure/bedrock-auth-okta.yaml
@@ -93,6 +93,7 @@ Resources:
             Action:
               - 'bedrock:InvokeModel'
               - 'bedrock:InvokeModelWithResponseStream'
+              - 'bedrock:CallWithBearerToken'
               - 'bedrock:ListFoundationModels'
               - 'bedrock:ListInferenceProfiles'
               - 'bedrock-runtime:InvokeModel'
@@ -110,6 +111,7 @@ Resources:
             Action:
               - 'bedrock:InvokeModel'
               - 'bedrock:InvokeModelWithResponseStream'
+              - 'bedrock:CallWithBearerToken'
               - 'bedrock:ListFoundationModels'
               - 'bedrock:ListInferenceProfiles'
               - 'bedrock-runtime:InvokeModel'

--- a/deployment/infrastructure/cognito-identity-pool.yaml
+++ b/deployment/infrastructure/cognito-identity-pool.yaml
@@ -137,6 +137,7 @@ Resources:
             Action:
               - 'bedrock:InvokeModel'
               - 'bedrock:InvokeModelWithResponseStream'
+              - 'bedrock:CallWithBearerToken'
               - 'bedrock:ListFoundationModels'
               - 'bedrock:ListInferenceProfiles'
             Resource:


### PR DESCRIPTION
## Problem

Claude Cowork (Desktop) using the `inferenceCredentialHelper` auth method fails with a 403 error because the IAM policies in the CloudFormation templates don't include the `bedrock:CallWithBearerToken` action.

Claude Code (CLI) uses standard STS credentials to call `bedrock-runtime:Converse`. Cowork's credential-helper converts STS credentials into a bearer token, which hits a different Bedrock API path requiring [`bedrock:CallWithBearerToken`](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-permissions.html) — the same action used by [Bedrock API keys](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys-use.html).

This means after a standard `ccwb deploy`, Claude Code works but Cowork returns: *"not authorized to perform: bedrock:CallWithBearerToken"*.

## Changes

Added `bedrock:CallWithBearerToken` to the Bedrock IAM policy in all 5 authentication CloudFormation templates:

- `cfn/okta.yaml`
- `cfn/azure.yaml`
- `cfn/auth0.yaml`
- `cfn/cognito-user-pool.yaml`
- `cfn/cognito-identity-pool.yaml`

## Testing

Deployed with the updated template and verified both Claude Code (CLI) and Cowork (Desktop) work with the same stack.