### PR TITLE
fix: replace hardcoded Okta labels with provider-aware display names

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1464,7 +1464,14 @@ class InitCommand(Command):
             if dist_type == "landing-page":
                 console.print("• Authenticated landing page distribution (ALB + Lambda + S3)")
                 idp_provider = config.get("distribution", {}).get("idp_provider", "")
-                console.print(f"• IdP authentication: {idp_provider.upper() if idp_provider else 'configured'}")
+                idp_display_names = {
+                    "okta": "Okta",
+                    "azure": "Azure AD / Entra ID",
+                    "auth0": "Auth0",
+                    "cognito": "AWS Cognito User Pool",
+                }
+                idp_label = idp_display_names.get(idp_provider, idp_provider.upper() if idp_provider else "configured")
+                console.print(f"• IdP authentication: {idp_label}")
                 if config.get("distribution", {}).get("custom_domain"):
                     console.print(f"• Custom domain: {config['distribution']['custom_domain']}")
             elif dist_type == "presigned-s3":

--- a/source/claude_code_with_bedrock/cli/commands/test.py
+++ b/source/claude_code_with_bedrock/cli/commands/test.py
@@ -435,14 +435,14 @@ class TestCommand(Command):
         if failed > 0:
             console.print("\n[red]Some tests failed. Please check the details above.[/red]")
             console.print("\n[bold]Troubleshooting tips:[/bold]")
-            provider_type = getattr(profile, "provider_type", None) or "okta"
+            provider_type = getattr(profile, "provider_type", None)
             provider_labels = {
                 "okta": "Okta",
                 "azure": "Microsoft Entra ID (Azure AD)",
                 "auth0": "Auth0",
                 "cognito": "AWS Cognito",
             }
-            provider_label = provider_labels.get(provider_type, provider_type.title())
+            provider_label = provider_labels.get(provider_type, provider_type.title() if provider_type else "your identity provider")
             console.print(f"• Ensure you have access to the {provider_label} application")
             console.print("• Check that the Cognito Identity Pool is deployed")
             console.print("• Verify IAM roles have correct permissions")

--- a/source/claude_code_with_bedrock/cli/utils/progress.py
+++ b/source/claude_code_with_bedrock/cli/utils/progress.py
@@ -74,10 +74,8 @@ class WizardProgress:
         step = self.get_last_step()
 
         summary_parts = []
-        if step == "okta_complete":
-            summary_parts.append(f"✓ Okta: {data.get('okta', {}).get('domain', 'Not set')}")
-        if step in ["aws_complete", "monitoring_complete", "bedrock_complete"]:
-            summary_parts.append(f"✓ Okta: {data.get('okta', {}).get('domain', 'Not set')}")
+        if step in ["oidc_complete", "aws_complete", "monitoring_complete", "bedrock_complete"]:
+            summary_parts.append(f"✓ OIDC Provider: {data.get('okta', {}).get('domain', 'Not set')}")
             summary_parts.append(f"✓ AWS Region: {data.get('aws', {}).get('region', 'Not set')}")
         if step == "monitoring_complete":
             summary_parts.append(


### PR DESCRIPTION
## Summary

- **Root cause**: Three locations in the installer wizard hardcoded "Okta" as the displayed IdP name regardless of the configured OIDC provider, affecting EntraID/Azure AD users most visibly
- `test.py`: Removed `or "okta"` fallback on `provider_type` — test failure output was always telling users to "Ensure you have access to the **Okta** application" even when using EntraID
- `init.py`: Added a provider label map to the wizard completion summary so Azure shows "Azure AD / Entra ID" instead of the raw uppercased key "AZURE"
- `progress.py`: Fixed the resume summary to display "✓ OIDC Provider:" and updated the stale step key check from `"okta_complete"` to `"oidc_complete"` (init.py already saves the new key name)

## Test plan

- [ ] Run `ccwb init` with an EntraID (`login.microsoftonline.com/...`) domain and verify the wizard completion summary shows "Azure AD / Entra ID"
- [ ] Simulate a test failure with an EntraID profile and verify the troubleshooting tip says "Microsoft Entra ID (Azure AD)" not "Okta"
- [ ] Interrupt `ccwb init` mid-way through with an EntraID profile, re-run, and verify the resume summary shows "✓ OIDC Provider:" with the correct domain
- [ ] Verify Okta users are unaffected — completion summary still shows "Okta"