### PR TITLE
fix(package): refuse macOS builds from non-macOS hosts

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -669,10 +669,20 @@ Pick based on what your developers report:
 
 **Package Workflow:**
 
-1. **Local builds**: macOS/Linux executables are built locally using PyInstaller
+1. **Local builds**: macOS and Linux executables are built locally using PyInstaller. See the host-OS matrix below — PyInstaller cannot cross-compile across operating systems, so **macOS binaries must be built on macOS** and **Linux binaries must be built on Linux** (or on macOS via Docker).
 2. **Windows builds**: Trigger AWS CodeBuild for Windows executables (20+ minutes) - requires enabling CodeBuild during `init`
 3. **Check status**: Monitor build progress with `poetry run ccwb builds`
 4. **Create distribution**: Use `distribute` to upload and generate presigned URLs
+
+**Host-OS requirements for each target:**
+
+| Target binary | Build host must be | Tooling |
+|---|---|---|
+| `macos-arm64`, `macos-intel` | macOS | PyInstaller (native) |
+| `linux-x64`, `linux-arm64` | Linux, **or** macOS with Docker Desktop | PyInstaller (Docker container used when building from macOS) |
+| `windows` | any host with CodeBuild enabled | AWS CodeBuild (remote build) |
+
+> **Linux admins cannot build macOS binaries.** PyInstaller on Linux emits Linux ELF binaries regardless of the requested target architecture, and macOS cannot load ELF. If you run `ccwb package --target-platform=macos-arm64` on Linux, the build refuses with a clear error. To produce macOS binaries, use a macOS workstation or a CI macOS runner (e.g. GitHub Actions `macos-latest`) and collect the artifacts from there.
 
 > **Note**: Windows builds are optional and require CodeBuild to be enabled during the `init` process. If not enabled, the package command will skip Windows builds and continue with other platforms.
 
@@ -691,8 +701,9 @@ The `dist/` folder will contain:
 
 The package builder:
 
-- Automatically builds binaries for both macOS and Linux by default
-- Uses Docker to cross-compile Linux binaries when running on macOS — **Docker Desktop must be installed and running**; if not present, Linux builds are skipped with a warning and macOS/Windows builds continue unaffected
+- Builds binaries for the platforms your current host supports (see host-OS matrix above). On a macOS host that's macOS natively plus Linux via Docker; on a Linux host that's Linux only
+- Uses Docker to produce Linux binaries from a macOS host — **Docker Desktop must be installed and running**; if not present, Linux builds are skipped with a warning and other platforms continue unaffected
+- Refuses to attempt macOS targets from a non-macOS host (fails fast with a clear error rather than silently producing invalid binaries)
 - Includes the OTEL helper for extracting user attributes from JWT tokens
 - Creates a unified installer that auto-detects the user's platform
 

--- a/assets/docs/CLI_REFERENCE.md
+++ b/assets/docs/CLI_REFERENCE.md
@@ -262,16 +262,28 @@ poetry run ccwb package [options]
 
 **Platform Support (Hybrid Build System):**
 
+PyInstaller is a runtime bundler, not a cross-OS compiler. It emits binaries in the host OS's native format (Mach-O on macOS, ELF on Linux). That constrains which targets each build host can produce:
+
+| Target binary | Build host required | Tooling |
+|---|---|---|
+| `macos-arm64`, `macos-intel` | **macOS** | PyInstaller (native) |
+| `linux-x64`, `linux-arm64` | Linux, **or** macOS with Docker Desktop | PyInstaller (Docker container when building from macOS) |
+| `windows` | any host | AWS CodeBuild (remote) |
+
+> **Linux admins cannot build macOS binaries.** There is no supported path for producing Mach-O binaries on Linux — Apple's platform design makes this infeasible. If `ccwb package` detects a macOS target on a non-macOS host, the build refuses with a clear error rather than silently producing an ELF binary labeled as macOS (which would fail on end-user Macs with `exec format error`).
+>
+> To produce macOS binaries, use a macOS workstation, a CI macOS runner (GitHub Actions `macos-latest`, AWS CodeBuild macOS project, or a self-hosted Mac runner), or an EC2 Mac instance, and collect the artifacts from there.
+
 - **macOS**: Uses PyInstaller with architecture-specific builds
   - ARM64: Native build on Apple Silicon Macs (works on all Macs)
   - Intel: **Optional** - requires x86_64 Python environment on ARM Macs
   - Universal: Requires both architectures' Python libraries (not currently automated)
