### PR TITLE
fix: anchor installers to their own directory so they work from any CWD

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -1854,6 +1854,9 @@ RUN pyinstaller \
 
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "${{BASH_SOURCE[0]}}")" && pwd)"
+cd "$SCRIPT_DIR"
+
 echo "======================================"
 echo "Claude Code Authentication Installer"
 echo "======================================"
@@ -2094,6 +2097,8 @@ echo
 
         installer_content = f"""@echo off
 SETLOCAL ENABLEDELAYEDEXPANSION
+SET "SCRIPT_DIR=%~dp0"
+CD /D "%SCRIPT_DIR%"
 REM Claude Code Authentication Installer for Windows
 REM Organization: {profile.provider_domain}
 REM Generated: {datetime.now().strftime("%Y-%m-%d %H:%M:%S")}


### PR DESCRIPTION
## Summary

- `install.sh`: adds `SCRIPT_DIR` resolution right after `set -e` and `cd`s into it
- `install.bat`: adds `SET "SCRIPT_DIR=%~dp0"` and `CD /D "%SCRIPT_DIR%"` after `SETLOCAL`

## Test plan

- [ ] Run `install.sh` from a different directory (e.g. `bash /path/to/package/install.sh`) and verify it finds its bundled files
- [ ] Run `install.bat` from a different directory and verify the same