### PR TITLE
fix: correct cowork-3p .reg format and register files in Windows installer

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -127,6 +127,16 @@
     }
   ],
   "results": {
+    "source/claude_code_with_bedrock/cli/utils/cowork_3p.py": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "source/claude_code_with_bedrock/cli/utils/cowork_3p.py",
+        "hashed_secret": "a0422442dba3fda71eda7b743f0e726ad8af17a5",
+        "is_verified": false,
+        "line_number": 234,
+        "is_secret": false
+      }
+    ],
     ".github/workflows/scanners.yml": [
       {
         "type": "Secret Keyword",

--- a/source/claude_code_with_bedrock/cli/commands/distribute.py
+++ b/source/claude_code_with_bedrock/cli/commands/distribute.py
@@ -497,6 +497,8 @@ class DistributeCommand(Command):
                 ("install.bat", "install.bat"),
                 ("config.json", "config.json"),
                 ("README.md", "README.md"),
+                ("cowork-3p.reg", "cowork-3p.reg"),
+                ("cowork-3p-config.json", "cowork-3p-config.json"),
             ],
             "linux": [
                 ("credential-process-linux-x64", "credential-process-linux-x64"),
@@ -506,6 +508,7 @@ class DistributeCommand(Command):
                 ("install.sh", "install.sh"),
                 ("config.json", "config.json"),
                 ("README.md", "README.md"),
+                ("cowork-3p-config.json", "cowork-3p-config.json"),
             ],
             "mac": [
                 ("credential-process-macos-arm64", "credential-process-macos-arm64"),
@@ -515,6 +518,8 @@ class DistributeCommand(Command):
                 ("install.sh", "install.sh"),
                 ("config.json", "config.json"),
                 ("README.md", "README.md"),
+                ("cowork-3p.mobileconfig", "cowork-3p.mobileconfig"),
+                ("cowork-3p-config.json", "cowork-3p-config.json"),
             ],
         }
 

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -2098,6 +2098,23 @@ REM Copy configuration
 echo Copying configuration...
 copy /Y "config.json" "%USERPROFILE%\\claude-code-with-bedrock\\" >nul
 
+REM Copy CoWork credential helper if present
+if exist "credential-helper-{profile.name}.exe" (
+    echo Copying CoWork credential helper...
+    copy /Y "credential-helper-{profile.name}.exe" "%USERPROFILE%\\claude-code-with-bedrock\\credential-helper-{profile.name}.exe" >nul
+)
+
+REM Apply CoWork registry settings if present
+if exist "cowork-3p.reg" (
+    echo Applying CoWork registry settings...
+    regedit /s "cowork-3p.reg"
+    if %errorlevel% neq 0 (
+        echo WARNING: Failed to apply CoWork registry settings
+    ) else (
+        echo OK CoWork registry settings applied
+    )
+)
+
 REM Copy Claude Code settings if they exist
 if exist "claude-settings" (
     echo Copying Claude Code telemetry settings...

--- a/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
+++ b/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
@@ -226,26 +226,30 @@ def generate_mobileconfig(output_dir: Path, mdm_config: dict) -> Path:
 def generate_reg_file(output_dir: Path, mdm_config: dict) -> Path:
     """Generate a Windows .reg file for Claude Cowork 3P.
 
+    All values are stored as REG_SZ strings — booleans, integers, and arrays
+    included — matching what Claude Desktop reads from the registry.
+
     Returns the path to the generated file.
     """
-    reg_key = r"HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Anthropic\Claude Desktop"
+    reg_key = r"HKEY_CURRENT_USER\SOFTWARE\Policies\Claude"
 
     lines = ["Windows Registry Editor Version 5.00", "", f"[{reg_key}]"]
 
     for key, value in _mdm_keys(mdm_config).items():
         if isinstance(value, bool):
-            dword_val = 1 if value else 0
-            lines.append(f'"{key}"=dword:{dword_val:08x}')
-        elif isinstance(value, int):
-            lines.append(f'"{key}"=dword:{value:08x}')
-        elif isinstance(value, list):
-            # Store arrays as JSON-encoded string with escaped inner quotes
-            json_str = json.dumps(value).replace('"', '\\"')
-            lines.append(f'"{key}"="{json_str}"')
+            string_value = "true" if value else "false"
+        elif isinstance(value, (list, dict)):
+            string_value = json.dumps(value)
         else:
-            # Escape backslashes for .reg format
-            escaped = str(value).replace("\\", "\\\\").replace('"', '\\"')
-            lines.append(f'"{key}"="{escaped}"')
+            string_value = str(value)
+        # Windows credential helper path: use %USERPROFILE%, backslashes, .exe suffix
+        if key == "inferenceCredentialHelper":
+            string_value = string_value.replace(str(Path.home()), "%USERPROFILE%").replace("/", "\\")
+            if not string_value.endswith(".exe"):
+                string_value += ".exe"
+        # Escape backslashes and quotes for .reg REG_SZ format
+        escaped = string_value.replace("\\", "\\\\").replace('"', '\\"')
+        lines.append(f'"{key}"="{escaped}"')
 
     lines.append("")  # Trailing newline
 


### PR DESCRIPTION
## Summary

- **Wrong registry key**: `.reg` was writing to `HKLM\SOFTWARE\Policies\Anthropic\Claude Desktop` — fixed to `HKCU\SOFTWARE\Policies\Claude`
- **Wrong value types**: booleans and integers were encoded as `dword:` — Claude Desktop expects all values as `REG_SZ` strings (`"true"`, `"3600"`, etc.)
- **Credential helper path**: `inferenceCredentialHelper` now uses `%USERPROFILE%` with backslashes and `.exe` suffix
- **Installer gaps**: `install.bat` now copies `credential-helper-<profile>.exe` to `%USERPROFILE%\claude-code-with-bedrock\` and applies `cowork-3p.reg` via `regedit /s`
- **Distribution ZIPs**: `cowork-3p.reg` + `cowork-3p-config.json` added to Windows ZIP; `cowork-3p.mobileconfig` + `cowork-3p-config.json` added to macOS ZIP (partial fix for #327)

## Test plan

- [x] Tested end-to-end on Windows Server 2025 via SSM — installer ran cleanly, registry key confirmed at `HKCU\SOFTWARE\Policies\Claude` with all correct string values