### PR TITLE
fix: simplify CoWork credential helper — standard AWS creds passthrough

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -127,6 +127,16 @@
     }
   ],
   "results": {
+    "source/claude_code_with_bedrock/cli/utils/cowork_3p.py": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "source/claude_code_with_bedrock/cli/utils/cowork_3p.py",
+        "hashed_secret": "a0422442dba3fda71eda7b743f0e726ad8af17a5",
+        "is_verified": false,
+        "line_number": 234,
+        "is_secret": false
+      }
+    ],
     ".github/workflows/scanners.yml": [
       {
         "type": "Secret Keyword",

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -127,16 +127,6 @@
     }
   ],
   "results": {
-    "source/claude_code_with_bedrock/cli/utils/cowork_3p.py": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "source/claude_code_with_bedrock/cli/utils/cowork_3p.py",
-        "hashed_secret": "a0422442dba3fda71eda7b743f0e726ad8af17a5",
-        "is_verified": false,
-        "line_number": 234,
-        "is_secret": false
-      }
-    ],
     ".github/workflows/scanners.yml": [
       {
         "type": "Secret Keyword",
@@ -164,26 +154,6 @@
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
         "line_number": 275,
-        "is_secret": false
-      }
-    ],
-    "assets/docs/CLI_REFERENCE.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": "assets/docs/CLI_REFERENCE.md",
-        "hashed_secret": "02c173fc064db3d5d36ffbea6e3d09a6ca93ae45",
-        "is_verified": false,
-        "line_number": 348,
-        "is_secret": false
-      }
-    ],
-    "assets/docs/providers/microsoft-entra-id-setup.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": "assets/docs/providers/microsoft-entra-id-setup.md",
-        "hashed_secret": "69986d29996e03f228348cf242b52ad6cec02085",
-        "is_verified": false,
-        "line_number": 154,
         "is_secret": false
       }
     ],
@@ -277,13 +247,23 @@
         "is_secret": false
       }
     ],
+    "source/claude_code_with_bedrock/cli/utils/cowork_3p.py": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "source/claude_code_with_bedrock/cli/utils/cowork_3p.py",
+        "hashed_secret": "a0422442dba3fda71eda7b743f0e726ad8af17a5",
+        "is_verified": false,
+        "line_number": 176,
+        "is_secret": false
+      }
+    ],
     "source/credential_provider/__main__.py": [
       {
         "type": "Secret Keyword",
         "filename": "source/credential_provider/__main__.py",
         "hashed_secret": "72c0bb5a2c016bd8fd0870d3850d52a2c48c2800",
         "is_verified": false,
-        "line_number": 472,
+        "line_number": 498,
         "is_secret": false
       }
     ],
@@ -313,32 +293,6 @@
         "is_secret": false
       }
     ],
