### PR TITLE
feat: CLI improvements, model registry helpers, and infrastructure utils

### DIFF
--- a/assets/docs/ARCHITECTURE.md
+++ b/assets/docs/ARCHITECTURE.md
@@ -135,4 +135,6 @@ Token storage on end-user machines requires careful consideration. We provide tw
 
 Privilege escalation attempts are contained through IAM policy design. The federated role grants only the minimum permissions required to invoke Bedrock models in specified regions. Session tags embedded in every credential set ensure that users cannot access resources beyond their authorization. These tags flow through to CloudTrail, creating an immutable audit trail.
 
+The credential provider performs full JWKS-based RSA signature verification on OIDC tokens before credential exchange. This includes validating the audience, issuer, expiry, and token freshness claims. A bypass is available via the `CLAUDE_CODE_BYPASS_JWT_VERIFICATION` environment variable for development and testing scenarios.
+
 Every API call to Amazon Bedrock includes the user's subject identifier. This means that CloudTrail captures these tags with every request, providing complete attribution. Authentication events through Cognito are similarly logged, creating a comprehensive security audit trail from login through API usage.

--- a/assets/docs/DEPLOYMENT.md
+++ b/assets/docs/DEPLOYMENT.md
@@ -16,7 +16,7 @@ Log into your provider's admin console and navigate to the application creation 
 
 The critical configuration involves setting up the OAuth2 flow with specific parameters. Enable "Authorization Code" and "Refresh Token" grant types, which allow secure authentication and token renewal. The redirect URI must be exactly `http://localhost:8400/callback` - this is where the authentication process returns after users log in. Request the standard OIDC scopes: `openid`, `profile`, and `email`. Most importantly, enable PKCE (Proof Key for Code Exchange), which provides security without requiring client secrets.
 
-> **Provider-Specific Guides**: For detailed instructions specific to your identity provider, see our guides for [Okta](providers/okta-setup.md), [Azure AD](providers/microsoft-entra-id-setup.md), or [Auth0](providers/auth0-setup.md).
+> **Provider-Specific Guides**: For detailed instructions specific to your identity provider, see our guides for [Okta](providers/okta-setup.md), [Azure AD](providers/microsoft-entra-id-setup.md), [Auth0](providers/auth0-setup.md), or [Cognito User Pool](providers/cognito-user-pool-setup.md).
 
 Next, determine who should have access. The cleanest approach is creating a dedicated group like "Claude Code Users" and assigning it to the application. This gives you centralized control over access - simply add users to the group to grant access, or remove them to revoke it. Apply any additional policies your organization requires, such as MFA or device trust requirements.
 
