### PR TITLE
feat: auto-install Python 3 and AWS CLI in install.sh

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -1898,7 +1898,71 @@ echo
 echo "Organization: {profile.provider_domain}"
 echo
 
+# Check prerequisites
+echo "Checking prerequisites..."
 
+# Auto-install Python 3 if missing
+if ! command -v python3 &> /dev/null; then
+    echo "⚠️  Python 3 not found. Installing..."
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        if command -v brew &> /dev/null; then
+            brew install python@3.12
+        else
+            echo "Installing Homebrew first..."
+            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+            eval "$(/opt/homebrew/bin/brew shellenv 2>/dev/null || /usr/local/bin/brew shellenv 2>/dev/null)"
+            brew install python@3.12
+        fi
+    elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        if command -v apt-get &> /dev/null; then
+            sudo apt-get update && sudo apt-get install -y python3
+        elif command -v yum &> /dev/null; then
+            sudo yum install -y python3
+        elif command -v dnf &> /dev/null; then
+            sudo dnf install -y python3
+        fi
+    fi
+    if command -v python3 &> /dev/null; then
+        echo "✓ Python 3 installed"
+    else
+        echo "❌ Failed to install Python 3. Please install manually."
+        exit 1
+    fi
+else
+    echo "✓ Python 3 found"
+fi
+
+# Auto-install AWS CLI if missing
+if ! command -v aws &> /dev/null; then
+    echo "⚠️  AWS CLI not found. Installing..."
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        if command -v brew &> /dev/null; then
+            brew install awscli
+        else
+            curl "https://awscli.amazonaws.com/AWSCLIV2.pkg" -o "/tmp/AWSCLIV2.pkg"
+            sudo installer -pkg /tmp/AWSCLIV2.pkg -target /
+            rm -f /tmp/AWSCLIV2.pkg
+        fi
+    elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        ARCH=$(uname -m)
+        if [[ "$ARCH" == "aarch64" ]] || [[ "$ARCH" == "arm64" ]]; then
+            curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "/tmp/awscliv2.zip"
+        else
+            curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "/tmp/awscliv2.zip"
+        fi
+        unzip -q /tmp/awscliv2.zip -d /tmp/aws-install
+        sudo /tmp/aws-install/aws/install
+        rm -rf /tmp/awscliv2.zip /tmp/aws-install
+    fi
+    if command -v aws &> /dev/null; then
+        echo "✓ AWS CLI installed"
+    else
+        echo "❌ Failed to install AWS CLI. Please install from https://aws.amazon.com/cli/"
+        exit 1
+    fi
+else
+    echo "✓ AWS CLI found"
+fi
 
 # Detect platform and architecture
 echo


### PR DESCRIPTION
## Summary
The generated install.sh now detects missing prerequisites and installs them automatically:

- **Python 3**: via Homebrew (macOS) or apt/yum/dnf (Linux)
- **AWS CLI v2**: via Homebrew (macOS) or official installer (Linux)

## Problem
End users receiving the distribution package often don't have Python 3 or AWS CLI pre-installed, leading to confusing errors during setup.

## Solution
Added prerequisite checks at the top of the generated install.sh that:
1. Check if python3 is available, install if missing
2. Check if aws CLI is available, install if missing
3. Fall back to clear error messages if auto-install fails

## Testing
Tested on macOS ARM64 (Homebrew path) and Ubuntu 22.04 (apt path).