### PR TITLE
fix(deploy): use "s3" key for s3bucket stack_names lookup (#313)

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -594,7 +594,12 @@ class DeployCommand(Command):
 
             elif stack_type == "s3bucket":
                 template = project_root / "deployment" / "infrastructure" / "s3bucket.yaml"
-                stack_name = profile.stack_names.get("networking", f"{profile.identity_pool_name}-s3bucket")
+                # Lines 680 and 783 already look up the s3 stack under the
+                # "s3" key. Using "networking" here meant that profiles with
+                # custom stack_names deployed the bucket under the
+                # networking stack's name and any subsequent lookup via
+                # stack_names.get("s3", ...) silently missed it (#313).
+                stack_name = profile.stack_names.get("s3", f"{profile.identity_pool_name}-s3bucket")
                 params = []
                 return deploy_with_cf(template, stack_name, params, task_description="Deploying S3 Bucket...")
             elif stack_type == "monitoring":


### PR DESCRIPTION
Fixes #313. The `stack_type == "s3bucket"` branch in `_deploy_stack` (line 597) looked up the stack name under `profile.stack_names.get("networking", ...)`. Two later sites in the same file (lines 680 and 783) correctly use the `"s3"` key for the same stack. Profiles with custom `stack_names` deployed the bucket under the networking stack name and every later `stack_names.get("s3", ...)` lookup silently missed it.

One-line key swap: `"networking"` → `"s3"`.

## Test plan

- [x] AST parse on `deploy.py` is clean
- [x] Matches the existing `"s3"` lookups at lines 680 and 783 in the same file