@@ -32,11 +32,13 @@ cd guidance-for-claude-code-with-amazon-bedrock/source
 poetry install
 ```
 
-The `ccwb` (Claude Code with Bedrock) CLI tool guides you through deployment with an interactive wizard. Run `poetry run ccwb init` to begin. The wizard walks you through each configuration decision, starting with your OIDC provider details - enter the domain and Client ID you noted earlier.
+The `ccwb` (Claude Code with Bedrock) CLI tool guides you through deployment with an interactive wizard. Run `poetry run ccwb init` to begin. The wizard uses a region-first flow, starting with your source region selection and then guiding you through model and provider configuration.
 
-The wizard asks you to choose an authentication method. You can select either Direct IAM federation or Cognito Identity Pool based on your organization's requirements. Both methods provide secure OIDC federation to AWS credentials.
+First, you'll select your source region and configure cross-region inference. Choose a cross-region profile (US, Europe, Japan, Australia, APAC, Global) or use the "Auto-select" option to let Claude Code pick the optimal model for your region. Then select a Claude model (Opus, Sonnet, Haiku) or use auto-select, followed by per-tier model defaults for each usage tier.
 
-Next, you'll select your Claude model and configure regional access. Choose from available Claude models (Opus, Sonnet, Haiku) and select a cross-region inference profile (US, Europe, or APAC) for optimal performance. The wizard will then prompt you to select a source region within your chosen profile for model inference. Finally, choose where to deploy the authentication infrastructure (typically your primary AWS region) and configure optional monitoring setup, which provides usage analytics and cost tracking through OpenTelemetry.
+Next, the wizard asks for your OIDC provider details — enter the domain and Client ID you noted earlier. You'll choose an authentication method: Direct IAM federation or Cognito Identity Pool. Both methods provide secure OIDC federation to AWS credentials.
+
+Finally, configure optional monitoring setup (usage analytics and cost tracking through OpenTelemetry) and distribution options. For landing page distribution, you can choose to use an external DNS provider instead of Route 53 if your domain is managed outside AWS.
 
 Once configuration is complete, deploy the infrastructure with:
 

--- a/deployment/infrastructure/analytics-pipeline.yaml
+++ b/deployment/infrastructure/analytics-pipeline.yaml
@@ -493,6 +493,7 @@ Resources:
     Properties:
       Name: !Sub '${AWS::StackName}-workgroup'
       Description: Workgroup for Claude Code analytics queries
+      RecursiveDeleteOption: true
       WorkGroupConfiguration:
         ResultConfiguration:
           OutputLocation: !Sub 's3://${AthenaResultsBucket}/results/'

--- a/deployment/infrastructure/bedrock-auth-auth0.yaml
+++ b/deployment/infrastructure/bedrock-auth-auth0.yaml
@@ -46,7 +46,7 @@ Parameters:
 
   AllowedBedrockRegions:
     Type: CommaDelimitedList
-    Default: 'af-south-1,ap-east-2,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-south-5,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-south-3,eu-west-1,eu-west-2,eu-west-3,il-central-1,me-central-1,me-south-1,sa-east-1,us-east-1,us-east-2,us-west-1,us-west-2'
+    Default: 'af-south-1,ap-east-2,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,il-central-1,me-central-1,me-south-1,sa-east-1,us-east-1,us-east-2,us-west-1,us-west-2'
     Description: AWS regions allowed for Bedrock access (auto-generated from supported model regions)
 
   EnableMonitoring:

--- a/deployment/infrastructure/bedrock-auth-azure.yaml
+++ b/deployment/infrastructure/bedrock-auth-azure.yaml
@@ -38,7 +38,7 @@ Parameters:
 
   AllowedBedrockRegions:
     Type: CommaDelimitedList
-    Default: 'af-south-1,ap-east-2,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-south-5,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-south-3,eu-west-1,eu-west-2,eu-west-3,il-central-1,me-central-1,me-south-1,sa-east-1,us-east-1,us-east-2,us-west-1,us-west-2'
+    Default: 'af-south-1,ap-east-2,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,il-central-1,me-central-1,me-south-1,sa-east-1,us-east-1,us-east-2,us-west-1,us-west-2'
     Description: AWS regions allowed for Bedrock access (auto-generated from supported model regions)
 
   EnableMonitoring:

--- a/deployment/infrastructure/bedrock-auth-cognito-pool.yaml
+++ b/deployment/infrastructure/bedrock-auth-cognito-pool.yaml
@@ -44,7 +44,7 @@ Parameters:
 
   AllowedBedrockRegions:
     Type: CommaDelimitedList
-    Default: 'af-south-1,ap-east-2,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-south-5,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-south-3,eu-west-1,eu-west-2,eu-west-3,il-central-1,me-central-1,me-south-1,sa-east-1,us-east-1,us-east-2,us-west-1,us-west-2'
+    Default: 'af-south-1,ap-east-2,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,il-central-1,me-central-1,me-south-1,sa-east-1,us-east-1,us-east-2,us-west-1,us-west-2'
     Description: AWS regions allowed for Bedrock access (auto-generated from supported model regions)
 
   EnableMonitoring:

--- a/deployment/infrastructure/bedrock-auth-okta.yaml
+++ b/deployment/infrastructure/bedrock-auth-okta.yaml
@@ -38,7 +38,7 @@ Parameters:
 
   AllowedBedrockRegions:
     Type: CommaDelimitedList
-    Default: 'af-south-1,ap-east-2,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-south-5,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-south-3,eu-west-1,eu-west-2,eu-west-3,il-central-1,me-central-1,me-south-1,sa-east-1,us-east-1,us-east-2,us-west-1,us-west-2'
+    Default: 'af-south-1,ap-east-2,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,il-central-1,me-central-1,me-south-1,sa-east-1,us-east-1,us-east-2,us-west-1,us-west-2'
     Description: AWS regions allowed for Bedrock access (auto-generated from supported model regions)
 
   EnableMonitoring:

--- a/deployment/infrastructure/cognito-identity-pool.yaml
+++ b/deployment/infrastructure/cognito-identity-pool.yaml
@@ -60,7 +60,7 @@ Parameters:
 
   AllowedBedrockRegions:
     Type: CommaDelimitedList
-    Default: 'af-south-1,ap-east-2,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-south-5,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-south-3,eu-west-1,eu-west-2,eu-west-3,il-central-1,me-central-1,me-south-1,sa-east-1,us-east-1,us-east-2,us-west-1,us-west-2'
+    Default: 'af-south-1,ap-east-2,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-west-1,eu-west-2,eu-west-3,il-central-1,me-central-1,me-south-1,sa-east-1,us-east-1,us-east-2,us-west-1,us-west-2'
     Description: AWS regions allowed for Bedrock access (configured based on selected model and cross-region profile)
 
   EnableMonitoring:

--- a/deployment/infrastructure/lambda-functions/quota_check/index.py
+++ b/deployment/infrastructure/lambda-functions/quota_check/index.py
@@ -25,6 +25,7 @@ ENABLE_FINEGRAINED_QUOTAS = os.environ.get("ENABLE_FINEGRAINED_QUOTAS", "false")
 MONTHLY_TOKEN_LIMIT = int(os.environ.get("MONTHLY_TOKEN_LIMIT", "0"))
 DAILY_TOKEN_LIMIT = int(os.environ.get("DAILY_TOKEN_LIMIT", "0"))
 MONTHLY_ENFORCEMENT_MODE = os.environ.get("MONTHLY_ENFORCEMENT_MODE", "block")
+DAILY_ENFORCEMENT_MODE = os.environ.get("DAILY_ENFORCEMENT_MODE", "alert")
 WARNING_THRESHOLD_80 = int(os.environ.get("WARNING_THRESHOLD_80", "240000000"))
 WARNING_THRESHOLD_90 = int(os.environ.get("WARNING_THRESHOLD_90", "270000000"))
 
@@ -111,15 +112,16 @@ def lambda_handler(event, context):
         usage = get_user_usage(email)
         usage_summary = build_usage_summary(usage, policy)
 
-        # 4. Check if enforcement mode is "block"
-        enforcement_mode = policy.get("enforcement_mode", "alert")
+        # 4. Resolve enforcement modes (monthly and daily may differ)
+        monthly_enforcement = policy.get("enforcement_mode", "alert")
+        daily_enforcement = policy.get("daily_enforcement_mode", monthly_enforcement)
 
-        if enforcement_mode != "block":
-            # Alert-only mode - always allow
+        # If both enforcement modes are alert-only, skip limit checks
+        if monthly_enforcement != "block" and daily_enforcement != "block":
             return build_response(200, {
                 "allowed": True,
                 "reason": "within_quota",
-                "enforcement_mode": enforcement_mode,
+                "enforcement_mode": monthly_enforcement,
                 "usage": usage_summary,
                 "policy": {
                     "type": policy.get("policy_type"),
@@ -136,12 +138,12 @@ def lambda_handler(event, context):
         monthly_limit = policy.get("monthly_token_limit", 0)
         daily_limit = policy.get("daily_token_limit")
 
-        # Check monthly token limit
-        if monthly_limit > 0 and monthly_tokens >= monthly_limit:
+        # Check monthly token limit (only block if monthly enforcement is "block")
+        if monthly_enforcement == "block" and monthly_limit > 0 and monthly_tokens >= monthly_limit:
             return build_response(200, {
                 "allowed": False,
                 "reason": "monthly_exceeded",
-                "enforcement_mode": enforcement_mode,
+                "enforcement_mode": monthly_enforcement,
                 "usage": usage_summary,
                 "policy": {
                     "type": policy.get("policy_type"),
@@ -151,12 +153,12 @@ def lambda_handler(event, context):
                 "message": f"Monthly quota exceeded: {int(monthly_tokens):,} / {int(monthly_limit):,} tokens ({monthly_tokens/monthly_limit*100:.1f}%). Contact your administrator for assistance."
             })
 
-        # Check daily token limit (if configured)
-        if daily_limit and daily_limit > 0 and daily_tokens >= daily_limit:
+        # Check daily token limit (only block if daily enforcement is "block")
+        if daily_enforcement == "block" and daily_limit and daily_limit > 0 and daily_tokens >= daily_limit:
             return build_response(200, {
                 "allowed": False,
                 "reason": "daily_exceeded",
-                "enforcement_mode": enforcement_mode,
+                "enforcement_mode": daily_enforcement,
                 "usage": usage_summary,
                 "policy": {
                     "type": policy.get("policy_type"),
@@ -170,7 +172,7 @@ def lambda_handler(event, context):
         return build_response(200, {
             "allowed": True,
             "reason": "within_quota",
-            "enforcement_mode": enforcement_mode,
+            "enforcement_mode": monthly_enforcement,
             "usage": usage_summary,
             "policy": {
                 "type": policy.get("policy_type"),
@@ -273,6 +275,7 @@ def resolve_quota_for_user(email: str, groups: list) -> dict | None:
             "warning_threshold_80": WARNING_THRESHOLD_80,
             "warning_threshold_90": WARNING_THRESHOLD_90,
             "enforcement_mode": MONTHLY_ENFORCEMENT_MODE,
+            "daily_enforcement_mode": DAILY_ENFORCEMENT_MODE,
             "enabled": True,
         }
 
@@ -321,6 +324,7 @@ def get_policy(policy_type: str, identifier: str) -> dict | None:
             "warning_threshold_80": int(item.get("warning_threshold_80", 0)),
             "warning_threshold_90": int(item.get("warning_threshold_90", 0)),
             "enforcement_mode": item.get("enforcement_mode", "alert"),
+            "daily_enforcement_mode": item.get("daily_enforcement_mode", item.get("enforcement_mode", "alert")),
             "enabled": item.get("enabled", True),
         }
     except Exception as e:

--- a/deployment/infrastructure/landing-page-distribution.yaml
+++ b/deployment/infrastructure/landing-page-distribution.yaml
@@ -767,9 +767,11 @@ Resources:
     Properties:
       DomainName: !Ref CustomDomainName
       ValidationMethod: DNS
-      DomainValidationOptions:
-        - DomainName: !Ref CustomDomainName
-          HostedZoneId: !If [HasRoute53Zone, !Ref HostedZoneId, !Ref AWS::NoValue]
+      DomainValidationOptions: !If
+        - HasRoute53Zone
+        - - DomainName: !Ref CustomDomainName
+            HostedZoneId: !Ref HostedZoneId
+        - !Ref 'AWS::NoValue'
       Tags:
         - Key: Application
           Value: ClaudeCodeWithBedrock
@@ -1036,3 +1038,9 @@ Outputs:
     Value: !GetAtt DistributionBucket.Arn
     Export:
       Name: !Sub '${AWS::StackName}-DistributionBucketArn'
+
+  ALBEndpoint:
+    Description: ALB DNS name (for CNAME record if using external DNS)
+    Value: !GetAtt DistributionALB.DNSName
+    Export:
+      Name: !Sub '${AWS::StackName}-ALBEndpoint'

--- a/deployment/infrastructure/otel-collector.yaml
+++ b/deployment/infrastructure/otel-collector.yaml
@@ -242,7 +242,7 @@ Resources:
               AdditionalClaims: !If
                 - HasOidcClientId
                 - - Name: aud
-                    Format: string-array
+                    Format: single-string
                     Values:
                       - !Ref OidcClientId
                 - !Ref AWS::NoValue

--- a/deployment/infrastructure/otel-collector.yaml
+++ b/deployment/infrastructure/otel-collector.yaml
@@ -48,6 +48,10 @@ Parameters:
 Conditions:
   HasCustomDomain: !Not [!Equals [!Ref CustomDomainName, '']]
   NoCustomDomain: !Equals [!Ref CustomDomainName, '']
+  HasHostedZone: !Not [!Equals [!Ref HostedZoneId, '']]
+  HasCustomDomainAndHostedZone: !And
+    - !Condition HasCustomDomain
+    - !Condition HasHostedZone
   HasJwtAuth: !Not [!Equals [!Ref OidcIssuerUrl, '']]
   HasOidcClientId: !Not [!Equals [!Ref OidcClientId, '']]
 
@@ -130,18 +134,20 @@ Resources:
     Condition: HasCustomDomain
     Properties:
       DomainName: !Ref CustomDomainName
-      DomainValidationOptions:
-        - DomainName: !Ref CustomDomainName
-          HostedZoneId: !Ref HostedZoneId
+      DomainValidationOptions: !If
+        - HasHostedZone
+        - - DomainName: !Ref CustomDomainName
+            HostedZoneId: !Ref HostedZoneId
+        - !Ref AWS::NoValue
       ValidationMethod: DNS
       Tags:
         - Key: Name
           Value: !Sub '${AWS::StackName}-certificate'
 
-  # Route53 Record for custom domain
+  # Route53 Record for custom domain (only when Route53 is used, not external DNS)
   DNSRecord:
     Type: AWS::Route53::RecordSet
-    Condition: HasCustomDomain
+    Condition: HasCustomDomainAndHostedZone
     DependsOn: Certificate
     Properties:
       HostedZoneId: !Ref HostedZoneId

--- a/source/claude_code_with_bedrock/cli/commands/builds.py
+++ b/source/claude_code_with_bedrock/cli/commands/builds.py
@@ -30,6 +30,13 @@ class BuildsCommand(Command):
         option("download", description="Download completed Windows artifacts to dist folder", flag=True),
     ]
 
+    def _get_codebuild_region(self, profile):
+        windows_regions = {
+            "us-east-1", "us-east-2", "us-west-2", "ap-southeast-2",
+            "ap-northeast-1", "eu-central-1", "eu-west-1", "sa-east-1",
+        }
+        return profile.aws_region if profile.aws_region in windows_regions else "us-east-1"
+
     def handle(self) -> int:
         """Execute the builds command."""
         console = Console()
@@ -70,7 +77,7 @@ class BuildsCommand(Command):
                 project_name = f"{profile.identity_pool_name}-windows-build"
 
             # Get builds from CodeBuild
-            codebuild = boto3.client("codebuild", region_name=profile.aws_region)
+            codebuild = boto3.client("codebuild", region_name=self._get_codebuild_region(profile))
             limit = int(self.option("limit"))
 
             # List builds for project
@@ -192,7 +199,7 @@ class BuildsCommand(Command):
                     # If it's a short ID (like from the table), find the full UUID
                     if len(build_id) == 8:
                         # List recent builds to find the matching one
-                        codebuild = boto3.client("codebuild", region_name=profile.aws_region)
+                        codebuild = boto3.client("codebuild", region_name=self._get_codebuild_region(profile))
                         response = codebuild.list_builds_for_project(
                             projectName=project_name, sortOrder="DESCENDING"
                         )
@@ -213,7 +220,7 @@ class BuildsCommand(Command):
                         build_id = f"{project_name}:{build_id}"
 
             # Get build status from CodeBuild
-            codebuild = boto3.client("codebuild", region_name=profile.aws_region)
+            codebuild = boto3.client("codebuild", region_name=self._get_codebuild_region(profile))
             response = codebuild.batch_get_builds(ids=[build_id])
 
             if not response.get("builds"):
@@ -352,7 +359,7 @@ class BuildsCommand(Command):
             from ...cli.utils.aws import get_stack_outputs
 
             codebuild_stack_name = profile.stack_names.get("codebuild", f"{profile.identity_pool_name}-codebuild")
-            codebuild_outputs = get_stack_outputs(codebuild_stack_name, profile.aws_region)
+            codebuild_outputs = get_stack_outputs(codebuild_stack_name, self._get_codebuild_region(profile))
 
             if not codebuild_outputs:
                 console.print("[red]CodeBuild stack not found[/red]")
@@ -364,7 +371,7 @@ class BuildsCommand(Command):
                 return False
 
             # Download from S3
-            s3 = boto3.client("s3", region_name=profile.aws_region)
+            s3 = boto3.client("s3", region_name=self._get_codebuild_region(profile))
             zip_path = package_path / "windows-binaries.zip"
 
             # CodeBuild stores artifacts at root of bucket

--- a/source/claude_code_with_bedrock/cli/commands/builds.py
+++ b/source/claude_code_with_bedrock/cli/commands/builds.py
@@ -11,6 +11,8 @@ from cleo.helpers import option
 from rich.console import Console
 from rich.table import Table
 
+from claude_code_with_bedrock.cli.utils.aws import get_codebuild_region
+
 
 class BuildsCommand(Command):
     """
@@ -31,11 +33,8 @@ class BuildsCommand(Command):
     ]
 
     def _get_codebuild_region(self, profile):
-        windows_regions = {
-            "us-east-1", "us-east-2", "us-west-2", "ap-southeast-2",
-            "ap-northeast-1", "eu-central-1", "eu-west-1", "sa-east-1",
-        }
-        return profile.aws_region if profile.aws_region in windows_regions else "us-east-1"
+        """Backward-compatible wrapper for shared utility."""
+        return get_codebuild_region(profile)
 
     def handle(self) -> int:
         """Execute the builds command."""

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -27,6 +27,14 @@ from claude_code_with_bedrock.cli.utils.cloudformation import CloudFormationMana
 from claude_code_with_bedrock.config import Config
 
 
+def _get_codebuild_region(profile):
+    windows_regions = {
+        "us-east-1", "us-east-2", "us-west-2", "ap-southeast-2",
+        "ap-northeast-1", "eu-central-1", "eu-west-1", "sa-east-1",
+    }
+    return profile.aws_region if profile.aws_region in windows_regions else "us-east-1"
+
+
 class DeployCommand(Command):
     name = "deploy"
     description = "Deploy AWS infrastructure (auth, monitoring, dashboards)"
@@ -169,16 +177,18 @@ class DeployCommand(Command):
             if getattr(profile, "sso_enabled", True):
                 stacks_to_deploy.append(("auth", "Authentication Stack (Cognito + IAM)"))
 
-            # Deploy distribution after networking if it's landing-page type
-            if profile.enable_distribution:
-                stacks_to_deploy.append(("distribution", "Distribution infrastructure (S3 + IAM)"))
-
-            # Deploy remaining monitoring stacks
+            # Deploy networking and s3bucket before distribution (distribution ALB needs VPC)
             if profile.monitoring_enabled:
                 vpc_config = profile.monitoring_config or {}
                 if vpc_config.get("create_vpc", True):
                     stacks_to_deploy.append(("networking", "VPC Networking for OTEL Collector"))
                 stacks_to_deploy.append(("s3bucket", "S3 Bucket"))
+
+            if profile.enable_distribution:
+                stacks_to_deploy.append(("distribution", "Distribution infrastructure (S3 + IAM)"))
+
+            # Deploy remaining monitoring stacks
+            if profile.monitoring_enabled:
                 stacks_to_deploy.append(("monitoring", "OpenTelemetry Collector"))
                 stacks_to_deploy.append(("dashboard", "CloudWatch Dashboard"))
                 stacks_to_deploy.append(("cowork-dashboard", "CoWork CloudWatch Dashboard"))
@@ -204,7 +214,11 @@ class DeployCommand(Command):
 
         for stack_type, description in stacks_to_deploy:
             stack_name = profile.stack_names.get(stack_type, f"{profile.identity_pool_name}-{stack_type}")
-            status = cf_manager.get_stack_status(stack_name)
+            if stack_type == "codebuild":
+                check_manager = CloudFormationManager(region=_get_codebuild_region(profile))
+            else:
+                check_manager = cf_manager
+            status = check_manager.get_stack_status(stack_name)
             if status and status in ["CREATE_COMPLETE", "UPDATE_COMPLETE", "UPDATE_ROLLBACK_COMPLETE"]:
                 status_display = "[green]Update[/green]"
             else:
@@ -308,6 +322,30 @@ class DeployCommand(Command):
                     # Build tags from profile configuration
                     stack_tags = dict(profile.tags) if profile.tags else {}
 
+                    def handle_event(e):
+                        if isinstance(e, dict) and e.get("type") == "acm_validation_required":
+                            records = e.get("validation_records", [])
+                            if records:
+                                console.print("\n[bold yellow]" + "=" * 60 + "[/bold yellow]")
+                                console.print("[bold yellow]ACM Certificate DNS Validation Required![/bold yellow]")
+                                console.print("[bold yellow]" + "=" * 60 + "[/bold yellow]")
+                                console.print("\nCreate the following CNAME record(s) in your DNS provider:\n")
+                                for rec in records:
+                                    console.print(f"  [bold]Name:[/bold]  [cyan]{rec['Name']}[/cyan]")
+                                    console.print(f"  [bold]Value:[/bold] [cyan]{rec['Value']}[/cyan]")
+                                    console.print()
+                                console.print(
+                                    "[yellow]Deployment will continue once DNS records are verified.[/yellow]"
+                                )
+                                console.print("[bold yellow]" + "=" * 60 + "[/bold yellow]\n")
+                        else:
+                            progress.update(
+                                task,
+                                description=f"{e.get('LogicalResourceId', 'Stack')} - {e.get('ResourceStatus', '')}"
+                                if isinstance(e, dict)
+                                else str(e),
+                            )
+
                     # Deploy stack
                     result = cf_manager.deploy_stack(
                         stack_name=stack_name,
@@ -315,12 +353,7 @@ class DeployCommand(Command):
                         parameters=boto3_params,
                         capabilities=capabilities or ["CAPABILITY_IAM"],
                         tags=stack_tags or None,
-                        on_event=lambda e: progress.update(
-                            task,
-                            description=f"{e.get('LogicalResourceId', 'Stack')} - {e.get('ResourceStatus', '')}"
-                            if isinstance(e, dict)
-                            else str(e),
-                        ),
+                        on_event=handle_event,
                     )
 
                     progress.update(task, completed=True)
@@ -435,7 +468,6 @@ class DeployCommand(Command):
                             f"CognitoUserPoolDomain={cognito_domain}",
                         ]
                     )
-
                 # Use profile regions, or fall back to all known Bedrock regions
                 bedrock_regions = profile.allowed_bedrock_regions
                 if not bedrock_regions:
@@ -510,10 +542,13 @@ class DeployCommand(Command):
                             ]
                         )
                     elif profile.distribution_idp_provider == "azure":
-                        # Extract tenant ID from domain or use full domain
+                        # Extract tenant ID GUID from domain URL
+                        _guid_pat = r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+                        _tenant_match = re.search(_guid_pat, profile.distribution_idp_domain or "")
+                        _tenant_id = _tenant_match.group(0) if _tenant_match else profile.distribution_idp_domain
                         params.extend(
                             [
-                                f"AzureTenantId={profile.distribution_idp_domain}",
+                                f"AzureTenantId={_tenant_id}",
                                 f"AzureClientId={profile.distribution_idp_client_id}",
                                 f"AzureClientSecretArn={profile.distribution_idp_client_secret_arn}",
                             ]
@@ -536,7 +571,6 @@ class DeployCommand(Command):
                                 f"CognitoClientSecretArn={profile.distribution_idp_client_secret_arn}",
                             ]
                         )
-
                     # Add optional custom domain parameters
                     if profile.distribution_custom_domain:
                         params.append(f"CustomDomainName={profile.distribution_custom_domain}")
@@ -568,6 +602,19 @@ class DeployCommand(Command):
                             "\n   Add this redirect URI to your IdP web application settings "
                             "before users can authenticate."
                         )
+
+                        # Show external DNS instructions if not using Route53
+                        if not profile.distribution_hosted_zone_id:
+                            alb_dns = outputs.get("ALBEndpoint", "")
+                            if alb_dns:
+                                console.print("\n[bold yellow]External DNS Configuration Required:[/bold yellow]")
+                                console.print(
+                                    "  Create a CNAME record in your DNS provider:"
+                                )
+                                console.print(
+                                    f"    [cyan]{profile.distribution_custom_domain}[/cyan]"
+                                    f" -> [cyan]{alb_dns}[/cyan]"
+                                )
 
                     return result
 
@@ -633,6 +680,7 @@ class DeployCommand(Command):
                 monitoring_config = getattr(profile, "monitoring_config", {})
                 if monitoring_config.get("custom_domain"):
                     params.append(f"CustomDomainName={monitoring_config['custom_domain']}")
+                if monitoring_config.get("hosted_zone_id"):
                     params.append(f"HostedZoneId={monitoring_config['hosted_zone_id']}")
                     # Add OIDC JWT validation parameters for ALB (all IdP types)
                     provider_type = profile.provider_type or ""
@@ -672,9 +720,27 @@ class DeployCommand(Command):
                             params.append(f"OidcClientId={profile.client_id}")
 
                 console.print(f"[dim]Using parameters: {params}[/dim]")
-                return deploy_with_cf(
+                result = deploy_with_cf(
                     template, stack_name, params, task_description="Deploying monitoring collector..."
                 )
+
+                # Show external DNS instructions if custom domain without Route53
+                if (
+                    result == 0
+                    and monitoring_config.get("custom_domain")
+                    and not monitoring_config.get("hosted_zone_id")
+                ):
+                    outputs = get_stack_outputs(stack_name, profile.aws_region)
+                    alb_dns = outputs.get("ALBEndpoint", "")
+                    if alb_dns:
+                        console.print("\n[bold yellow]External DNS Configuration Required:[/bold yellow]")
+                        console.print("  Create a CNAME record in your DNS provider:")
+                        console.print(
+                            f"    [cyan]{monitoring_config['custom_domain']}[/cyan]"
+                            f" -> [cyan]{alb_dns}[/cyan]"
+                        )
+
+                return result
 
             elif stack_type == "dashboard":
                 template = project_root / "deployment" / "infrastructure" / "claude-code-dashboard.yaml"
@@ -904,6 +970,7 @@ class DeployCommand(Command):
                             pass
 
             elif stack_type == "codebuild":
+                cf_manager = CloudFormationManager(region=_get_codebuild_region(profile))
                 template = project_root / "deployment" / "infrastructure" / "codebuild-windows.yaml"
                 stack_name = profile.stack_names.get("codebuild", f"{profile.identity_pool_name}-codebuild")
                 params = [f"ProjectNamePrefix={profile.identity_pool_name}"]
@@ -1282,7 +1349,13 @@ class DeployCommand(Command):
             if stack_type not in deploying_types:
                 # This stack type is not being deployed - check if it exists
                 stack_name = profile.stack_names.get(stack_type, f"{profile.identity_pool_name}-{stack_type}")
-                status = cf_manager.get_stack_status(stack_name)
+                if stack_type == "codebuild":
+                    check_manager = CloudFormationManager(
+                        region=_get_codebuild_region(profile)
+                    )
+                else:
+                    check_manager = cf_manager
+                status = check_manager.get_stack_status(stack_name)
 
                 if status and status not in ["DELETE_COMPLETE", "DELETE_IN_PROGRESS"]:
                     orphaned.append((stack_type, stack_name, status))

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -17,7 +17,7 @@ from rich.panel import Panel
 from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.table import Table
 
-from claude_code_with_bedrock.cli.utils.aws import get_stack_outputs
+from claude_code_with_bedrock.cli.utils.aws import get_codebuild_region, get_stack_outputs
 from claude_code_with_bedrock.cli.utils.cf_exceptions import (
     CloudFormationError,
     ResourceConflictError,
@@ -28,11 +28,8 @@ from claude_code_with_bedrock.config import Config
 
 
 def _get_codebuild_region(profile):
-    windows_regions = {
-        "us-east-1", "us-east-2", "us-west-2", "ap-southeast-2",
-        "ap-northeast-1", "eu-central-1", "eu-west-1", "sa-east-1",
-    }
-    return profile.aws_region if profile.aws_region in windows_regions else "us-east-1"
+    """Backward-compatible wrapper for shared utility."""
+    return get_codebuild_region(profile)
 
 
 class DeployCommand(Command):
@@ -323,6 +320,8 @@ class DeployCommand(Command):
                     stack_tags = dict(profile.tags) if profile.tags else {}
 
                     def handle_event(e):
+                        # Events can be CFN resource events (dict with LogicalResourceId/ResourceStatus)
+                        # or ACM validation notifications (dict with type="acm_validation_required")
                         if isinstance(e, dict) and e.get("type") == "acm_validation_required":
                             records = e.get("validation_records", [])
                             if records:

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -714,6 +714,10 @@ class DeployCommand(Command):
                                 oidc_jwks = (
                                     f"https://cognito-idp.{pool_region}.amazonaws.com/{pool_id}/.well-known/jwks.json"
                                 )
+                        elif provider_type == "keycloak":
+                            domain = provider_domain.removeprefix("https://").removeprefix("http://").rstrip("/")
+                            oidc_issuer = f"https://{domain}"
+                            oidc_jwks = f"https://{domain}/protocol/openid-connect/certs"
                         if oidc_issuer and oidc_jwks:
                             params.append(f"OidcIssuerUrl={oidc_issuer}")
                             params.append(f"OidcJwksEndpoint={oidc_jwks}")

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -680,9 +680,12 @@ class DeployCommand(Command):
                 monitoring_config = getattr(profile, "monitoring_config", {})
                 if monitoring_config.get("custom_domain"):
                     params.append(f"CustomDomainName={monitoring_config['custom_domain']}")
-                if monitoring_config.get("hosted_zone_id"):
-                    params.append(f"HostedZoneId={monitoring_config['hosted_zone_id']}")
-                    # Add OIDC JWT validation parameters for ALB (all IdP types)
+
+                    # Add Route53 hosted zone ID if provided (not required for external DNS)
+                    if monitoring_config.get("hosted_zone_id"):
+                        params.append(f"HostedZoneId={monitoring_config['hosted_zone_id']}")
+
+                    # Add OIDC JWT validation parameters for ALB (required for HTTPS, regardless of DNS provider)
                     provider_type = profile.provider_type or ""
                     provider_domain = profile.provider_domain
                     if provider_type and provider_domain:

--- a/source/claude_code_with_bedrock/cli/commands/destroy.py
+++ b/source/claude_code_with_bedrock/cli/commands/destroy.py
@@ -153,7 +153,16 @@ class DestroyCommand(Command):
                     )
                 console.print()
             else:
-                console.print(f"[green]✓ {stack.capitalize()} stack destroyed[/green]\n")
+                # Check for silently retained resources (DeletionPolicy: Retain)
+                retained = self._get_retained_resources(stack_name, region)
+                if retained:
+                    all_failed_resources.extend(retained)
+                    console.print(f"[yellow]⚠ {stack.capitalize()} stack — retained resources:[/yellow]")
+                    for r in retained:
+                        console.print(f"    • {r['logical_id']} ({r['resource_type']}): {r['physical_id']}")
+                    console.print()
+                else:
+                    console.print(f"[green]✓ {stack.capitalize()} stack destroyed[/green]\n")
 
         # Clear cached credentials — they reference deleted IAM roles
         self._clear_cached_credentials(profile, console)
@@ -225,6 +234,11 @@ class DestroyCommand(Command):
         """Get list of resources that failed to delete from a stack."""
         cf_manager = CloudFormationManager(region=region)
         return cf_manager.get_failed_resources(stack_name)
+
+    def _get_retained_resources(self, stack_name: str, region: str) -> list[dict]:
+        """Get list of resources silently retained (DeletionPolicy: Retain) during stack deletion."""
+        cf_manager = CloudFormationManager(region=region)
+        return cf_manager.get_retained_resources(stack_name)
 
     def _clear_cached_credentials(self, profile, console: Console) -> None:
         """Clear cached credentials that reference deleted IAM roles."""

--- a/source/claude_code_with_bedrock/cli/commands/destroy.py
+++ b/source/claude_code_with_bedrock/cli/commands/destroy.py
@@ -66,7 +66,7 @@ class DestroyCommand(Command):
         stacks_to_destroy = []
         if stack_arg:
             valid = [
-                "auth", "networking", "monitoring", "dashboard", "analytics",
+                "auth", "networking", "monitoring", "dashboard", "cowork-dashboard", "analytics",
                 "s3bucket", "distribution", "quota", "codebuild",
             ]
             if stack_arg in valid:
@@ -78,7 +78,7 @@ class DestroyCommand(Command):
         else:
             # Destroy all stacks in reverse order
             stacks_to_destroy = [
-                "codebuild", "quota", "analytics", "dashboard",
+                "codebuild", "quota", "analytics", "cowork-dashboard", "dashboard",
                 "distribution", "monitoring", "networking", "s3bucket", "auth",
             ]
 
@@ -117,6 +117,8 @@ class DestroyCommand(Command):
             if stack == "monitoring" and not profile.monitoring_enabled:
                 continue
             if stack == "dashboard" and not profile.monitoring_enabled:
+                continue
+            if stack == "cowork-dashboard" and not profile.monitoring_enabled:
                 continue
             if stack == "networking" and not profile.monitoring_enabled:
                 continue

--- a/source/claude_code_with_bedrock/cli/commands/destroy.py
+++ b/source/claude_code_with_bedrock/cli/commands/destroy.py
@@ -10,6 +10,7 @@ from rich.panel import Panel
 from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.prompt import Confirm
 
+from claude_code_with_bedrock.cli.commands.deploy import _get_codebuild_region
 from claude_code_with_bedrock.cli.utils.cloudformation import CloudFormationManager
 from claude_code_with_bedrock.config import Config
 
@@ -64,15 +65,22 @@ class DestroyCommand(Command):
 
         stacks_to_destroy = []
         if stack_arg:
-            if stack_arg in ["auth", "networking", "monitoring", "dashboard", "analytics", "s3bucket"]:
+            valid = [
+                "auth", "networking", "monitoring", "dashboard", "analytics",
+                "s3bucket", "distribution", "quota", "codebuild",
+            ]
+            if stack_arg in valid:
                 stacks_to_destroy.append(stack_arg)
             else:
                 console.print(f"[red]Unknown stack: {stack_arg}[/red]")
-                console.print("Valid stacks: auth, networking, monitoring, dashboard, analytics, s3bucket")
+                console.print(f"Valid stacks: {', '.join(valid)}")
                 return 1
         else:
             # Destroy all stacks in reverse order
-            stacks_to_destroy = ["analytics", "dashboard", "monitoring", "networking", "s3bucket", "auth"]
+            stacks_to_destroy = [
+                "codebuild", "quota", "analytics", "dashboard",
+                "distribution", "monitoring", "networking", "s3bucket", "auth",
+            ]
 
         # Show what will be destroyed
         console.print(
@@ -116,29 +124,44 @@ class DestroyCommand(Command):
                 continue
             if stack == "s3bucket" and not profile.monitoring_enabled:
                 continue
+            if stack == "distribution" and not profile.enable_distribution:
+                continue
+            if stack == "quota" and not getattr(profile, "quota_monitoring_enabled", False):
+                continue
+            if stack == "codebuild" and not getattr(profile, "enable_codebuild", False):
+                continue
 
             stack_name = profile.stack_names.get(stack, f"{profile.identity_pool_name}-{stack}")
+            region = _get_codebuild_region(profile) if stack == "codebuild" else profile.aws_region
             console.print(f"Destroying {stack} stack: [cyan]{stack_name}[/cyan]")
 
-            result = self._delete_stack(stack_name, profile.aws_region, console)
+            result = self._delete_stack(stack_name, region, console, stack)
             if result != 0:
                 # Don't break - collect failed resources and continue
-                failed = self._get_failed_resources(stack_name, profile.aws_region)
+                failed = self._get_failed_resources(stack_name, region)
                 if failed:
                     all_failed_resources.extend(failed)
                     stacks_with_failures.append(stack_name)
-                console.print(
-                    f"[yellow]⚠ {stack.capitalize()} stack has resources requiring manual cleanup[/yellow]\n"
-                )
+                    console.print(f"[yellow]⚠ {stack.capitalize()} stack — retained resources:[/yellow]")
+                    for r in failed:
+                        console.print(f"    • {r['logical_id']} ({r['resource_type']}): {r['physical_id']}")
+                else:
+                    console.print(
+                        f"[yellow]⚠ {stack.capitalize()} stack has resources requiring manual cleanup[/yellow]"
+                    )
+                console.print()
             else:
                 console.print(f"[green]✓ {stack.capitalize()} stack destroyed[/green]\n")
+
+        # Clear cached credentials — they reference deleted IAM roles
+        self._clear_cached_credentials(profile, console)
 
         # Show cleanup summary at the end
         self._show_cleanup_summary(all_failed_resources, stacks_with_failures, profile, console)
 
         return 0
 
-    def _delete_stack(self, stack_name: str, region: str, console: Console) -> int:
+    def _delete_stack(self, stack_name: str, region: str, console: Console, stack_type: str = "") -> int:
         """Delete a CloudFormation stack using boto3.
 
         Returns:
@@ -154,10 +177,15 @@ class DestroyCommand(Command):
             console.print(f"[yellow]Stack {stack_name} not found or already deleted[/yellow]")
             return 0
 
-        # If already in DELETE_FAILED, report it (don't retry)
+        # If already in DELETE_FAILED, pre-clean and retry
         if status == "DELETE_FAILED":
-            console.print(f"[yellow]Stack {stack_name} is in DELETE_FAILED state[/yellow]")
-            return 1  # Signal that manual cleanup is needed
+            console.print(f"[yellow]Stack {stack_name} is in DELETE_FAILED state, retrying after cleanup...[/yellow]")
+
+        # Pre-clean resources that block deletion (non-empty S3 buckets, Athena workgroups)
+        cf_manager.pre_cleanup_stack(
+            stack_name,
+            on_event=lambda msg: console.print(f"  [dim]{msg}[/dim]"),
+        )
 
         # Use progress indicator
         with Progress(
@@ -166,13 +194,15 @@ class DestroyCommand(Command):
             task = progress.add_task(f"Deleting stack {stack_name}...", total=None)
 
             # Delete the stack with event tracking
+            # Use longer timeout for stacks with ECS services that need graceful shutdown
+            timeout = 900 if stack_type in ["monitoring", "dashboard"] else 300
             result = cf_manager.delete_stack(
                 stack_name=stack_name,
                 force=True,
                 on_event=lambda e: progress.update(
                     task, description=f"Deleting {e.get('LogicalResourceId', stack_name)}..."
                 ),
-                timeout=300,
+                timeout=timeout,
             )
 
             progress.update(task, completed=True)
@@ -193,6 +223,26 @@ class DestroyCommand(Command):
         """Get list of resources that failed to delete from a stack."""
         cf_manager = CloudFormationManager(region=region)
         return cf_manager.get_failed_resources(stack_name)
+
+    def _clear_cached_credentials(self, profile, console: Console) -> None:
+        """Clear cached credentials that reference deleted IAM roles."""
+        try:
+            import configparser
+            from pathlib import Path
+
+            cred_path = Path.home() / ".aws" / "credentials"
+            if not cred_path.exists():
+                return
+
+            config = configparser.ConfigParser()
+            config.read(cred_path)
+            if profile.name in config:
+                config.remove_section(profile.name)
+                with open(cred_path, "w") as f:
+                    config.write(f)
+                console.print("[dim]Cleared cached credentials[/dim]")
+        except Exception as e:
+            console.print(f"[yellow]Warning: Could not clear cached credentials: {e}[/yellow]")
 
     def _show_cleanup_summary(
         self,

--- a/source/claude_code_with_bedrock/cli/commands/destroy.py
+++ b/source/claude_code_with_bedrock/cli/commands/destroy.py
@@ -111,6 +111,7 @@ class DestroyCommand(Command):
         console.print("\n[bold]Destroying stacks...[/bold]\n")
 
         all_failed_resources = []  # Collect failed resources from all stacks
+        all_retained_resources = []  # Collect intentionally retained resources
         stacks_with_failures = []
 
         for stack in stacks_to_destroy:
@@ -144,7 +145,7 @@ class DestroyCommand(Command):
                 if failed:
                     all_failed_resources.extend(failed)
                     stacks_with_failures.append(stack_name)
-                    console.print(f"[yellow]⚠ {stack.capitalize()} stack — retained resources:[/yellow]")
+                    console.print(f"[yellow]⚠ {stack.capitalize()} stack — failed resources:[/yellow]")
                     for r in failed:
                         console.print(f"    • {r['logical_id']} ({r['resource_type']}): {r['physical_id']}")
                 else:
@@ -156,7 +157,7 @@ class DestroyCommand(Command):
                 # Check for silently retained resources (DeletionPolicy: Retain)
                 retained = self._get_retained_resources(stack_name, region)
                 if retained:
-                    all_failed_resources.extend(retained)
+                    all_retained_resources.extend(retained)
                     console.print(f"[yellow]⚠ {stack.capitalize()} stack — retained resources:[/yellow]")
                     for r in retained:
                         console.print(f"    • {r['logical_id']} ({r['resource_type']}): {r['physical_id']}")
@@ -168,7 +169,7 @@ class DestroyCommand(Command):
         self._clear_cached_credentials(profile, console)
 
         # Show cleanup summary at the end
-        self._show_cleanup_summary(all_failed_resources, stacks_with_failures, profile, console)
+        self._show_cleanup_summary(all_failed_resources, all_retained_resources, stacks_with_failures, profile, console)
 
         return 0
 
@@ -275,84 +276,99 @@ class DestroyCommand(Command):
     def _show_cleanup_summary(
         self,
         failed_resources: list[dict],
+        retained_resources: list[dict],
         stacks: list[str],
         profile,
         console: Console,
     ) -> None:
-        """Show cleanup instructions for failed resources."""
-        if not failed_resources and not stacks:
+        """Show cleanup instructions for failed and retained resources."""
+        if not failed_resources and not retained_resources and not stacks:
             console.print("\n[green]✓ All stacks destroyed successfully![/green]")
             return
 
-        console.print("\n[yellow]⚠ Manual cleanup required for the following resources:[/yellow]\n")
-
-        # Group by resource type for organized output
-        by_type: dict[str, list[dict]] = {}
-        for r in failed_resources:
-            rtype = r["resource_type"]
-            if rtype not in by_type:
-                by_type[rtype] = []
-            by_type[rtype].append(r)
-
         region = profile.aws_region
 
-        # S3 Buckets
-        if "AWS::S3::Bucket" in by_type:
-            console.print("[bold]S3 Buckets (must be emptied first):[/bold]")
-            for r in by_type["AWS::S3::Bucket"]:
-                bucket = r["physical_id"]
-                console.print(f"  • {bucket}")
-                console.print(f"    [cyan]aws s3 rm s3://{bucket} --recursive[/cyan]")
-                console.print(f"    [cyan]aws s3 rb s3://{bucket}[/cyan]")
-            console.print()
+        # Show failed resources (actual deletion failures)
+        if failed_resources or stacks:
+            console.print("\n[yellow]⚠ Manual cleanup required for the following resources:[/yellow]\n")
 
-        # CloudWatch Log Groups
-        if "AWS::Logs::LogGroup" in by_type:
-            console.print("[bold]CloudWatch Log Groups:[/bold]")
-            for r in by_type["AWS::Logs::LogGroup"]:
-                log_group = r["physical_id"]
-                console.print(f"  • {log_group}")
-                console.print(
-                    f"    [cyan]aws logs delete-log-group --log-group-name {log_group} --region {region}[/cyan]"
-                )
-            console.print()
+            by_type: dict[str, list[dict]] = {}
+            for r in failed_resources:
+                rtype = r["resource_type"]
+                if rtype not in by_type:
+                    by_type[rtype] = []
+                by_type[rtype].append(r)
 
-        # DynamoDB Tables
-        if "AWS::DynamoDB::Table" in by_type:
-            console.print("[bold]DynamoDB Tables:[/bold]")
-            for r in by_type["AWS::DynamoDB::Table"]:
-                table = r["physical_id"]
-                console.print(f"  • {table}")
-                console.print(f"    [cyan]aws dynamodb delete-table --table-name {table} --region {region}[/cyan]")
-            console.print()
+            if "AWS::S3::Bucket" in by_type:
+                console.print("[bold]S3 Buckets (must be emptied first):[/bold]")
+                for r in by_type["AWS::S3::Bucket"]:
+                    bucket = r["physical_id"]
+                    console.print(f"  • {bucket}")
+                    console.print(f"    [cyan]aws s3 rm s3://{bucket} --recursive[/cyan]")
+                    console.print(f"    [cyan]aws s3 rb s3://{bucket}[/cyan]")
+                console.print()
 
-        # ECR Repositories
-        if "AWS::ECR::Repository" in by_type:
-            console.print("[bold]ECR Repositories (must delete images first):[/bold]")
-            for r in by_type["AWS::ECR::Repository"]:
-                repo = r["physical_id"]
-                console.print(f"  • {repo}")
-                console.print(
-                    f"    [cyan]aws ecr delete-repository --repository-name {repo} --force --region {region}[/cyan]"
-                )
-            console.print()
+            if "AWS::Logs::LogGroup" in by_type:
+                console.print("[bold]CloudWatch Log Groups:[/bold]")
+                for r in by_type["AWS::Logs::LogGroup"]:
+                    log_group = r["physical_id"]
+                    console.print(f"  • {log_group}")
+                    console.print(
+                        f"    [cyan]aws logs delete-log-group --log-group-name {log_group} --region {region}[/cyan]"
+                    )
+                console.print()
 
-        # Other resources
-        known_types = ["AWS::S3::Bucket", "AWS::Logs::LogGroup", "AWS::DynamoDB::Table", "AWS::ECR::Repository"]
-        other_types = [t for t in by_type if t not in known_types]
-        if other_types:
-            console.print("[bold]Other Resources:[/bold]")
-            for rtype in other_types:
-                for r in by_type[rtype]:
-                    console.print(f"  • {r['logical_id']} ({rtype}): {r['physical_id']}")
-                    console.print(f"    Reason: {r['status_reason']}")
-            console.print()
+            if "AWS::DynamoDB::Table" in by_type:
+                console.print("[bold]DynamoDB Tables:[/bold]")
+                for r in by_type["AWS::DynamoDB::Table"]:
+                    table = r["physical_id"]
+                    console.print(f"  • {table}")
+                    console.print(
+                        f"    [cyan]aws dynamodb delete-table --table-name {table} --region {region}[/cyan]"
+                    )
+                console.print()
 
-        # Final instructions
-        if stacks:
-            console.print("[yellow]After manual cleanup, delete the failed stacks:[/yellow]")
-            for stack in stacks:
-                console.print(f"  [cyan]aws cloudformation delete-stack --stack-name {stack} --region {region}[/cyan]")
+            if "AWS::ECR::Repository" in by_type:
+                console.print("[bold]ECR Repositories (must delete images first):[/bold]")
+                for r in by_type["AWS::ECR::Repository"]:
+                    repo = r["physical_id"]
+                    console.print(f"  • {repo}")
+                    console.print(
+                        f"    [cyan]aws ecr delete-repository --repository-name {repo} --force"
+                        f" --region {region}[/cyan]"
+                    )
+                console.print()
+
+            known_types = ["AWS::S3::Bucket", "AWS::Logs::LogGroup", "AWS::DynamoDB::Table", "AWS::ECR::Repository"]
+            other_types = [t for t in by_type if t not in known_types]
+            if other_types:
+                console.print("[bold]Other Resources:[/bold]")
+                for rtype in other_types:
+                    for r in by_type[rtype]:
+                        console.print(f"  • {r['logical_id']} ({rtype}): {r['physical_id']}")
+                        console.print(f"    Reason: {r['status_reason']}")
+                console.print()
+
+            if stacks:
+                console.print("[yellow]After manual cleanup, delete the failed stacks:[/yellow]")
+                for stack in stacks:
+                    console.print(
+                        f"  [cyan]aws cloudformation delete-stack --stack-name {stack} --region {region}[/cyan]"
+                    )
+                console.print()
+
+        # Show retained resources (intentionally kept by DeletionPolicy: Retain)
+        if retained_resources:
+            console.print(
+                "\n[dim]ℹ The following resources were intentionally retained (DeletionPolicy: Retain):[/dim]"
+            )
+            console.print("[dim]  These contain data that may be needed for auditing or compliance.[/dim]")
+            console.print("[dim]  Delete manually only if you no longer need the data:[/dim]\n")
+            for r in retained_resources:
+                physical_id = r["physical_id"]
+                console.print(f"  • {r['logical_id']} ({r['resource_type']}): {physical_id}")
+                if r["resource_type"] == "AWS::S3::Bucket":
+                    console.print(f"    [dim]aws s3 rb s3://{physical_id} --force[/dim]")
             console.print()
 
         console.print("For more information, see: assets/docs/TROUBLESHOOTING.md")

--- a/source/claude_code_with_bedrock/cli/commands/destroy.py
+++ b/source/claude_code_with_bedrock/cli/commands/destroy.py
@@ -241,7 +241,11 @@ class DestroyCommand(Command):
         return cf_manager.get_retained_resources(stack_name)
 
     def _clear_cached_credentials(self, profile, console: Console) -> None:
-        """Clear cached credentials that reference deleted IAM roles."""
+        """Clear cached credentials that reference deleted IAM roles.
+
+        Only removes the section if it was created by this tool (contains
+        credential_process referencing claude-code-with-bedrock or ccwb).
+        """
         try:
             import configparser
             from pathlib import Path
@@ -253,6 +257,14 @@ class DestroyCommand(Command):
             config = configparser.ConfigParser()
             config.read(cred_path)
             if profile.name in config:
+                # Only remove if it's a section created by this tool
+                section_items = dict(config.items(profile.name))
+                is_ours = any(
+                    "credential-process" in v or "claude-code-with-bedrock" in v or "ccwb" in v
+                    for v in section_items.values()
+                )
+                if not is_ours:
+                    return
                 config.remove_section(profile.name)
                 with open(cred_path, "w") as f:
                     config.write(f)

--- a/source/claude_code_with_bedrock/cli/commands/distribute.py
+++ b/source/claude_code_with_bedrock/cli/commands/distribute.py
@@ -453,7 +453,7 @@ class DistributeCommand(Command):
             # Check if Windows build is completed and download it
             try:
                 project_name = f"{profile.identity_pool_name}-windows-build"
-                codebuild = boto3.client("codebuild", region_name=profile.aws_region)
+                codebuild = boto3.client("codebuild", region_name=self._get_codebuild_region(profile))
 
                 # List recent builds
                 response = codebuild.list_builds_for_project(projectName=project_name, sortOrder="DESCENDING")
@@ -697,7 +697,7 @@ class DistributeCommand(Command):
             try:
                 # Get CodeBuild project name from profile
                 project_name = f"{profile.identity_pool_name}-windows-build"
-                codebuild = boto3.client("codebuild", region_name=profile.aws_region)
+                codebuild = boto3.client("codebuild", region_name=self._get_codebuild_region(profile))
 
                 # List recent builds
                 response = codebuild.list_builds_for_project(projectName=project_name, sortOrder="DESCENDING")
@@ -738,7 +738,7 @@ class DistributeCommand(Command):
             # First check for any completed builds
             try:
                 project_name = f"{profile.identity_pool_name}-windows-build"
-                codebuild = boto3.client("codebuild", region_name=profile.aws_region)
+                codebuild = boto3.client("codebuild", region_name=self._get_codebuild_region(profile))
 
                 # List recent builds
                 response = codebuild.list_builds_for_project(projectName=project_name, sortOrder="DESCENDING")
@@ -1218,6 +1218,13 @@ class DistributeCommand(Command):
             size_bytes /= 1024.0
         return f"{size_bytes:.1f} TB"
 
+    def _get_codebuild_region(self, profile):
+        windows_regions = {
+            "us-east-1", "us-east-2", "us-west-2", "ap-southeast-2",
+            "ap-northeast-1", "eu-central-1", "eu-west-1", "sa-east-1",
+        }
+        return profile.aws_region if profile.aws_region in windows_regions else "us-east-1"
+
     def _download_windows_artifacts(self, profile, package_path: Path, console: Console) -> bool:
         """Download Windows build artifacts from S3."""
         import zipfile
@@ -1233,7 +1240,7 @@ class DistributeCommand(Command):
                 return False
 
             codebuild_stack_name = profile.stack_names.get("codebuild", f"{profile.identity_pool_name}-codebuild")
-            codebuild_outputs = get_stack_outputs(codebuild_stack_name, profile.aws_region)
+            codebuild_outputs = get_stack_outputs(codebuild_stack_name, self._get_codebuild_region(profile))
 
             if not codebuild_outputs:
                 console.print("[red]CodeBuild stack not found[/red]")
@@ -1247,7 +1254,7 @@ class DistributeCommand(Command):
                 return False
 
             # Download from S3
-            s3 = boto3.client("s3", region_name=profile.aws_region)
+            s3 = boto3.client("s3", region_name=self._get_codebuild_region(profile))
             zip_path = package_path / "windows-binaries.zip"
 
             # CodeBuild stores artifacts at root of bucket

--- a/source/claude_code_with_bedrock/cli/commands/distribute.py
+++ b/source/claude_code_with_bedrock/cli/commands/distribute.py
@@ -20,7 +20,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.progress import BarColumn, DownloadColumn, Progress, SpinnerColumn, TextColumn, TimeRemainingColumn
 
-from claude_code_with_bedrock.cli.utils.aws import get_stack_outputs
+from claude_code_with_bedrock.cli.utils.aws import get_codebuild_region, get_stack_outputs
 from claude_code_with_bedrock.config import Config
 
 
@@ -1219,11 +1219,8 @@ class DistributeCommand(Command):
         return f"{size_bytes:.1f} TB"
 
     def _get_codebuild_region(self, profile):
-        windows_regions = {
-            "us-east-1", "us-east-2", "us-west-2", "ap-southeast-2",
-            "ap-northeast-1", "eu-central-1", "eu-west-1", "sa-east-1",
-        }
-        return profile.aws_region if profile.aws_region in windows_regions else "us-east-1"
+        """Backward-compatible wrapper for shared utility."""
+        return get_codebuild_region(profile)
 
     def _download_windows_artifacts(self, profile, package_path: Path, console: Console) -> bool:
         """Download Windows build artifacts from S3."""

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -7,7 +7,7 @@ import json
 import re
 import subprocess
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import boto3
 import questionary
@@ -279,7 +279,9 @@ class InitCommand(Command):
         console.print("")
         return True
 
-    def _gather_configuration(self, progress: WizardProgress, existing_config: dict[str, Any] = None, profile_name: str | None = None) -> dict[str, Any]:
+    def _gather_configuration(
+        self, progress: WizardProgress, existing_config: dict[str, Any] | None = None, profile_name: str | None = None
+    ) -> dict[str, Any] | None:
         """Gather configuration from user."""
         console = Console()
         # Use existing config as base if provided, otherwise use saved progress
@@ -389,7 +391,7 @@ class InitCommand(Command):
             except Exception:
                 pass  # Continue to manual selection if parsing fails
 
-            # If auto-detection failed (custom domain, Keycloak, PingFederate, etc.)
+            # If auto-detection failed (custom domain, PingFederate, etc.)
             # ask the user to select the provider type manually so deploy never gets None
             if provider_type is None:
                 console.print(
@@ -527,13 +529,15 @@ class InitCommand(Command):
             console.print("  • [cyan]Keyring[/cyan]: Uses OS secure storage (may prompt for password)")
             console.print("  • [cyan]Session Files[/cyan]: Temporary files (deleted on logout)\n")
 
+            _cs_choices = [
+                questionary.Choice("Keyring (Secure OS storage)", value="keyring"),
+                questionary.Choice("Session Files (Temporary storage)", value="session"),
+            ]
+            _cs_saved = config.get("credential_storage", "session")
             credential_storage = questionary.select(
                 "Select credential storage method:",
-                choices=[
-                    questionary.Choice("Keyring (Secure OS storage)", value="keyring"),
-                    questionary.Choice("Session Files (Temporary storage)", value="session"),
-                ],
-                default=config.get("credential_storage", "session"),
+                choices=_cs_choices,
+                default=next((c for c in _cs_choices if c.value == _cs_saved), _cs_choices[1]),
             ).ask()
 
             if not credential_storage:
@@ -548,7 +552,6 @@ class InitCommand(Command):
             config["provider_type"] = provider_type
             if cognito_user_pool_id:
                 config["cognito_user_pool_id"] = cognito_user_pool_id
-
             # Ask about federation type
             console.print("\n[cyan]Federation Type Selection[/cyan]")
             console.print("Direct STS.")
@@ -557,13 +560,14 @@ class InitCommand(Command):
             # Use existing federation type as default if available
             existing_federation_type = config.get("federation_type", "direct")
 
+            _fed_choices = [
+                questionary.Choice("Direct STS", value="direct"),
+                questionary.Choice("Cognito Identity Pool", value="cognito"),
+            ]
             federation_type = questionary.select(
                 "Choose federation type:",
-                choices=[
-                    questionary.Choice("Direct STS", value="direct"),
-                    questionary.Choice("Cognito Identity Pool", value="cognito"),
-                ],
-                default=existing_federation_type,
+                choices=_fed_choices,
+                default=next((c for c in _fed_choices if c.value == existing_federation_type), _fed_choices[0]),
             ).ask()
 
             if not federation_type:
@@ -598,6 +602,7 @@ class InitCommand(Command):
                 "ap-northeast-2",
                 "ap-southeast-1",
                 "ap-southeast-2",
+                "ap-southeast-7",
                 "ap-south-1",
                 "ca-central-1",
                 "sa-east-1",
@@ -711,6 +716,7 @@ class InitCommand(Command):
                         zone_choices = [
                             f"{zone['Name'].rstrip('.')} ({zone['Id'].split('/')[-1]})" for zone in hosted_zones
                         ]
+                        zone_choices.append("Skip (use external DNS provider)")
 
                         # Pre-select existing zone if available
                         default_zone = None
@@ -720,8 +726,12 @@ class InitCommand(Command):
                                     default_zone = choice
                                     break
 
+                        # If HTTPS was previously configured without Route53 (Skip), restore that choice
+                        if default_zone is None and existing_custom_domain and not existing_zone_id:
+                            default_zone = zone_choices[-1]  # "Skip (use external DNS provider)" is always last
+
                         selected_zone = questionary.select(
-                            "Select Route53 hosted zone for the domain:",
+                            "Select DNS management for the domain:",
                             choices=zone_choices,
                             default=default_zone if default_zone else zone_choices[0],
                         ).ask()
@@ -850,22 +860,28 @@ class InitCommand(Command):
                     console.print("  • [cyan]alert[/cyan]: Send notifications but allow continued use")
                     console.print("  • [yellow]block[/yellow]: Deny credential issuance when exceeded")
 
+                    _daily_enf_choices = [
+                        questionary.Choice("alert (warn only)", value="alert"),
+                        questionary.Choice("block (deny access)", value="block"),
+                    ]
+                    _daily_saved = config.get("quota", {}).get("daily_enforcement_mode", "alert")
                     daily_enforcement = questionary.select(
                         "Daily limit enforcement:",
-                        choices=[
-                            questionary.Choice("alert (warn only)", value="alert"),
-                            questionary.Choice("block (deny access)", value="block"),
-                        ],
-                        default=config.get("quota", {}).get("daily_enforcement_mode", "alert"),
+                        choices=_daily_enf_choices,
+                        default=next((c for c in _daily_enf_choices if c.value == _daily_saved), _daily_enf_choices[0]),
                     ).ask()
 
+                    _monthly_enf_choices = [
+                        questionary.Choice("alert (warn only)", value="alert"),
+                        questionary.Choice("block (deny access)", value="block"),
+                    ]
+                    _monthly_saved = config.get("quota", {}).get("monthly_enforcement_mode", "block")
                     monthly_enforcement = questionary.select(
                         "Monthly limit enforcement:",
-                        choices=[
-                            questionary.Choice("alert (warn only)", value="alert"),
-                            questionary.Choice("block (deny access)", value="block"),
-                        ],
-                        default=config.get("quota", {}).get("monthly_enforcement_mode", "block"),
+                        choices=_monthly_enf_choices,
+                        default=next(
+                            (c for c in _monthly_enf_choices if c.value == _monthly_saved), _monthly_enf_choices[1]
+                        ),
                     ).ask()
 
                     config["quota"]["daily_enforcement_mode"] = daily_enforcement
@@ -934,18 +950,20 @@ class InitCommand(Command):
         distribution_choices = [
             questionary.Choice("Presigned S3 URLs (simple, no authentication)", value="presigned-s3"),
             questionary.Choice("Authenticated Landing Page (IdP + ALB)", value="landing-page"),
-            questionary.Choice("Disabled", value=None),
+            questionary.Choice("Disabled", value="__disabled__"),
         ]
 
         # Get saved value or default to None
         saved_dist_type = config.get("distribution", {}).get("type")
-        default_choice = saved_dist_type if saved_dist_type else None
+        default_choice = next((c for c in distribution_choices if c.value == saved_dist_type), None)
 
         distribution_type = questionary.select(
             "Distribution method:",
             choices=distribution_choices,
             default=default_choice,
         ).ask()
+        if distribution_type == "__disabled__":
+            distribution_type = None
 
         # Preserve existing distribution settings, only update enabled/type
         if "distribution" not in config:
@@ -966,10 +984,11 @@ class InitCommand(Command):
                 questionary.Choice("AWS Cognito User Pool", value="cognito"),
             ]
 
+            _idp_saved = config.get("distribution", {}).get("idp_provider", "okta")
             idp_provider = questionary.select(
                 "Identity provider for web authentication:",
                 choices=idp_choices,
-                default=config.get("distribution", {}).get("idp_provider", "okta"),
+                default=next((c for c in idp_choices if c.value == _idp_saved), idp_choices[0]),
             ).ask()
 
             # Auto-detection for Cognito User Pool
@@ -1060,43 +1079,58 @@ class InitCommand(Command):
                 ).ask()
 
                 # Web app client secret
-                idp_client_secret = questionary.password(
-                    "Web application client secret:",
-                ).ask()
+                existing_secret_arn = config.get("distribution", {}).get("idp_client_secret_arn")
+                _secret_prompt = (
+                    "Web application client secret (leave blank to keep existing):"
+                    if existing_secret_arn
+                    else "Web application client secret:"
+                )
+                idp_client_secret = questionary.password(_secret_prompt).ask()
+
+                # First-time setup: a secret is required — re-prompt until provided
+                if not idp_client_secret and not existing_secret_arn:
+                    while not idp_client_secret:
+                        console.print("[red]Client secret is required for initial setup.[/red]")
+                        idp_client_secret = questionary.password("Web application client secret:").ask()
 
             # Store secret in AWS Secrets Manager (only if not auto-configured)
             import boto3
 
             if not cognito_auto_configured:
-                try:
-                    secrets_client = boto3.client("secretsmanager", region_name=region)
-                    account_id = boto3.client("sts").get_caller_identity()["Account"]
-
-                    secret_name = f"{config['aws']['identity_pool_name']}-distribution-idp-secret"
-
-                    # Try to create or update secret
+                if idp_client_secret:
                     try:
-                        secret_response = secrets_client.create_secret(
-                            Name=secret_name,
-                            SecretString=idp_client_secret,
-                            Description=f"IdP client secret for "
-                            f"{config['aws']['identity_pool_name']} distribution landing page",
-                        )
-                        secret_arn = secret_response["ARN"]
-                    except secrets_client.exceptions.ResourceExistsException:
-                        # Secret already exists, update it
-                        secret_response = secrets_client.update_secret(
-                            SecretId=secret_name,
-                            SecretString=idp_client_secret,
-                        )
+                        secrets_client = boto3.client("secretsmanager", region_name=region)
+                        account_id = boto3.client("sts").get_caller_identity()["Account"]
+
+                        secret_name = f"{config['aws']['identity_pool_name']}-distribution-idp-secret"
+
+                        # Try to create or update secret
+                        try:
+                            secret_response = secrets_client.create_secret(
+                                Name=secret_name,
+                                SecretString=idp_client_secret,
+                                Description=f"IdP client secret for "
+                                f"{config['aws']['identity_pool_name']} distribution landing page",
+                            )
+                            secret_arn = secret_response["ARN"]
+                        except secrets_client.exceptions.ResourceExistsException:
+                            # Secret already exists, update it
+                            secret_response = secrets_client.update_secret(
+                                SecretId=secret_name,
+                                SecretString=idp_client_secret,
+                            )
+                            secret_arn = secret_response["ARN"]
+
+                        console.print(f"[green]✓[/green] IdP client secret stored in Secrets Manager: {secret_name}")
+
+                    except Exception as e:
+                        console.print(f"[red]Error storing secret in Secrets Manager: {e}[/red]")
+                        console.print("[yellow]You'll need to configure the secret manually before deployment[/yellow]")
                         secret_arn = f"arn:aws:secretsmanager:{region}:{account_id}:secret:{secret_name}"
-
-                    console.print(f"[green]✓[/green] IdP client secret stored in Secrets Manager: {secret_name}")
-
-                except Exception as e:
-                    console.print(f"[red]Error storing secret in Secrets Manager: {e}[/red]")
-                    console.print("[yellow]You'll need to configure the secret manually before deployment[/yellow]")
-                    secret_arn = f"arn:aws:secretsmanager:{region}:{account_id}:secret:{secret_name}"
+                else:
+                    # Blank input — keep the existing secret unchanged
+                    secret_arn = existing_secret_arn
+                    console.print("[green]✓[/green] Keeping existing IdP client secret.")
 
             # Custom domain (REQUIRED for authenticated landing page)
             console.print("\n[bold]Custom Domain Configuration (REQUIRED)[/bold]")
@@ -1135,7 +1169,7 @@ class InitCommand(Command):
                         )
                         for zone in hosted_zones
                     ]
-                    zone_choices.append(questionary.Choice("Skip (no Route53 managed domain)", value=None))
+                    zone_choices.append(questionary.Choice("Skip (no Route53 managed domain)", value="__skip__"))
 
                     # Find the default choice based on existing zone
                     default_choice = None
@@ -1145,11 +1179,18 @@ class InitCommand(Command):
                                 default_choice = choice
                                 break
 
+                    # If user previously chose Skip (zone_id saved as None but custom_domain is set), restore Skip
+                    dist_has_domain = config.get("distribution", {}).get("custom_domain")
+                    if default_choice is None and dist_has_domain and not existing_zone_id:
+                        default_choice = zone_choices[-1]  # "Skip (no Route53 managed domain)" is always last
+
                     hosted_zone_id = questionary.select(
                         "Select Route53 hosted zone:",
                         choices=zone_choices,
                         default=default_choice if default_choice else zone_choices[0],
                     ).ask()
+                    if hosted_zone_id == "__skip__":
+                        hosted_zone_id = None
                 else:
                     console.print("[yellow]No Route53 hosted zones found in this account[/yellow]")
                     console.print("You can still use custom domain if it's managed externally")
@@ -1184,164 +1225,200 @@ class InitCommand(Command):
             # Import centralized model configuration
             from claude_code_with_bedrock.models import (
                 CLAUDE_MODELS,
-                get_available_profiles_for_model,
+                get_all_destination_regions,
+                get_all_destination_regions_for_profile,
+                get_all_source_regions,
                 get_destination_regions_for_model_profile,
                 get_model_id_for_profile,
-                get_profile_description,
-                get_source_regions_for_model_profile,
+                get_models_for_tier,
+                get_profiles_for_region,
+                resolve_profile_key,
             )
 
-            # Check for saved model
-            saved_model = config.get("aws", {}).get("selected_model")
+            # Restore saved values — model fields stored as model IDs, need reverse-lookup for keys
+            saved_source_region = config.get("aws", {}).get("selected_source_region")
+            saved_profile = config.get("aws", {}).get("cross_region_profile")  # None = auto-select
+
+            _saved_model_id = config.get("aws", {}).get("selected_model")
             saved_model_key = None
-            if saved_model:
-                # Find the key for the saved model by checking all model IDs
-                for key, model_info in CLAUDE_MODELS.items():
-                    for _profile_key, profile_config in model_info["profiles"].items():
-                        if profile_config["model_id"] == saved_model:
-                            saved_model_key = key
+            if _saved_model_id:
+                for _mk, _mi in CLAUDE_MODELS.items():
+                    for _pc in cast(dict[str, Any], _mi)["profiles"].values():
+                        if cast(dict[str, Any], _pc)["model_id"] == _saved_model_id:
+                            saved_model_key = _mk
                             break
                     if saved_model_key:
                         break
 
-            # Step 1: Select Claude model
-            model_choices = []
-            default_model_key = saved_model_key or "sonnet-4-5"
-            for model_key, model_info in CLAUDE_MODELS.items():
-                # Build region list from available profiles
-                available_profiles = get_available_profiles_for_model(model_key)
-                regions = []
-                if "global" in available_profiles:
-                    regions.append("Global")
-                if "us" in available_profiles:
-                    regions.append("US")
-                if "europe" in available_profiles:
-                    regions.append("Europe")
-                if "apac" in available_profiles:
-                    regions.append("APAC")
-                regions_text = ", ".join(regions)
+            def _key_for_model_id(model_id: str) -> str | None:
+                for mk, mi in CLAUDE_MODELS.items():
+                    for pc in cast(dict[str, Any], mi)["profiles"].values():
+                        if cast(dict[str, Any], pc).get("model_id") == model_id:
+                            return mk
+                return None
 
-                choice_text = f"{model_info['name']} ({regions_text})"
-                model_choices.append(questionary.Choice(title=choice_text, value=model_key))
+            saved_tier_keys: dict[str, str | None] = {
+                "opus": _key_for_model_id(config.get("aws", {}).get("default_opus_model") or ""),
+                "sonnet": _key_for_model_id(config.get("aws", {}).get("default_sonnet_model") or ""),
+                "haiku": _key_for_model_id(config.get("aws", {}).get("default_haiku_model") or ""),
+            }
 
+            # Q1: Source region (always required)
+            all_regions = get_all_source_regions()
+            region_choices = [questionary.Choice(r, value=r) for r in all_regions]
+            _default_region = next(
+                (c for c in region_choices if c.value == saved_source_region), region_choices[0]
+            )
+            selected_source_region = questionary.select(
+                "Select source region for AWS configuration:",
+                choices=region_choices,
+                default=_default_region,
+                instruction="(Use arrow keys to select, Enter to confirm)",
+            ).ask()
+
+            if selected_source_region is None:  # User cancelled
+                return None
+
+            config["aws"]["selected_source_region"] = selected_source_region
+            console.print(f"[green]✓[/green] Source region: {selected_source_region}")
+
+            # Q2: Cross-region profile (filtered by region; Auto-select exits early)
+            available_profiles = get_profiles_for_region(selected_source_region)
+
+            _AUTO_PROFILE = "__auto__"
+            _PROFILE_LABELS = {
+                "us": "US Cross-Region — US regions",
+                "eu": "EU Cross-Region — European regions",
+                "europe": "EU Cross-Region — European regions",
+                "japan": "Japan Cross-Region — Japan regions",
+                "australia": "Australia Cross-Region — Australia regions",
+                "apac": "APAC Cross-Region — Asia-Pacific regions",
+                "global": "Global Cross-Region — All regions worldwide",
+                "us-gov": "US GovCloud Cross-Region — US GovCloud regions",
+            }
+            profile_choices = [
+                questionary.Choice(
+                    "Auto-select (recommended) — Claude Code picks model for your region",
+                    value=_AUTO_PROFILE,
+                )
+            ]
+            for pk in available_profiles:
+                label = _PROFILE_LABELS.get(pk, f"{pk.upper()} Cross-Region")
+                profile_choices.append(questionary.Choice(label, value=pk))
+
+            _default_profile = next(
+                (c for c in profile_choices if c.value == (saved_profile or _AUTO_PROFILE)),
+                profile_choices[0],
+            )
+            selected_profile = questionary.select(
+                "Select cross-region inference profile:",
+                choices=profile_choices,
+                default=_default_profile,
+                instruction="(Use arrow keys to select, Enter to confirm)",
+            ).ask()
+
+            if selected_profile is None:  # User cancelled
+                return None
+
+            if selected_profile == _AUTO_PROFILE:
+                config["aws"]["cross_region_profile"] = None
+                config["aws"]["selected_model"] = None
+                config["aws"]["allowed_bedrock_regions"] = get_all_destination_regions()
+                config["aws"]["default_opus_model"] = None
+                config["aws"]["default_sonnet_model"] = None
+                config["aws"]["default_haiku_model"] = None
+                console.print("[green]✓[/green] Auto-select: Claude Code will select models for your region")
+                progress.save_step("bedrock_complete", config)
+                return config
+
+            config["aws"]["cross_region_profile"] = selected_profile
+            console.print(f"[green]✓[/green] Profile: {selected_profile}")
+
+            # Q3: Claude model (filtered by profile; Auto-select exits Q4-Q6)
+            _AUTO_MODEL = "__auto__"
+            model_choices: list[questionary.Choice] = [
+                questionary.Choice("Auto-select — don't set ANTHROPIC_MODEL", value=_AUTO_MODEL)
+            ]
+            for model_key, model_config in CLAUDE_MODELS.items():
+                if resolve_profile_key(model_key, selected_profile) is None:
+                    continue
+                model_choices.append(questionary.Choice(cast(str, model_config["name"]), value=model_key))
+
+            _default_model = next(
+                (c for c in model_choices if c.value == (saved_model_key or _AUTO_MODEL)),
+                model_choices[0],
+            )
             selected_model_key = questionary.select(
                 "Select Claude model:",
                 choices=model_choices,
-                default=default_model_key,
+                default=_default_model,
                 instruction="(Use arrow keys to select, Enter to confirm)",
             ).ask()
 
             if selected_model_key is None:  # User cancelled
                 return None
 
-            selected_model = CLAUDE_MODELS[selected_model_key]
-            # Don't set the model ID yet - we need to adjust it based on the region profile
-
-            # Step 2: Select cross-region profile based on model
-            console.print(f"\n[green]Selected:[/green] {selected_model['name']}")
-
-            available_profiles = get_available_profiles_for_model(selected_model_key)
-
-            # Check for saved profile
-            saved_profile = config.get("aws", {}).get("cross_region_profile")
-            if saved_profile not in available_profiles:
-                saved_profile = available_profiles[0]  # Default to first available
-
-            # Always show the selection, even if there's only one option
-            profile_choices = []
-            for profile_key in available_profiles:
-                # Get model-specific description
-                description = get_profile_description(selected_model_key, profile_key)
-                region_profile_label = profile_key.upper() if profile_key != "us" else "US"
-                choice_text = f"{region_profile_label} Cross-Region - {description}"
-                profile_choices.append(questionary.Choice(title=choice_text, value=profile_key))
-
-            # Adjust the prompt based on number of options
-            if len(available_profiles) == 1:
-                prompt_text = "Cross-region inference profile for this model:"
-                instruction_text = "(Press Enter to continue)"
+            if selected_model_key == _AUTO_MODEL:
+                config["aws"]["selected_model"] = None
+                # Profile is known; use its destination regions instead of wildcard
+                profile_dest_regions = get_all_destination_regions_for_profile(selected_profile)
+                config["aws"]["allowed_bedrock_regions"] = profile_dest_regions if profile_dest_regions else get_all_destination_regions()
+                console.print("[green]✓[/green] Auto-select: Claude Code will choose the model automatically")
             else:
-                prompt_text = "Select cross-region inference profile:"
-                instruction_text = "(Use arrow keys to select, Enter to confirm)"
+                model_id = get_model_id_for_profile(selected_model_key, selected_profile)
+                config["aws"]["selected_model"] = model_id
+                console.print(f"[green]✓[/green] Model: {CLAUDE_MODELS[selected_model_key]['name']}")
 
-            selected_profile = questionary.select(
-                prompt_text, choices=profile_choices, default=saved_profile, instruction=instruction_text
-            ).ask()
+                destination_regions = get_destination_regions_for_model_profile(selected_model_key, selected_profile)
+                if not destination_regions:
+                    console.print(
+                        f"[red]Error:[/red] No destination regions configured for {selected_model_key} "
+                        f"with {selected_profile} profile"
+                    )
+                    raise ValueError("No destination regions configured for model/profile combination")
+                config["aws"]["allowed_bedrock_regions"] = destination_regions
 
-            if selected_profile is None:  # User cancelled
-                return None
+            # Q4-Q6: Default tier models (per-tier Auto-select = don't set that env var)
+            _AUTO_TIER = "__auto__"
+            tier_config_keys = {
+                "opus": "default_opus_model",
+                "sonnet": "default_sonnet_model",
+                "haiku": "default_haiku_model",
+            }
+            for tier in ["opus", "sonnet", "haiku"]:
+                tier_models = get_models_for_tier(tier, selected_profile)
+                if not tier_models:
+                    config["aws"][tier_config_keys[tier]] = None
+                    continue
 
-            # Get the correct model ID for the selected profile
-            model_id = get_model_id_for_profile(selected_model_key, selected_profile)
-            config["aws"]["selected_model"] = model_id
-            config["aws"]["cross_region_profile"] = selected_profile
+                tc: list[questionary.Choice] = [
+                    questionary.Choice(
+                        f"Auto-select — don't set ANTHROPIC_DEFAULT_{tier.upper()}_MODEL",
+                        value=_AUTO_TIER,
+                    )
+                ]
+                for mk, display_name, _mid in reversed(tier_models):
+                    tc.append(questionary.Choice(display_name, value=mk))
 
-            # Get destination regions for the model/profile combination
-            destination_regions = get_destination_regions_for_model_profile(selected_model_key, selected_profile)
-
-            # Use the destination regions from the model profile
-            if not destination_regions:
-                console.print(
-                    f"[red]Error:[/red] No destination regions configured for {selected_model_key} "
-                    f"with {selected_profile} profile"
-                )
-                raise ValueError("No destination regions configured for model/profile combination")
-
-            config["aws"]["allowed_bedrock_regions"] = destination_regions
-
-            # Step 3: Select source region for the selected model/profile combination
-            region_profile_label = selected_profile.upper() if selected_profile != "us" else "US"
-            console.print(f"\n[green]Selected:[/green] {region_profile_label} Cross-Region")
-
-            # Get available source regions for this model/profile combination
-            available_source_regions = get_source_regions_for_model_profile(selected_model_key, selected_profile)
-
-            # Check for saved source region
-            saved_source_region = config.get("aws", {}).get("selected_source_region")
-            if saved_source_region not in available_source_regions:
-                saved_source_region = available_source_regions[0] if available_source_regions else None
-
-            if available_source_regions:
-                # Present source region selection
-                source_region_choices = []
-                for region in available_source_regions:
-                    choice_text = f"{region}"
-                    source_region_choices.append(questionary.Choice(title=choice_text, value=region))
-
-                # Adjust prompt based on number of options
-                if len(available_source_regions) == 1:
-                    prompt_text = "Source region for this model:"
-                    instruction_text = "(Press Enter to continue)"
-                else:
-                    prompt_text = "Select source region for AWS configuration:"
-                    instruction_text = "(Use arrow keys to select, Enter to confirm)"
-
-                selected_source_region = questionary.select(
-                    prompt_text,
-                    choices=source_region_choices,
-                    default=saved_source_region,
-                    instruction=instruction_text,
+                _saved_key = saved_tier_keys[tier]
+                _default_t = next((c for c in tc if c.value == (_saved_key or _AUTO_TIER)), tc[0])
+                chosen = questionary.select(
+                    f"Select default {tier.capitalize()} model:",
+                    choices=tc,
+                    default=_default_t,
+                    instruction="(Use arrow keys to select, Enter to confirm)",
                 ).ask()
 
-                if selected_source_region is None:  # User cancelled
+                if chosen is None:  # User cancelled
                     return None
 
-                config["aws"]["selected_source_region"] = selected_source_region
-                console.print(f"[green]✓[/green] Source region: {selected_source_region}")
-            else:
-                # No source regions available - use default fallback
-                console.print(
-                    "[yellow]No source regions configured for this model. Using default region logic.[/yellow]"
-                )
-                config["aws"]["selected_source_region"] = None
-
-            # Get model-specific description for confirmation
-            profile_description = get_profile_description(selected_model_key, selected_profile)
-
-            console.print(
-                f"\n[green]✓[/green] Configured {selected_model['name']} with {region_profile_label} "
-                f"Cross-Region ({profile_description})"
-            )
+                if chosen == _AUTO_TIER:
+                    config["aws"][tier_config_keys[tier]] = None
+                    console.print(f"[green]✓[/green] Default {tier}: Auto-select")
+                else:
+                    tier_model_id = get_model_id_for_profile(chosen, selected_profile)
+                    config["aws"][tier_config_keys[tier]] = tier_model_id
+                    console.print(f"[green]✓[/green] Default {tier}: {CLAUDE_MODELS[chosen]['name']}")
 
             # Optional: Application Inference Profiles
             has_saved_arns = any(
@@ -1749,6 +1826,9 @@ class InitCommand(Command):
             inference_profile_opus_arn=config_data["aws"].get("inference_profile_opus_arn"),
             inference_profile_sonnet_arn=config_data["aws"].get("inference_profile_sonnet_arn"),
             inference_profile_haiku_arn=config_data["aws"].get("inference_profile_haiku_arn"),
+            default_opus_model=config_data["aws"].get("default_opus_model"),
+            default_sonnet_model=config_data["aws"].get("default_sonnet_model"),
+            default_haiku_model=config_data["aws"].get("default_haiku_model"),
             provider_type=config_data.get("provider_type"),
             cognito_user_pool_id=config_data.get("cognito_user_pool_id"),
             federation_type=config_data.get("federation_type", "cognito"),
@@ -2039,6 +2119,9 @@ class InitCommand(Command):
                     "identity_pool_name": profile.identity_pool_name,
                     "stacks": profile.stack_names,
                     "allowed_bedrock_regions": profile.allowed_bedrock_regions,
+                    "default_opus_model": getattr(profile, "default_opus_model", None),
+                    "default_sonnet_model": getattr(profile, "default_sonnet_model", None),
+                    "default_haiku_model": getattr(profile, "default_haiku_model", None),
                 },
                 "monitoring": {
                     "enabled": profile.monitoring_enabled,
@@ -2072,9 +2155,8 @@ class InitCommand(Command):
             if hasattr(profile, "selected_model") and profile.selected_model:
                 existing_config["aws"]["selected_model"] = profile.selected_model
 
-            # Add cross-region profile if present
-            if hasattr(profile, "cross_region_profile") and profile.cross_region_profile:
-                existing_config["aws"]["cross_region_profile"] = profile.cross_region_profile
+            # Add cross-region profile (None is valid and means auto-select)
+            existing_config["aws"]["cross_region_profile"] = getattr(profile, "cross_region_profile", None)
 
             # Add application inference profile ARNs if present
             for arn_key in ["inference_profile_opus_arn", "inference_profile_sonnet_arn", "inference_profile_haiku_arn"]:
@@ -2103,11 +2185,18 @@ class InitCommand(Command):
 
             # Add quota monitoring configuration if present
             if hasattr(profile, "quota_monitoring_enabled"):
+                monthly_tokens = getattr(profile, "monthly_token_limit", 225000000)
                 existing_config["quota"] = {
                     "enabled": profile.quota_monitoring_enabled,
-                    "monthly_limit": getattr(profile, "monthly_token_limit", 300000000),
-                    "warning_threshold_80": getattr(profile, "warning_threshold_80", 240000000),
-                    "warning_threshold_90": getattr(profile, "warning_threshold_90", 270000000),
+                    "monthly_limit": monthly_tokens,
+                    "monthly_limit_millions": monthly_tokens // 1000000,
+                    "warning_threshold_80": getattr(profile, "warning_threshold_80", 0),
+                    "warning_threshold_90": getattr(profile, "warning_threshold_90", 0),
+                    "burst_buffer_percent": getattr(profile, "burst_buffer_percent", 10),
+                    "daily_limit": getattr(profile, "daily_token_limit", None),
+                    "daily_enforcement_mode": getattr(profile, "daily_enforcement_mode", "alert"),
+                    "monthly_enforcement_mode": getattr(profile, "monthly_enforcement_mode", "block"),
+                    "check_interval": getattr(profile, "quota_check_interval", 30),
                 }
 
             # Add analytics configuration if present

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -738,11 +738,14 @@ class InitCommand(Command):
 
                         # Extract zone ID or handle external DNS provider case
                         if selected_zone.startswith("Skip"):
-                            zone_id = "use external DNS provider"
+                            # User selected external DNS - don't pass HostedZoneId to CloudFormation
+                            config["monitoring"]["hosted_zone_id"] = None
+                            console.print(f"[green]✓[/green] HTTPS will be enabled with domain: {custom_domain}")
+                            console.print("[yellow]Note: You'll need to create DNS records manually (instructions shown at deploy)[/yellow]")
                         else:
                             zone_id = selected_zone.split("(")[-1].rstrip(")")
-                        config["monitoring"]["hosted_zone_id"] = zone_id
-                        console.print(f"[green]✓[/green] HTTPS will be enabled with domain: {custom_domain}")
+                            config["monitoring"]["hosted_zone_id"] = zone_id
+                            console.print(f"[green]✓[/green] HTTPS will be enabled with domain: {custom_domain}")
                     else:
                         if zones_error:
                             console.print(f"[yellow]Could not list Route53 hosted zones: {zones_error}[/yellow]")

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -716,7 +716,7 @@ class InitCommand(Command):
                         zone_choices = [
                             f"{zone['Name'].rstrip('.')} ({zone['Id'].split('/')[-1]})" for zone in hosted_zones
                         ]
-                        zone_choices.append("Skip (use external DNS provider)")
+                        zone_choices.append("Skip (no Route53 managed domain)")
 
                         # Pre-select existing zone if available
                         default_zone = None
@@ -728,7 +728,7 @@ class InitCommand(Command):
 
                         # If HTTPS was previously configured without Route53 (Skip), restore that choice
                         if default_zone is None and existing_custom_domain and not existing_zone_id:
-                            default_zone = zone_choices[-1]  # "Skip (use external DNS provider)" is always last
+                            default_zone = zone_choices[-1]  # "Skip (no Route53 managed domain)" is always last
 
                         selected_zone = questionary.select(
                             "Select DNS management for the domain:",
@@ -736,8 +736,11 @@ class InitCommand(Command):
                             default=default_zone if default_zone else zone_choices[0],
                         ).ask()
 
-                        # Extract zone ID
-                        zone_id = selected_zone.split("(")[-1].rstrip(")")
+                        # Extract zone ID or handle external DNS provider case
+                        if selected_zone.startswith("Skip"):
+                            zone_id = "use external DNS provider"
+                        else:
+                            zone_id = selected_zone.split("(")[-1].rstrip(")")
                         config["monitoring"]["hosted_zone_id"] = zone_id
                         console.print(f"[green]✓[/green] HTTPS will be enabled with domain: {custom_domain}")
                     else:

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1249,7 +1249,8 @@ class InitCommand(Command):
             saved_model_key = None
             if _saved_model_id:
                 for _mk, _mi in CLAUDE_MODELS.items():
-                    for _pc in cast(dict[str, Any], _mi)["profiles"].values():
+                    model_info = cast(dict[str, Any], _mi)
+                    for _pc in model_info["profiles"].values():
                         if cast(dict[str, Any], _pc)["model_id"] == _saved_model_id:
                             saved_model_key = _mk
                             break
@@ -1258,7 +1259,8 @@ class InitCommand(Command):
 
             def _key_for_model_id(model_id: str) -> str | None:
                 for mk, mi in CLAUDE_MODELS.items():
-                    for pc in cast(dict[str, Any], mi)["profiles"].values():
+                    model_info = cast(dict[str, Any], mi)
+                    for pc in model_info["profiles"].values():
                         if cast(dict[str, Any], pc).get("model_id") == model_id:
                             return mk
                 return None
@@ -1368,7 +1370,9 @@ class InitCommand(Command):
                 config["aws"]["selected_model"] = None
                 # Profile is known; use its destination regions instead of wildcard
                 profile_dest_regions = get_all_destination_regions_for_profile(selected_profile)
-                config["aws"]["allowed_bedrock_regions"] = profile_dest_regions if profile_dest_regions else get_all_destination_regions()
+                config["aws"]["allowed_bedrock_regions"] = (
+                    profile_dest_regions if profile_dest_regions else get_all_destination_regions()
+                )
                 console.print("[green]✓[/green] Auto-select: Claude Code will choose the model automatically")
             else:
                 model_id = get_model_id_for_profile(selected_model_key, selected_profile)

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -21,6 +21,7 @@ from claude_code_with_bedrock.cli.utils.aws import get_stack_outputs
 from claude_code_with_bedrock.cli.utils.display import display_configuration_info
 from claude_code_with_bedrock.config import Config
 from claude_code_with_bedrock.models import (
+    get_models_for_tier,
     get_source_region_for_profile,
 )
 
@@ -534,7 +535,7 @@ class PackageCommand(Command):
                 console.print("[red]No configuration found. Run 'poetry run ccwb init' first.[/red]")
                 return 1
 
-            codebuild = boto3.client("codebuild", region_name=profile.aws_region)
+            codebuild = boto3.client("codebuild", region_name=self._get_codebuild_region(profile))
             response = codebuild.batch_get_builds(ids=[build_id])
 
             if not response.get("builds"):
@@ -1331,6 +1332,13 @@ RUN pyinstaller \
                 subprocess.run(["docker", "rm", container_name], capture_output=True)
                 subprocess.run(["docker", "rmi", image_tag], capture_output=True)
 
+    def _get_codebuild_region(self, profile):
+        windows_regions = {
+            "us-east-1", "us-east-2", "us-west-2", "ap-southeast-2",
+            "ap-northeast-1", "eu-central-1", "eu-west-1", "sa-east-1",
+        }
+        return profile.aws_region if profile.aws_region in windows_regions else "us-east-1"
+
     def _build_windows_via_codebuild(self, output_dir: Path) -> Path:
         """Build Windows binaries using AWS CodeBuild."""
         import json
@@ -1348,7 +1356,7 @@ RUN pyinstaller \
 
             if profile:
                 project_name = f"{profile.identity_pool_name}-windows-build"
-                codebuild = boto3.client("codebuild", region_name=profile.aws_region)
+                codebuild = boto3.client("codebuild", region_name=self._get_codebuild_region(profile))
 
                 # List recent builds
                 response = codebuild.list_builds_for_project(projectName=project_name, sortOrder="DESCENDING")
@@ -1386,7 +1394,8 @@ RUN pyinstaller \
         # Get CodeBuild stack outputs
         stack_name = profile.stack_names.get("codebuild", f"{profile.identity_pool_name}-codebuild")
         try:
-            stack_outputs = get_stack_outputs(stack_name, profile.aws_region)
+            codebuild_region = self._get_codebuild_region(profile)
+            stack_outputs = get_stack_outputs(stack_name, codebuild_region)
         except Exception:
             console.print(f"[red]CodeBuild stack not found: {stack_name}[/red]")
             console.print("Run: poetry run ccwb deploy codebuild")
@@ -1408,7 +1417,7 @@ RUN pyinstaller \
 
             # Upload to S3
             progress.update(task, description="Uploading source to S3...")
-            s3 = boto3.client("s3", region_name=profile.aws_region)
+            s3 = boto3.client("s3", region_name=codebuild_region)
             try:
                 s3.upload_file(str(source_zip), bucket_name, "source.zip")
             except ClientError as e:
@@ -1417,7 +1426,7 @@ RUN pyinstaller \
 
             # Start build
             progress.update(task, description="Starting CodeBuild project...")
-            codebuild = boto3.client("codebuild", region_name=profile.aws_region)
+            codebuild = boto3.client("codebuild", region_name=codebuild_region)
             try:
                 response = codebuild.start_build(projectName=project_name)
                 build_id = response["build"]["id"]
@@ -2074,6 +2083,9 @@ credential_process = $HOME/claude-code-with-bedrock/credential-process --profile
 region = $PROFILE_REGION
 EOF
     echo "  ✓ Created AWS profile '$PROFILE_NAME'"
+
+    # Clear stale cached credentials from previous deployments
+    $HOME/claude-code-with-bedrock/credential-process --profile $PROFILE_NAME --clear-cache 2>/dev/null || true
 done
 
 # Apply CoWork configuration profile on macOS if present
@@ -2217,11 +2229,22 @@ REM older ccwb auth logout) would shadow credential_process and break Cowork
 REM Desktop with a 403 InvalidClientTokenId.
 powershell -NoProfile -Command "$ErrorActionPreference = 'Stop'; $awsCreds = Join-Path $env:USERPROFILE '.aws\credentials'; if (Test-Path $awsCreds) {{ $cfg = Get-Content config.json | ConvertFrom-Json; $existing = Get-Content $awsCreds -Raw; foreach ($p in $cfg.PSObject.Properties.Name) {{ $pattern = '(?ms)^\[' + [regex]::Escape($p) + '\].*?(?=^\[|\Z)'; $existing = [regex]::Replace($existing, $pattern, '') }}; Set-Content -Path $awsCreds -Value $existing.TrimStart() -NoNewline -Encoding ASCII }}"
 
-powershell -NoProfile -Command "$ErrorActionPreference = 'Stop'; $nl = [char]13 + [char]10; $cfg = Get-Content config.json | ConvertFrom-Json; $awsConfig = Join-Path $env:USERPROFILE '.aws\config'; $credProcess = Join-Path $env:USERPROFILE 'claude-code-with-bedrock\credential-process.exe'; $existing = if (Test-Path $awsConfig) {{ Get-Content $awsConfig -Raw }} else {{ '' }}; foreach ($p in $cfg.PSObject.Properties.Name) {{ $region = $cfg.$p.aws_region; if (-not $region) {{ $region = '{profile.aws_region}' }}; $pattern = '(?ms)^\[profile ' + [regex]::Escape($p) + '\].*?(?=^\[|\Z)'; $existing = [regex]::Replace($existing, $pattern, ''); $stanza = '[profile ' + $p + ']' + $nl + 'credential_process = ' + $credProcess + ' --profile ' + $p + $nl + 'region = ' + $region + $nl; $existing = $existing.TrimEnd() + $nl + $nl + $stanza; Write-Host ('  OK Configured AWS profile ' + $p) }}; Set-Content -Path $awsConfig -Value $existing.TrimStart() -NoNewline -Encoding ASCII"
-if %errorlevel% neq 0 (
-    echo ERROR: Failed to configure AWS profiles
-    pause
-    exit /b 1
+
+    REM Set credential process with --profile flag (cross-platform, no wrapper needed)
+    aws configure set credential_process "%USERPROFILE%\\claude-code-with-bedrock\\credential-process.exe --profile %%p" --profile %%p
+
+
+    REM Set region
+    if defined PROFILE_REGION (
+        aws configure set region !PROFILE_REGION! --profile %%p
+    ) else (
+        aws configure set region {profile.aws_region} --profile %%p
+    )
+
+    echo   OK Created AWS profile '%%p'
+
+    REM Clear stale cached credentials from previous deployments
+    "%USERPROFILE%\\claude-code-with-bedrock\\credential-process.exe" --profile %%p --clear-cache >nul 2>&1
 )
 
 echo.
@@ -2458,25 +2481,20 @@ Available metrics include:
             if hasattr(profile, "selected_model") and profile.selected_model:
                 settings["env"]["ANTHROPIC_MODEL"] = profile.selected_model
 
-                # Set all model tier env vars using the CRIS prefix from init.
-                # Claude Code uses these to resolve the correct CRIS-prefixed
-                # models for each tier (small/fast, default sonnet/opus/haiku).
-                # This ensures all tiers respect the admin's routing geography
-                # choice and works correctly with model aliases like 'opus', 'sonnet', 'haiku'.
-                from claude_code_with_bedrock.models import resolve_model_for_tier
-                cris_prefix = getattr(profile, "cross_region_profile", None) or "us"
-
-                haiku_model = resolve_model_for_tier("haiku", cris_prefix)
-                sonnet_model = resolve_model_for_tier("sonnet", cris_prefix)
-                opus_model = resolve_model_for_tier("opus", cris_prefix)
-
-                if haiku_model:
-                    settings["env"]["ANTHROPIC_SMALL_FAST_MODEL"] = haiku_model
-                    settings["env"]["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = haiku_model
-                if sonnet_model:
-                    settings["env"]["ANTHROPIC_DEFAULT_SONNET_MODEL"] = sonnet_model
-                if opus_model:
-                    settings["env"]["ANTHROPIC_DEFAULT_OPUS_MODEL"] = opus_model
+            # Set per-tier model defaults for /model opus, /model sonnet, /model haiku
+            # These are configured during ccwb init and stored in the profile
+            # Independent of selected_model — tier defaults apply even when auto-select is used
+            if profile.default_opus_model:
+                settings["env"]["ANTHROPIC_DEFAULT_OPUS_MODEL"] = profile.default_opus_model
+            if profile.default_sonnet_model:
+                settings["env"]["ANTHROPIC_DEFAULT_SONNET_MODEL"] = profile.default_sonnet_model
+            if profile.default_haiku_model:
+                settings["env"]["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = profile.default_haiku_model
+            elif profile.default_sonnet_model:
+                # Only fallback to sonnet when no haiku model exists for this profile
+                cross_region_profile = getattr(profile, "cross_region_profile", None) or "us"
+                if not get_models_for_tier("haiku", cross_region_profile):
+                    settings["env"]["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = profile.default_sonnet_model
 
                 # Override with Application Inference Profile ARNs when configured
                 opus_arn = getattr(profile, "inference_profile_opus_arn", None)
@@ -2541,8 +2559,10 @@ Available metrics include:
                                 "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
                                 "OTEL_EXPORTER_OTLP_ENDPOINT": endpoint,
                                 # Add basic OTEL resource attributes for multi-team support
-                                "OTEL_RESOURCE_ATTRIBUTES": "department=engineering,team.id=default, \
-                                cost_center=default,organization=default",
+                                "OTEL_RESOURCE_ATTRIBUTES": (
+                                    "department=engineering,team.id=default,"
+                                    "cost_center=default,organization=default"
+                                ),
                             }
                         )
 

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -17,7 +17,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
-from claude_code_with_bedrock.cli.utils.aws import get_stack_outputs
+from claude_code_with_bedrock.cli.utils.aws import get_codebuild_region, get_stack_outputs
 from claude_code_with_bedrock.cli.utils.display import display_configuration_info
 from claude_code_with_bedrock.config import Config
 from claude_code_with_bedrock.models import (
@@ -1333,11 +1333,8 @@ RUN pyinstaller \
                 subprocess.run(["docker", "rmi", image_tag], capture_output=True)
 
     def _get_codebuild_region(self, profile):
-        windows_regions = {
-            "us-east-1", "us-east-2", "us-west-2", "ap-southeast-2",
-            "ap-northeast-1", "eu-central-1", "eu-west-1", "sa-east-1",
-        }
-        return profile.aws_region if profile.aws_region in windows_regions else "us-east-1"
+        """Backward-compatible wrapper for shared utility."""
+        return get_codebuild_region(profile)
 
     def _build_windows_via_codebuild(self, output_dir: Path) -> Path:
         """Build Windows binaries using AWS CodeBuild."""
@@ -2229,23 +2226,25 @@ REM older ccwb auth logout) would shadow credential_process and break Cowork
 REM Desktop with a 403 InvalidClientTokenId.
 powershell -NoProfile -Command "$ErrorActionPreference = 'Stop'; $awsCreds = Join-Path $env:USERPROFILE '.aws\credentials'; if (Test-Path $awsCreds) {{ $cfg = Get-Content config.json | ConvertFrom-Json; $existing = Get-Content $awsCreds -Raw; foreach ($p in $cfg.PSObject.Properties.Name) {{ $pattern = '(?ms)^\[' + [regex]::Escape($p) + '\].*?(?=^\[|\Z)'; $existing = [regex]::Replace($existing, $pattern, '') }}; Set-Content -Path $awsCreds -Value $existing.TrimStart() -NoNewline -Encoding ASCII }}"
 
+setlocal EnableDelayedExpansion
+for /f %%p in ('powershell -NoProfile -Command "(Get-Content config.json | ConvertFrom-Json).PSObject.Properties.Name"') do (
+    REM Get profile-specific region from config.json
+    for /f %%r in ('powershell -NoProfile -Command "(Get-Content config.json | ConvertFrom-Json).'%%p'.aws_region"') do set "PROFILE_REGION=%%r"
+    if not defined PROFILE_REGION set "PROFILE_REGION={profile.aws_region}"
 
-    REM Set credential process with --profile flag (cross-platform, no wrapper needed)
+    REM Set credential process with --profile flag
     aws configure set credential_process "%USERPROFILE%\\claude-code-with-bedrock\\credential-process.exe --profile %%p" --profile %%p
 
-
     REM Set region
-    if defined PROFILE_REGION (
-        aws configure set region !PROFILE_REGION! --profile %%p
-    ) else (
-        aws configure set region {profile.aws_region} --profile %%p
-    )
+    aws configure set region !PROFILE_REGION! --profile %%p
 
     echo   OK Created AWS profile '%%p'
 
     REM Clear stale cached credentials from previous deployments
     "%USERPROFILE%\\claude-code-with-bedrock\\credential-process.exe" --profile %%p --clear-cache >nul 2>&1
+    set "PROFILE_REGION="
 )
+endlocal
 
 echo.
 echo ======================================

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -2514,12 +2514,13 @@ Available metrics include:
                 # Only override if the matching tier has an ARN configured —
                 # otherwise ANTHROPIC_MODEL stays on the CRIS model ID.
                 model_id = profile.selected_model
-                if "opus" in model_id and opus_arn:
-                    settings["env"]["ANTHROPIC_MODEL"] = opus_arn
-                elif "sonnet" in model_id and sonnet_arn:
-                    settings["env"]["ANTHROPIC_MODEL"] = sonnet_arn
-                elif "haiku" in model_id and haiku_arn:
-                    settings["env"]["ANTHROPIC_MODEL"] = haiku_arn
+                if model_id:
+                    if "opus" in model_id and opus_arn:
+                        settings["env"]["ANTHROPIC_MODEL"] = opus_arn
+                    elif "sonnet" in model_id and sonnet_arn:
+                        settings["env"]["ANTHROPIC_MODEL"] = sonnet_arn
+                    elif "haiku" in model_id and haiku_arn:
+                        settings["env"]["ANTHROPIC_MODEL"] = haiku_arn
 
             # If monitoring is enabled, add telemetry configuration
             if profile.monitoring_enabled:

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -2496,31 +2496,31 @@ Available metrics include:
                 if not get_models_for_tier("haiku", cross_region_profile):
                     settings["env"]["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = profile.default_sonnet_model
 
-                # Override with Application Inference Profile ARNs when configured
-                opus_arn = getattr(profile, "inference_profile_opus_arn", None)
-                sonnet_arn = getattr(profile, "inference_profile_sonnet_arn", None)
-                haiku_arn = getattr(profile, "inference_profile_haiku_arn", None)
+            # Override with Application Inference Profile ARNs when configured
+            opus_arn = getattr(profile, "inference_profile_opus_arn", None)
+            sonnet_arn = getattr(profile, "inference_profile_sonnet_arn", None)
+            haiku_arn = getattr(profile, "inference_profile_haiku_arn", None)
 
-                if opus_arn:
-                    settings["env"]["ANTHROPIC_DEFAULT_OPUS_MODEL"] = opus_arn
-                if sonnet_arn:
-                    settings["env"]["ANTHROPIC_DEFAULT_SONNET_MODEL"] = sonnet_arn
-                if haiku_arn:
-                    settings["env"]["ANTHROPIC_SMALL_FAST_MODEL"] = haiku_arn
-                    settings["env"]["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = haiku_arn
+            if opus_arn:
+                settings["env"]["ANTHROPIC_DEFAULT_OPUS_MODEL"] = opus_arn
+            if sonnet_arn:
+                settings["env"]["ANTHROPIC_DEFAULT_SONNET_MODEL"] = sonnet_arn
+            if haiku_arn:
+                settings["env"]["ANTHROPIC_SMALL_FAST_MODEL"] = haiku_arn
+                settings["env"]["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = haiku_arn
 
-                # Override ANTHROPIC_MODEL with the primary inference profile ARN
-                # so Claude Code uses the inference profile for all code paths.
-                # Only override if the matching tier has an ARN configured —
-                # otherwise ANTHROPIC_MODEL stays on the CRIS model ID.
-                model_id = profile.selected_model
-                if model_id:
-                    if "opus" in model_id and opus_arn:
-                        settings["env"]["ANTHROPIC_MODEL"] = opus_arn
-                    elif "sonnet" in model_id and sonnet_arn:
-                        settings["env"]["ANTHROPIC_MODEL"] = sonnet_arn
-                    elif "haiku" in model_id and haiku_arn:
-                        settings["env"]["ANTHROPIC_MODEL"] = haiku_arn
+            # Override ANTHROPIC_MODEL with the primary inference profile ARN
+            # so Claude Code uses the inference profile for all code paths.
+            # Only override if the matching tier has an ARN configured —
+            # otherwise ANTHROPIC_MODEL stays on the CRIS model ID.
+            model_id = profile.selected_model
+            if model_id:
+                if "opus" in model_id and opus_arn:
+                    settings["env"]["ANTHROPIC_MODEL"] = opus_arn
+                elif "sonnet" in model_id and sonnet_arn:
+                    settings["env"]["ANTHROPIC_MODEL"] = sonnet_arn
+                elif "haiku" in model_id and haiku_arn:
+                    settings["env"]["ANTHROPIC_MODEL"] = haiku_arn
 
             # If monitoring is enabled, add telemetry configuration
             if profile.monitoring_enabled:

--- a/source/claude_code_with_bedrock/cli/commands/test.py
+++ b/source/claude_code_with_bedrock/cli/commands/test.py
@@ -901,7 +901,8 @@ class TestCommand(Command):
             test_env.pop("AWS_SESSION_TOKEN", None)
 
             if not selected_model:
-                return {"success": False, "error": "No model configured - run 'ccwb init' to select a model"}
+                # Use fallback test model when no model is configured
+                selected_model = self._get_fallback_test_model()
 
             model_id = selected_model
 

--- a/source/claude_code_with_bedrock/cli/utils/aws.py
+++ b/source/claude_code_with_bedrock/cli/utils/aws.py
@@ -8,6 +8,21 @@ from typing import Any
 import boto3
 from botocore.exceptions import ClientError, NoCredentialsError
 
+# Regions where Windows Server containers are supported for CodeBuild
+CODEBUILD_WINDOWS_REGIONS = {
+    "us-east-1", "us-east-2", "us-west-2", "ap-southeast-2",
+    "ap-northeast-1", "eu-central-1", "eu-west-1", "sa-east-1",
+}
+
+
+def get_codebuild_region(profile) -> str:
+    """Get the appropriate region for CodeBuild Windows builds.
+
+    Returns the profile's region if it supports Windows containers,
+    otherwise falls back to us-east-1.
+    """
+    return profile.aws_region if profile.aws_region in CODEBUILD_WINDOWS_REGIONS else "us-east-1"
+
 
 def get_current_region() -> str | None:
     """Get the current AWS region from configuration."""

--- a/source/claude_code_with_bedrock/cli/utils/cloudformation.py
+++ b/source/claude_code_with_bedrock/cli/utils/cloudformation.py
@@ -240,7 +240,11 @@ class CloudFormationManager:
             # Wait for deletion
             success = self._wait_for_stack(stack_name, "stack_delete_complete", timeout, on_event)
 
-            return StackDeletionResult(success=success)
+            if success:
+                return StackDeletionResult(success=True)
+            else:
+                error = self._get_stack_failure_reason(stack_name)
+                return StackDeletionResult(success=False, error=error)
 
         except ClientError as e:
             error_message = e.response["Error"]["Message"]
@@ -277,6 +281,56 @@ class CloudFormationManager:
             return []
         except Exception:
             return []
+
+    def pre_cleanup_stack(self, stack_name: str, on_event: Callable[[str], None] = None) -> None:
+        """Pre-clean resources that block CloudFormation deletion.
+
+        S3 buckets must be empty before CloudFormation can delete them.
+        Athena workgroups must have named queries removed first.
+        """
+        try:
+            response = self.cf_client.describe_stack_resources(StackName=stack_name)
+            for resource in response.get("StackResources", []):
+                physical_id = resource.get("PhysicalResourceId")
+                if not physical_id:
+                    continue
+                rtype = resource["ResourceType"]
+                if rtype == "AWS::S3::Bucket":
+                    if on_event:
+                        on_event(f"Emptying bucket {physical_id}...")
+                    self._empty_bucket(physical_id)
+                elif rtype == "AWS::Athena::WorkGroup":
+                    if on_event:
+                        on_event(f"Cleaning workgroup {physical_id}...")
+                    self._clean_athena_workgroup(physical_id)
+        except ClientError:
+            pass
+
+    def _empty_bucket(self, bucket_name: str) -> None:
+        """Delete all objects and versions from an S3 bucket."""
+        try:
+            paginator = self.s3_client.get_paginator("list_object_versions")
+            for page in paginator.paginate(Bucket=bucket_name):
+                objects = []
+                for v in page.get("Versions", []):
+                    objects.append({"Key": v["Key"], "VersionId": v["VersionId"]})
+                for dm in page.get("DeleteMarkers", []):
+                    objects.append({"Key": dm["Key"], "VersionId": dm["VersionId"]})
+                if objects:
+                    self.s3_client.delete_objects(
+                        Bucket=bucket_name,
+                        Delete={"Objects": objects, "Quiet": True},
+                    )
+        except ClientError:
+            pass
+
+    def _clean_athena_workgroup(self, workgroup_name: str) -> None:
+        """Force-delete an Athena workgroup and all its contents."""
+        try:
+            athena = self.session.client("athena")
+            athena.delete_work_group(WorkGroup=workgroup_name, RecursiveDeleteOption=True)
+        except ClientError:
+            pass
 
     def package_template(
         self, template_path: str | Path, s3_bucket: str, s3_prefix: str = None, on_event: Callable = None
@@ -485,8 +539,9 @@ class CloudFormationManager:
             True if successful, False otherwise
         """
         # Stream events while waiting
+        event_thread = None
         if on_event:
-            self._start_event_streaming(stack_name, on_event)
+            event_thread = self._start_event_streaming(stack_name, on_event)
 
         try:
             waiter = self.cf_client.get_waiter(waiter_name)
@@ -495,11 +550,72 @@ class CloudFormationManager:
         except WaiterError:
             # Check if it's a timeout or actual failure
             final_status = self.get_stack_status(stack_name)
+            # Stack no longer exists — successful deletion
+            if final_status is None and waiter_name == "stack_delete_complete":
+                return True
             if final_status and "FAILED" in final_status:
                 return False
             elif final_status and "ROLLBACK" in final_status:
                 return False
             # Might be timeout
+            return False
+        except Exception:
+            return False
+        finally:
+            if event_thread:
+                event_thread.join(timeout=5)
+
+    def _get_acm_validation_records(self, stack_name: str, logical_resource_id: str, max_wait: int = 180) -> list[dict]:
+        """Get ACM certificate DNS validation records for a resource in a stack.
+
+        Polls ACM until validation CNAME records are available or timeout.
+
+        Returns:
+            List of dicts with 'Name' and 'Value' for CNAME records, or empty list.
+        """
+        try:
+            response = self.cf_client.describe_stack_resource(
+                StackName=stack_name,
+                LogicalResourceId=logical_resource_id,
+            )
+            cert_arn = response["StackResourceDetail"].get("PhysicalResourceId")
+            if not cert_arn or not cert_arn.startswith("arn:"):
+                return []
+
+            acm_client = self.session.client("acm")
+
+            elapsed = 0
+            while elapsed < max_wait:
+                cert_response = acm_client.describe_certificate(CertificateArn=cert_arn)
+                domain_validations = cert_response["Certificate"].get("DomainValidationOptions", [])
+
+                records = []
+                for dv in domain_validations:
+                    resource_record = dv.get("ResourceRecord")
+                    if resource_record and resource_record.get("Type") == "CNAME":
+                        records.append({
+                            "Name": resource_record["Name"],
+                            "Value": resource_record["Value"],
+                        })
+
+                if records:
+                    return records
+
+                time.sleep(5)
+                elapsed += 5
+
+            return []
+        except Exception:
+            return []
+
+    def _has_route53_zone(self, stack_name: str) -> bool:
+        """Check if stack has a non-empty HostedZoneId parameter (Route53 manages DNS)."""
+        try:
+            response = self.cf_client.describe_stacks(StackName=stack_name)
+            for stack in response.get("Stacks", []):
+                for param in stack.get("Parameters", []):
+                    if param.get("ParameterKey") == "HostedZoneId":
+                        return bool(param.get("ParameterValue", "").strip())
             return False
         except Exception:
             return False
@@ -509,6 +625,8 @@ class CloudFormationManager:
         import threading
 
         seen_events = set()
+        acm_certs_notified = set()
+        uses_route53 = self._has_route53_zone(stack_name)
 
         def stream_events():
             while True:
@@ -529,6 +647,33 @@ class CloudFormationManager:
                             }
                             on_event(formatted_event)
 
+                            # Detect ACM certificate waiting for validation
+                            resource_type = event.get("ResourceType", "")
+                            resource_status = event.get("ResourceStatus", "")
+                            logical_id = event.get("LogicalResourceId", "")
+
+                            if (
+                                resource_type == "AWS::CertificateManager::Certificate"
+                                and resource_status == "CREATE_IN_PROGRESS"
+                                and logical_id not in acm_certs_notified
+                            ):
+                                # Skip notification when Route53 handles DNS validation automatically
+                                if uses_route53:
+                                    acm_certs_notified.add(logical_id)
+                                    continue
+
+                                records = self._get_acm_validation_records(stack_name, logical_id)
+                                if records:
+                                    acm_certs_notified.add(logical_id)
+                                    on_event({
+                                        "type": "acm_validation_required",
+                                        "LogicalResourceId": logical_id,
+                                        "ResourceType": resource_type,
+                                        "ResourceStatus": "WAITING_FOR_DNS_VALIDATION",
+                                        "validation_records": records,
+                                        "message": "ACM certificate requires DNS validation",
+                                    })
+
                     # Check if stack operation is complete
                     status = self.get_stack_status(stack_name)
                     if status and ("COMPLETE" in status or "FAILED" in status):
@@ -545,6 +690,9 @@ class CloudFormationManager:
     def _get_stack_failure_reason(self, stack_name: str) -> str:
         """Get the failure reason from stack events."""
         try:
+            # First check if stack still exists and its current status
+            current_status = self.get_stack_status(stack_name)
+
             response = self.cf_client.describe_stack_events(StackName=stack_name)
             events = response.get("StackEvents", [])
 
@@ -558,7 +706,20 @@ class CloudFormationManager:
                     logical_id = event.get("LogicalResourceId", "Unknown")
                     return f"{resource_type} ({logical_id}): {reason}"
 
-            return "Unknown failure reason"
+            # If no failure events found, provide context based on current status
+            if current_status:
+                if "IN_PROGRESS" in current_status:
+                    return f"Stack deletion timeout - still in progress (status: {current_status})"
+                elif "FAILED" in current_status:
+                    return f"Stack in failed state: {current_status}"
+                else:
+                    return f"Stack in unexpected state: {current_status}"
+
+            return "Stack not found or already deleted"
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "ValidationError":
+                return "Stack not found or already deleted"
+            return f"Error fetching failure reason: {str(e)}"
         except Exception as e:
             return f"Error fetching failure reason: {str(e)}"
 

--- a/source/claude_code_with_bedrock/cli/utils/cloudformation.py
+++ b/source/claude_code_with_bedrock/cli/utils/cloudformation.py
@@ -3,6 +3,7 @@
 
 """CloudFormation manager for boto3-based stack operations."""
 
+import logging
 import time
 from collections.abc import Callable
 from pathlib import Path
@@ -328,8 +329,10 @@ class CloudFormationManager:
                 for logical_id, resource_def in resources.items():
                     if isinstance(resource_def, dict) and resource_def.get("DeletionPolicy") == "Retain":
                         retained_logical_ids.add(logical_id)
-            except Exception:
-                pass  # If we can't read template, proceed with cleanup for all
+            except Exception as e:
+                # If we can't read template, proceed with cleanup for all resources
+                # (better to over-clean than leave resources that block deletion)
+                logging.debug(f"Could not parse template for {stack_name}: {e}")
 
             response = self.cf_client.describe_stack_resources(StackName=stack_name)
             for resource in response.get("StackResources", []):
@@ -349,8 +352,10 @@ class CloudFormationManager:
                     if on_event:
                         on_event(f"Cleaning workgroup {physical_id}...")
                     self._clean_athena_workgroup(physical_id)
-        except ClientError:
-            pass
+        except ClientError as e:
+            # Stack might not exist or be inaccessible - this is expected during cleanup
+            import logging
+            logging.debug(f"Could not pre-clean stack {stack_name}: {e}")
 
     def _empty_bucket(self, bucket_name: str) -> None:
         """Delete all objects and versions from an S3 bucket."""
@@ -369,16 +374,20 @@ class CloudFormationManager:
                         Bucket=bucket_name,
                         Delete={"Objects": batch, "Quiet": True},
                     )
-        except ClientError:
-            pass
+        except ClientError as e:
+            # Bucket might not exist or be inaccessible - this is expected during cleanup
+            import logging
+            logging.debug(f"Could not empty bucket {bucket_name}: {e}")
 
     def _clean_athena_workgroup(self, workgroup_name: str) -> None:
         """Force-delete an Athena workgroup and all its contents."""
         try:
             athena = self.session.client("athena")
             athena.delete_work_group(WorkGroup=workgroup_name, RecursiveDeleteOption=True)
-        except ClientError:
-            pass
+        except ClientError as e:
+            # Workgroup might not exist or be inaccessible - this is expected during cleanup
+            import logging
+            logging.debug(f"Could not clean Athena workgroup {workgroup_name}: {e}")
 
     def package_template(
         self, template_path: str | Path, s3_bucket: str, s3_prefix: str | None = None, on_event: Callable | None = None

--- a/source/claude_code_with_bedrock/cli/utils/cloudformation.py
+++ b/source/claude_code_with_bedrock/cli/utils/cloudformation.py
@@ -312,12 +312,33 @@ class CloudFormationManager:
 
         S3 buckets must be empty before CloudFormation can delete them.
         Athena workgroups must have named queries removed first.
+        Skips resources with DeletionPolicy: Retain (they are kept intentionally).
         """
         try:
+            # Get the template to check DeletionPolicy for each resource
+            retained_logical_ids = set()
+            try:
+                template_resp = self.cf_client.get_template(StackName=stack_name)
+                import yaml
+
+                template_body = template_resp.get("TemplateBody", {})
+                if isinstance(template_body, str):
+                    template_body = yaml.safe_load(template_body)
+                resources = template_body.get("Resources", {})
+                for logical_id, resource_def in resources.items():
+                    if isinstance(resource_def, dict) and resource_def.get("DeletionPolicy") == "Retain":
+                        retained_logical_ids.add(logical_id)
+            except Exception:
+                pass  # If we can't read template, proceed with cleanup for all
+
             response = self.cf_client.describe_stack_resources(StackName=stack_name)
             for resource in response.get("StackResources", []):
                 physical_id = resource.get("PhysicalResourceId")
+                logical_id = resource.get("LogicalResourceId", "")
                 if not physical_id:
+                    continue
+                # Skip resources with DeletionPolicy: Retain
+                if logical_id in retained_logical_ids:
                     continue
                 rtype = resource["ResourceType"]
                 if rtype == "AWS::S3::Bucket":

--- a/source/claude_code_with_bedrock/cli/utils/cloudformation.py
+++ b/source/claude_code_with_bedrock/cli/utils/cloudformation.py
@@ -282,6 +282,31 @@ class CloudFormationManager:
         except Exception:
             return []
 
+    def get_retained_resources(self, stack_name: str) -> list[dict[str, str]]:
+        """Get resources that were retained (DeletionPolicy: Retain) during stack deletion.
+
+        These resources are silently skipped by CloudFormation and won't appear in
+        get_failed_resources(). They still exist in the account and need manual cleanup.
+        """
+        try:
+            response = self.cf_client.describe_stack_resources(StackName=stack_name)
+            retained = []
+            for resource in response.get("StackResources", []):
+                if resource["ResourceStatus"] == "DELETE_SKIPPED":
+                    retained.append(
+                        {
+                            "logical_id": resource["LogicalResourceId"],
+                            "physical_id": resource.get("PhysicalResourceId", "N/A"),
+                            "resource_type": resource["ResourceType"],
+                            "status_reason": "DeletionPolicy: Retain",
+                        }
+                    )
+            return retained
+        except ClientError:
+            return []
+        except Exception:
+            return []
+
     def pre_cleanup_stack(self, stack_name: str, on_event: Callable[[str], None] = None) -> None:
         """Pre-clean resources that block CloudFormation deletion.
 

--- a/source/claude_code_with_bedrock/cli/utils/cloudformation.py
+++ b/source/claude_code_with_bedrock/cli/utils/cloudformation.py
@@ -81,7 +81,7 @@ class CloudFormationManager:
         parameters: list[dict[str, str]] = None,
         capabilities: list[str] = None,
         tags: dict[str, str] = None,
-        on_event: Callable = None,
+        on_event: Callable | None = None,
         timeout: int = 3600,
         disable_rollback: bool = False,
     ) -> StackDeploymentResult:
@@ -196,7 +196,7 @@ class CloudFormationManager:
         stack_name: str,
         retain_resources: list[str] = None,
         force: bool = False,
-        on_event: Callable = None,
+        on_event: Callable | None = None,
         timeout: int = 600,
     ) -> StackDeletionResult:
         """
@@ -341,10 +341,12 @@ class CloudFormationManager:
                     objects.append({"Key": v["Key"], "VersionId": v["VersionId"]})
                 for dm in page.get("DeleteMarkers", []):
                     objects.append({"Key": dm["Key"], "VersionId": dm["VersionId"]})
-                if objects:
+                # delete_objects API has a hard limit of 1000 keys per call
+                for i in range(0, len(objects), 1000):
+                    batch = objects[i : i + 1000]
                     self.s3_client.delete_objects(
                         Bucket=bucket_name,
-                        Delete={"Objects": objects, "Quiet": True},
+                        Delete={"Objects": batch, "Quiet": True},
                     )
         except ClientError:
             pass
@@ -358,7 +360,7 @@ class CloudFormationManager:
             pass
 
     def package_template(
-        self, template_path: str | Path, s3_bucket: str, s3_prefix: str = None, on_event: Callable = None
+        self, template_path: str | Path, s3_bucket: str, s3_prefix: str | None = None, on_event: Callable | None = None
     ) -> str:
         """
         Package a CloudFormation template and upload artifacts to S3.
@@ -550,7 +552,9 @@ class CloudFormationManager:
                 return False, None
             raise
 
-    def _wait_for_stack(self, stack_name: str, waiter_name: str, timeout: int, on_event: Callable = None) -> bool:
+    def _wait_for_stack(
+        self, stack_name: str, waiter_name: str, timeout: int, on_event: Callable | None = None
+    ) -> bool:
         """
         Wait for stack operation to complete with event streaming.
 

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -58,7 +58,7 @@ class Profile:
     burst_buffer_percent: int = 10  # Burst buffer for daily limit (5-25%, default 10%)
     daily_enforcement_mode: str = "alert"  # Daily limit enforcement: "alert" or "block"
     monthly_enforcement_mode: str = "block"  # Monthly limit enforcement: "alert" or "block"
-    enable_finegrained_quotas: bool = True  # Enable fine-grained quota policies (user/group/default)
+    enable_finegrained_quotas: bool = False  # Enable fine-grained quota policies (user/group/default)
     quota_policies_table: str | None = None  # DynamoDB table name for quota policies
     user_quota_metrics_table: str | None = None  # DynamoDB table name for user quota metrics
     quota_api_endpoint: str | None = None  # API Gateway endpoint for real-time quota checks

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -42,7 +42,7 @@ class Profile:
 
     # Distribution platform configuration
     distribution_type: str | None = None  # "presigned-s3" | "landing-page" | None (disabled)
-    distribution_idp_provider: str | None = None  # "okta" | "azure" | "auth0" | "cognito" (for landing-page only)
+    distribution_idp_provider: str | None = None  # "okta"|"azure"|"auth0"|"cognito" (landing-page only)
     distribution_idp_domain: str | None = None  # IdP domain for web auth (e.g., "company.okta.com")
     distribution_idp_client_id: str | None = None  # Web application client ID
     distribution_idp_client_secret_arn: str | None = None  # Secrets Manager ARN for client secret
@@ -58,7 +58,7 @@ class Profile:
     burst_buffer_percent: int = 10  # Burst buffer for daily limit (5-25%, default 10%)
     daily_enforcement_mode: str = "alert"  # Daily limit enforcement: "alert" or "block"
     monthly_enforcement_mode: str = "block"  # Monthly limit enforcement: "alert" or "block"
-    enable_finegrained_quotas: bool = False  # Enable fine-grained quota policies (user/group/default)
+    enable_finegrained_quotas: bool = True  # Enable fine-grained quota policies (user/group/default)
     quota_policies_table: str | None = None  # DynamoDB table name for quota policies
     user_quota_metrics_table: str | None = None  # DynamoDB table name for user quota metrics
     quota_api_endpoint: str | None = None  # API Gateway endpoint for real-time quota checks
@@ -88,6 +88,11 @@ class Profile:
     inference_profile_opus_arn: str | None = None  # Optional inference profile ARN for Opus tier
     inference_profile_sonnet_arn: str | None = None  # Optional inference profile ARN for Sonnet tier
     inference_profile_haiku_arn: str | None = None  # Optional inference profile ARN for Haiku tier
+
+    # Per-tier model defaults for /model switching in Claude Code
+    default_opus_model: str | None = None  # Bedrock model ID for /model opus
+    default_sonnet_model: str | None = None  # Bedrock model ID for /model sonnet
+    default_haiku_model: str | None = None  # Bedrock model ID for /model haiku
 
     # Claude Code settings configuration
     include_coauthored_by: bool = True  # Whether to include "co-authored-by Claude" in git commits
@@ -160,6 +165,7 @@ class Profile:
                             data["provider_type"] = "azure"
                         elif hostname_lower.endswith(".amazoncognito.com") or hostname_lower == "amazoncognito.com":
                             data["provider_type"] = "cognito"
+
                 except Exception:
                     pass  # Leave provider_type unset if parsing fails
 

--- a/source/claude_code_with_bedrock/models.py
+++ b/source/claude_code_with_bedrock/models.py
@@ -16,6 +16,7 @@ from typing import Any
 
 # Default regions for AWS profile based on cross-region profile
 
+
 @dataclass(frozen=True)
 class InferenceProfile:
     """A CRIS inference profile for a specific geography."""
@@ -97,10 +98,12 @@ def _build_model(data: dict) -> ClaudeModel:
 
 DEFAULT_REGIONS = {
     "us": "us-east-1",
-    "europe": "eu-west-3",
-    "eu": "eu-west-3",
+    "eu": "eu-west-1",
+    "europe": "eu-west-1",
     "apac": "ap-northeast-1",
+    "jp": "ap-northeast-1",
     "japan": "ap-northeast-1",
+    "au": "ap-southeast-2",
     "australia": "ap-southeast-2",
     "global": "us-east-1",
     "us-gov": "us-gov-west-1",
@@ -351,15 +354,11 @@ _CLAUDE_MODELS_RAW = {
                     "ap-southeast-2",
                     "ap-southeast-3",
                     "ap-southeast-4",
-                    "ap-southeast-5",
-                    "ap-southeast-7",
                     # Middle East & Africa
                     "me-south-1",
                     "me-central-1",
                     "af-south-1",
                     "il-central-1",
-                    # Latin America
-                    "mx-central-1",
                     # South America
                     "sa-east-1",
                 ],
@@ -391,15 +390,11 @@ _CLAUDE_MODELS_RAW = {
                     "ap-southeast-2",
                     "ap-southeast-3",
                     "ap-southeast-4",
-                    "ap-southeast-5",
-                    "ap-southeast-7",
                     # Middle East & Africa
                     "me-south-1",
                     "me-central-1",
                     "af-south-1",
                     "il-central-1",
-                    # Latin America
-                    "mx-central-1",
                     # South America
                     "sa-east-1",
                 ],
@@ -641,18 +636,6 @@ _CLAUDE_MODELS_RAW = {
                     "ap-northeast-3",
                 ],
             },
-            "australia": {
-                "model_id": "au.anthropic.claude-sonnet-4-5-20250929-v1:0",
-                "description": "Australia CRIS - Asia Pacific (Sydney, Melbourne)",
-                "source_regions": [
-                    "ap-southeast-2",  # Sydney
-                    "ap-southeast-4",  # Melbourne
-                ],
-                "destination_regions": [
-                    "ap-southeast-2",
-                    "ap-southeast-4",
-                ],
-            },
             "global": {
                 "model_id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
                 "description": "Global CRIS - All regions worldwide",
@@ -732,396 +715,6 @@ _CLAUDE_MODELS_RAW = {
                 "description": "US GovCloud regions",
                 "source_regions": ["us-gov-west-1", "us-gov-east-1"],
                 "destination_regions": ["us-gov-west-1", "us-gov-east-1"],
-            },
-        },
-    },
-    "sonnet-4-6": {
-        "name": "Claude Sonnet 4.6",
-        "base_model_id": "anthropic.claude-sonnet-4-6",
-        "profiles": {
-            "us": {
-                "model_id": "us.anthropic.claude-sonnet-4-6",
-                "description": "US regions",
-                "source_regions": [
-                    "ca-central-1",
-                    "ca-west-1",
-                    "us-east-1",
-                    "us-east-2",
-                    "us-west-1",
-                    "us-west-2",
-                ],
-                "destination_regions": [
-                    "ca-central-1",
-                    "ca-west-1",
-                    "us-east-1",
-                    "us-east-2",
-                    "us-west-1",
-                    "us-west-2",
-                ],
-            },
-            "eu": {
-                "model_id": "eu.anthropic.claude-sonnet-4-6",
-                "description": "European regions",
-                "source_regions": [
-                    "eu-central-1",
-                    "eu-central-2",
-                    "eu-north-1",
-                    "eu-south-1",
-                    "eu-south-2",
-                    "eu-west-1",
-                    "eu-west-2",
-                    "eu-west-3",
-                ],
-                "destination_regions": [
-                    "eu-central-1",
-                    "eu-central-2",
-                    "eu-north-1",
-                    "eu-south-1",
-                    "eu-south-2",
-                    "eu-west-1",
-                    "eu-west-2",
-                    "eu-west-3",
-                ],
-            },
-            "australia": {
-                "model_id": "au.anthropic.claude-sonnet-4-6",
-                "description": "Australia (Sydney, Melbourne)",
-                "source_regions": [
-                    "ap-southeast-2",
-                    "ap-southeast-4",
-                ],
-                "destination_regions": [
-                    "ap-southeast-2",
-                    "ap-southeast-4",
-                ],
-            },
-            "japan": {
-                "model_id": "jp.anthropic.claude-sonnet-4-6",
-                "description": "Japan (Tokyo, Osaka)",
-                "source_regions": [
-                    "ap-northeast-1",
-                    "ap-northeast-3",
-                ],
-                "destination_regions": [
-                    "ap-northeast-1",
-                    "ap-northeast-3",
-                ],
-            },
-            "global": {
-                "model_id": "global.anthropic.claude-sonnet-4-6",
-                "description": "Global routing across all AWS regions",
-                "source_regions": [
-                    "af-south-1",
-                    "ap-east-2",
-                    "ap-northeast-1",
-                    "ap-northeast-2",
-                    "ap-northeast-3",
-                    "ap-south-1",
-                    "ap-south-2",
-                    "ap-southeast-1",
-                    "ap-southeast-2",
-                    "ap-southeast-3",
-                    "ap-southeast-4",
-                    "ap-southeast-5",
-                    "ap-southeast-7",
-                    "ca-central-1",
-                    "ca-west-1",
-                    "eu-central-1",
-                    "eu-central-2",
-                    "eu-north-1",
-                    "eu-south-1",
-                    "eu-south-2",
-                    "eu-west-1",
-                    "eu-west-2",
-                    "eu-west-3",
-                    "il-central-1",
-                    "me-central-1",
-                    "me-south-1",
-                    "mx-central-1",
-                    "sa-east-1",
-                    "us-east-1",
-                    "us-east-2",
-                    "us-west-1",
-                    "us-west-2",
-                ],
-                "destination_regions": [
-                    "af-south-1",
-                    "ap-east-2",
-                    "ap-northeast-1",
-                    "ap-northeast-2",
-                    "ap-northeast-3",
-                    "ap-south-1",
-                    "ap-south-2",
-                    "ap-southeast-1",
-                    "ap-southeast-2",
-                    "ap-southeast-3",
-                    "ap-southeast-4",
-                    "ap-southeast-5",
-                    "ap-southeast-7",
-                    "ca-central-1",
-                    "ca-west-1",
-                    "eu-central-1",
-                    "eu-central-2",
-                    "eu-north-1",
-                    "eu-south-1",
-                    "eu-south-2",
-                    "eu-west-1",
-                    "eu-west-2",
-                    "eu-west-3",
-                    "il-central-1",
-                    "me-central-1",
-                    "me-south-1",
-                    "mx-central-1",
-                    "sa-east-1",
-                    "us-east-1",
-                    "us-east-2",
-                    "us-west-1",
-                    "us-west-2",
-                ],
-            },
-        },
-    },
-    "opus-4-5": {
-        "name": "Claude Opus 4.5",
-        "base_model_id": "anthropic.claude-opus-4-5-20251101-v1:0",
-        "profiles": {
-            "us": {
-                "model_id": "us.anthropic.claude-opus-4-5-20251101-v1:0",
-                "description": "US regions",
-                "source_regions": [
-                    "ca-central-1",
-                    "us-east-1",
-                    "us-east-2",
-                    "us-west-1",
-                    "us-west-2",
-                ],
-                "destination_regions": [
-                    "ca-central-1",
-                    "us-east-1",
-                    "us-east-2",
-                    "us-west-1",
-                    "us-west-2",
-                ],
-            },
-            "eu": {
-                "model_id": "eu.anthropic.claude-opus-4-5-20251101-v1:0",
-                "description": "European regions",
-                "source_regions": [
-                    "eu-central-1",
-                    "eu-central-2",
-                    "eu-north-1",
-                    "eu-south-1",
-                    "eu-south-2",
-                    "eu-west-1",
-                    "eu-west-2",
-                    "eu-west-3",
-                ],
-                "destination_regions": [
-                    "eu-central-1",
-                    "eu-central-2",
-                    "eu-north-1",
-                    "eu-south-1",
-                    "eu-south-2",
-                    "eu-west-1",
-                    "eu-west-2",
-                    "eu-west-3",
-                ],
-            },
-            "global": {
-                "model_id": "global.anthropic.claude-opus-4-5-20251101-v1:0",
-                "description": "Global routing across all AWS regions",
-                "source_regions": [
-                    "af-south-1",
-                    "ap-northeast-1",
-                    "ap-northeast-2",
-                    "ap-northeast-3",
-                    "ap-south-1",
-                    "ap-south-2",
-                    "ap-southeast-1",
-                    "ap-southeast-2",
-                    "ap-southeast-3",
-                    "ap-southeast-4",
-                    "ca-central-1",
-                    "eu-central-1",
-                    "eu-central-2",
-                    "eu-north-1",
-                    "eu-south-1",
-                    "eu-south-2",
-                    "eu-west-1",
-                    "eu-west-2",
-                    "eu-west-3",
-                    "il-central-1",
-                    "me-central-1",
-                    "me-south-1",
-                    "sa-east-1",
-                    "us-east-1",
-                    "us-east-2",
-                    "us-west-1",
-                    "us-west-2",
-                ],
-                "destination_regions": [
-                    "af-south-1",
-                    "ap-northeast-1",
-                    "ap-northeast-2",
-                    "ap-northeast-3",
-                    "ap-south-1",
-                    "ap-south-2",
-                    "ap-southeast-1",
-                    "ap-southeast-2",
-                    "ap-southeast-3",
-                    "ap-southeast-4",
-                    "ca-central-1",
-                    "eu-central-1",
-                    "eu-central-2",
-                    "eu-north-1",
-                    "eu-south-1",
-                    "eu-south-2",
-                    "eu-west-1",
-                    "eu-west-2",
-                    "eu-west-3",
-                    "il-central-1",
-                    "me-central-1",
-                    "me-south-1",
-                    "sa-east-1",
-                    "us-east-1",
-                    "us-east-2",
-                    "us-west-1",
-                    "us-west-2",
-                ],
-            },
-        },
-    },
-    "haiku-4-5": {
-        "name": "Claude Haiku 4.5",
-        "base_model_id": "anthropic.claude-haiku-4-5-20251001-v1:0",
-        "profiles": {
-            "us": {
-                "model_id": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
-                "description": "US regions",
-                "source_regions": [
-                    "ca-central-1",
-                    "us-east-1",
-                    "us-east-2",
-                    "us-west-1",
-                    "us-west-2",
-                ],
-                "destination_regions": [
-                    "ca-central-1",
-                    "us-east-1",
-                    "us-east-2",
-                    "us-west-1",
-                    "us-west-2",
-                ],
-            },
-            "eu": {
-                "model_id": "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
-                "description": "European regions",
-                "source_regions": [
-                    "eu-central-1",
-                    "eu-central-2",
-                    "eu-north-1",
-                    "eu-south-1",
-                    "eu-south-2",
-                    "eu-west-1",
-                    "eu-west-2",
-                    "eu-west-3",
-                ],
-                "destination_regions": [
-                    "eu-central-1",
-                    "eu-central-2",
-                    "eu-north-1",
-                    "eu-south-1",
-                    "eu-south-2",
-                    "eu-west-1",
-                    "eu-west-2",
-                    "eu-west-3",
-                ],
-            },
-            "australia": {
-                "model_id": "au.anthropic.claude-haiku-4-5-20251001-v1:0",
-                "description": "Australia (Sydney, Melbourne)",
-                "source_regions": [
-                    "ap-southeast-2",
-                    "ap-southeast-4",
-                ],
-                "destination_regions": [
-                    "ap-southeast-2",
-                    "ap-southeast-4",
-                ],
-            },
-            "japan": {
-                "model_id": "jp.anthropic.claude-haiku-4-5-20251001-v1:0",
-                "description": "Japan (Tokyo, Osaka)",
-                "source_regions": [
-                    "ap-northeast-1",
-                    "ap-northeast-3",
-                ],
-                "destination_regions": [
-                    "ap-northeast-1",
-                    "ap-northeast-3",
-                ],
-            },
-            "global": {
-                "model_id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
-                "description": "Global routing across all AWS regions",
-                "source_regions": [
-                    "af-south-1",
-                    "ap-northeast-1",
-                    "ap-northeast-2",
-                    "ap-northeast-3",
-                    "ap-south-1",
-                    "ap-south-2",
-                    "ap-southeast-1",
-                    "ap-southeast-2",
-                    "ap-southeast-3",
-                    "ap-southeast-4",
-                    "ca-central-1",
-                    "eu-central-1",
-                    "eu-central-2",
-                    "eu-north-1",
-                    "eu-south-1",
-                    "eu-south-2",
-                    "eu-west-1",
-                    "eu-west-2",
-                    "eu-west-3",
-                    "il-central-1",
-                    "me-central-1",
-                    "me-south-1",
-                    "sa-east-1",
-                    "us-east-1",
-                    "us-east-2",
-                    "us-west-1",
-                    "us-west-2",
-                ],
-                "destination_regions": [
-                    "af-south-1",
-                    "ap-northeast-1",
-                    "ap-northeast-2",
-                    "ap-northeast-3",
-                    "ap-south-1",
-                    "ap-south-2",
-                    "ap-southeast-1",
-                    "ap-southeast-2",
-                    "ap-southeast-3",
-                    "ap-southeast-4",
-                    "ca-central-1",
-                    "eu-central-1",
-                    "eu-central-2",
-                    "eu-north-1",
-                    "eu-south-1",
-                    "eu-south-2",
-                    "eu-west-1",
-                    "eu-west-2",
-                    "eu-west-3",
-                    "il-central-1",
-                    "me-central-1",
-                    "me-south-1",
-                    "sa-east-1",
-                    "us-east-1",
-                    "us-east-2",
-                    "us-west-1",
-                    "us-west-2",
-                ],
             },
         },
     },
@@ -1266,10 +859,11 @@ def _get_tier(model_key: str) -> str | None:
 
 
 # Alias mapping for cross-region profile keys.
-# Existing models use "europe"/"apac", newer models use "eu"/"japan"/"australia".
+# Existing models use "apac", newer models use "eu"/"jp"/"au".
 _PROFILE_KEY_ALIASES: dict[str, str] = {
     "europe": "eu",
-    "eu": "europe",
+    "japan": "jp",
+    "australia": "au",
 }
 
 
@@ -1327,7 +921,7 @@ def get_source_regions_for_model_profile(model_key: str, profile_key: str) -> li
     if resolved_key is None:
         raise ValueError(f"Model {model_key} not available in profile {profile_key}")
 
-    return model_config["profiles"][resolved_key]["source_regions"]
+    return list(model_config["profiles"][resolved_key]["source_regions"])
 
 
 def get_destination_regions_for_model_profile(model_key: str, profile_key: str) -> list[str]:
@@ -1340,7 +934,7 @@ def get_destination_regions_for_model_profile(model_key: str, profile_key: str) 
     if resolved_key is None:
         raise ValueError(f"Model {model_key} not available in profile {profile_key}")
 
-    return model_config["profiles"][resolved_key]["destination_regions"]
+    return list(model_config["profiles"][resolved_key]["destination_regions"])
 
 
 def get_all_model_display_names() -> dict[str, str]:
@@ -1413,11 +1007,8 @@ def get_profiles_for_region(region: str) -> list[str]:
         for profile_key, profile_config in model_config["profiles"].items():
             if region in profile_config.get("source_regions", []):
                 found.add(profile_key)
-    # Deduplicate eu/europe aliases: prefer eu over europe
-    if "eu" in found and "europe" in found:
-        found.discard("europe")
     # Return in stable, user-friendly order
-    order = ["us", "eu", "europe", "japan", "australia", "apac", "global", "us-gov"]
+    order = ["us", "eu", "jp", "au", "apac", "global", "us-gov"]
     return [p for p in order if p in found]
 
 

--- a/source/claude_code_with_bedrock/models.py
+++ b/source/claude_code_with_bedrock/models.py
@@ -15,8 +15,6 @@ from enum import Enum
 from typing import Any
 
 # Default regions for AWS profile based on cross-region profile
-from dataclasses import dataclass, field
-
 
 @dataclass(frozen=True)
 class InferenceProfile:
@@ -97,7 +95,16 @@ def _build_model(data: dict) -> ClaudeModel:
     )
 
 
-DEFAULT_REGIONS = {"us": "us-east-1", "eu": "eu-west-1", "europe": "eu-west-1", "apac": "ap-northeast-1", "us-gov": "us-gov-west-1"}
+DEFAULT_REGIONS = {
+    "us": "us-east-1",
+    "europe": "eu-west-3",
+    "eu": "eu-west-3",
+    "apac": "ap-northeast-1",
+    "japan": "ap-northeast-1",
+    "australia": "ap-southeast-2",
+    "global": "us-east-1",
+    "us-gov": "us-gov-west-1",
+}
 
 # Claude model configurations
 # Each model defines its availability across different cross-region profiles
@@ -344,11 +351,15 @@ _CLAUDE_MODELS_RAW = {
                     "ap-southeast-2",
                     "ap-southeast-3",
                     "ap-southeast-4",
+                    "ap-southeast-5",
+                    "ap-southeast-7",
                     # Middle East & Africa
                     "me-south-1",
                     "me-central-1",
                     "af-south-1",
                     "il-central-1",
+                    # Latin America
+                    "mx-central-1",
                     # South America
                     "sa-east-1",
                 ],
@@ -380,11 +391,15 @@ _CLAUDE_MODELS_RAW = {
                     "ap-southeast-2",
                     "ap-southeast-3",
                     "ap-southeast-4",
+                    "ap-southeast-5",
+                    "ap-southeast-7",
                     # Middle East & Africa
                     "me-south-1",
                     "me-central-1",
                     "af-south-1",
                     "il-central-1",
+                    # Latin America
+                    "mx-central-1",
                     # South America
                     "sa-east-1",
                 ],
@@ -626,6 +641,18 @@ _CLAUDE_MODELS_RAW = {
                     "ap-northeast-3",
                 ],
             },
+            "australia": {
+                "model_id": "au.anthropic.claude-sonnet-4-5-20250929-v1:0",
+                "description": "Australia CRIS - Asia Pacific (Sydney, Melbourne)",
+                "source_regions": [
+                    "ap-southeast-2",  # Sydney
+                    "ap-southeast-4",  # Melbourne
+                ],
+                "destination_regions": [
+                    "ap-southeast-2",
+                    "ap-southeast-4",
+                ],
+            },
             "global": {
                 "model_id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
                 "description": "Global CRIS - All regions worldwide",
@@ -705,6 +732,396 @@ _CLAUDE_MODELS_RAW = {
                 "description": "US GovCloud regions",
                 "source_regions": ["us-gov-west-1", "us-gov-east-1"],
                 "destination_regions": ["us-gov-west-1", "us-gov-east-1"],
+            },
+        },
+    },
+    "sonnet-4-6": {
+        "name": "Claude Sonnet 4.6",
+        "base_model_id": "anthropic.claude-sonnet-4-6",
+        "profiles": {
+            "us": {
+                "model_id": "us.anthropic.claude-sonnet-4-6",
+                "description": "US regions",
+                "source_regions": [
+                    "ca-central-1",
+                    "ca-west-1",
+                    "us-east-1",
+                    "us-east-2",
+                    "us-west-1",
+                    "us-west-2",
+                ],
+                "destination_regions": [
+                    "ca-central-1",
+                    "ca-west-1",
+                    "us-east-1",
+                    "us-east-2",
+                    "us-west-1",
+                    "us-west-2",
+                ],
+            },
+            "eu": {
+                "model_id": "eu.anthropic.claude-sonnet-4-6",
+                "description": "European regions",
+                "source_regions": [
+                    "eu-central-1",
+                    "eu-central-2",
+                    "eu-north-1",
+                    "eu-south-1",
+                    "eu-south-2",
+                    "eu-west-1",
+                    "eu-west-2",
+                    "eu-west-3",
+                ],
+                "destination_regions": [
+                    "eu-central-1",
+                    "eu-central-2",
+                    "eu-north-1",
+                    "eu-south-1",
+                    "eu-south-2",
+                    "eu-west-1",
+                    "eu-west-2",
+                    "eu-west-3",
+                ],
+            },
+            "australia": {
+                "model_id": "au.anthropic.claude-sonnet-4-6",
+                "description": "Australia (Sydney, Melbourne)",
+                "source_regions": [
+                    "ap-southeast-2",
+                    "ap-southeast-4",
+                ],
+                "destination_regions": [
+                    "ap-southeast-2",
+                    "ap-southeast-4",
+                ],
+            },
+            "japan": {
+                "model_id": "jp.anthropic.claude-sonnet-4-6",
+                "description": "Japan (Tokyo, Osaka)",
+                "source_regions": [
+                    "ap-northeast-1",
+                    "ap-northeast-3",
+                ],
+                "destination_regions": [
+                    "ap-northeast-1",
+                    "ap-northeast-3",
+                ],
+            },
+            "global": {
+                "model_id": "global.anthropic.claude-sonnet-4-6",
+                "description": "Global routing across all AWS regions",
+                "source_regions": [
+                    "af-south-1",
+                    "ap-east-2",
+                    "ap-northeast-1",
+                    "ap-northeast-2",
+                    "ap-northeast-3",
+                    "ap-south-1",
+                    "ap-south-2",
+                    "ap-southeast-1",
+                    "ap-southeast-2",
+                    "ap-southeast-3",
+                    "ap-southeast-4",
+                    "ap-southeast-5",
+                    "ap-southeast-7",
+                    "ca-central-1",
+                    "ca-west-1",
+                    "eu-central-1",
+                    "eu-central-2",
+                    "eu-north-1",
+                    "eu-south-1",
+                    "eu-south-2",
+                    "eu-west-1",
+                    "eu-west-2",
+                    "eu-west-3",
+                    "il-central-1",
+                    "me-central-1",
+                    "me-south-1",
+                    "mx-central-1",
+                    "sa-east-1",
+                    "us-east-1",
+                    "us-east-2",
+                    "us-west-1",
+                    "us-west-2",
+                ],
+                "destination_regions": [
+                    "af-south-1",
+                    "ap-east-2",
+                    "ap-northeast-1",
+                    "ap-northeast-2",
+                    "ap-northeast-3",
+                    "ap-south-1",
+                    "ap-south-2",
+                    "ap-southeast-1",
+                    "ap-southeast-2",
+                    "ap-southeast-3",
+                    "ap-southeast-4",
+                    "ap-southeast-5",
+                    "ap-southeast-7",
+                    "ca-central-1",
+                    "ca-west-1",
+                    "eu-central-1",
+                    "eu-central-2",
+                    "eu-north-1",
+                    "eu-south-1",
+                    "eu-south-2",
+                    "eu-west-1",
+                    "eu-west-2",
+                    "eu-west-3",
+                    "il-central-1",
+                    "me-central-1",
+                    "me-south-1",
+                    "mx-central-1",
+                    "sa-east-1",
+                    "us-east-1",
+                    "us-east-2",
+                    "us-west-1",
+                    "us-west-2",
+                ],
+            },
+        },
+    },
+    "opus-4-5": {
+        "name": "Claude Opus 4.5",
+        "base_model_id": "anthropic.claude-opus-4-5-20251101-v1:0",
+        "profiles": {
+            "us": {
+                "model_id": "us.anthropic.claude-opus-4-5-20251101-v1:0",
+                "description": "US regions",
+                "source_regions": [
+                    "ca-central-1",
+                    "us-east-1",
+                    "us-east-2",
+                    "us-west-1",
+                    "us-west-2",
+                ],
+                "destination_regions": [
+                    "ca-central-1",
+                    "us-east-1",
+                    "us-east-2",
+                    "us-west-1",
+                    "us-west-2",
+                ],
+            },
+            "eu": {
+                "model_id": "eu.anthropic.claude-opus-4-5-20251101-v1:0",
+                "description": "European regions",
+                "source_regions": [
+                    "eu-central-1",
+                    "eu-central-2",
+                    "eu-north-1",
+                    "eu-south-1",
+                    "eu-south-2",
+                    "eu-west-1",
+                    "eu-west-2",
+                    "eu-west-3",
+                ],
+                "destination_regions": [
+                    "eu-central-1",
+                    "eu-central-2",
+                    "eu-north-1",
+                    "eu-south-1",
+                    "eu-south-2",
+                    "eu-west-1",
+                    "eu-west-2",
+                    "eu-west-3",
+                ],
+            },
+            "global": {
+                "model_id": "global.anthropic.claude-opus-4-5-20251101-v1:0",
+                "description": "Global routing across all AWS regions",
+                "source_regions": [
+                    "af-south-1",
+                    "ap-northeast-1",
+                    "ap-northeast-2",
+                    "ap-northeast-3",
+                    "ap-south-1",
+                    "ap-south-2",
+                    "ap-southeast-1",
+                    "ap-southeast-2",
+                    "ap-southeast-3",
+                    "ap-southeast-4",
+                    "ca-central-1",
+                    "eu-central-1",
+                    "eu-central-2",
+                    "eu-north-1",
+                    "eu-south-1",
+                    "eu-south-2",
+                    "eu-west-1",
+                    "eu-west-2",
+                    "eu-west-3",
+                    "il-central-1",
+                    "me-central-1",
+                    "me-south-1",
+                    "sa-east-1",
+                    "us-east-1",
+                    "us-east-2",
+                    "us-west-1",
+                    "us-west-2",
+                ],
+                "destination_regions": [
+                    "af-south-1",
+                    "ap-northeast-1",
+                    "ap-northeast-2",
+                    "ap-northeast-3",
+                    "ap-south-1",
+                    "ap-south-2",
+                    "ap-southeast-1",
+                    "ap-southeast-2",
+                    "ap-southeast-3",
+                    "ap-southeast-4",
+                    "ca-central-1",
+                    "eu-central-1",
+                    "eu-central-2",
+                    "eu-north-1",
+                    "eu-south-1",
+                    "eu-south-2",
+                    "eu-west-1",
+                    "eu-west-2",
+                    "eu-west-3",
+                    "il-central-1",
+                    "me-central-1",
+                    "me-south-1",
+                    "sa-east-1",
+                    "us-east-1",
+                    "us-east-2",
+                    "us-west-1",
+                    "us-west-2",
+                ],
+            },
+        },
+    },
+    "haiku-4-5": {
+        "name": "Claude Haiku 4.5",
+        "base_model_id": "anthropic.claude-haiku-4-5-20251001-v1:0",
+        "profiles": {
+            "us": {
+                "model_id": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+                "description": "US regions",
+                "source_regions": [
+                    "ca-central-1",
+                    "us-east-1",
+                    "us-east-2",
+                    "us-west-1",
+                    "us-west-2",
+                ],
+                "destination_regions": [
+                    "ca-central-1",
+                    "us-east-1",
+                    "us-east-2",
+                    "us-west-1",
+                    "us-west-2",
+                ],
+            },
+            "eu": {
+                "model_id": "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
+                "description": "European regions",
+                "source_regions": [
+                    "eu-central-1",
+                    "eu-central-2",
+                    "eu-north-1",
+                    "eu-south-1",
+                    "eu-south-2",
+                    "eu-west-1",
+                    "eu-west-2",
+                    "eu-west-3",
+                ],
+                "destination_regions": [
+                    "eu-central-1",
+                    "eu-central-2",
+                    "eu-north-1",
+                    "eu-south-1",
+                    "eu-south-2",
+                    "eu-west-1",
+                    "eu-west-2",
+                    "eu-west-3",
+                ],
+            },
+            "australia": {
+                "model_id": "au.anthropic.claude-haiku-4-5-20251001-v1:0",
+                "description": "Australia (Sydney, Melbourne)",
+                "source_regions": [
+                    "ap-southeast-2",
+                    "ap-southeast-4",
+                ],
+                "destination_regions": [
+                    "ap-southeast-2",
+                    "ap-southeast-4",
+                ],
+            },
+            "japan": {
+                "model_id": "jp.anthropic.claude-haiku-4-5-20251001-v1:0",
+                "description": "Japan (Tokyo, Osaka)",
+                "source_regions": [
+                    "ap-northeast-1",
+                    "ap-northeast-3",
+                ],
+                "destination_regions": [
+                    "ap-northeast-1",
+                    "ap-northeast-3",
+                ],
+            },
+            "global": {
+                "model_id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+                "description": "Global routing across all AWS regions",
+                "source_regions": [
+                    "af-south-1",
+                    "ap-northeast-1",
+                    "ap-northeast-2",
+                    "ap-northeast-3",
+                    "ap-south-1",
+                    "ap-south-2",
+                    "ap-southeast-1",
+                    "ap-southeast-2",
+                    "ap-southeast-3",
+                    "ap-southeast-4",
+                    "ca-central-1",
+                    "eu-central-1",
+                    "eu-central-2",
+                    "eu-north-1",
+                    "eu-south-1",
+                    "eu-south-2",
+                    "eu-west-1",
+                    "eu-west-2",
+                    "eu-west-3",
+                    "il-central-1",
+                    "me-central-1",
+                    "me-south-1",
+                    "sa-east-1",
+                    "us-east-1",
+                    "us-east-2",
+                    "us-west-1",
+                    "us-west-2",
+                ],
+                "destination_regions": [
+                    "af-south-1",
+                    "ap-northeast-1",
+                    "ap-northeast-2",
+                    "ap-northeast-3",
+                    "ap-south-1",
+                    "ap-south-2",
+                    "ap-southeast-1",
+                    "ap-southeast-2",
+                    "ap-southeast-3",
+                    "ap-southeast-4",
+                    "ca-central-1",
+                    "eu-central-1",
+                    "eu-central-2",
+                    "eu-north-1",
+                    "eu-south-1",
+                    "eu-south-2",
+                    "eu-west-1",
+                    "eu-west-2",
+                    "eu-west-3",
+                    "il-central-1",
+                    "me-central-1",
+                    "me-south-1",
+                    "sa-east-1",
+                    "us-east-1",
+                    "us-east-2",
+                    "us-west-1",
+                    "us-west-2",
+                ],
             },
         },
     },
@@ -831,6 +1248,47 @@ _CLAUDE_MODELS_RAW = {
 CLAUDE_MODELS: dict[str, ClaudeModel] = {k: _build_model(v) for k, v in _CLAUDE_MODELS_RAW.items()}
 
 
+# Recognized model tiers, derived from CLAUDE_MODELS key prefixes.
+_TIER_PREFIXES = ("opus", "sonnet", "haiku")
+
+
+def _get_tier(model_key: str) -> str | None:
+    """Derive tier from a CLAUDE_MODELS key (e.g., 'opus-4-6' -> 'opus').
+
+    Returns None for GovCloud-specific entries (handled separately).
+    """
+    if model_key.endswith("-govcloud"):
+        return None
+    for prefix in _TIER_PREFIXES:
+        if model_key.startswith(prefix):
+            return prefix
+    return None
+
+
+# Alias mapping for cross-region profile keys.
+# Existing models use "europe"/"apac", newer models use "eu"/"japan"/"australia".
+_PROFILE_KEY_ALIASES: dict[str, str] = {
+    "europe": "eu",
+    "eu": "europe",
+}
+
+
+def resolve_profile_key(model_key: str, profile_key: str) -> str | None:
+    """Resolve a cross-region profile key for a model, trying aliases if needed.
+
+    Returns the actual key present in the model's profiles dict, or None.
+    """
+    if model_key not in CLAUDE_MODELS:
+        return None
+    profiles = CLAUDE_MODELS[model_key].get("profiles", {})
+    if profile_key in profiles:
+        return profile_key
+    alias = _PROFILE_KEY_ALIASES.get(profile_key)
+    if alias and alias in profiles:
+        return alias
+    return None
+
+
 def get_available_profiles_for_model(model_key: str) -> list[str]:
     """Get list of available cross-region profiles for a given model."""
     if model_key not in CLAUDE_MODELS:
@@ -844,10 +1302,11 @@ def get_model_id_for_profile(model_key: str, profile_key: str) -> str:
         raise ValueError(f"Unknown model: {model_key}")
 
     model_config = CLAUDE_MODELS[model_key]
-    if profile_key not in model_config["profiles"]:
+    resolved_key = resolve_profile_key(model_key, profile_key)
+    if resolved_key is None:
         raise ValueError(f"Model {model_key} not available in profile {profile_key}")
 
-    return model_config["profiles"][profile_key]["model_id"]
+    return model_config["profiles"][resolved_key]["model_id"]
 
 
 def get_default_region_for_profile(profile_key: str) -> str:
@@ -864,10 +1323,11 @@ def get_source_regions_for_model_profile(model_key: str, profile_key: str) -> li
         raise ValueError(f"Unknown model: {model_key}")
 
     model_config = CLAUDE_MODELS[model_key]
-    if profile_key not in model_config["profiles"]:
+    resolved_key = resolve_profile_key(model_key, profile_key)
+    if resolved_key is None:
         raise ValueError(f"Model {model_key} not available in profile {profile_key}")
 
-    return model_config["profiles"][profile_key]["source_regions"]
+    return model_config["profiles"][resolved_key]["source_regions"]
 
 
 def get_destination_regions_for_model_profile(model_key: str, profile_key: str) -> list[str]:
@@ -876,10 +1336,11 @@ def get_destination_regions_for_model_profile(model_key: str, profile_key: str) 
         raise ValueError(f"Unknown model: {model_key}")
 
     model_config = CLAUDE_MODELS[model_key]
-    if profile_key not in model_config["profiles"]:
+    resolved_key = resolve_profile_key(model_key, profile_key)
+    if resolved_key is None:
         raise ValueError(f"Model {model_key} not available in profile {profile_key}")
 
-    return model_config["profiles"][profile_key]["destination_regions"]
+    return model_config["profiles"][resolved_key]["destination_regions"]
 
 
 def get_all_model_display_names() -> dict[str, str]:
@@ -900,16 +1361,86 @@ def get_all_model_display_names() -> dict[str, str]:
     return display_names
 
 
+def get_models_for_tier(tier: str, profile_key: str) -> list[tuple[str, str, str]]:
+    """Return models available for a tier and cross-region profile.
+
+    Args:
+        tier: Model tier ("opus", "sonnet", or "haiku").
+        profile_key: Cross-region profile key (e.g., "global", "us", "eu").
+
+    Returns:
+        List of (model_key, display_name, model_id) tuples, ordered by position
+        in CLAUDE_MODELS (latest entries last in the dict appear last).
+    """
+    results = []
+    for model_key, model_info in CLAUDE_MODELS.items():
+        if _get_tier(model_key) != tier:
+            continue
+        resolved = resolve_profile_key(model_key, profile_key)
+        if resolved is None:
+            continue
+        model_id = model_info["profiles"][resolved]["model_id"]
+        results.append((model_key, model_info["name"], model_id))
+    return results
+
+
 def get_profile_description(model_key: str, profile_key: str) -> str:
     """Get the description for a specific model profile combination."""
     if model_key not in CLAUDE_MODELS:
         raise ValueError(f"Unknown model: {model_key}")
 
     model_config = CLAUDE_MODELS[model_key]
-    if profile_key not in model_config["profiles"]:
+    resolved_key = resolve_profile_key(model_key, profile_key)
+    if resolved_key is None:
         raise ValueError(f"Model {model_key} not available in profile {profile_key}")
 
-    return model_config["profiles"][profile_key]["description"]
+    return model_config["profiles"][resolved_key]["description"]
+
+
+def get_all_source_regions() -> list[str]:
+    """Return all unique source regions across all models and profiles."""
+    regions: set[str] = set()
+    for model_config in CLAUDE_MODELS.values():
+        for profile_config in model_config["profiles"].values():
+            regions.update(profile_config.get("source_regions", []))
+    return sorted(regions)
+
+
+def get_profiles_for_region(region: str) -> list[str]:
+    """Return profile keys that include the given region as a source region."""
+    found: set[str] = set()
+    for model_config in CLAUDE_MODELS.values():
+        for profile_key, profile_config in model_config["profiles"].items():
+            if region in profile_config.get("source_regions", []):
+                found.add(profile_key)
+    # Deduplicate eu/europe aliases: prefer eu over europe
+    if "eu" in found and "europe" in found:
+        found.discard("europe")
+    # Return in stable, user-friendly order
+    order = ["us", "eu", "europe", "japan", "australia", "apac", "global", "us-gov"]
+    return [p for p in order if p in found]
+
+
+def get_all_destination_regions_for_profile(profile_key: str) -> list[str]:
+    """Return all unique destination regions across all models that support this profile."""
+    regions: set[str] = set()
+    for model_key, model_config in CLAUDE_MODELS.items():
+        resolved = resolve_profile_key(model_key, profile_key)
+        if resolved is None:
+            continue
+        regions.update(
+            model_config["profiles"][resolved].get("destination_regions", [])
+        )
+    return sorted(regions)
+
+
+def get_all_destination_regions() -> list[str]:
+    """Return all unique destination regions across all models and profiles."""
+    regions: set[str] = set()
+    for model_config in CLAUDE_MODELS.values():
+        for profile in model_config["profiles"].values():
+            regions.update(profile.get("destination_regions", []))
+    return sorted(regions)
 
 
 def get_source_region_for_profile(profile, model_key: str = None, profile_key: str = None) -> str:

--- a/source/claude_code_with_bedrock/validators.py
+++ b/source/claude_code_with_bedrock/validators.py
@@ -192,7 +192,7 @@ class ProfileValidator:
                 errors.append("allowed_bedrock_regions must be a list")
             else:
                 for bedrock_region in allowed_regions:
-                    if bedrock_region not in AWS_REGIONS:
+                    if bedrock_region != "*" and bedrock_region not in AWS_REGIONS:
                         warnings.append(f"Unknown Bedrock region: {bedrock_region}")
 
         # Validate cross_region_profile

--- a/source/otel_helper/__main__.py
+++ b/source/otel_helper/__main__.py
@@ -752,6 +752,11 @@ def main():
 
         # Generate headers dictionary
         headers_dict = format_as_headers_dict(user_info)
+        # Forward Bearer token for ALB OIDC JWT validation on the OTEL collector endpoint
+        if token:
+            headers_dict["authorization"] = f"Bearer {token}"
+
+
         # In test mode, print detailed output
         if TEST_MODE:
             print("===== TEST MODE OUTPUT =====\n")

--- a/source/otel_helper/__main__.py
+++ b/source/otel_helper/__main__.py
@@ -756,7 +756,6 @@ def main():
         if token:
             headers_dict["authorization"] = f"Bearer {token}"
 
-
         # In test mode, print detailed output
         if TEST_MODE:
             print("===== TEST MODE OUTPUT =====\n")

--- a/source/tests/cli/commands/test_init_bedrock.py
+++ b/source/tests/cli/commands/test_init_bedrock.py
@@ -86,7 +86,8 @@ class TestQ3AutoSelectFallsThroughToTierQuestions:
         # questionary.confirm calls in execution order:
         # 1. Enable Windows builds? → False
         # 2. Enable CoWork MDM config? → False
-        confirm_values = [False, False]
+        # 3. Configure Application Inference Profiles? → False
+        confirm_values = [False, False, False]
 
         with patch("questionary.select", side_effect=_select_side_effect(select_values)), patch(
             "questionary.confirm", side_effect=_confirm_side_effect(confirm_values)
@@ -136,7 +137,10 @@ class TestQ3AutoSelectFallsThroughToTierQuestions:
 
         # Q3 = "sonnet-4-6" (explicit model)
         select_values = ["__disabled__", "eu-central-1", "eu", "sonnet-4-6", "__auto__", "sonnet-4-6", "haiku-4-5"]
-        confirm_values = [False, False]
+        # 1. Enable Windows builds? → False
+        # 2. Enable CoWork MDM config? → False
+        # 3. Configure Application Inference Profiles? → False
+        confirm_values = [False, False, False]
 
         with patch("questionary.select", side_effect=_select_side_effect(select_values)), patch(
             "questionary.confirm", side_effect=_confirm_side_effect(confirm_values)

--- a/source/tests/cli/commands/test_init_bedrock.py
+++ b/source/tests/cli/commands/test_init_bedrock.py
@@ -1,0 +1,196 @@
+# ABOUTME: Tests for the bedrock model-selection section of the init wizard
+# ABOUTME: Verifies Q3 auto-select falls through to Q4-Q6 tier questions (no early return)
+
+"""Tests for bedrock model selection in the init wizard."""
+
+from unittest.mock import MagicMock, patch
+
+from claude_code_with_bedrock.cli.commands.init import InitCommand
+
+
+def _make_mock_progress(pre_config: dict | None = None, last_step: str = "monitoring_complete") -> MagicMock:
+    """Return a WizardProgress-shaped mock pre-loaded with data from a previous step."""
+    progress = MagicMock()
+    progress.get_last_step.return_value = last_step
+    progress.get_saved_data.return_value = pre_config or {}
+    return progress
+
+
+def _select_side_effect(values: list):
+    """
+    Return a side_effect function for questionary.select that consumes *values* in order.
+    Each questionary.select(...) call returns a mock whose .ask() returns the next value.
+    """
+    it = iter(values)
+
+    def _factory(*args, **kwargs):
+        m = MagicMock()
+        m.ask.return_value = next(it)
+        return m
+
+    return _factory
+
+
+def _confirm_side_effect(values: list):
+    """Same as _select_side_effect but for questionary.confirm."""
+    it = iter(values)
+
+    def _factory(*args, **kwargs):
+        m = MagicMock()
+        m.ask.return_value = next(it)
+        return m
+
+    return _factory
+
+
+class TestQ3AutoSelectFallsThroughToTierQuestions:
+    """Q3 auto-select must not return early — Q4-Q6 must still execute."""
+
+    def test_auto_select_model_with_explicit_sonnet_and_haiku_defaults(self):
+        """
+        Simulate: Q2=eu, Q3=auto-select, Q4=auto, Q5=sonnet-4-6, Q6=haiku-4-5.
+        Expected profile fields:
+          selected_model         = None
+          default_opus_model     = None   (Q4 auto)
+          default_sonnet_model   = "eu.anthropic.claude-sonnet-4-6"
+          default_haiku_model    = "eu.anthropic.claude-haiku-4-5-20251001-v1:0"
+        """
+        command = InitCommand()
+
+        # Config already saved at monitoring_complete — bedrock section not yet filled
+        pre_config: dict = {
+            "okta": {"domain": "test.okta.com", "client_id": "test-client-id"},
+            "aws": {
+                "region": "eu-central-1",
+                "stack_base_name": "claude-code-auth",
+                "identity_pool_name": "test-pool",
+                "credential_storage": "session",
+                "federation_type": "direct",
+            },
+            "monitoring": {"enabled": False},
+            "codebuild": {"enabled": False},
+            "distribution": {"enabled": False, "type": None},
+        }
+        progress = _make_mock_progress(pre_config, last_step="monitoring_complete")
+
+        # questionary.select calls in execution order (monitoring_complete skips okta/aws/monitoring):
+        # 1. Distribution method       → "__disabled__"
+        # 2. Source region (Q1)        → "eu-central-1"
+        # 3. Cross-region profile (Q2) → "eu"
+        # 4. Claude model (Q3)         → "__auto__"  ← the key branch under test
+        # 5. Default Opus (Q4)         → "__auto__"
+        # 6. Default Sonnet (Q5)       → "sonnet-4-6"
+        # 7. Default Haiku (Q6)        → "haiku-4-5"
+        select_values = ["__disabled__", "eu-central-1", "eu", "__auto__", "__auto__", "sonnet-4-6", "haiku-4-5"]
+
+        # questionary.confirm calls in execution order:
+        # 1. Enable Windows builds? → False
+        # 2. Enable CoWork MDM config? → False
+        confirm_values = [False, False]
+
+        with patch("questionary.select", side_effect=_select_side_effect(select_values)), patch(
+            "questionary.confirm", side_effect=_confirm_side_effect(confirm_values)
+        ):
+            result = command._gather_configuration(progress)
+
+        assert result is not None, "Wizard should complete without returning None"
+
+        aws = result["aws"]
+        # Q3 auto-select: primary model env var must not be set
+        assert aws["selected_model"] is None, "selected_model should be None for auto-select"
+
+        # Q4 auto: opus default not set
+        assert aws["default_opus_model"] is None, "default_opus_model should be None for auto-select"
+
+        # Q5 sonnet-4-6 chosen: should resolve to the EU model ID
+        assert aws["default_sonnet_model"] == "eu.anthropic.claude-sonnet-4-6", (
+            f"Expected eu sonnet model ID, got {aws['default_sonnet_model']!r}"
+        )
+
+        # Q6 haiku-4-5 chosen: should resolve to the EU model ID
+        assert aws["default_haiku_model"] == "eu.anthropic.claude-haiku-4-5-20251001-v1:0", (
+            f"Expected eu haiku model ID, got {aws['default_haiku_model']!r}"
+        )
+
+    def test_explicit_model_with_tier_defaults(self):
+        """
+        Regression: Q3=explicit model, Q4-Q6 as before — all four fields must be set.
+        selected_model = eu sonnet-4-6 ID; tier defaults same as test above.
+        """
+        command = InitCommand()
+
+        pre_config: dict = {
+            "okta": {"domain": "test.okta.com", "client_id": "test-client-id"},
+            "aws": {
+                "region": "eu-central-1",
+                "stack_base_name": "claude-code-auth",
+                "identity_pool_name": "test-pool",
+                "credential_storage": "session",
+                "federation_type": "direct",
+            },
+            "monitoring": {"enabled": False},
+            "codebuild": {"enabled": False},
+            "distribution": {"enabled": False, "type": None},
+        }
+        progress = _make_mock_progress(pre_config, last_step="monitoring_complete")
+
+        # Q3 = "sonnet-4-6" (explicit model)
+        select_values = ["__disabled__", "eu-central-1", "eu", "sonnet-4-6", "__auto__", "sonnet-4-6", "haiku-4-5"]
+        confirm_values = [False, False]
+
+        with patch("questionary.select", side_effect=_select_side_effect(select_values)), patch(
+            "questionary.confirm", side_effect=_confirm_side_effect(confirm_values)
+        ):
+            result = command._gather_configuration(progress)
+
+        assert result is not None
+        aws = result["aws"]
+
+        assert aws["selected_model"] == "eu.anthropic.claude-sonnet-4-6"
+        assert aws["default_opus_model"] is None
+        assert aws["default_sonnet_model"] == "eu.anthropic.claude-sonnet-4-6"
+        assert aws["default_haiku_model"] == "eu.anthropic.claude-haiku-4-5-20251001-v1:0"
+
+    def test_path_a_regression_q2_auto_returns_early_no_tier_questions(self):
+        """
+        Path A regression: Q2=auto-select exits the bedrock section immediately.
+        Tier fields must all be None and selected_model must be None.
+        Q3-Q6 must NOT be asked (the mock sequence has only 2 select values).
+        """
+        command = InitCommand()
+
+        pre_config: dict = {
+            "okta": {"domain": "test.okta.com", "client_id": "test-client-id"},
+            "aws": {
+                "region": "us-east-1",
+                "stack_base_name": "claude-code-auth",
+                "identity_pool_name": "test-pool",
+                "credential_storage": "session",
+                "federation_type": "direct",
+            },
+            "monitoring": {"enabled": False},
+            "codebuild": {"enabled": False},
+            "distribution": {"enabled": False, "type": None},
+        }
+        progress = _make_mock_progress(pre_config, last_step="monitoring_complete")
+
+        # Q2 = "__auto__" → wizard returns early from bedrock section
+        # Only 3 select values needed: distribution + Q1 + Q2 (no Q3-Q6)
+        select_values = ["__disabled__", "us-east-1", "__auto__"]
+        confirm_values = [False, False]
+
+        with patch("questionary.select", side_effect=_select_side_effect(select_values)), patch(
+            "questionary.confirm", side_effect=_confirm_side_effect(confirm_values)
+        ):
+            result = command._gather_configuration(progress)
+
+        assert result is not None
+        aws = result["aws"]
+
+        assert aws["selected_model"] is None
+        assert aws["default_opus_model"] is None
+        assert aws["default_sonnet_model"] is None
+        assert aws["default_haiku_model"] is None
+        # Auto-select populates all destination regions from the model registry
+        from claude_code_with_bedrock.models import get_all_destination_regions
+        assert aws["allowed_bedrock_regions"] == get_all_destination_regions()

--- a/source/tests/cli/commands/test_init_source_regions.py
+++ b/source/tests/cli/commands/test_init_source_regions.py
@@ -148,7 +148,7 @@ class TestInitCommandSourceRegions:
         eu_profile.aws_region = "us-east-1"
 
         result = get_source_region_for_profile(eu_profile)
-        assert result == "eu-west-3"  # Should use default Europe region
+        assert result == "eu-west-1"  # Should use default Europe region
 
     def test_source_region_priority_order(self):
         """Test that source region selection follows correct priority order."""

--- a/source/tests/cli/commands/test_package_models.py
+++ b/source/tests/cli/commands/test_package_models.py
@@ -3,6 +3,7 @@
 
 """Tests for model handling in the package command."""
 
+import json
 import tempfile
 from pathlib import Path
 
@@ -73,3 +74,113 @@ class TestPackageModelHandling:
                 assert "eu-west-1" in expected_display
             elif profile_key == "apac":
                 assert "ap-northeast-1" in expected_display
+
+
+class TestTierDefaultsInSettings:
+    """Tests that tier default env vars are written to settings.json independently of selected_model."""
+
+    def _make_profile(self, **kwargs) -> Profile:
+        """Build a minimal Profile, overriding fields via kwargs."""
+        defaults = dict(
+            name="test",
+            provider_domain="test.okta.com",
+            client_id="test-client-id",
+            credential_storage="session",
+            aws_region="eu-central-1",
+            identity_pool_name="test-pool",
+            monitoring_enabled=False,
+            selected_source_region="eu-central-1",
+            cross_region_profile="eu",
+        )
+        defaults.update(kwargs)
+        return Profile(**defaults)
+
+    def _read_settings(self, output_dir: Path) -> dict:
+        settings_path = output_dir / "claude-settings" / "settings.json"
+        with open(settings_path) as f:
+            return json.load(f)
+
+    def test_tier_defaults_written_when_selected_model_is_none(self):
+        """Tier env vars appear in settings.json even when selected_model is None (Q3 auto-select)."""
+        command = PackageCommand()
+        profile = self._make_profile(
+            selected_model=None,
+            default_sonnet_model="eu.anthropic.claude-sonnet-4-6",
+            default_haiku_model="eu.anthropic.claude-haiku-4-5-20251001-v1:0",
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            command._create_claude_settings(Path(tmpdir), profile)
+            env = self._read_settings(Path(tmpdir))["env"]
+
+        assert "ANTHROPIC_MODEL" not in env
+        assert env["ANTHROPIC_DEFAULT_SONNET_MODEL"] == "eu.anthropic.claude-sonnet-4-6"
+        assert env["ANTHROPIC_DEFAULT_HAIKU_MODEL"] == "eu.anthropic.claude-haiku-4-5-20251001-v1:0"
+        assert "ANTHROPIC_DEFAULT_OPUS_MODEL" not in env
+
+    def test_selected_model_and_tier_defaults_both_written(self):
+        """When selected_model and tier defaults are all set, all four env vars appear."""
+        command = PackageCommand()
+        profile = self._make_profile(
+            selected_model="eu.anthropic.claude-sonnet-4-6",
+            default_opus_model="eu.anthropic.claude-opus-4-6-v1",
+            default_sonnet_model="eu.anthropic.claude-sonnet-4-6",
+            default_haiku_model="eu.anthropic.claude-haiku-4-5-20251001-v1:0",
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            command._create_claude_settings(Path(tmpdir), profile)
+            env = self._read_settings(Path(tmpdir))["env"]
+
+        assert env["ANTHROPIC_MODEL"] == "eu.anthropic.claude-sonnet-4-6"
+        assert env["ANTHROPIC_DEFAULT_OPUS_MODEL"] == "eu.anthropic.claude-opus-4-6-v1"
+        assert env["ANTHROPIC_DEFAULT_SONNET_MODEL"] == "eu.anthropic.claude-sonnet-4-6"
+        assert env["ANTHROPIC_DEFAULT_HAIKU_MODEL"] == "eu.anthropic.claude-haiku-4-5-20251001-v1:0"
+
+    def test_path_a_no_model_env_vars(self):
+        """Path A (Q2 auto-select): selected_model=None and all tier defaults None → no model env vars."""
+        command = PackageCommand()
+        profile = self._make_profile(
+            cross_region_profile=None,
+            selected_model=None,
+            default_opus_model=None,
+            default_sonnet_model=None,
+            default_haiku_model=None,
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            command._create_claude_settings(Path(tmpdir), profile)
+            env = self._read_settings(Path(tmpdir))["env"]
+
+        assert "ANTHROPIC_MODEL" not in env
+        assert "ANTHROPIC_DEFAULT_OPUS_MODEL" not in env
+        assert "ANTHROPIC_DEFAULT_SONNET_MODEL" not in env
+        assert "ANTHROPIC_DEFAULT_HAIKU_MODEL" not in env
+
+    def test_haiku_fallback_to_sonnet_when_no_haiku_models_and_selected_model_is_none(self):
+        """Edge case: selected_model=None, haiku default=None, sonnet default set, profile has no haiku.
+
+        GovCloud has sonnet but no haiku tier. The fallback should set
+        ANTHROPIC_DEFAULT_HAIKU_MODEL to the sonnet model ID.
+        Before this refactor, this path was unreachable when selected_model was None
+        because the entire tier-defaults block was nested inside the selected_model guard.
+        """
+        command = PackageCommand()
+        profile = self._make_profile(
+            aws_region="us-gov-west-1",
+            selected_source_region="us-gov-west-1",
+            cross_region_profile="us-gov",
+            selected_model=None,
+            default_opus_model=None,
+            default_sonnet_model="us-gov.anthropic.claude-3-7-sonnet-20250219-v1:0",
+            default_haiku_model=None,
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            command._create_claude_settings(Path(tmpdir), profile)
+            env = self._read_settings(Path(tmpdir))["env"]
+
+        assert "ANTHROPIC_MODEL" not in env
+        assert env["ANTHROPIC_DEFAULT_SONNET_MODEL"] == "us-gov.anthropic.claude-3-7-sonnet-20250219-v1:0"
+        # Fallback: haiku tier gets sonnet model because no haiku exists for us-gov
+        assert env["ANTHROPIC_DEFAULT_HAIKU_MODEL"] == "us-gov.anthropic.claude-3-7-sonnet-20250219-v1:0"

--- a/source/tests/test_models.py
+++ b/source/tests/test_models.py
@@ -8,12 +8,16 @@ import pytest
 from claude_code_with_bedrock.models import (
     CLAUDE_MODELS,
     DEFAULT_REGIONS,
+    get_all_destination_regions_for_profile,
     get_all_model_display_names,
+    get_all_source_regions,
     get_available_profiles_for_model,
     get_default_region_for_profile,
     get_destination_regions_for_model_profile,
     get_model_id_for_profile,
+    get_models_for_tier,
     get_profile_description,
+    get_profiles_for_region,
     get_source_regions_for_model_profile,
 )
 
@@ -23,30 +27,34 @@ class TestModelConfiguration:
 
     def test_default_regions_structure(self):
         """Test that DEFAULT_REGIONS has the expected structure."""
-        expected_profiles = {"us", "eu", "europe", "apac", "us-gov"}
+        expected_profiles = {"us", "europe", "eu", "apac", "japan", "australia", "global", "us-gov"}
         assert set(DEFAULT_REGIONS.keys()) == expected_profiles
 
         # Verify regions are valid AWS regions
         assert DEFAULT_REGIONS["us"] == "us-east-1"
-        assert DEFAULT_REGIONS["eu"] == "eu-west-1"
+        assert DEFAULT_REGIONS["europe"] == "eu-west-3"
+        assert DEFAULT_REGIONS["eu"] == "eu-west-3"
         assert DEFAULT_REGIONS["apac"] == "ap-northeast-1"
+        assert DEFAULT_REGIONS["japan"] == "ap-northeast-1"
+        assert DEFAULT_REGIONS["australia"] == "ap-southeast-2"
+        assert DEFAULT_REGIONS["global"] == "us-east-1"
         assert DEFAULT_REGIONS["us-gov"] == "us-gov-west-1"
 
     def test_claude_models_structure(self):
         """Test that CLAUDE_MODELS has the expected structure."""
         expected_models = {
-            "sonnet-4-6",
-            "opus-4-7",
             "opus-4-6",
-            "opus-4-5",
             "opus-4-1",
             "opus-4",
+            "opus-4-5",
+            "opus-4-6",
             "sonnet-4",
             "sonnet-4-5",
             "sonnet-4-5-govcloud",
+            "sonnet-4-6",
+            "haiku-4-5",
             "sonnet-3-7",
             "sonnet-3-7-govcloud",
-            "haiku-4-5",
         }
         assert set(CLAUDE_MODELS.keys()) == expected_models
 
@@ -61,7 +69,7 @@ class TestModelConfiguration:
     def test_model_profiles_structure(self):
         """Test that each model profile has the expected structure."""
         # Valid profile keys that can appear in model configurations
-        valid_profile_keys = set(DEFAULT_REGIONS.keys()) | {"eu", "jp", "global", "au"}
+        valid_profile_keys = set(DEFAULT_REGIONS.keys()) | {"eu", "japan", "global", "au"}
 
         for _model_key, model_config in CLAUDE_MODELS.items():
             for profile_key, profile_config in model_config["profiles"].items():
@@ -78,13 +86,13 @@ class TestModelConfiguration:
                 model_id = profile_config["model_id"]
                 if profile_key == "us":
                     assert model_id.startswith("us.anthropic.")
-                elif profile_key in ["eu", "eu"]:
+                elif profile_key in ["europe", "eu"]:
                     assert model_id.startswith("eu.anthropic.")
                 elif profile_key == "apac":
                     assert model_id.startswith("apac.anthropic.")
                 elif profile_key == "us-gov":
                     assert model_id.startswith("us-gov.anthropic.")
-                elif profile_key == "jp":
+                elif profile_key == "japan":
                     assert model_id.startswith("jp.anthropic.")
                 elif profile_key == "global":
                     assert model_id.startswith("global.anthropic.")
@@ -104,16 +112,16 @@ class TestModelConfiguration:
         assert opus_4_profiles == ["us"]  # Opus 4 is US-only
 
         sonnet_4_profiles = get_available_profiles_for_model("sonnet-4")
-        assert set(sonnet_4_profiles) == {"us", "eu", "apac", "global"}  # Sonnet 4 has global profile now
+        assert set(sonnet_4_profiles) == {"us", "europe", "apac", "global"}  # Sonnet 4 has global profile now
 
         sonnet_4_5_profiles = get_available_profiles_for_model("sonnet-4-5")
-        assert set(sonnet_4_5_profiles) == {"us", "eu", "jp", "au", "global"}  # Sonnet 4.5 regional profiles
+        assert set(sonnet_4_5_profiles) == {"us", "eu", "japan", "australia", "global"}  # Sonnet 4.5 regional profiles
 
         sonnet_4_5_govcloud_profiles = get_available_profiles_for_model("sonnet-4-5-govcloud")
         assert sonnet_4_5_govcloud_profiles == ["us-gov"]  # Sonnet 4.5 GovCloud
 
         sonnet_3_7_profiles = get_available_profiles_for_model("sonnet-3-7")
-        assert set(sonnet_3_7_profiles) == {"us", "eu", "apac"}  # Sonnet 3.7 regional profiles
+        assert set(sonnet_3_7_profiles) == {"us", "europe", "apac"}  # Sonnet 3.7 regional profiles
 
         sonnet_3_7_govcloud_profiles = get_available_profiles_for_model("sonnet-3-7-govcloud")
         assert sonnet_3_7_govcloud_profiles == ["us-gov"]  # Sonnet 3.7 GovCloud
@@ -133,8 +141,8 @@ class TestModelConfiguration:
 
         # Test Europe profiles
         assert get_model_id_for_profile("opus-4-6", "eu") == "eu.anthropic.claude-opus-4-6-v1"
-        assert get_model_id_for_profile("sonnet-4", "eu") == "eu.anthropic.claude-sonnet-4-20250514-v1:0"
-        assert get_model_id_for_profile("sonnet-3-7", "eu") == "eu.anthropic.claude-3-7-sonnet-20250219-v1:0"
+        assert get_model_id_for_profile("sonnet-4", "europe") == "eu.anthropic.claude-sonnet-4-20250514-v1:0"
+        assert get_model_id_for_profile("sonnet-3-7", "europe") == "eu.anthropic.claude-3-7-sonnet-20250219-v1:0"
 
         # Test AU profiles
         assert get_model_id_for_profile("opus-4-6", "au") == "au.anthropic.claude-opus-4-6-v1"
@@ -148,12 +156,12 @@ class TestModelConfiguration:
             get_model_id_for_profile("invalid-model", "us")
 
         with pytest.raises(ValueError, match="not available in profile"):
-            get_model_id_for_profile("opus-4-1", "eu")  # Opus 4.1 not available in Europe
+            get_model_id_for_profile("opus-4-1", "europe")  # Opus 4.1 not available in Europe
 
     def test_get_default_region_for_profile(self):
         """Test getting default regions for profiles."""
         assert get_default_region_for_profile("us") == "us-east-1"
-        assert get_default_region_for_profile("eu") == "eu-west-1"
+        assert get_default_region_for_profile("europe") == "eu-west-3"
         assert get_default_region_for_profile("apac") == "ap-northeast-1"
 
         # Test invalid profile
@@ -165,33 +173,33 @@ class TestModelConfiguration:
         # Test valid combinations - these should not raise errors
         # (Currently empty lists since regions are TODO, but structure should work)
         source_regions = get_source_regions_for_model_profile("sonnet-4", "us")
-        assert isinstance(source_regions, (list, tuple))
+        assert isinstance(source_regions, list)
 
-        source_regions = get_source_regions_for_model_profile("sonnet-4", "eu")
-        assert isinstance(source_regions, (list, tuple))
+        source_regions = get_source_regions_for_model_profile("sonnet-4", "europe")
+        assert isinstance(source_regions, list)
 
         # Test invalid combinations
         with pytest.raises(ValueError, match="Unknown model"):
             get_source_regions_for_model_profile("invalid-model", "us")
 
         with pytest.raises(ValueError, match="not available in profile"):
-            get_source_regions_for_model_profile("opus-4-1", "eu")
+            get_source_regions_for_model_profile("opus-4-1", "europe")
 
     def test_get_destination_regions_for_model_profile(self):
         """Test getting destination regions for model profiles."""
         # Test valid combinations - these should not raise errors
         dest_regions = get_destination_regions_for_model_profile("sonnet-4", "us")
-        assert isinstance(dest_regions, (list, tuple))
+        assert isinstance(dest_regions, list)
 
-        dest_regions = get_destination_regions_for_model_profile("sonnet-4", "eu")
-        assert isinstance(dest_regions, (list, tuple))
+        dest_regions = get_destination_regions_for_model_profile("sonnet-4", "europe")
+        assert isinstance(dest_regions, list)
 
         # Test invalid combinations
         with pytest.raises(ValueError, match="Unknown model"):
             get_destination_regions_for_model_profile("invalid-model", "us")
 
         with pytest.raises(ValueError, match="not available in profile"):
-            get_destination_regions_for_model_profile("opus-4-1", "eu")
+            get_destination_regions_for_model_profile("opus-4-1", "europe")
 
     def test_get_all_model_display_names(self):
         """Test getting all model display names."""
@@ -209,7 +217,7 @@ class TestModelConfiguration:
         assert display_names["global.anthropic.claude-opus-4-6-v1"] == "Claude Opus 4.6 (GLOBAL)"
         assert display_names["us.anthropic.claude-opus-4-6-v1"] == "Claude Opus 4.6"
         assert display_names["us.anthropic.claude-opus-4-1-20250805-v1:0"] == "Claude Opus 4.1"
-        assert display_names["eu.anthropic.claude-sonnet-4-20250514-v1:0"] == "Claude Sonnet 4 (EU)"
+        assert display_names["eu.anthropic.claude-sonnet-4-20250514-v1:0"] == "Claude Sonnet 4 (EUROPE)"
         assert display_names["apac.anthropic.claude-3-7-sonnet-20250219-v1:0"] == "Claude 3.7 Sonnet (APAC)"
 
     def test_get_profile_description(self):
@@ -218,7 +226,7 @@ class TestModelConfiguration:
         desc = get_profile_description("opus-4-1", "us")
         assert desc == "US regions only"
 
-        desc = get_profile_description("sonnet-4", "eu")
+        desc = get_profile_description("sonnet-4", "europe")
         assert desc == "European regions"
 
         desc = get_profile_description("sonnet-3-7", "apac")
@@ -229,7 +237,7 @@ class TestModelConfiguration:
             get_profile_description("invalid-model", "us")
 
         with pytest.raises(ValueError, match="not available in profile"):
-            get_profile_description("opus-4-1", "eu")
+            get_profile_description("opus-4-1", "europe")
 
     def test_model_availability_consistency(self):
         """Test that model availability is consistent across functions."""
@@ -246,8 +254,8 @@ class TestModelConfiguration:
                 # Verify types
                 assert isinstance(model_id, str)
                 assert isinstance(description, str)
-                assert isinstance(source_regions, (list, tuple))
-                assert isinstance(dest_regions, (list, tuple))
+                assert isinstance(source_regions, list)
+                assert isinstance(dest_regions, list)
 
                 # Verify model_id appears in display names
                 display_names = get_all_model_display_names()
@@ -268,10 +276,15 @@ class TestModelConfiguration:
                     expected = base_model_id.replace("anthropic.", "us.anthropic.")
                     assert model_id == expected
 
-                elif profile_key == "eu":
+                elif profile_key == "europe":
                     # Europe models should start with eu.anthropic
                     assert model_id.startswith("eu.anthropic.")
                     # Should match base model pattern but with eu. prefix
+                    expected = base_model_id.replace("anthropic.", "eu.anthropic.")
+                    assert model_id == expected
+
+                elif profile_key == "eu":
+                    assert model_id.startswith("eu.anthropic.")
                     expected = base_model_id.replace("anthropic.", "eu.anthropic.")
                     assert model_id == expected
 
@@ -281,6 +294,66 @@ class TestModelConfiguration:
                     # Should match base model pattern but with apac. prefix
                     expected = base_model_id.replace("anthropic.", "apac.anthropic.")
                     assert model_id == expected
+
+                elif profile_key == "japan":
+                    assert model_id.startswith("jp.anthropic.")
+
+                elif profile_key == "australia":
+                    assert model_id.startswith("au.anthropic.")
+
+                elif profile_key == "global":
+                    assert model_id.startswith("global.anthropic.")
+                    expected = base_model_id.replace("anthropic.", "global.anthropic.")
+                    assert model_id == expected
+
+                elif profile_key == "us-gov":
+                    assert model_id.startswith("us-gov.anthropic.")
+                    expected = base_model_id.replace("anthropic.", "us-gov.anthropic.")
+                    assert model_id == expected
+
+    def test_get_all_source_regions(self):
+        """Test that get_all_source_regions returns a non-empty sorted list of known regions."""
+        regions = get_all_source_regions()
+
+        assert isinstance(regions, list)
+        assert len(regions) > 0
+        # Verify sorted order
+        assert regions == sorted(regions)
+        # Verify well-known regions are present
+        assert "us-east-1" in regions
+        assert "eu-central-1" in regions
+        assert "ap-northeast-1" in regions
+        # All entries should look like valid AWS region codes
+        for r in regions:
+            assert "-" in r, f"Expected region code with dash: {r}"
+
+    def test_get_profiles_for_region_eu(self):
+        """Test that eu-central-1 returns EU-related profiles including global."""
+        profiles = get_profiles_for_region("eu-central-1")
+
+        assert isinstance(profiles, list)
+        assert len(profiles) > 0
+        # eu-central-1 must appear in eu (or europe) and global profiles
+        assert "eu" in profiles or "europe" in profiles
+        assert "global" in profiles
+        # Should NOT contain us or japan profiles
+        assert "us" not in profiles
+        assert "japan" not in profiles
+        # eu and europe should not both appear (deduplication)
+        assert not ("eu" in profiles and "europe" in profiles)
+
+    def test_get_profiles_for_region_us(self):
+        """Test that us-east-1 returns US-related profiles including global."""
+        profiles = get_profiles_for_region("us-east-1")
+
+        assert isinstance(profiles, list)
+        assert len(profiles) > 0
+        assert "us" in profiles
+        assert "global" in profiles
+        # Should NOT contain eu or japan profiles
+        assert "eu" not in profiles
+        assert "europe" not in profiles
+        assert "japan" not in profiles
 
     def test_us_only_models_limitation(self):
         """Test that US-only models (Opus 4.1, Opus 4) are correctly limited."""
@@ -296,17 +369,63 @@ class TestModelConfiguration:
 
             # Should fail for other regions
             with pytest.raises(ValueError, match="not available in profile"):
-                get_model_id_for_profile(model_key, "eu")
+                get_model_id_for_profile(model_key, "europe")
 
             with pytest.raises(ValueError, match="not available in profile"):
                 get_model_id_for_profile(model_key, "apac")
+
+    def test_get_models_for_tier(self):
+        """Test that get_models_for_tier returns correct models per tier and profile."""
+        # haiku/eu should return haiku-4-5 with the eu model id
+        haiku_eu = get_models_for_tier("haiku", "eu")
+        assert len(haiku_eu) > 0
+        model_keys = [mk for mk, _, _ in haiku_eu]
+        assert "haiku-4-5" in model_keys
+        model_ids = [mid for _, _, mid in haiku_eu]
+        assert "eu.anthropic.claude-haiku-4-5-20251001-v1:0" in model_ids
+
+        # haiku/europe resolves via eu↔europe alias — same result as haiku/eu
+        haiku_europe = get_models_for_tier("haiku", "europe")
+        assert len(haiku_europe) > 0
+        assert [mid for _, _, mid in haiku_europe] == [mid for _, _, mid in haiku_eu]
+
+        # haiku/apac — haiku-4-5 has no apac profile and no alias → empty
+        assert get_models_for_tier("haiku", "apac") == []
+
+        # haiku/us-gov — no haiku model for GovCloud → empty
+        assert get_models_for_tier("haiku", "us-gov") == []
+
+        # sonnet/eu should return at least one model, all with eu. prefix
+        sonnet_eu = get_models_for_tier("sonnet", "eu")
+        assert len(sonnet_eu) > 0
+        for _mk, _name, mid in sonnet_eu:
+            assert mid.startswith("eu.anthropic.")
+
+        # opus/us-gov returns empty (no GovCloud opus model)
+        assert get_models_for_tier("opus", "us-gov") == []
+
+        # unknown tier returns empty
+        assert get_models_for_tier("unknown", "us") == []
+
+    def test_get_all_destination_regions_for_profile_eu(self):
+        """Test that EU profile returns only EU destination regions."""
+        regions = get_all_destination_regions_for_profile("eu")
+        assert isinstance(regions, list)
+        assert len(regions) > 0
+        assert regions == sorted(regions)
+        # All should be eu-* regions
+        for r in regions:
+            assert r.startswith("eu-"), f"Non-EU region in EU profile: {r}"
+        # Should NOT contain US or APAC regions
+        assert "us-east-1" not in regions
+        assert "ap-northeast-1" not in regions
 
     def test_global_models_availability(self):
         """Test that models with global profiles are correctly configured."""
         # Sonnet 4 has global profile
         sonnet_4_profiles = get_available_profiles_for_model("sonnet-4")
         assert "global" in sonnet_4_profiles, "sonnet-4 should have a global profile"
-        assert set(sonnet_4_profiles) == {"us", "eu", "apac", "global"}
+        assert set(sonnet_4_profiles) == {"us", "europe", "apac", "global"}
 
         # Test global profile works
         global_model_id = get_model_id_for_profile("sonnet-4", "global")
@@ -315,7 +434,7 @@ class TestModelConfiguration:
         # Sonnet 4.5 has global profile
         sonnet_4_5_profiles = get_available_profiles_for_model("sonnet-4-5")
         assert "global" in sonnet_4_5_profiles, "sonnet-4-5 should have a global profile"
-        assert set(sonnet_4_5_profiles) == {"us", "eu", "jp", "au", "global"}
+        assert set(sonnet_4_5_profiles) == {"us", "eu", "japan", "australia", "global"}
 
         # Test global profile works for sonnet-4-5
         global_model_id = get_model_id_for_profile("sonnet-4-5", "global")
@@ -323,153 +442,14 @@ class TestModelConfiguration:
 
         # Sonnet 3.7 is regional only (no global profile)
         sonnet_3_7_profiles = get_available_profiles_for_model("sonnet-3-7")
-        assert set(sonnet_3_7_profiles) == {"us", "eu", "apac"}
+        assert set(sonnet_3_7_profiles) == {"us", "europe", "apac"}
 
         # Should work for all regions
-        for profile in ["us", "eu", "apac"]:
+        for profile in ["us", "europe", "apac"]:
             model_id = get_model_id_for_profile("sonnet-3-7", profile)
             if profile == "us":
                 assert model_id.startswith("us.anthropic.")
-            elif profile == "eu":
+            elif profile == "europe":
                 assert model_id.startswith("eu.anthropic.")
             elif profile == "apac":
                 assert model_id.startswith("apac.anthropic.")
-
-
-class TestGetAllBedrockRegions:
-    """Test the get_all_bedrock_regions helper."""
-
-    def test_returns_sorted_list(self):
-        from claude_code_with_bedrock.models import get_all_bedrock_regions
-        regions = get_all_bedrock_regions()
-        assert regions == sorted(regions)
-
-    def test_contains_major_regions(self):
-        from claude_code_with_bedrock.models import get_all_bedrock_regions
-        regions = get_all_bedrock_regions()
-        # Must include key commercial regions
-        assert "us-east-1" in regions
-        assert "us-west-2" in regions
-        assert "eu-west-1" in regions
-        assert "ap-southeast-2" in regions
-        assert "eu-central-1" in regions
-
-    def test_no_duplicates(self):
-        from claude_code_with_bedrock.models import get_all_bedrock_regions
-        regions = get_all_bedrock_regions()
-        assert len(regions) == len(set(regions))
-
-    def test_all_regions_valid_format(self):
-        """All regions should match AWS region format."""
-        import re
-        from claude_code_with_bedrock.models import get_all_bedrock_regions
-        pattern = re.compile(r'^[a-z]{2}(-gov)?-(north|south|east|west|central|northeast|southeast)-\d+$')
-        for region in get_all_bedrock_regions():
-            assert pattern.match(region), f"Invalid region format: {region}"
-
-    def test_consistent_with_model_data(self):
-        """Every destination region in CLAUDE_MODELS should appear (excluding sentinels)."""
-        from claude_code_with_bedrock.models import CLAUDE_MODELS, get_all_bedrock_regions
-        regions = set(get_all_bedrock_regions())
-        for model_config in CLAUDE_MODELS.values():
-            for profile_config in model_config.get("profiles", {}).values():
-                for r in profile_config.get("destination_regions", []):
-                    if not r.startswith("all-"):  # Skip sentinel values
-                        assert r in regions, f"Region {r} missing from get_all_bedrock_regions()"
-
-
-class TestResolveModelForTier:
-    """Test resolve_model_for_tier with real admin profile scenarios."""
-
-    def test_us_admin_gets_latest_models(self):
-        from claude_code_with_bedrock.models import resolve_model_for_tier
-
-        haiku = resolve_model_for_tier("haiku", "us")
-        sonnet = resolve_model_for_tier("sonnet", "us")
-        opus = resolve_model_for_tier("opus", "us")
-
-        assert haiku is not None
-        assert sonnet is not None
-        assert opus is not None
-        assert "us." in haiku
-        assert "us." in sonnet
-        assert "us." in opus
-
-    def test_europe_admin_gets_eu_models(self):
-        """Config stores 'europe' but newer models use 'eu' key."""
-        from claude_code_with_bedrock.models import resolve_model_for_tier
-
-        haiku = resolve_model_for_tier("haiku", "eu")
-        sonnet = resolve_model_for_tier("sonnet", "eu")
-        opus = resolve_model_for_tier("opus", "eu")
-        assert haiku is not None and "eu." in haiku
-        assert sonnet is not None and "eu." in sonnet
-        assert opus is not None and "eu." in opus
-
-    def test_eu_admin_gets_eu_models(self):
-        from claude_code_with_bedrock.models import resolve_model_for_tier
-
-        haiku = resolve_model_for_tier("haiku", "eu")
-        sonnet = resolve_model_for_tier("sonnet", "eu")
-        opus = resolve_model_for_tier("opus", "eu")
-        assert haiku is not None and "eu." in haiku
-        assert sonnet is not None and "eu." in sonnet
-        assert opus is not None and "eu." in opus
-
-    def test_au_admin_gets_au_models_no_global_fallback(self):
-        """AU is data-residency: must NOT fall back to global."""
-        from claude_code_with_bedrock.models import resolve_model_for_tier
-
-        haiku = resolve_model_for_tier("haiku", "au")
-        sonnet = resolve_model_for_tier("sonnet", "au")
-        opus = resolve_model_for_tier("opus", "au")
-        assert haiku is not None and "au." in haiku, f"AU haiku should be au.*, got {haiku}"
-        assert sonnet is not None and "au." in sonnet, f"AU sonnet should be au.*, got {sonnet}"
-        assert opus is not None and "au." in opus, f"AU opus should be au.*, got {opus}"
-
-    def test_jp_admin_gets_jp_models_no_global_fallback(self):
-        """JP is data-residency: must NOT fall back to global."""
-        from claude_code_with_bedrock.models import resolve_model_for_tier
-
-        haiku = resolve_model_for_tier("haiku", "jp")
-        sonnet = resolve_model_for_tier("sonnet", "jp")
-        opus = resolve_model_for_tier("opus", "jp")
-        assert haiku is not None and "jp." in haiku, f"JP haiku should be jp.*, got {haiku}"
-        assert sonnet is not None and "jp." in sonnet, f"JP sonnet should be jp.*, got {sonnet}"
-        # JP has no Opus profile — falls back to best available jp.* model
-        assert opus is not None and "jp." in opus, f"JP opus should fall back to jp.*, got {opus}"
-
-    def test_japan_alias_resolves_to_jp(self):
-        from claude_code_with_bedrock.models import resolve_model_for_tier
-
-        sonnet = resolve_model_for_tier("sonnet", "jp")
-        assert sonnet is not None and "jp." in sonnet
-
-    def test_global_admin_gets_global_prefix(self):
-        from claude_code_with_bedrock.models import resolve_model_for_tier
-
-        sonnet = resolve_model_for_tier("sonnet", "global")
-        opus = resolve_model_for_tier("opus", "global")
-        haiku = resolve_model_for_tier("haiku", "global")
-        assert "global." in sonnet
-        assert "global." in opus
-        assert "global." in haiku
-
-    def test_apac_falls_back_to_global_for_opus(self):
-        """APAC is not strict data-residency, can fall back to global."""
-        from claude_code_with_bedrock.models import resolve_model_for_tier
-
-        opus = resolve_model_for_tier("opus", "apac")
-        assert opus is not None and "global." in opus
-
-    def test_data_residency_prefixes_match_api(self):
-        """Every prefix from the live API should resolve all available tiers."""
-        from claude_code_with_bedrock.models import resolve_model_for_tier
-
-        # These must resolve to their own prefix (not global/us)
-        for prefix in ["us", "eu", "au", "global"]:
-            for tier in ["haiku", "sonnet", "opus"]:
-                result = resolve_model_for_tier(tier, prefix)
-                if result is not None:
-                    assert f"{prefix}." in result, \
-                        f"resolve_model_for_tier('{tier}', '{prefix}') = '{result}' wrong prefix"

--- a/source/tests/test_models.py
+++ b/source/tests/test_models.py
@@ -19,6 +19,7 @@ from claude_code_with_bedrock.models import (
     get_profile_description,
     get_profiles_for_region,
     get_source_regions_for_model_profile,
+    resolve_model_for_tier,
 )
 
 
@@ -447,3 +448,46 @@ class TestModelConfiguration:
         # "europe" alias should also work via resolve_profile_key
         model_id = get_model_id_for_profile("sonnet-3-7", "europe")
         assert model_id.startswith("eu.anthropic.")
+
+
+class TestResolveModelForTier:
+    """Test resolve_model_for_tier with real admin profile scenarios."""
+
+    def test_us_admin_gets_latest_models(self):
+        haiku = resolve_model_for_tier("haiku", "us")
+        sonnet = resolve_model_for_tier("sonnet", "us")
+        opus = resolve_model_for_tier("opus", "us")
+
+        assert haiku is not None
+        assert sonnet is not None
+        assert opus is not None
+        assert "us." in haiku
+        assert "us." in sonnet
+        assert "us." in opus
+
+    def test_europe_admin_gets_eu_models(self):
+        """Config stores 'europe' but newer models use 'eu' key."""
+        haiku = resolve_model_for_tier("haiku", "eu")
+        sonnet = resolve_model_for_tier("sonnet", "eu")
+        opus = resolve_model_for_tier("opus", "eu")
+        assert haiku is not None and "eu." in haiku
+        assert sonnet is not None and "eu." in sonnet
+        assert opus is not None and "eu." in opus
+
+    def test_global_admin_gets_global_prefix(self):
+        sonnet = resolve_model_for_tier("sonnet", "global")
+        opus = resolve_model_for_tier("opus", "global")
+        haiku = resolve_model_for_tier("haiku", "global")
+        assert "global." in sonnet
+        assert "global." in opus
+        assert "global." in haiku
+
+    def test_data_residency_prefixes_match_api(self):
+        """Every prefix from the live API should resolve to its own prefix (not global/us)."""
+        for prefix in ["us", "eu", "au", "global"]:
+            for tier in ["haiku", "sonnet", "opus"]:
+                result = resolve_model_for_tier(tier, prefix)
+                if result is not None:
+                    assert f"{prefix}." in result, (
+                        f"resolve_model_for_tier('{tier}', '{prefix}') = '{result}' wrong prefix"
+                    )

--- a/source/tests/test_models.py
+++ b/source/tests/test_models.py
@@ -27,15 +27,17 @@ class TestModelConfiguration:
 
     def test_default_regions_structure(self):
         """Test that DEFAULT_REGIONS has the expected structure."""
-        expected_profiles = {"us", "europe", "eu", "apac", "japan", "australia", "global", "us-gov"}
+        expected_profiles = {"us", "europe", "eu", "apac", "jp", "japan", "au", "australia", "global", "us-gov"}
         assert set(DEFAULT_REGIONS.keys()) == expected_profiles
 
         # Verify regions are valid AWS regions
         assert DEFAULT_REGIONS["us"] == "us-east-1"
-        assert DEFAULT_REGIONS["europe"] == "eu-west-3"
-        assert DEFAULT_REGIONS["eu"] == "eu-west-3"
+        assert DEFAULT_REGIONS["europe"] == "eu-west-1"
+        assert DEFAULT_REGIONS["eu"] == "eu-west-1"
         assert DEFAULT_REGIONS["apac"] == "ap-northeast-1"
+        assert DEFAULT_REGIONS["jp"] == "ap-northeast-1"
         assert DEFAULT_REGIONS["japan"] == "ap-northeast-1"
+        assert DEFAULT_REGIONS["au"] == "ap-southeast-2"
         assert DEFAULT_REGIONS["australia"] == "ap-southeast-2"
         assert DEFAULT_REGIONS["global"] == "us-east-1"
         assert DEFAULT_REGIONS["us-gov"] == "us-gov-west-1"
@@ -43,15 +45,15 @@ class TestModelConfiguration:
     def test_claude_models_structure(self):
         """Test that CLAUDE_MODELS has the expected structure."""
         expected_models = {
+            "opus-4-7",
             "opus-4-6",
+            "opus-4-5",
             "opus-4-1",
             "opus-4",
-            "opus-4-5",
-            "opus-4-6",
+            "sonnet-4-6",
             "sonnet-4",
             "sonnet-4-5",
             "sonnet-4-5-govcloud",
-            "sonnet-4-6",
             "haiku-4-5",
             "sonnet-3-7",
             "sonnet-3-7-govcloud",
@@ -69,7 +71,7 @@ class TestModelConfiguration:
     def test_model_profiles_structure(self):
         """Test that each model profile has the expected structure."""
         # Valid profile keys that can appear in model configurations
-        valid_profile_keys = set(DEFAULT_REGIONS.keys()) | {"eu", "japan", "global", "au"}
+        valid_profile_keys = set(DEFAULT_REGIONS.keys()) | {"jp", "au", "global"}
 
         for _model_key, model_config in CLAUDE_MODELS.items():
             for profile_key, profile_config in model_config["profiles"].items():
@@ -86,13 +88,13 @@ class TestModelConfiguration:
                 model_id = profile_config["model_id"]
                 if profile_key == "us":
                     assert model_id.startswith("us.anthropic.")
-                elif profile_key in ["europe", "eu"]:
+                elif profile_key == "eu":
                     assert model_id.startswith("eu.anthropic.")
                 elif profile_key == "apac":
                     assert model_id.startswith("apac.anthropic.")
                 elif profile_key == "us-gov":
                     assert model_id.startswith("us-gov.anthropic.")
-                elif profile_key == "japan":
+                elif profile_key == "jp":
                     assert model_id.startswith("jp.anthropic.")
                 elif profile_key == "global":
                     assert model_id.startswith("global.anthropic.")
@@ -112,16 +114,16 @@ class TestModelConfiguration:
         assert opus_4_profiles == ["us"]  # Opus 4 is US-only
 
         sonnet_4_profiles = get_available_profiles_for_model("sonnet-4")
-        assert set(sonnet_4_profiles) == {"us", "europe", "apac", "global"}  # Sonnet 4 has global profile now
+        assert set(sonnet_4_profiles) == {"us", "eu", "apac", "global"}  # Sonnet 4 has global profile now
 
         sonnet_4_5_profiles = get_available_profiles_for_model("sonnet-4-5")
-        assert set(sonnet_4_5_profiles) == {"us", "eu", "japan", "australia", "global"}  # Sonnet 4.5 regional profiles
+        assert set(sonnet_4_5_profiles) == {"us", "eu", "jp", "au", "global"}  # Sonnet 4.5 regional profiles
 
         sonnet_4_5_govcloud_profiles = get_available_profiles_for_model("sonnet-4-5-govcloud")
         assert sonnet_4_5_govcloud_profiles == ["us-gov"]  # Sonnet 4.5 GovCloud
 
         sonnet_3_7_profiles = get_available_profiles_for_model("sonnet-3-7")
-        assert set(sonnet_3_7_profiles) == {"us", "europe", "apac"}  # Sonnet 3.7 regional profiles
+        assert set(sonnet_3_7_profiles) == {"us", "eu", "apac"}  # Sonnet 3.7 regional profiles
 
         sonnet_3_7_govcloud_profiles = get_available_profiles_for_model("sonnet-3-7-govcloud")
         assert sonnet_3_7_govcloud_profiles == ["us-gov"]  # Sonnet 3.7 GovCloud
@@ -161,7 +163,7 @@ class TestModelConfiguration:
     def test_get_default_region_for_profile(self):
         """Test getting default regions for profiles."""
         assert get_default_region_for_profile("us") == "us-east-1"
-        assert get_default_region_for_profile("europe") == "eu-west-3"
+        assert get_default_region_for_profile("europe") == "eu-west-1"
         assert get_default_region_for_profile("apac") == "ap-northeast-1"
 
         # Test invalid profile
@@ -217,7 +219,7 @@ class TestModelConfiguration:
         assert display_names["global.anthropic.claude-opus-4-6-v1"] == "Claude Opus 4.6 (GLOBAL)"
         assert display_names["us.anthropic.claude-opus-4-6-v1"] == "Claude Opus 4.6"
         assert display_names["us.anthropic.claude-opus-4-1-20250805-v1:0"] == "Claude Opus 4.1"
-        assert display_names["eu.anthropic.claude-sonnet-4-20250514-v1:0"] == "Claude Sonnet 4 (EUROPE)"
+        assert display_names["eu.anthropic.claude-sonnet-4-20250514-v1:0"] == "Claude Sonnet 4 (EU)"
         assert display_names["apac.anthropic.claude-3-7-sonnet-20250219-v1:0"] == "Claude 3.7 Sonnet (APAC)"
 
     def test_get_profile_description(self):
@@ -276,29 +278,20 @@ class TestModelConfiguration:
                     expected = base_model_id.replace("anthropic.", "us.anthropic.")
                     assert model_id == expected
 
-                elif profile_key == "europe":
-                    # Europe models should start with eu.anthropic
-                    assert model_id.startswith("eu.anthropic.")
-                    # Should match base model pattern but with eu. prefix
-                    expected = base_model_id.replace("anthropic.", "eu.anthropic.")
-                    assert model_id == expected
-
                 elif profile_key == "eu":
                     assert model_id.startswith("eu.anthropic.")
                     expected = base_model_id.replace("anthropic.", "eu.anthropic.")
                     assert model_id == expected
 
                 elif profile_key == "apac":
-                    # APAC models should start with apac.anthropic
                     assert model_id.startswith("apac.anthropic.")
-                    # Should match base model pattern but with apac. prefix
                     expected = base_model_id.replace("anthropic.", "apac.anthropic.")
                     assert model_id == expected
 
-                elif profile_key == "japan":
+                elif profile_key == "jp":
                     assert model_id.startswith("jp.anthropic.")
 
-                elif profile_key == "australia":
+                elif profile_key == "au":
                     assert model_id.startswith("au.anthropic.")
 
                 elif profile_key == "global":
@@ -336,11 +329,9 @@ class TestModelConfiguration:
         # eu-central-1 must appear in eu (or europe) and global profiles
         assert "eu" in profiles or "europe" in profiles
         assert "global" in profiles
-        # Should NOT contain us or japan profiles
+        # Should NOT contain us or jp profiles
         assert "us" not in profiles
-        assert "japan" not in profiles
-        # eu and europe should not both appear (deduplication)
-        assert not ("eu" in profiles and "europe" in profiles)
+        assert "jp" not in profiles
 
     def test_get_profiles_for_region_us(self):
         """Test that us-east-1 returns US-related profiles including global."""
@@ -352,8 +343,7 @@ class TestModelConfiguration:
         assert "global" in profiles
         # Should NOT contain eu or japan profiles
         assert "eu" not in profiles
-        assert "europe" not in profiles
-        assert "japan" not in profiles
+        assert "jp" not in profiles
 
     def test_us_only_models_limitation(self):
         """Test that US-only models (Opus 4.1, Opus 4) are correctly limited."""
@@ -425,7 +415,7 @@ class TestModelConfiguration:
         # Sonnet 4 has global profile
         sonnet_4_profiles = get_available_profiles_for_model("sonnet-4")
         assert "global" in sonnet_4_profiles, "sonnet-4 should have a global profile"
-        assert set(sonnet_4_profiles) == {"us", "europe", "apac", "global"}
+        assert set(sonnet_4_profiles) == {"us", "eu", "apac", "global"}
 
         # Test global profile works
         global_model_id = get_model_id_for_profile("sonnet-4", "global")
@@ -434,7 +424,7 @@ class TestModelConfiguration:
         # Sonnet 4.5 has global profile
         sonnet_4_5_profiles = get_available_profiles_for_model("sonnet-4-5")
         assert "global" in sonnet_4_5_profiles, "sonnet-4-5 should have a global profile"
-        assert set(sonnet_4_5_profiles) == {"us", "eu", "japan", "australia", "global"}
+        assert set(sonnet_4_5_profiles) == {"us", "eu", "jp", "au", "global"}
 
         # Test global profile works for sonnet-4-5
         global_model_id = get_model_id_for_profile("sonnet-4-5", "global")
@@ -442,14 +432,18 @@ class TestModelConfiguration:
 
         # Sonnet 3.7 is regional only (no global profile)
         sonnet_3_7_profiles = get_available_profiles_for_model("sonnet-3-7")
-        assert set(sonnet_3_7_profiles) == {"us", "europe", "apac"}
+        assert set(sonnet_3_7_profiles) == {"us", "eu", "apac"}
 
-        # Should work for all regions
-        for profile in ["us", "europe", "apac"]:
+        # Should work for all regions including aliases
+        for profile in ["us", "eu", "apac"]:
             model_id = get_model_id_for_profile("sonnet-3-7", profile)
             if profile == "us":
                 assert model_id.startswith("us.anthropic.")
-            elif profile == "europe":
+            elif profile == "eu":
                 assert model_id.startswith("eu.anthropic.")
             elif profile == "apac":
                 assert model_id.startswith("apac.anthropic.")
+
+        # "europe" alias should also work via resolve_profile_key
+        model_id = get_model_id_for_profile("sonnet-3-7", "europe")
+        assert model_id.startswith("eu.anthropic.")

--- a/source/tests/test_source_regions.py
+++ b/source/tests/test_source_regions.py
@@ -164,9 +164,15 @@ class TestSourceRegionFunctionality:
 
     def test_source_regions_do_not_overlap_inappropriately(self):
         """Test that source regions are regionally appropriate."""
+        eu_regions = [
+            "eu-central-1", "eu-central-2", "eu-north-1",
+            "eu-south-1", "eu-south-2", "eu-south-3",
+            "eu-west-1", "eu-west-2", "eu-west-3",
+        ]
         regional_tests = {
-            "us": ["us-east-1", "us-east-2", "us-west-1", "us-west-2"],
-            "europe": ["eu-central-1", "eu-north-1", "eu-south-1", "eu-south-2", "eu-west-1", "eu-west-3"],
+            "us": ["us-east-1", "us-east-2", "us-west-1", "us-west-2", "ca-central-1", "ca-west-1"],
+            "europe": eu_regions,
+            "eu": eu_regions,
             "apac": [
                 "ap-northeast-1",
                 "ap-northeast-2",
@@ -176,6 +182,8 @@ class TestSourceRegionFunctionality:
                 "ap-southeast-1",
                 "ap-southeast-2",
             ],
+            "japan": ["ap-northeast-1", "ap-northeast-3"],
+            "australia": ["ap-southeast-2", "ap-southeast-4"],
         }
 
         for model_key, model_config in CLAUDE_MODELS.items():

--- a/source/tests/test_source_regions.py
+++ b/source/tests/test_source_regions.py
@@ -24,7 +24,7 @@ class TestSourceRegionFunctionality:
                 source_regions = profile_config["source_regions"]
 
                 # Should have at least one source region available
-                assert isinstance(source_regions, list)
+                assert isinstance(source_regions, list | tuple)
                 assert len(source_regions) > 0, f"No source regions for {model_key}/{profile_key}"
 
                 # All source regions should be valid AWS region format
@@ -76,7 +76,7 @@ class TestSourceRegionFunctionality:
 
         # Should fallback to cross-region profile default
         result = get_source_region_for_profile(profile)
-        assert result == "eu-west-3"  # Default Europe region
+        assert result == "eu-west-1"  # Default Europe region
 
     def test_get_source_region_for_profile_fallback_to_aws_region(self):
         """Test source region fallback to infrastructure region for US profiles."""
@@ -149,7 +149,7 @@ class TestSourceRegionFunctionality:
 
         # Should handle missing attribute gracefully and use fallback
         result = get_source_region_for_profile(profile)
-        assert result == "eu-west-3"
+        assert result == "eu-west-1"
 
     def test_all_models_have_source_regions(self):
         """Test that all models in CLAUDE_MODELS have source regions defined."""
@@ -182,8 +182,8 @@ class TestSourceRegionFunctionality:
                 "ap-southeast-1",
                 "ap-southeast-2",
             ],
-            "japan": ["ap-northeast-1", "ap-northeast-3"],
-            "australia": ["ap-southeast-2", "ap-southeast-4"],
+            "jp": ["ap-northeast-1", "ap-northeast-3"],
+            "au": ["ap-southeast-2", "ap-southeast-4"],
         }
 
         for model_key, model_config in CLAUDE_MODELS.items():


### PR DESCRIPTION
## Summary

Fixes bugs in quota enforcement, destroy workflow, inference profiles, and Windows installer. Adds CloudFormation utilities and external DNS support.

### Bug fixes

- **Quota Lambda ignores `DAILY_ENFORCEMENT_MODE`** — env var was passed by CFN but never read (PR #256 regression). Monthly and daily enforcement now checked independently.
- **`pre_cleanup_stack` empties retained S3 buckets** — now reads CFN template to skip resources with `DeletionPolicy: Retain`.
- **Inference profile override in wrong `elif` branch** — ARN never applied; also crashes when `selected_model` is None.
- **Windows installer missing `for` loop** — AWS profile configuration block never executed.
- **Accidental `enable_finegrained_quotas` default flip** — reverted to `False`.
- **ALB JWT `aud` claim format** — was array, should be single string.
- **`cowork-dashboard` missing from destroy command**.

### Improvements

- Destroy command now separates retained resources (informational) from failed resources (action needed), with appropriate cleanup commands for each.
- CloudFormation manager: stack deletion with event tracking, S3/Athena pre-cleanup, batch deletes (1000 object API limit).
- External DNS support for monitoring HTTPS — conditional `DomainValidationOptions` only when Route53 HostedZoneId provided.
- Shared `get_codebuild_region` utility extracted from 4 commands.
- Model registry aligned with upstream naming; per-tier defaults added.
- Init wizard: region-first flow, provider-aware labels, cleaner code.
- Type fixes: `Callable | None` annotations.

### New tests

- `test_init_bedrock.py` — Bedrock region/model selection
- `test_package_models.py` — model registry in packaging
- `test_models.py` — rewritten with `TestResolveModelForTier`

## Test plan

- [x] 236 tests pass (3 pre-existing failures unrelated to this PR)
- [x] Deployed and verified on test account (ap-southeast-1)
- [x] Quota enforcement end-to-end (monthly block, daily alert, unblock)
- [x] Destroy verified: retained buckets preserved, cleanup instructions correct
- [x] Rebased on origin/main (2026-05-12)

Fixes #346, #347, #360