-    "source/tests/test_silent_refresh.py": [
-      {
-        "type": "AWS Access Key",
-        "filename": "source/tests/test_silent_refresh.py",
-        "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
-        "is_verified": false,
-        "line_number": 55,
-        "is_secret": false
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "source/tests/test_silent_refresh.py",
-        "hashed_secret": "d70eab08607a4d05faa2d0d6647206599e9abc65",
-        "is_verified": false,
-        "line_number": 56,
-        "is_secret": false
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "source/tests/test_silent_refresh.py",
-        "hashed_secret": "d70eab08607a4d05faa2d0d6647206599e9abc65",
-        "is_verified": false,
-        "line_number": 56,
-        "is_secret": false
-      }
-    ],
     "source/tests/test_url_validation_security.py": [
       {
         "type": "Secret Keyword",
@@ -358,5 +312,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-02T16:40:17Z"
+  "generated_at": "2026-05-04T01:44:40Z"
 }

--- a/source/claude_code_with_bedrock/cli/commands/cowork.py
+++ b/source/claude_code_with_bedrock/cli/commands/cowork.py
@@ -14,7 +14,6 @@ from claude_code_with_bedrock.cli.utils.cowork_3p import (
     add_monitoring_config,
     build_mdm_config,
     derive_model_aliases,
-    generate_credential_helper_wrapper,
     generate_json,
     generate_mobileconfig,
     generate_reg_file,
@@ -129,9 +128,8 @@ class CoworkGenerateCommand(Command):
             credential_helper_ttl=credential_helper_ttl,
         )
 
-        # Generate the credential helper script CoWork will call
-        wrapper_path = generate_credential_helper_wrapper(profile_name, bedrock_region)
-        console.print(f"[dim]Credential helper: {wrapper_path}[/dim]")
+        # Show where the credential helper wrapper will be written by install.sh/install.bat
+        console.print(f"[dim]Credential helper path (written by installer): ~/claude-code-with-bedrock/credential-helper-{profile_name}[/dim]")
 
         # Add monitoring OTLP endpoint if available
         add_monitoring_config(mdm_config, profile, console)

--- a/source/claude_code_with_bedrock/cli/commands/distribute.py
+++ b/source/claude_code_with_bedrock/cli/commands/distribute.py
@@ -497,6 +497,8 @@ class DistributeCommand(Command):
                 ("install.bat", "install.bat"),
                 ("config.json", "config.json"),
                 ("README.md", "README.md"),
+                ("cowork-3p.reg", "cowork-3p.reg"),
+                ("cowork-3p-config.json", "cowork-3p-config.json"),
             ],
             "linux": [
                 ("credential-process-linux-x64", "credential-process-linux-x64"),
@@ -506,6 +508,7 @@ class DistributeCommand(Command):
                 ("install.sh", "install.sh"),
                 ("config.json", "config.json"),
                 ("README.md", "README.md"),
+                ("cowork-3p-config.json", "cowork-3p-config.json"),
             ],
             "mac": [
                 ("credential-process-macos-arm64", "credential-process-macos-arm64"),
@@ -515,6 +518,8 @@ class DistributeCommand(Command):
                 ("install.sh", "install.sh"),
                 ("config.json", "config.json"),
                 ("README.md", "README.md"),
+                ("cowork-3p.mobileconfig", "cowork-3p.mobileconfig"),
+                ("cowork-3p-config.json", "cowork-3p-config.json"),
             ],
         }
 

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -1896,6 +1896,16 @@ cp "$CREDENTIAL_BINARY" ~/claude-code-with-bedrock/credential-process
 cp config.json ~/claude-code-with-bedrock/
 chmod +x ~/claude-code-with-bedrock/credential-process
 
+# Write per-profile CoWork credential helper wrappers
+PROFILES=$(python3 -c "import json; print(' '.join(json.load(open('config.json')).keys()))" 2>/dev/null || echo "")
+for PROFILE_NAME in $PROFILES; do
+    WRAPPER="$HOME/claude-code-with-bedrock/credential-helper-$PROFILE_NAME"
+    printf '#!/bin/bash\nexec "$HOME/claude-code-with-bedrock/credential-process" --profile "%s"\n' "$PROFILE_NAME" > "$WRAPPER"
+    chmod +x "$WRAPPER"
+    xattr -d com.apple.quarantine "$WRAPPER" 2>/dev/null || true
+    echo "  ✓ Created CoWork credential helper for profile '$PROFILE_NAME'"
+done
+
 # macOS Gatekeeper + Keychain notices
 if [[ "$OSTYPE" == "darwin"* ]]; then
     # Remove quarantine flag added by macOS when downloading unsigned binaries.
@@ -2098,10 +2108,11 @@ REM Copy configuration
 echo Copying configuration...
 copy /Y "config.json" "%USERPROFILE%\\claude-code-with-bedrock\\" >nul
 
-REM Copy CoWork credential helper if present
-if exist "credential-helper-{profile.name}.exe" (
-    echo Copying CoWork credential helper...
-    copy /Y "credential-helper-{profile.name}.exe" "%USERPROFILE%\\claude-code-with-bedrock\\credential-helper-{profile.name}.exe" >nul
+REM Write per-profile CoWork credential helper wrappers
+for /f %%p in ('powershell -NoProfile -Command "$c=Get-Content config.json|ConvertFrom-Json;$c.PSObject.Properties.Name"') do (
+    set "WRAPPER=%USERPROFILE%\\claude-code-with-bedrock\\credential-helper-%%p.bat"
+    (echo @echo off & echo "%USERPROFILE%\\claude-code-with-bedrock\\credential-process.exe" --profile %%p) > "!WRAPPER!"
+    echo   OK Created CoWork credential helper for profile '%%p'
 )
 
 REM Apply CoWork registry settings if present
@@ -2510,7 +2521,6 @@ Available metrics include:
             build_mdm_config,
             derive_model_aliases,
             generate_all,
-            generate_credential_helper_wrapper,
         )
 
         console = Console()
@@ -2525,7 +2535,6 @@ Available metrics include:
                 profile_name=profile_name,
             )
 
