### PR TITLE
feat(cognito): inject custom user attributes into ID tokens

### DIFF
--- a/assets/docs/providers/cognito-user-pool-setup.md
+++ b/assets/docs/providers/cognito-user-pool-setup.md
@@ -173,6 +173,34 @@ Similar process for Okta, Auth0, Azure AD:
 
 ## Troubleshooting
 
+### Group-Level Dashboards Show Default Values
+
+If CloudWatch dimensions show `department: "unspecified"` or `team: "default-team"`, your Cognito tokens may not include custom attributes. Enable the Pre-Token-Generation trigger:
+
+```bash
+# Redeploy with custom claim injection enabled
+aws cloudformation deploy \
+  --template-file deployment/infrastructure/cognito-user-pool-setup.yaml \
+  --stack-name claude-code-user-pool \
+  --capabilities CAPABILITY_IAM \
+  --parameter-overrides \
+    EnableCustomClaimInjection=true
+```
+
+Then ensure users have custom attributes set:
+```bash
+aws cognito-idp admin-update-user-attributes \
+  --user-pool-id <pool-id> \
+  --username user@example.com \
+  --user-attributes \
+    Name=custom:department,Value=engineering \
+    Name=custom:team,Value=platform
+```
+
+Users must re-authenticate for the new claims to appear in their tokens.
+
+> **Note:** This is only needed for pure Cognito deployments. If you use an external IdP (Okta, Azure AD, Google), those providers already emit standard claims via OIDC.
+
 ### Domain Already Exists
 If you get a domain conflict error, choose a different `DomainPrefix`. Cognito domains must be globally unique.
 

--- a/deployment/infrastructure/cognito-user-pool-setup.yaml
+++ b/deployment/infrastructure/cognito-user-pool-setup.yaml
@@ -46,11 +46,25 @@ Parameters:
     Description: Client secret from Federate service profile (required if using Federate)
     NoEcho: true
 
+  EnableCustomClaimInjection:
+    Type: String
+    Default: 'false'
+    AllowedValues: ['true', 'false']
+    Description: >-
+      When 'true', deploys a Pre-Token-Generation Lambda that copies any
+      custom:* user attributes (department, team, cost_center, organization,
+      location, role, manager) into ID-token claims. Cognito's OAuth2
+      Hosted-UI flow does not include custom attributes by default; this
+      trigger is the standard workaround so OTLP/CloudWatch dimensions
+      populate per-user. Safe to leave 'false' for deployments that don't
+      need group-level dashboards.
+
 Conditions:
   UseFederate: !Not [!Equals [!Ref FederateEnvironment, 'none']]
   NotUseFederate: !Equals [!Ref FederateEnvironment, 'none']
   UseFederateInteg: !Equals [!Ref FederateEnvironment, 'integ']
   UseFederateProd: !Equals [!Ref FederateEnvironment, 'prod']
+  InjectCustomClaims: !Equals [!Ref EnableCustomClaimInjection, 'true']
 
 Resources:
   # Cognito User Pool with settings matching Amazon Federate requirements
@@ -101,6 +115,12 @@ Resources:
         Name: !Ref UserPoolName
         Purpose: 'Claude Code Authentication'
         FederateIntegration: !If [UseFederate, 'true', 'false']
+      # Optional Pre-Token-Generation trigger that injects custom:* attributes
+      # into ID tokens. Required when group-level CloudWatch dashboards are needed.
+      LambdaConfig: !If
+        - InjectCustomClaims
+        - PreTokenGeneration: !GetAtt PreTokenGenerationFunction.Arn
+        - !Ref AWS::NoValue
 
   # App Client with specific token validity settings
   UserPoolClient:
@@ -450,6 +470,54 @@ Resources:
       UserPoolId: !Ref UserPool
       ClientId: !Ref DistributionWebClient
       SecretName: !Sub '${AWS::StackName}-distribution-web-client-secret'
+
+  # Pre-Token-Generation Lambda — injects custom:* attributes into ID tokens.
+  # Cognito's OAuth2 Hosted-UI flow does not surface custom attributes via
+  # standard OIDC scopes; this trigger is the documented workaround.
+  PreTokenGenerationRole:
+    Type: AWS::IAM::Role
+    Condition: InjectCustomClaims
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+
+  PreTokenGenerationFunction:
+    Type: AWS::Lambda::Function
+    Condition: InjectCustomClaims
+    Properties:
+      Runtime: python3.12
+      Handler: index.handler
+      Role: !GetAtt PreTokenGenerationRole.Arn
+      Timeout: 5
+      Description: Injects custom:* user attributes into Cognito ID tokens
+      Code:
+        ZipFile: |
+          def handler(event, context):
+              attrs = event.get('request', {}).get('userAttributes', {}) or {}
+              custom = {k: v for k, v in attrs.items() if k.startswith('custom:') and v}
+              if custom:
+                  event['response'] = {
+                      'claimsOverrideDetails': {
+                          'claimsToAddOrOverride': custom
+                      }
+                  }
+              return event
+
+  PreTokenGenerationPermission:
+    Type: AWS::Lambda::Permission
+    Condition: InjectCustomClaims
+    Properties:
+      FunctionName: !Ref PreTokenGenerationFunction
+      Action: lambda:InvokeFunction
+      Principal: cognito-idp.amazonaws.com
+      SourceArn: !GetAtt UserPool.Arn
 
 Outputs:
   UserPoolId:

