### PR TITLE
fix(cowork): remove opusplan from default inferenceModels

### DIFF
--- a/assets/docs/COWORK_3P.md
+++ b/assets/docs/COWORK_3P.md
@@ -88,7 +88,7 @@ In the **Bedrock Credentials** section, configure:
 - **AWS profile**: The named profile the installer writes to `~/.aws/config` — `ClaudeCode` by default
 
 In the **Identity & Models** section:
-- **Model list**: Add the model aliases your organization has enabled (e.g., `opus`, `sonnet`, `opusplan`)
+- **Model list**: Add the model aliases your organization has enabled (e.g., `opus`, `sonnet`, `haiku`)
 
 Once configured, use **Export** to generate a `.mobileconfig` (macOS) or `.reg` (Windows) file for MDM distribution, or **Apply locally** for immediate testing.
 
@@ -107,7 +107,7 @@ For automated deployment at scale, create an MDM profile with the following esse
   "inferenceProvider": "bedrock",
   "inferenceBedrockRegion": "us-west-2",
   "inferenceBedrockProfile": "ClaudeCode",
-  "inferenceModels": ["opus", "sonnet", "haiku", "opusplan"]
+  "inferenceModels": ["opus", "sonnet", "haiku"]
 }
 ```
 
@@ -123,9 +123,9 @@ For automated deployment at scale, create an MDM profile with the following esse
 | `inferenceBedrockProfile` | Name of the AWS named profile in `~/.aws/config` that Claude Desktop should use for Bedrock calls. The installer configures this profile with `credential_process` pointing at the bundled `credential-process` binary |
 | `inferenceBedrockRegion` | AWS region for Bedrock API calls (e.g., `us-west-2`, `us-east-1`) |
 | `inferenceBedrockAwsDir` | Path to the directory containing AWS config/credentials files (default: `~/.aws`) |
-| `inferenceModels` | JSON array of model aliases available to users (`opus`, `sonnet`, `haiku`, `opusplan`). First entry is the default |
+| `inferenceModels` | JSON array of model aliases available to users (`opus`, `sonnet`, `haiku`). First entry is the default |
 
-> **Note:** The model aliases used by CoWork 3P (`opus`, `sonnet`, `haiku`, `opusplan`) are resolved internally by Claude Desktop and may differ from the CRIS model IDs configured for Claude Code via `ANTHROPIC_MODEL`. The `ccwb cowork generate` command includes all available aliases by default. Use `--models` to customize the list for your organization.
+> **Note:** The model aliases used by CoWork 3P (`opus`, `sonnet`, `haiku`) are resolved internally by Claude Desktop and may differ from the CRIS model IDs configured for Claude Code via `ANTHROPIC_MODEL`. The `ccwb cowork generate` command includes all available aliases by default. Use `--models` to customize the list for your organization.
 
 ### How Credentials Flow
 
@@ -178,7 +178,7 @@ The full set of MDM configuration keys is documented in the [official Anthropic 
 | `inferenceBedrockRegion` | string | AWS region for Bedrock |
 | `inferenceBedrockAwsDir` | string | Path to AWS config directory (default: `~/.aws`) |
 | `inferenceBedrockBaseUrl` | string | Override Bedrock endpoint (e.g., VPC interface endpoint) |
-| `inferenceModels` | string | JSON-encoded array of model aliases (e.g., `"[\"opus\", \"sonnet\", \"haiku\", \"opusplan\"]"`) |
+| `inferenceModels` | string | JSON-encoded array of model aliases (e.g., `"[\"opus\", \"sonnet\", \"haiku\"]"`) |
 | `inferenceBedrockProfile` | string | Named AWS profile (in `~/.aws/config`) that Claude Desktop uses for Bedrock authentication |
 
 > **Note:** Array-typed MDM keys (such as `inferenceModels`, `managedMcpServers`, `allowedWorkspaceFolders`) are delivered as **JSON-encoded strings** — the value is a string containing a JSON array, not a native array. For example, `inferenceModels` is set to `"[\"opus\", \"sonnet\"]"`, not `["opus", "sonnet"]`. The Claude Desktop Setup UI and the `.mobileconfig`/`.reg` export handle this encoding automatically.

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -2425,7 +2425,7 @@ Available metrics include:
                 # Claude Code uses these to resolve the correct CRIS-prefixed
                 # models for each tier (small/fast, default sonnet/opus/haiku).
                 # This ensures all tiers respect the admin's routing geography
-                # choice and works correctly with model aliases like 'opusplan'.
+                # choice and works correctly with model aliases like 'opus', 'sonnet', 'haiku'.
                 from claude_code_with_bedrock.models import resolve_model_for_tier
                 cris_prefix = getattr(profile, "cross_region_profile", None) or "us"
 

--- a/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
+++ b/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
@@ -15,7 +15,7 @@ from claude_code_with_bedrock.cli.utils.aws import get_stack_outputs
 # CoWork 3P model aliases — defined by Anthropic's Claude Desktop client.
 # These may differ from the model IDs used by Claude Code (ANTHROPIC_MODEL env var).
 # The ccwb cowork generate --models flag allows admins to override if needed.
-COWORK_DEFAULT_ALIASES = ["opus", "sonnet", "haiku", "opusplan"]
+COWORK_DEFAULT_ALIASES = ["opus", "sonnet", "haiku"]
 
 
 def derive_model_aliases() -> list[str]:
@@ -23,9 +23,9 @@ def derive_model_aliases() -> list[str]:
 
     Returns the standard alias list. Admins can override via the --models CLI flag.
 
-    Note: CoWork model aliases (opus, sonnet, haiku, opusplan) are resolved by
-    Claude Desktop internally and may differ from the CRIS model IDs configured
-    for Claude Code via ANTHROPIC_MODEL.
+    Note: CoWork model aliases (opus, sonnet, haiku) are resolved by Claude Desktop
+    internally and may differ from the CRIS model IDs configured for Claude Code via
+    ANTHROPIC_MODEL.
     """
     return list(COWORK_DEFAULT_ALIASES)
 
@@ -46,7 +46,7 @@ def build_mdm_config(
 
     Args:
         bedrock_region: AWS region for Bedrock API calls.
-        model_aliases: List of model aliases (e.g., ["opus", "sonnet", "opusplan"]).
+        model_aliases: List of model aliases (e.g., ["opus", "sonnet", "haiku"]).
         profile_name: AWS named profile (matches ~/.aws/config stanza).
 
     Returns:


### PR DESCRIPTION
## Summary

- Removes `opusplan` from `COWORK_DEFAULT_ALIASES` in `cowork_3p.py`
- Claude Desktop 1.6259.1 introduced validation requiring all `inferenceModels` entries to be recognized Anthropic model identifiers with a Bedrock model equivalent; `opusplan` fails this check and prevents CoWork from starting
- Updated all references in docs and comments

## Test plan

- [ ] Run `ccwb cowork generate` and verify the output JSON contains only `["opus", "sonnet", "haiku"]`
- [ ] Confirm CoWork starts without the `Invalid custom3p enterprise config: inferenceModels` error on Claude Desktop 1.6259.1+