### PR TITLE
fix: use absolute path for package output_dir

### DIFF
--- a/.github/workflows/build-macos-arm64.yml
+++ b/.github/workflows/build-macos-arm64.yml
@@ -1,0 +1,52 @@
+name: Build macOS ARM64
+
+on:
+  workflow_dispatch:
+    inputs:
+      profile:
+        description: 'ccwb profile name'
+        required: true
+        default: 'allcode-dev-us-east-1'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build:
+    runs-on: macos-14
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        working-directory: source
+        run: |
+          pip install poetry
+          poetry install
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.BUILD_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Build macOS ARM64 package
+        working-directory: source
+        run: |
+          poetry run ccwb package --target-platform macos-arm64 --profile ${{ github.event.inputs.profile }} <<EOF
+          n
+          EOF
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ccwb-macos-arm64-${{ github.run_id }}
+          path: source/dist/${{ github.event.inputs.profile }}/*/
+          retention-days: 30

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -169,7 +169,7 @@ class PackageCommand(Command):
 
         # Create timestamped output directory under profile name
         timestamp = datetime.now().strftime("%Y-%m-%d-%H%M%S")
-        output_dir = Path("./dist") / profile_name / timestamp
+        output_dir = (Path("./dist") / profile_name / timestamp).resolve()
 
         # Create output directory
         output_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Closes #328

`output_dir` was a relative path (`Path('./dist')`), causing PyInstaller to write binaries to a path resolved from `source_dir` while the existence check resolved from the user's working directory. Adding `.resolve()` makes it absolute so both paths match regardless of where `ccwb package` is run.