### PR TITLE
fix: resolve Windows native packaging bugs (issue #168)

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -310,6 +310,7 @@ class PackageCommand(Command):
         for platform_name in platforms_to_build:
             # Build credential process
             console.print(f"[cyan]Building credential process for {platform_name}...[/cyan]")
+            executable_path = None  # Initialize to prevent UnboundLocalError if build fails
             try:
                 executable_path = self._build_executable(output_dir, platform_name)
                 # Check if this was an async Windows build
@@ -593,7 +594,7 @@ class PackageCommand(Command):
             binary_name = "credential-process-linux"
         elif target_platform == "windows":
             platform_variant = "x86_64"
-            # binary_name already set above
+            binary_name = "credential-process-windows.exe"
         else:
             raise ValueError(f"Unsupported target platform: {target_platform}")
 
@@ -629,7 +630,7 @@ class PackageCommand(Command):
         # Check if Nuitka is available (through Poetry)
         source_dir = Path(__file__).parent.parent.parent.parent
         nuitka_check = subprocess.run(
-            ["poetry", "run", "which", "nuitka"], capture_output=True, text=True, cwd=source_dir
+            ["poetry", "run", "python", "-m", "nuitka", "--version"], capture_output=True, text=True, cwd=source_dir
         )
         if nuitka_check.returncode != 0:
             raise RuntimeError(
@@ -1442,14 +1443,18 @@ RUN pyinstaller \
 
     def _build_otel_helper(self, output_dir: Path, target_platform: str) -> Path:
         """Build executable for OTEL helper script."""
-        # Windows uses Nuitka via CodeBuild
+        import platform as platform_mod
+
+        # Windows builds
         if target_platform == "windows":
-            # Check if the Windows binary already exists (built by _build_executable)
+            if platform_mod.system().lower() == "windows":
+                # Native Windows build with Nuitka
+                return self._build_native_otel_helper(output_dir, "windows")
+            # Check if the Windows binary already exists (built via CodeBuild)
             windows_binary = output_dir / "otel-helper-windows.exe"
             if windows_binary.exists():
                 return windows_binary
             else:
-                # If not, we need to build via CodeBuild (but this should have been done already)
                 raise RuntimeError("Windows otel-helper should have been built with credential-process")
 
         # macOS builds use PyInstaller
@@ -1612,6 +1617,9 @@ RUN pyinstaller \
         elif target_platform == "linux":
             platform_variant = "x86_64"
             binary_name = "otel-helper-linux"
+        elif target_platform == "windows":
+            platform_variant = "x86_64"
+            binary_name = "otel-helper-windows.exe"
         else:
             raise ValueError(f"Unsupported target platform: {target_platform}")
 
@@ -1620,6 +1628,8 @@ RUN pyinstaller \
             raise RuntimeError(f"Cannot build macOS binary on {current_system}. Nuitka requires native builds.")
         elif target_platform == "linux" and current_system != "linux":
             raise RuntimeError(f"Cannot build Linux binary on {current_system}. Nuitka requires native builds.")
+        elif target_platform == "windows" and current_system != "windows":
+            raise RuntimeError(f"Cannot build Windows binary on {current_system}. Nuitka requires native builds.")
 
         # Find the source file
         src_file = Path(__file__).parent.parent.parent.parent / "otel_helper" / "__main__.py"


### PR DESCRIPTION
## Summary

Fixes critical Windows native packaging bugs reported in #168. Enables users to build Windows binaries natively using Nuitka without requiring CodeBuild or cross-compilation.

## Attribution

Windows packaging fixes based on work by @pipeflo in PR #146. This PR extracts just the Windows-specific fixes and adds a critical bug fix for the `executable_path` initialization issue.

## Problems Fixed

### 1. UnboundLocalError crash (Critical - not in PR #146)
**Issue:** When `_build_executable()` raises an exception, `executable_path` is never initialized, causing `UnboundLocalError` on line 327 when checking for Windows CodeBuild scenarios.

**Fix:** Initialize `executable_path = None` before the try block.

**Impact:** Prevents crash when Nuitka is missing or build fails for any reason.

### 2. Missing binary_name for Windows
**Issue:** Line 596 had a comment `# binary_name already set above` but it was never actually set, causing undefined variable errors.

**Fix:** Set `binary_name = "credential-process-windows.exe"` for Windows target.

**Impact:** Enables Windows binary generation.

### 3. Unix-only Nuitka detection
**Issue:** Used `which nuitka` command which doesn't exist on Windows, causing "Nuitka not found" errors even when Nuitka is installed.

**Fix:** Use cross-platform `python -m nuitka --version` instead.

**Impact:** Proper Nuitka detection on Windows.

### 4. OTEL helper Windows build path
**Issue:** No native Windows build path for otel-helper; always errored when monitoring was enabled.

**Fix:** Add native Windows build support in `_build_otel_helper()` and `_build_native_otel_helper()`.

**Impact:** Complete Windows packaging with monitoring support.

## Testing

- ✅ Code changes validated against the error in #168
- ✅ Logic verified for all four bug fixes
- ✅ Based on latest main (rebased)

Full end-to-end Windows testing requires a Windows machine with Nuitka installed.

## Files Changed

- `source/claude_code_with_bedrock/cli/commands/package.py` (+15/-5 lines)

Closes #168
Based on PR #146