-- **Linux**: Uses PyInstaller in Docker containers (cross-compiled from macOS host)
+- **Linux**: Uses PyInstaller in Docker containers (when building from a macOS host)
   - x64: Uses linux/amd64 Docker platform
   - ARM64: Uses linux/arm64 Docker platform
   - Docker Desktop handles architecture emulation automatically
   - **Requires Docker Desktop to be installed and running** — see Graceful Fallback Behavior below
-  - Not required for macOS or Windows builds
+  - On a Linux host, PyInstaller runs natively — Docker is not required
 - **Windows**: Uses Nuitka via AWS CodeBuild (if enabled during init)
   - Automated builds take 12-15 minutes
   - Requires CodeBuild to be enabled during `init`
@@ -312,6 +324,7 @@ The package command is designed to handle missing optional components gracefully
   - Docker is not installed (`docker` binary not found in `$PATH`) — install Docker Desktop from https://docs.docker.com/get-docker/
   - Docker is installed but the daemon is not running — open Docker Desktop and wait for it to start, then retry
   - macOS and Windows builds are **unaffected** by Docker availability
+- **macOS builds (from non-macOS host)**: Refused with a clear error explaining that PyInstaller cannot cross-compile and listing alternative paths (macOS workstation, CI runner, EC2 Mac). Other targets in the same `ccwb package` invocation continue to build normally.
 - **At least one platform must build successfully** for the package command to succeed
 
 This ensures that packaging always works, even if some optional platforms are not available.

--- a/assets/docs/DEPLOYMENT.md
+++ b/assets/docs/DEPLOYMENT.md
@@ -68,16 +68,26 @@ poetry run ccwb package --target-platform=linux      # Linux via Docker
 
 **Platform Build Methods (Hybrid System):**
 