--- a/source/otel_helper/__main__.py
+++ b/source/otel_helper/__main__.py
@@ -184,12 +184,12 @@ def extract_user_info(payload):
 
     # Extract team/department information - these fields vary by IdP
     # Provide defaults for consistent metric dimensions
-    department = payload.get("department") or payload.get("dept") or payload.get("division") or "unspecified"
-    team = payload.get("team") or payload.get("team_id") or payload.get("group") or "default-team"
-    cost_center = payload.get("cost_center") or payload.get("costCenter") or payload.get("cost_code") or "general"
-    manager = payload.get("manager") or payload.get("manager_email") or "unassigned"
-    location = payload.get("location") or payload.get("office_location") or payload.get("office") or "remote"
-    role = payload.get("role") or payload.get("job_title") or payload.get("title") or "user"
+    department = payload.get("custom:department") or payload.get("department") or payload.get("dept") or payload.get("division") or "unspecified"
+    team = payload.get("custom:team") or payload.get("team") or payload.get("team_id") or payload.get("group") or "default-team"
+    cost_center = payload.get("custom:cost_center") or payload.get("cost_center") or payload.get("costCenter") or payload.get("cost_code") or "general"
+    manager = payload.get("custom:manager") or payload.get("manager") or payload.get("manager_email") or "unassigned"
+    location = payload.get("custom:location") or payload.get("location") or payload.get("office_location") or payload.get("office") or "remote"
+    role = payload.get("custom:role") or payload.get("role") or payload.get("job_title") or payload.get("title") or "user"
 
     return {
         "email": email,

--- a/source/otel_helper/__main__.py
+++ b/source/otel_helper/__main__.py
@@ -190,12 +190,12 @@ def extract_user_info(payload):
 
     # Extract team/department information - these fields vary by IdP
     # Provide defaults for consistent metric dimensions
-    department = payload.get("department") or payload.get("dept") or payload.get("division") or "unspecified"
-    team = payload.get("team") or payload.get("team_id") or payload.get("group") or "default-team"
-    cost_center = payload.get("cost_center") or payload.get("costCenter") or payload.get("cost_code") or "general"
-    manager = payload.get("manager") or payload.get("manager_email") or "unassigned"
-    location = payload.get("location") or payload.get("office_location") or payload.get("office") or "remote"
-    role = payload.get("role") or payload.get("job_title") or payload.get("title") or "user"
+    department = payload.get("custom:department") or payload.get("department") or payload.get("dept") or payload.get("division") or "unspecified"
+    team = payload.get("custom:team") or payload.get("team") or payload.get("team_id") or payload.get("group") or "default-team"
+    cost_center = payload.get("custom:cost_center") or payload.get("cost_center") or payload.get("costCenter") or payload.get("cost_code") or "general"
+    manager = payload.get("custom:manager") or payload.get("manager") or payload.get("manager_email") or "unassigned"
+    location = payload.get("custom:location") or payload.get("location") or payload.get("office_location") or payload.get("office") or "remote"
+    role = payload.get("custom:role") or payload.get("role") or payload.get("job_title") or payload.get("title") or "user"
 
     return {
         "email": email,

--- a/source/tests/test_cognito_custom_claims.py
+++ b/source/tests/test_cognito_custom_claims.py
@@ -1,0 +1,93 @@
+# ABOUTME: Tests for custom:* claim prefix priority in otel_helper extract_user_info
+# ABOUTME: Ensures Cognito custom attributes take precedence over standard claim names
+
+"""Regression tests for custom:* attribute priority in otel_helper."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+# Load otel_helper/__main__.py as a module without conflicting with pytest's __main__
+_spec = importlib.util.spec_from_file_location(
+    "otel_helper_main",
+    Path(__file__).resolve().parents[1] / "otel_helper" / "__main__.py",
+)
+_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_module)
+extract_user_info = _module.extract_user_info
+
+
+class TestCustomClaimPriority:
+    """Verify custom:* prefixed claims take priority over standard names."""
+
+    def test_custom_department_takes_priority(self):
+        """custom:department overrides department claim."""
+        payload = {
+            "email": "alice@co.com",
+            "sub": "abc123",
+            "department": "fallback-dept",
+            "custom:department": "cloud-foundations",
+        }
+        result = extract_user_info(payload)
+        assert result["department"] == "cloud-foundations"
+
+    def test_custom_team_takes_priority(self):
+        """custom:team overrides team claim."""
+        payload = {
+            "email": "alice@co.com",
+            "sub": "abc123",
+            "team": "fallback-team",
+            "custom:team": "platform-eng",
+        }
+        result = extract_user_info(payload)
+        assert result["team"] == "platform-eng"
+
+    def test_custom_cost_center_takes_priority(self):
+        """custom:cost_center overrides cost_center claim."""
+        payload = {
+            "email": "alice@co.com",
+            "sub": "abc123",
+            "cost_center": "fallback-cc",
+            "custom:cost_center": "CC-1234",
+        }
+        result = extract_user_info(payload)
+        assert result["cost_center"] == "CC-1234"
+
+    def test_falls_back_to_standard_when_no_custom(self):
+        """Standard claims still work when custom:* prefix not present."""
+        payload = {
+            "email": "bob@co.com",
+            "sub": "def456",
+            "department": "engineering",
+            "team": "backend",
+            "cost_center": "CC-5678",
+        }
+        result = extract_user_info(payload)
+        assert result["department"] == "engineering"
+        assert result["team"] == "backend"
+        assert result["cost_center"] == "CC-5678"
+
+    def test_defaults_when_no_claims_at_all(self):
+        """Falls back to defaults when neither custom: nor standard claims exist."""
+        payload = {
+            "email": "carol@co.com",
+            "sub": "ghi789",
+        }
+        result = extract_user_info(payload)
+        assert result["department"] == "unspecified"
+        assert result["team"] == "default-team"
+        assert result["cost_center"] == "general"
+        assert result["manager"] == "unassigned"
+        assert result["location"] == "remote"
+        assert result["role"] == "user"
+
+    def test_empty_custom_claim_falls_through(self):
+        """Empty custom:* values are skipped (falsy), standard claim used instead."""
+        payload = {
+            "email": "dave@co.com",
+            "sub": "jkl012",
+            "custom:department": "",
+            "department": "real-dept",
+        }
+        result = extract_user_info(payload)
+        assert result["department"] == "real-dept"


### PR DESCRIPTION
## Summary

- Adds an opt-in **Pre-Token-Generation Lambda** trigger to `cognito-user-pool-setup.yaml`, gated by a new `EnableCustomClaimInjection` parameter (default `false`).
- Fixes `otel_helper.extract_user_info` to read the `custom:<name>` form of attributes — required for Cognito-issued tokens where attributes are namespaced.

## Problem

For deployments using a pure Cognito User Pool (no upstream IdP federation), Cognito's OAuth2 Hosted-UI flow does **not** include `custom:*` user attributes in ID tokens — even when those attributes are populated on the user. There is no OAuth scope that maps to custom attributes, so `ReadAttributes` settings on the user-pool client have no effect on Hosted-UI tokens.

This leaves `claude_code.token.usage` (and other OTLP-exported metrics) with all group dimensions stuck at fallback defaults:

| Dimension | Actual value (CloudWatch) | Expected |
|---|---|---|
| `department` | `unspecified` | from JWT `custom:department` |
| `team.id` | `default-team` | from JWT `custom:team` |
| `cost_center` | `general` | from JWT `custom:cost_center` |
| `organization` | `default` | from JWT `custom:organization` |

Group-level dashboard views and group-scoped quota policies (`ccwb quota set-group ...`) are silently broken on pure-Cognito deployments as a result.

## Fix

The standard Cognito workaround is a **Pre-Token-Generation Lambda trigger**, which fires on every token issuance and can inject claims via `claimsOverrideDetails.claimsToAddOrOverride`. This PR adds:

1. A 15-line inline Python Lambda that copies all non-empty `custom:*` user attributes into the claim override.
2. An IAM execution role (basic execution policy only).
3. The Lambda invocation permission for `cognito-idp.amazonaws.com`.
4. The `LambdaConfig.PreTokenGeneration` wiring on the existing `UserPool` resource.

All four are gated on `EnableCustomClaimInjection=true`, so existing stacks see **zero change** unless they explicitly opt in.

The `otel_helper` change adds `custom:<name>` as the first lookup tier in each attribute fallback chain.

## Why opt-in / default off

- **No silent behavior change** for existing customers.
- **No new IAM role** unless the operator wants the trigger.
- **No Lambda cost** unless enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)