### PR TITLE
fix(package): auto-create per-arch venvs from universal2 Python for macOS cross-arch builds

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -24,10 +24,10 @@ uname -m
 
 | Output | Your Mac | Builds natively |
 |--------|----------|----------------|
-| `arm64` | Apple Silicon (M1/M2/M3/M4) | `macos-arm64` — Intel requires [optional setup](assets/docs/CLI_REFERENCE.md#intel-mac-build-setup-optional) |
-| `x86_64` | Intel Mac | `macos-intel` — cannot build `macos-arm64` |
+| `arm64` | Apple Silicon (M1/M2/M3/M4) | `macos-arm64` — Apple Silicon only; Intel Macs cannot run it |
+| `x86_64` | Intel Mac | `macos-intel` — covers all Macs (runs natively on Intel, via Rosetta on Apple Silicon) |
 
-> Intel (`macos-intel`) binaries run on both Intel and Apple Silicon Macs (via Rosetta). ARM64 binaries only run on Apple Silicon. If your developers have a **mixed fleet**, build `macos-intel` — it covers everyone.
+> Intel (`macos-intel`) binaries run via Rosetta on Apple Silicon Macs, so a single Intel binary covers your entire Mac fleet. ARM64 binaries only run on Apple Silicon. If your admin is on Apple Silicon, use the [cross-arch setup](assets/docs/CLI_REFERENCE.md#cross-arch-macos-build-setup-optional) to build the Intel binary.
 
 ### AWS Requirements
 
@@ -665,7 +665,7 @@ Pick based on what your developers report:
 | `x86_64` (Intel) | `macos-intel` |
 | Both | `macos-arm64` + `macos-intel` |
 
-> **Note:** Building `macos-intel` on an Apple Silicon Mac requires a one-time x86_64 Python setup. If not configured, the Intel build is skipped and **no binary is included in the package**. Complete the [Intel Mac Build Setup](assets/docs/CLI_REFERENCE.md#intel-mac-build-setup-optional) before selecting `macos-intel`.
+> **Note:** `macos-intel` binaries run on all Macs — natively on Intel, via Rosetta on Apple Silicon. If you have Intel Mac users in your org, build `macos-intel`. On Apple Silicon, this requires a universal2 Python (see [Cross-arch macOS Build Setup](assets/docs/CLI_REFERENCE.md#cross-arch-macos-build-setup-optional)).
 
 **Package Workflow:**
 
@@ -775,21 +775,21 @@ See [Distribution Comparison](assets/docs/distribution/comparison.md) for detail
 
 - **Windows**: AWS CodeBuild with Nuitka (automated)
 - **macOS**: PyInstaller with architecture-specific builds
-  - ARM64: Native build on Apple Silicon Macs
-  - Intel: Optional - requires x86_64 Python environment on ARM Macs
-  - Universal: Requires both architectures' Python libraries
+  - ARM64: Native build on Apple Silicon Macs only — cannot run on Intel Macs
+  - Intel: Native build on Intel Macs — cross-arch from Apple Silicon requires universal2 Python (optional)
+  - Universal: Requires universal2 Python (optional)
 - **Linux**: Docker with PyInstaller (cross-compiled from macOS host)
   - Requires [Docker Desktop](https://docs.docker.com/get-docker/) installed and running
   - If Docker is not installed or its daemon is not running, Linux builds are skipped with a warning
   - macOS and Windows builds have **no dependency on Docker**
 
-### Optional: Intel Mac Builds
+### Optional: Cross-arch macOS Builds
 
-Intel Mac builds require an x86_64 Python environment on Apple Silicon Macs.
+By default, `ccwb package` builds only for your Mac's own architecture. If you need to also build for the other architecture (e.g. Intel on Apple Silicon), install a universal2 Python from python.org — `ccwb` will detect it automatically.
 
-See [CLI Reference - Intel Mac Build Setup](assets/docs/CLI_REFERENCE.md#intel-mac-build-setup-optional) for setup instructions.
+See [CLI Reference - Cross-arch macOS Build Setup](assets/docs/CLI_REFERENCE.md#cross-arch-macos-build-setup-optional) for setup instructions.
 
-If not configured, the package command will skip Intel builds and continue with other platforms.
+If not configured, cross-arch builds are skipped and the package command continues with other platforms. Intel (`macos-intel`) binaries cover all Macs via Rosetta, so admins on Intel Macs can skip this. Admins on Apple Silicon who have Intel Mac users in their org should install the universal2 Python to produce the Intel binary.
 
 ---
 
@@ -893,11 +893,9 @@ file ~/claude-code-with-bedrock/credential-process        # binary's CPU arch
 **Fix (admin) — rebuild with both macOS architectures:**
 
 ```bash
-# One-time setup: x86_64 Python environment on Apple Silicon Mac
-arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-arch -x86_64 /usr/local/bin/brew install python@3.12
-arch -x86_64 /usr/local/bin/python3.12 -m venv ~/venv-x86
-arch -x86_64 ~/venv-x86/bin/pip install pyinstaller boto3 keyring
+# One-time setup: install Python universal2 from https://www.python.org/downloads/macos/
+# Download the "macOS 64-bit universal2 installer" for Python 3.12 and run it.
+# ccwb detects it automatically at /Library/Frameworks/Python.framework/
 
 # Rebuild — now produces both macos-arm64 and macos-intel
 poetry run ccwb package --target-platform all
@@ -905,7 +903,7 @@ poetry run ccwb package --target-platform all
 
 Redistribute the new package. The installer auto-detects architecture and installs the correct binary.
 
-> **Why this happens:** Building on Apple Silicon only produces `credential-process-macos-arm64` by default. The Intel (`macos-intel`) build is optional and requires the x86_64 Python environment above. ARM64 binaries cannot run on Intel Macs — unlike the reverse (Intel binaries run on Apple Silicon via Rosetta).
+> **Why this happens:** Without a universal2 Python, `ccwb package` builds only for the host Mac's architecture. An ARM64-only package has no Intel binary, so Intel Mac users get `exec format error` — ARM64 binaries cannot run on Intel Macs. Install a universal2 Python to also build the Intel binary, which covers all Mac users.
 
 ### Windows `install.bat` — `-replace was unexpected at this time.`
 

--- a/assets/docs/CLI_REFERENCE.md
+++ b/assets/docs/CLI_REFERENCE.md
@@ -237,7 +237,7 @@ poetry run ccwb package [options]
 - `--target-platform <platform>` - Target platform for binary (default: "all")
   - `macos` - Build for current macOS architecture
   - `macos-arm64` - Build for Apple Silicon Macs
-  - `macos-intel` - Build for Intel Macs (uses Rosetta on ARM Macs)
+  - `macos-intel` - Build for Intel Macs (cross-arch on Apple Silicon requires universal2 Python)
   - `linux` - Build for Linux (native, current architecture)
   - `linux-x64` - Build for Linux x64 using Docker
   - `linux-arm64` - Build for Linux ARM64 using Docker
@@ -263,9 +263,9 @@ poetry run ccwb package [options]
 **Platform Support (Hybrid Build System):**
 
 - **macOS**: Uses PyInstaller with architecture-specific builds
-  - ARM64: Native build on Apple Silicon Macs (works on all Macs)
-  - Intel: **Optional** - requires x86_64 Python environment on ARM Macs
-  - Universal: Requires both architectures' Python libraries (not currently automated)
+  - ARM64: Native build on Apple Silicon Macs only — cannot run on Intel Macs
+  - Intel: Runs natively on Intel Macs and on Apple Silicon via Rosetta — covers all Mac users with one binary
+  - Cross-arch: **Optional** — build the other architecture from your current Mac; requires a universal2 Python (see below)
 - **Linux**: Uses PyInstaller in Docker containers (cross-compiled from macOS host)
   - x64: Uses linux/amd64 Docker platform
   - ARM64: Uses linux/arm64 Docker platform
@@ -277,36 +277,30 @@ poetry run ccwb package [options]
   - Requires CodeBuild to be enabled during `init`
   - Will be skipped if CodeBuild is not enabled
 
-**Intel Mac Build Setup (Optional):**
+**Cross-arch macOS Build Setup (Optional):**
 
-To enable Intel builds on Apple Silicon Macs (optional):
+By default, `ccwb package` builds a binary for your Mac's own architecture. The Intel (`macos-intel`) binary covers all Mac users — it runs natively on Intel Macs and via Rosetta on Apple Silicon — so an Apple Silicon admin who needs to support Intel Mac users should build the Intel binary using this setup.
 
-```bash
-# Step 1: Install x86_64 Homebrew (if not already installed)
-arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+To build for the other architecture (e.g. Intel binary on Apple Silicon, or ARM64 binary on Intel), install a universal2 Python:
 
-# Step 2: Install x86_64 Python
-arch -x86_64 /usr/local/bin/brew install python@3.12
+1. Download the **macOS 64-bit universal2 installer** for Python 3.12 from [python.org/downloads/macos](https://www.python.org/downloads/macos/)
+2. Run the installer — it places Python at `/Library/Frameworks/Python.framework/`
+3. Re-run `ccwb package` — it detects the universal2 Python automatically
 
-# Step 3: Create x86_64 virtual environment
-arch -x86_64 /usr/local/bin/python3.12 -m venv ~/venv-x86
+`ccwb` creates an isolated per-arch build environment at `~/.ccwb/build-venvs/` on first cross-arch build (~30s). Subsequent runs reuse it.
 
-# Step 4: Install required packages
-arch -x86_64 ~/venv-x86/bin/pip install pyinstaller boto3 keyring
-```
+**Behavior when universal2 Python is not installed:**
 
-**Behavior when Intel environment is not set up:**
-
-- For `--target-platform=all`: Skips Intel builds with a note, builds all other platforms
-- For `--target-platform=macos-intel`: Shows instructions for optional setup, skips the build
-- The package process continues successfully without Intel binaries
-- Intel (`macos-intel`) binaries can be distributed to all Mac users — they run natively on Intel Macs and via Rosetta on Apple Silicon. ARM64 binaries only run on Apple Silicon and cannot run on Intel Macs.
+- For `--target-platform=all`: Skips the cross-arch target with a note, builds all other platforms normally
+- For an explicit cross-arch target (e.g. `--target-platform=macos-intel` on Apple Silicon): Fails with a clear error pointing to the python.org installer
+- The package process continues successfully without cross-arch binaries
+- Note: Intel (`macos-intel`) binaries run natively on Intel Macs and via Rosetta on Apple Silicon — they cover all Mac users. ARM64 binaries only run on Apple Silicon and cannot run on Intel Macs.
 
 **Graceful Fallback Behavior:**
 
 The package command is designed to handle missing optional components gracefully:
 
-- **Intel Mac builds**: Skipped if x86_64 Python environment is not available on ARM Macs
+- **Cross-arch macOS builds**: Skipped if universal2 Python is not installed (see Cross-arch macOS Build Setup above)
 - **Windows builds**: Skipped if CodeBuild was not enabled during `init`
 - **Linux builds (from macOS)**: Skipped with a warning in two cases:
   - Docker is not installed (`docker` binary not found in `$PATH`) — install Docker Desktop from https://docs.docker.com/get-docker/

--- a/assets/docs/DEPLOYMENT.md
+++ b/assets/docs/DEPLOYMENT.md
@@ -71,21 +71,37 @@ poetry run ccwb package --target-platform=linux      # Linux via Docker
 - **Windows**: Uses Nuitka via AWS CodeBuild
   - Optimized for performance and minimal antivirus false positives
 - **macOS**: Uses PyInstaller with architecture-specific builds
-  - ARM64: Native build on Apple Silicon Macs (works on all Macs via Rosetta)
-  - Intel: **Optional** - requires x86_64 Python environment on ARM Macs
-  - Universal: Requires both architectures' Python libraries
+  - ARM64: Native build on Apple Silicon Macs only — cannot run on Intel Macs
+  - Intel: Runs natively on Intel Macs and on Apple Silicon via Rosetta — covers all Mac users with one binary
+  - Cross-arch: **Optional** — build the other architecture from your current Mac; requires a universal2 Python (see below)
 - **Linux x64/ARM64**: Uses PyInstaller in Docker containers (cross-compiled from macOS)
   - Automatically builds both architectures when Docker is available
   - Docker Desktop handles architecture emulation via Rosetta
   - **Requires Docker Desktop installed and running** — if absent, Linux builds are skipped with a warning and all other platforms continue normally
   - macOS and Windows builds have no dependency on Docker
 
-**Optional: Intel Mac Setup**
+**Which macOS binary should you ship?**
 
-To build Intel binaries on Apple Silicon Macs, you'll need an x86_64 Python environment.
-See [CLI Reference](CLI_REFERENCE.md#intel-mac-build-setup-optional) for setup instructions.
+| Your developer fleet | Recommended binary | Notes |
+|---|---|---|
+| Apple Silicon only | `macos-arm64` | Native, no extra setup |
+| Intel only | `macos-intel` | Native, no extra setup |
+| Mixed (or unknown) | `macos-intel` | Covers everyone — runs natively on Intel, via Rosetta on Apple Silicon |
+| Performance-conscious mixed fleet | Both `macos-arm64` + `macos-intel` | Installer picks the right one per device |
 
-The package command will continue successfully even without this setup.
+> **Rosetta translation:** Intel (`x86_64`) binaries run on Apple Silicon via Apple's Rosetta 2 translation layer — users don't need to do anything. ARM64 binaries cannot run on Intel Macs at all.
+
+**Optional: Cross-arch macOS Builds**
+
+By default, `ccwb package` builds only for your Mac's own architecture (arm64 on Apple Silicon, x86_64 on Intel). To build for the other architecture — for example, an Apple Silicon admin building the Intel binary to cover Intel Mac users — install a universal2 Python:
+
+1. Download the **macOS 64-bit universal2 installer** for Python 3.12 from [python.org/downloads/macos](https://www.python.org/downloads/macos/)
+2. Run the installer — it places Python at `/Library/Frameworks/Python.framework/`
+3. Re-run `ccwb package` — it detects the universal2 Python automatically and builds both architectures
+
+On first cross-arch build, `ccwb` creates an isolated build environment at `~/.ccwb/build-venvs/` (~30s). Subsequent runs reuse it.
+
+Without universal2 Python: `--target-platform=all` skips the cross-arch target with a note and continues normally. Explicitly requesting the cross-arch target (e.g. `--target-platform=macos-intel` on Apple Silicon) fails with a clear error pointing to the python.org installer.
 
 This command performs several operations. First, it retrieves the Cognito Identity Pool ID from your deployed CloudFormation stack. Then it compiles the Python authentication code into standalone executables using PyInstaller for macOS/Linux and Nuitka for Windows. Your organization's configuration - provider domain, client ID, and infrastructure details - gets written to a config.json file that the executables read at runtime.
 

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -24,6 +24,83 @@ from claude_code_with_bedrock.models import (
     get_source_region_for_profile,
 )
 
+# Runtime packages bundled into the credential provider binary.
+_CREDENTIAL_PROVIDER_RUNTIME_DEPS = ["boto3", "requests", "PyJWT", "keyring", "cryptography"]
+_OTEL_HELPER_RUNTIME_DEPS: list[str] = []  # otel_helper uses only stdlib
+_PYINSTALLER_PIN = "pyinstaller==6.*"
+
+
+def _find_universal2_python() -> Path | None:
+    """Return the first universal2 Python ≥3.10 found in the standard python.org install location, or None."""
+    import glob
+
+    candidates = sorted(
+        glob.glob("/Library/Frameworks/Python.framework/Versions/*/bin/python3*"),
+        reverse=True,  # prefer higher versions
+    )
+    for candidate in candidates:
+        p = Path(candidate)
+        if not p.is_file() or not p.stat().st_size:
+            continue
+        result = subprocess.run(["/usr/bin/lipo", "-info", str(p)], capture_output=True, text=True)  # nosec B603 B607
+        if result.returncode != 0:
+            continue
+        out = result.stdout.strip()
+        # universal2 shows "are: x86_64 arm64" or "are: arm64 x86_64"
+        if "are:" in out and "x86_64" in out and "arm64" in out:
+            # Verify version ≥3.10
+            ver = subprocess.run([str(p), "--version"], capture_output=True, text=True)  # nosec B603 B607
+            if ver.returncode == 0:
+                try:
+                    parts = ver.stdout.strip().split()[1].split(".")
+                    if int(parts[0]) >= 3 and int(parts[1]) >= 10:
+                        return p
+                except (IndexError, ValueError):
+                    continue
+    return None
+
+
+def _ensure_cross_arch_venv(arch: str, universal2_python: Path, runtime_packages: list[str], console: Console) -> Path:
+    """Create (or reuse) ~/.ccwb/build-venvs/<arch>/ seeded from a universal2 Python.
+
+    The venv is created under `arch -<arch>` so pip pulls arch-matched wheels for every
+    native extension (cffi, cryptography, etc.). Reused on subsequent runs unless stale.
+    """
+    venv_dir = Path.home() / ".ccwb" / "build-venvs" / arch
+    pyinstaller_bin = venv_dir / "bin" / "pyinstaller"
+    python_bin = venv_dir / "bin" / "python3"
+
+    if pyinstaller_bin.exists() and python_bin.exists():
+        # Validate the venv's Python is actually the right arch
+        result = subprocess.run(["/usr/bin/lipo", "-info", str(python_bin)], capture_output=True, text=True)  # nosec B603 B607
+        if result.returncode == 0 and arch in result.stdout:
+            return venv_dir
+        # Wrong arch — rebuild
+        import shutil
+        console.print(f"[yellow]Rebuilding {arch} build venv (wrong architecture detected)[/yellow]")
+        shutil.rmtree(venv_dir, ignore_errors=True)
+
+    venv_dir.parent.mkdir(parents=True, exist_ok=True)
+    console.print(f"[cyan]Preparing {arch} build venv at {venv_dir} (first run, ~30s)...[/cyan]")
+
+    create = subprocess.run(  # nosec B603 B607
+        ["/usr/bin/arch", f"-{arch}", str(universal2_python), "-m", "venv", str(venv_dir)],
+        capture_output=True, text=True,
+    )
+    if create.returncode != 0:
+        raise RuntimeError(f"Failed to create {arch} build venv: {create.stderr}")
+
+    pip = venv_dir / "bin" / "pip"
+    install = subprocess.run(  # nosec B603 B607
+        ["/usr/bin/arch", f"-{arch}", str(pip), "install", "--quiet", _PYINSTALLER_PIN, *runtime_packages],
+        capture_output=True, text=True,
+    )
+    if install.returncode != 0:
+        raise RuntimeError(f"Failed to install deps into {arch} build venv: {install.stderr or install.stdout}")
+
+    console.print(f"[green]✓ {arch} build venv ready[/green]")
+    return venv_dir
+
 
 class PackageCommand(Command):
     """
@@ -198,25 +275,9 @@ class PackageCommand(Command):
         # Build package
         console.print("\n[bold]Building package...[/bold]")
 
-        # Pre-flight check for Intel builds on ARM Macs
-        if platform.system().lower() == "darwin" and platform.machine().lower() == "arm64":
-            if target_platform in ["macos-intel", "all"]:
-                x86_venv_path = Path.home() / "venv-x86"
-                if not (x86_venv_path.exists() and (x86_venv_path / "bin" / "pyinstaller").exists()):
-                    if target_platform == "macos-intel":
-                        console.print("\n[yellow]⚠️  Intel Mac build environment not found[/yellow]")
-                        console.print("[dim]Intel builds require an x86_64 Python environment on Apple Silicon.[/dim]")
-                        console.print("[dim]ARM64 binaries work on Intel Macs via Rosetta, so this is optional.[/dim]")
-                        console.print("\n[dim]To set up Intel builds (optional):[/dim]")
-                        console.print("[dim]1. Install x86_64 Homebrew:[/dim]")
-                        console.print(
-                            '[dim]   arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"[/dim]'
-                        )
-                        console.print("[dim]2. Install Python and create environment:[/dim]")
-                        console.print("[dim]   arch -x86_64 /usr/local/bin/brew install python@3.12[/dim]")
-                        console.print("[dim]   arch -x86_64 /usr/local/bin/python3.12 -m venv ~/venv-x86[/dim]")
-                        console.print("[dim]   arch -x86_64 ~/venv-x86/bin/pip install pyinstaller boto3 keyring[/dim]")
-                        console.print()
+        # Cross-arch macOS builds auto-create per-arch venvs from a universal2 Python.
+        # Detect once here so both the platforms_to_build assembly and _build_macos_pyinstaller share the same result.
+        _universal2_python = _find_universal2_python() if platform.system().lower() == "darwin" else None
 
         # Build executable(s) using PyInstaller/Docker
         # Handle both list and single platform selection
@@ -230,13 +291,16 @@ class PackageCommand(Command):
                     current_machine = platform.machine().lower()
 
                     if current_os == "darwin":
-                        if current_machine == "arm64":
-                            platforms_to_build.append("macos-arm64")
-                            x86_venv_path = Path.home() / "venv-x86"
-                            if x86_venv_path.exists() and (x86_venv_path / "bin" / "pyinstaller").exists():
-                                platforms_to_build.append("macos-intel")
+                        host_arch = current_machine  # arm64 or x86_64
+                        platforms_to_build.append(f"macos-{'arm64' if host_arch == 'arm64' else 'intel'}")
+                        cross_arch = "x86_64" if host_arch == "arm64" else "arm64"
+                        cross_platform = "macos-intel" if host_arch == "arm64" else "macos-arm64"
+                        if _universal2_python:
+                            platforms_to_build.append(cross_platform)
                         else:
-                            platforms_to_build.append("macos-intel")
+                            console.print(
+                                f"[dim]Note: {cross_platform} skipped — install Python universal2 from python.org to enable.[/dim]"
+                            )
 
                         try:
                             docker_check = subprocess.run(["docker", "--version"], capture_output=True)
@@ -264,22 +328,15 @@ class PackageCommand(Command):
             current_machine = platform.machine().lower()
 
             if current_os == "darwin":
-                # On macOS, build for current architecture
-                if current_machine == "arm64":
-                    platforms_to_build.append("macos-arm64")
-                    # Check if x86_64 environment is available for Intel builds
-                    x86_venv_path = Path.home() / "venv-x86"
-                    if x86_venv_path.exists() and (x86_venv_path / "bin" / "pyinstaller").exists():
-                        platforms_to_build.append("macos-intel")
-                    else:
-                        # Check if Rosetta is available (for informational message)
-                        rosetta_check = subprocess.run(["arch", "-x86_64", "true"], capture_output=True)
-                        if rosetta_check.returncode == 0:
-                            console.print(
-                                "[dim]Note: Intel Mac builds available with optional setup. See docs for details.[/dim]"
-                            )
+                host_arch = current_machine  # arm64 or x86_64
+                platforms_to_build.append(f"macos-{'arm64' if host_arch == 'arm64' else 'intel'}")
+                cross_platform = "macos-intel" if host_arch == "arm64" else "macos-arm64"
+                if _universal2_python:
+                    platforms_to_build.append(cross_platform)
                 else:
-                    platforms_to_build.append("macos-intel")
+                    console.print(
+                        f"[dim]Note: {cross_platform} skipped — install Python universal2 from python.org to enable.[/dim]"
+                    )
 
                 # Check if Docker is available for Linux builds
                 try:
@@ -738,44 +795,35 @@ class PackageCommand(Command):
 
         console.print(f"[yellow]Building macOS {arch} binary with PyInstaller...[/yellow]")
 
-        # Check if we need to use x86_64 Python for Intel builds
-        use_x86_python = False
-        x86_venv_path = Path.home() / "venv-x86"
-
-        if arch == "x86_64" and platform.machine().lower() == "arm64":
-            # On ARM Mac building Intel binary - check for x86_64 environment
-            if x86_venv_path.exists() and (x86_venv_path / "bin" / "pyinstaller").exists():
-                use_x86_python = True
-                console.print("[dim]Using x86_64 Python environment for Intel build[/dim]")
-            else:
-                console.print("\n[yellow]⚠️  Intel Mac build skipped (optional)[/yellow]")
-                console.print("[dim]Intel binaries are optional. ARM64 binaries work on Intel Macs via Rosetta.[/dim]")
-                console.print("[dim]To enable Intel builds on Apple Silicon, see:[/dim]")
-                console.print(
-                    "[dim]https://github.com/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock#optional-intel-mac-builds[/dim]\n"
-                )
-                # Return dummy path - the main loop will handle this gracefully
-                return output_dir / binary_name
+        host_arch = platform.machine().lower()
+        cross_arch = arch != host_arch and arch != "universal2"
 
         # Determine log level based on verbose flag
         log_level = "INFO" if verbose else "WARN"
 
-        # Build PyInstaller command
-        if use_x86_python:
-            # Use x86_64 Python environment
+        if cross_arch:
+            # Cross-arch build: need a per-arch venv seeded from a universal2 Python
+            universal2_python = _find_universal2_python()
+            if universal2_python is None:
+                raise RuntimeError(
+                    f"Cross-arch macOS build requires a universal2 Python but none was found.\n\n"
+                    f"Install Python universal2 from python.org:\n"
+                    f"  https://www.python.org/downloads/macos/\n\n"
+                    f"Download the 'macOS 64-bit universal2 installer' for Python 3.12, then re-run.\n\n"
+                    f"To build only the host arch ({host_arch}), omit the cross-arch target."
+                )
+            venv_dir = _ensure_cross_arch_venv(arch, universal2_python, _CREDENTIAL_PROVIDER_RUNTIME_DEPS, console)
+            work_root = Path.home() / ".ccwb" / "build-work"
+            work_root.mkdir(parents=True, exist_ok=True)
             cmd = [
-                "arch",
-                "-x86_64",
-                str(x86_venv_path / "bin" / "pyinstaller"),
-                "--onefile",
-                "--clean",
-                "--noconfirm",
+                "/usr/bin/arch", f"-{arch}",
+                str(venv_dir / "bin" / "pyinstaller"),
+                "--onefile", "--clean", "--noconfirm",
                 f"--name={binary_name}",
                 f"--distpath={str(output_dir)}",
-                "--workpath=/tmp/pyinstaller-x86",
-                "--specpath=/tmp/pyinstaller-x86",
+                f"--workpath={str(work_root / arch)}",
+                f"--specpath={str(work_root / arch)}",
                 f"--log-level={log_level}",
-                # Hidden imports for our dependencies
                 "--hidden-import=keyring.backends.macOS",
                 "--hidden-import=keyring.backends.SecretService",
                 "--hidden-import=keyring.backends.Windows",
@@ -783,21 +831,16 @@ class PackageCommand(Command):
                 str(src_file),
             ]
         else:
-            # Use regular Poetry environment
+            # Native build: use Poetry environment directly
             cmd = [
-                "poetry",
-                "run",
-                "pyinstaller",
-                "--onefile",
-                "--clean",
-                "--noconfirm",
+                "poetry", "run", "pyinstaller",
+                "--onefile", "--clean", "--noconfirm",
                 f"--target-arch={arch}",
                 f"--name={binary_name}",
                 f"--distpath={str(output_dir)}",
                 "--workpath=/tmp/pyinstaller",
                 "--specpath=/tmp/pyinstaller",
                 f"--log-level={log_level}",
-                # Hidden imports for our dependencies
                 "--hidden-import=keyring.backends.macOS",
                 "--hidden-import=keyring.backends.SecretService",
                 "--hidden-import=keyring.backends.Windows",
@@ -1513,50 +1556,37 @@ RUN pyinstaller \
 
         console.print(f"[yellow]Building OTEL helper for {platform_name} {arch or ''} with PyInstaller...[/yellow]")
 
-        # Check if we need to use x86_64 Python for Intel builds on macOS
-        use_x86_python = False
-        x86_venv_path = Path.home() / "venv-x86"
-
-        if platform_name == "macos" and arch == "x86_64" and platform_module.machine().lower() == "arm64":
-            # On ARM Mac building Intel binary - check for x86_64 environment
-            if x86_venv_path.exists() and (x86_venv_path / "bin" / "pyinstaller").exists():
-                use_x86_python = True
-                console.print("[dim]Using x86_64 Python environment for Intel OTEL helper build[/dim]")
-            else:
-                console.print("[yellow]Warning: x86_64 Python environment not found at ~/venv-x86[/yellow]")
-                console.print("[yellow]Skipping Intel OTEL helper build[/yellow]")
-                # For OTEL helper, we can skip if not available (it's optional)
-                return output_dir / binary_name  # Return expected path even if not built
-
         # Determine log level based on verbose flag
         log_level = "INFO" if verbose else "WARN"
 
+        host_arch = platform_module.machine().lower()
+        cross_arch = platform_name == "macos" and arch is not None and arch != host_arch and arch != "universal2"
+
         # Build PyInstaller command
-        if use_x86_python:
-            # Use x86_64 Python environment
+        if cross_arch:
+            # Cross-arch build: need a per-arch venv seeded from a universal2 Python
+            universal2_python = _find_universal2_python()
+            if universal2_python is None:
+                console.print(f"[yellow]Warning: Skipping {binary_name} — cross-arch build requires universal2 Python (not found)[/yellow]")
+                return output_dir / binary_name
+            venv_dir = _ensure_cross_arch_venv(arch, universal2_python, _OTEL_HELPER_RUNTIME_DEPS, console)
+            work_root = Path.home() / ".ccwb" / "build-work"
+            work_root.mkdir(parents=True, exist_ok=True)
             cmd = [
-                "arch",
-                "-x86_64",
-                str(x86_venv_path / "bin" / "pyinstaller"),
-                "--onefile",
-                "--clean",
-                "--noconfirm",
+                "/usr/bin/arch", f"-{arch}",
+                str(venv_dir / "bin" / "pyinstaller"),
+                "--onefile", "--clean", "--noconfirm",
                 f"--name={binary_name}",
                 f"--distpath={str(output_dir)}",
-                "--workpath=/tmp/pyinstaller-x86",
-                "--specpath=/tmp/pyinstaller-x86",
+                f"--workpath={str(work_root / arch)}",
+                f"--specpath={str(work_root / arch)}",
                 f"--log-level={log_level}",
                 str(src_file),
             ]
         else:
-            # Use regular Poetry environment
             cmd = [
-                "poetry",
-                "run",
-                "pyinstaller",
-                "--onefile",
-                "--clean",
-                "--noconfirm",
+                "poetry", "run", "pyinstaller",
+                "--onefile", "--clean", "--noconfirm",
                 f"--name={binary_name}",
                 f"--distpath={str(output_dir)}",
                 "--workpath=/tmp/pyinstaller",
@@ -1565,8 +1595,8 @@ RUN pyinstaller \
                 str(src_file),
             ]
 
-        # Add target architecture for macOS (only for regular Poetry environment)
-        if not use_x86_python and platform_name == "macos" and arch:
+        # Add target architecture for macOS (only for native Poetry build)
+        if not cross_arch and platform_name == "macos" and arch:
             cmd.insert(5, f"--target-arch={arch}")
 
         # Run PyInstaller from source directory


### PR DESCRIPTION
## Summary

- Fixes silent wrong-arch binary production on macOS: cross-arch builds (e.g. Intel binary on Apple Silicon) previously required a manually-created `~/venv-x86` environment; without it, `--target-arch` was overridden by the host Python's arch, producing a mislabeled binary that crashed on the target platform
- Auto-provisions `~/.ccwb/build-venvs/<arch>/` from a universal2 Python on first cross-arch build (~30s); subsequent runs reuse it
- Without universal2 Python: `--target-platform=all` skips cross-arch with an informational note; an explicit cross-arch target fails with a clear error pointing to the python.org installer
- Corrects Rosetta direction in all docs (Intel binaries run on Apple Silicon via Rosetta — not the other way around)
- Replaces `~/venv-x86` manual setup instructions with universal2 Python approach throughout docs
- Adds "which binary to ship" decision table in DEPLOYMENT.md

## How it works

`_find_universal2_python()` scans `/Library/Frameworks/Python.framework/` for a universal2 interpreter ≥3.10. When found, `_ensure_cross_arch_venv(arch, ...)` creates a venv under `arch -<arch> <universal2-python> -m venv` — pip then auto-pulls arch-matched wheels for all native extensions (cffi, cryptography, etc.). PyInstaller runs from that venv under `arch -<arch>`, guaranteeing a genuine single-arch output.

## Test plan

- [x] Native arm64 build on Apple Silicon → pure arm64 binary (`lipo` verified)
- [x] Cross-arch x86_64 build with universal2 Python → pure x86_64 binary (`lipo` verified)
- [x] universal2 fat binary via lipo of both slices → both arches present (`lipo` verified)
- [x] Native arm64 build without universal2 Python → succeeds unchanged
- [x] Cross-arch x86_64 without universal2 Python → clear `RuntimeError` with python.org link
- [x] `--all` expansion without universal2 Python → skips cross-arch with note, continues