-            generate_credential_helper_wrapper(profile_name, bedrock_region)
             add_monitoring_config(mdm_config, profile, console)
             generate_all(output_dir, mdm_config, console)
 

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -2098,6 +2098,23 @@ REM Copy configuration
 echo Copying configuration...
 copy /Y "config.json" "%USERPROFILE%\\claude-code-with-bedrock\\" >nul
 
+REM Copy CoWork credential helper if present
+if exist "credential-helper-{profile.name}.exe" (
+    echo Copying CoWork credential helper...
+    copy /Y "credential-helper-{profile.name}.exe" "%USERPROFILE%\\claude-code-with-bedrock\\credential-helper-{profile.name}.exe" >nul
+)
+
+REM Apply CoWork registry settings if present
+if exist "cowork-3p.reg" (
+    echo Applying CoWork registry settings...
+    regedit /s "cowork-3p.reg"
+    if %errorlevel% neq 0 (
+        echo WARNING: Failed to apply CoWork registry settings
+    ) else (
+        echo OK CoWork registry settings applied
+    )
+)
+
 REM Copy Claude Code settings if they exist
 if exist "claude-settings" (
     echo Copying Claude Code telemetry settings...

--- a/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
+++ b/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
@@ -226,26 +226,30 @@ def generate_mobileconfig(output_dir: Path, mdm_config: dict) -> Path:
 def generate_reg_file(output_dir: Path, mdm_config: dict) -> Path:
     """Generate a Windows .reg file for Claude Cowork 3P.
 
+    All values are stored as REG_SZ strings — booleans, integers, and arrays
+    included — matching what Claude Desktop reads from the registry.
+
     Returns the path to the generated file.
     """
-    reg_key = r"HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Anthropic\Claude Desktop"
+    reg_key = r"HKEY_CURRENT_USER\SOFTWARE\Policies\Claude"
 
     lines = ["Windows Registry Editor Version 5.00", "", f"[{reg_key}]"]
 
     for key, value in _mdm_keys(mdm_config).items():
         if isinstance(value, bool):
-            dword_val = 1 if value else 0
-            lines.append(f'"{key}"=dword:{dword_val:08x}')
-        elif isinstance(value, int):
-            lines.append(f'"{key}"=dword:{value:08x}')
-        elif isinstance(value, list):
-            # Store arrays as JSON-encoded string with escaped inner quotes
-            json_str = json.dumps(value).replace('"', '\\"')
-            lines.append(f'"{key}"="{json_str}"')
+            string_value = "true" if value else "false"
+        elif isinstance(value, (list, dict)):
+            string_value = json.dumps(value)
         else:
-            # Escape backslashes for .reg format
-            escaped = str(value).replace("\\", "\\\\").replace('"', '\\"')
-            lines.append(f'"{key}"="{escaped}"')
+            string_value = str(value)
+        # Windows credential helper path: use %USERPROFILE%, backslashes, .exe suffix
+        if key == "inferenceCredentialHelper":
+            string_value = string_value.replace(str(Path.home()), "%USERPROFILE%").replace("/", "\\")
+            if not string_value.endswith(".exe"):
+                string_value += ".exe"
+        # Escape backslashes and quotes for .reg REG_SZ format
+        escaped = string_value.replace("\\", "\\\\").replace('"', '\\"')
+        lines.append(f'"{key}"="{escaped}"')
 
     lines.append("")  # Trailing newline
 

--- a/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
+++ b/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
@@ -47,9 +47,7 @@ def build_mdm_config(
     Returns:
         Dictionary of MDM configuration key-value pairs.
     """
-    credential_helper_path = str(
-        Path(f"~/claude-code-with-bedrock/credential-helper-{profile_name}").expanduser()
-    )
+    credential_helper_path = f"~/claude-code-with-bedrock/credential-helper-{profile_name}"
 
     return {
         "inferenceProvider": "bedrock",
@@ -64,62 +62,6 @@ def build_mdm_config(
         "isLocalDevMcpEnabled": True,
     }
 
-
-def generate_credential_helper_wrapper(profile_name: str, bedrock_region: str) -> Path:
-    """Generate a bearer-token credential helper script for CoWork.
-
-    CoWork requires inferenceCredentialHelper to be an absolute path to an executable
-    that takes no arguments and outputs {"token": "bedrock-api-key-..."} JSON.
-    This script calls credential-process, signs a Bedrock bearer token, and outputs
-    the correct JSON format.
-
-    Returns the absolute path to the generated script.
-    """
-    base_dir = Path("~/claude-code-with-bedrock").expanduser()
-    credential_process = base_dir / "credential-process"
-    wrapper_path = base_dir / f"credential-helper-{profile_name}"
-
-    script = f'''#!/usr/bin/env python3
-"""Auto-generated CoWork credential helper — outputs {{"token": "bedrock-api-key-..."}}."""
-
-import base64
-import json
-import subprocess
-import sys
-
-from botocore.auth import SigV4QueryAuth
-from botocore.awsrequest import AWSRequest
-from botocore.credentials import Credentials
-
-try:
-    raw = subprocess.check_output(
-        ["{credential_process}", "--profile", "{profile_name}"],
-        stderr=subprocess.DEVNULL,
-    )
-    creds = json.loads(raw)
-except Exception as e:
-    print(json.dumps({{"error": str(e)}}), file=sys.stderr)
-    sys.exit(1)
-
-try:
-    credentials = Credentials(creds["AccessKeyId"], creds["SecretAccessKey"], creds["SessionToken"])
-    request = AWSRequest(
-        method="POST",
-        url="https://bedrock.amazonaws.com/",
-        headers={{"host": "bedrock.amazonaws.com"}},
-        params={{"Action": "CallWithBearerToken"}},
-    )
-    SigV4QueryAuth(credentials, "bedrock", "{bedrock_region}", expires=43200).add_auth(request)
-    presigned = request.url.replace("https://", "") + "&Version=1"
-    token = "bedrock-api-key-" + base64.b64encode(presigned.encode()).decode()
-    print(json.dumps({{"token": token}}))
-except Exception as e:
-    print(json.dumps({{"error": str(e)}}), file=sys.stderr)
-    sys.exit(1)
-'''
-    wrapper_path.write_text(script)
-    wrapper_path.chmod(0o755)
-    return wrapper_path
 
 
 def add_monitoring_config(mdm_config: dict, profile, console: Console) -> None:
@@ -242,11 +184,11 @@ def generate_reg_file(output_dir: Path, mdm_config: dict) -> Path:
             string_value = json.dumps(value)
         else:
             string_value = str(value)
-        # Windows credential helper path: use %USERPROFILE%, backslashes, .exe suffix
+        # Windows credential helper path: use %USERPROFILE%, backslashes, .bat suffix
         if key == "inferenceCredentialHelper":
-            string_value = string_value.replace(str(Path.home()), "%USERPROFILE%").replace("/", "\\")
-            if not string_value.endswith(".exe"):
-                string_value += ".exe"
+            string_value = string_value.replace("~", "%USERPROFILE%").replace("/", "\\")
+            if not string_value.endswith(".bat"):
+                string_value += ".bat"
         # Escape backslashes and quotes for .reg REG_SZ format
         escaped = string_value.replace("\\", "\\\\").replace('"', '\\"')
         lines.append(f'"{key}"="{escaped}"')


### PR DESCRIPTION
## Summary

- Removes the over-engineered botocore-based SigV4 bearer token generation in `generate_credential_helper_wrapper()` — Claude Desktop handles Bedrock SigV4 signing internally when `inferenceProvider = bedrock`
- `inferenceCredentialHelper` only needs to output standard AWS credentials (`AccessKeyId`, `SecretAccessKey`, `SessionToken`), which is already what `credential-process` outputs
- `install.sh` and `install.bat` now write a thin per-profile no-arg wrapper at install time that simply delegates to `credential-process --profile <name>` — no botocore, no external dependencies on end-user machines
- Fixes `build_mdm_config()` baking the admin's home dir into generated configs — now emits portable `~/...` path
- Fixes Windows `.reg` to use `%USERPROFILE%` + `.bat` suffix instead of `.exe`

## Test plan

- [ ] Run `ccwb package` with a CoWork-enabled profile and verify `install.sh` contains the credential helper wrapper loop
- [ ] Run `install.sh` and verify `~/claude-code-with-bedrock/credential-helper-<profile>` is created and executable
- [ ] Verify the generated wrapper outputs valid AWS credentials when called with no arguments
- [ ] Run `ccwb package` and verify `cowork-3p.reg` uses `%USERPROFILE%\...\credential-helper-<profile>.bat`
- [ ] Run `ccwb cowork generate` and verify it no longer attempts to write to admin's home dir

Fixes #327