+PyInstaller emits binaries in the host OS's native format, so the build host must match the target OS. Only Windows (via CodeBuild) escapes this constraint.
+
+| Target binary | Build host required | Tooling |
+|---|---|---|
+| `macos-arm64`, `macos-intel` | **macOS** | PyInstaller (native) |
+| `linux-x64`, `linux-arm64` | Linux, **or** macOS with Docker Desktop | PyInstaller (Docker container when building from macOS) |
+| `windows` | any host | AWS CodeBuild (remote) |
+
+**Linux admins cannot produce macOS binaries** — see [CLI Reference: Platform Support](CLI_REFERENCE.md#platform-support-hybrid-build-system) for details. The package command refuses this combination with a clear error; to produce macOS binaries use a macOS workstation, a CI macOS runner, or an EC2 Mac instance.
+
 - **Windows**: Uses Nuitka via AWS CodeBuild
   - Optimized for performance and minimal antivirus false positives
-- **macOS**: Uses PyInstaller with architecture-specific builds
+- **macOS**: Uses PyInstaller with architecture-specific builds (must be run on a macOS host)
   - ARM64: Native build on Apple Silicon Macs (works on all Macs via Rosetta)
   - Intel: **Optional** - requires x86_64 Python environment on ARM Macs
   - Universal: Requires both architectures' Python libraries
-- **Linux x64/ARM64**: Uses PyInstaller in Docker containers (cross-compiled from macOS)
+- **Linux x64/ARM64**: Uses PyInstaller — natively on a Linux host, or via Docker on a macOS host
   - Automatically builds both architectures when Docker is available
   - Docker Desktop handles architecture emulation via Rosetta
-  - **Requires Docker Desktop installed and running** — if absent, Linux builds are skipped with a warning and all other platforms continue normally
+  - **When building from macOS, requires Docker Desktop installed and running** — if absent, Linux builds are skipped with a warning and all other platforms continue normally
   - macOS and Windows builds have no dependency on Docker
 
 **Optional: Intel Mac Setup**

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -25,6 +25,40 @@ from claude_code_with_bedrock.models import (
 )
 
 
+def _assert_host_os_can_build_macos() -> None:
+    """Refuse to produce macOS binaries from a non-macOS host.
+
+    PyInstaller is not a cross-OS compiler: run on Linux, it emits Linux ELF
+    binaries regardless of --target-arch. Without this guard, a Linux-host
+    build would write ELF content into a macOS-named output file, and the
+    resulting package would fail on end-user Macs with "exec format error"
+    (the macOS kernel cannot load ELF binaries and Rosetta only translates
+    Mach-O, not ELF).
+
+    macOS binaries must be built on macOS — this is a property of Apple's
+    platform, not a limitation of this tool.
+    """
+    host = platform.system().lower()
+    if host == "darwin":
+        return
+    raise RuntimeError(
+        f"Cannot build macOS binaries on {platform.system()}.\n"
+        f"\n"
+        f"PyInstaller cannot cross-compile across operating systems. On "
+        f"{platform.system()}, it produces {platform.system()}-native binaries "
+        f"regardless of --target-arch.\n"
+        f"\n"
+        f"Options for producing macOS binaries:\n"
+        f"  1. Run `ccwb package` on a macOS workstation\n"
+        f"  2. Use a CI macOS runner (GitHub Actions `macos-latest`, AWS\n"
+        f"     CodeBuild macOS project, or a self-hosted Mac runner) and\n"
+        f"     collect the artifacts from there\n"
+        f"  3. Drop macOS targets from this build — run with\n"
+        f"     --target-platform=linux-x64,linux-arm64,windows\n"
+        f"     to build only the platforms your current host supports"
+    )
+
+
 class PackageCommand(Command):
     """
     Build distribution packages for your organization
@@ -718,6 +752,7 @@ class PackageCommand(Command):
 
     def _build_macos_pyinstaller(self, output_dir: Path, arch: str) -> Path:
         """Build macOS executable using PyInstaller with target architecture."""
+        _assert_host_os_can_build_macos()
         console = Console()
         verbose = self.option("build-verbose")
 
@@ -1482,6 +1517,9 @@ RUN pyinstaller \
     def _build_otel_helper_pyinstaller(self, output_dir: Path, platform_name: str, arch: str | None) -> Path:
         """Build OTEL helper using PyInstaller."""
         import platform as platform_module
+
+        if platform_name == "macos":
+            _assert_host_os_can_build_macos()
 
         console = Console()
         verbose = self.option("build-verbose")


### PR DESCRIPTION
## Summary

Fixes a bug where `ccwb package --target-platform=macos-arm64` (or `macos-intel`) run on a Linux host would silently produce a Linux ELF binary written to a macOS-named output file. End users on macOS would then hit `[Errno 8] Exec format error` when the AWS SDK invoked `credential-process` — the macOS kernel cannot load ELF, and Rosetta only translates Mach-O.

PyInstaller is a runtime bundler, not a cross-OS compiler. It emits binaries in the host OS's native format regardless of `--target-arch`. This PR adds a hard guard that refuses macOS targets on non-macOS hosts with a clear error listing three realistic alternatives (macOS workstation, CI macOS runner, drop macOS targets).

## What changes

**Code** (`source/claude_code_with_bedrock/cli/commands/package.py`):
- New module-level helper `_assert_host_os_can_build_macos()` called from `_build_macos_pyinstaller` and the macOS path of `_build_otel_helper_pyinstaller`
- On Darwin: no-op. On any other host: raises `RuntimeError` with remediation options
- Other build targets (linux, windows) in the same `ccwb package` invocation continue normally — only macOS targets are refused

**Docs** (`QUICK_START.md`, `assets/docs/CLI_REFERENCE.md`, `assets/docs/DEPLOYMENT.md`):
- Add a host-OS matrix stating explicitly that macOS binaries must be built on macOS
- Replace ambiguous wording about cross-compilation direction

## Verification

**Reproduced the original bug on Amazon Linux 2023 aarch64 (EC2):**
```
$ poetry run pyinstaller --target-arch=arm64 --name=credential-process-macos-arm64 ...
✓ build completes, no error
$ file /tmp/macbuild/credential-process-macos-arm64
credential-process-macos-arm64: ELF 64-bit LSB executable, ARM aarch64 ... GNU/Linux
```

**With the guard applied, same command path:**
```
$ poetry run python /tmp/test_guard.py
GUARD TRIGGERED — build refused as expected.
---
Cannot build macOS binaries on Linux.

PyInstaller cannot cross-compile across operating systems. On Linux,
it produces Linux-native binaries regardless of --target-arch.

Options for producing macOS binaries:
  1. Run `ccwb package` on a macOS workstation
  2. Use a CI macOS runner (GitHub Actions `macos-latest`, AWS
     CodeBuild macOS project, or a self-hosted Mac runner) and
     collect the artifacts from there
  3. Drop macOS targets from this build — run with
     --target-platform=linux-x64,linux-arm64,windows
     to build only the platforms your current host supports
```

## Test plan

- [x] Existing `test_package.py`, `test_package_async.py`, `test_package_models.py` — 13/13 pass unchanged
- [x] Manual reproduction on Amazon Linux 2023 (EC2) — guard triggers, no invalid binary written
- [x] Manual smoke on macOS — guard no-ops, normal macOS builds unaffected
- [ ] Maintainer: verify on a Linux CI runner that `--target-platform=all` (which on Linux auto-selects linux-x64, linux-arm64) continues to work unchanged — the guard only fires on explicit macOS target selection