### PR TITLE
feat: sidecar monitoring mode fixes and Cowork telemetry guardrails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - OTLP-First Metrics
+## [2.4.0] - 2026-05-22 - OTLP-First Metrics
+
+### Added
+
+- **Sidecar monitoring mode**: New "sidecar" collector option during `ccwb init` — runs a local OTel collector on each dev machine, no ECS/VPC infrastructure needed
+- **Monitoring mode backward compatibility**: Existing profiles without `monitoring_mode` default to "central", preserving current behavior on upgrade without re-running init
 
 ### Changed
 
@@ -14,6 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Quota monitoring**: Quota monitor Lambda now queries CloudWatch Prometheus-compatible API (`/api/v1/query`) for usage data instead of relying on MetricsAggregator
 - **Auth templates**: Removed `cloudwatch:namespace` IAM conditions (OTLP metrics don't use CW namespaces)
 - **Dashboard deployment**: No longer requires S3 packaging (no Lambda functions to package)
+- **Init wizard**: Sidecar mode description now clearly states that Claude Cowork (desktop) telemetry is not supported
+- **CoWork MDM generation**: Sidecar mode no longer emits `otlpEndpoint`/`otlpProtocol` in MDM config files
+
+### Fixed
+
+- **Orphaned stack deletion order**: Stacks are now deleted in reverse deployment order, respecting dependencies (e.g., monitoring before networking)
+- **CoWork MDM OTLP endpoint**: Central mode correctly resolves the collector endpoint from CloudFormation stack outputs
+- **CoWork dashboard in sidecar mode**: Blocked deployment of CoWork dashboard when in sidecar mode (Cowork desktop cannot reach localhost collector)
+- **Orphaned stack detection**: Added `cowork-dashboard` to orphaned stack detection so it is offered for cleanup when switching from central to sidecar
 
 ### Removed
 

--- a/deployment/infrastructure/claude-code-dashboard.yaml
+++ b/deployment/infrastructure/claude-code-dashboard.yaml
@@ -32,7 +32,7 @@ Resources:
                 "title": "Total Tokens Used",
                 "view": "number",
                 "region": "${MetricsRegion}",
-                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.token.usage\"})", "step": 60, "label": "Tokens" }] },
+                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.token.usage\", \"@resource.service.name\"=\"claude-code\"})", "step": 60, "label": "Tokens" }] },
                 "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
@@ -43,7 +43,7 @@ Resources:
                 "title": "Active Users",
                 "view": "number",
                 "region": "${MetricsRegion}",
-                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "count(group by (\"user.email\")({\"claude_code.session.count\"}))", "step": 60, "label": "Users" }] },
+                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "count(group by (\"user.email\")({\"claude_code.session.count\", \"@resource.service.name\"=\"claude-code\"}))", "step": 60, "label": "Users" }] },
                 "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
@@ -54,7 +54,7 @@ Resources:
                 "title": "Sessions",
                 "view": "number",
                 "region": "${MetricsRegion}",
-                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.session.count\"})", "step": 60, "label": "Sessions" }] },
+                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.session.count\", \"@resource.service.name\"=\"claude-code\"})", "step": 60, "label": "Sessions" }] },
                 "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
@@ -65,7 +65,7 @@ Resources:
                 "title": "Cache Hit Rate",
                 "view": "number",
                 "region": "${MetricsRegion}",
-                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.token.usage\", type=\"cacheRead\"}) / sum({\"claude_code.token.usage\"}) * 100", "step": 60, "label": "%" }] },
+                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.token.usage\", type=\"cacheRead\", \"@resource.service.name\"=\"claude-code\"}) / sum({\"claude_code.token.usage\", \"@resource.service.name\"=\"claude-code\"}) * 100", "step": 60, "label": "%" }] },
                 "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
@@ -82,9 +82,9 @@ Resources:
                 "view": "line",
                 "region": "${MetricsRegion}",
                 "data": { "queries": [
-                  { "id": "total", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.token.usage\"})", "step": 60, "label": "Total Tokens" }
+                  { "id": "total", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.token.usage\", \"@resource.service.name\"=\"claude-code\"})", "step": 60, "label": "Total Tokens" }
                 ] },
-                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": false, "width": 2, "pattern": "solid", "spline": false } } }
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
@@ -95,12 +95,12 @@ Resources:
                 "view": "line",
                 "region": "${MetricsRegion}",
                 "data": { "queries": [
-                  { "id": "input", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.token.usage\", type=\"input\"})", "step": 60, "label": "Input" },
-                  { "id": "output", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.token.usage\", type=\"output\"})", "step": 60, "label": "Output" },
-                  { "id": "cache", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.token.usage\", type=\"cacheRead\"})", "step": 60, "label": "Cache Read" },
-                  { "id": "cacheCreate", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.token.usage\", type=\"cacheCreation\"})", "step": 60, "label": "Cache Creation" }
+                  { "id": "input", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.token.usage\", type=\"input\", \"@resource.service.name\"=\"claude-code\"})", "step": 60, "label": "Input" },
+                  { "id": "output", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.token.usage\", type=\"output\", \"@resource.service.name\"=\"claude-code\"})", "step": 60, "label": "Output" },
+                  { "id": "cache", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.token.usage\", type=\"cacheRead\", \"@resource.service.name\"=\"claude-code\"})", "step": 60, "label": "Cache Read" },
+                  { "id": "cacheCreate", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.token.usage\", type=\"cacheCreation\", \"@resource.service.name\"=\"claude-code\"})", "step": 60, "label": "Cache Creation" }
                 ] },
-                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false } } }
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
@@ -111,9 +111,9 @@ Resources:
                 "view": "line",
                 "region": "${MetricsRegion}",
                 "data": { "queries": [
-                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (model)({\"claude_code.token.usage\"}))", "step": 60 }
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (model)({\"claude_code.token.usage\", \"@resource.service.name\"=\"claude-code\"}))", "step": 60 }
                 ] },
-                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": true, "width": 2, "pattern": "solid", "spline": false } } }
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": true, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
@@ -124,9 +124,9 @@ Resources:
                 "view": "line",
                 "region": "${MetricsRegion}",
                 "data": { "queries": [
-                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (\"user.email\")({\"claude_code.token.usage\"}))", "step": 60 }
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (\"user.email\")({\"claude_code.token.usage\", \"@resource.service.name\"=\"claude-code\"}))", "step": 60 }
                 ] },
-                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false } } }
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
@@ -137,9 +137,9 @@ Resources:
                 "view": "line",
                 "region": "${MetricsRegion}",
                 "data": { "queries": [
-                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (\"user.email\")({\"claude_code.cost.usage\"}))", "step": 60 }
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (\"user.email\")({\"claude_code.cost.usage\", \"@resource.service.name\"=\"claude-code\"}))", "step": 60 }
                 ] },
-                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false } } }
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
@@ -150,9 +150,9 @@ Resources:
                 "view": "line",
                 "region": "${MetricsRegion}",
                 "data": { "queries": [
-                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "count(group by (\"user.email\")({\"claude_code.session.count\"}))", "step": 60, "label": "Active Users" }
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "count(group by (\"user.email\")({\"claude_code.session.count\", \"@resource.service.name\"=\"claude-code\"}))", "step": 60, "label": "Active Users" }
                 ] },
-                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": false, "width": 2, "pattern": "solid", "spline": false } } }
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
@@ -168,10 +168,10 @@ Resources:
                 "view": "line",
                 "region": "${MetricsRegion}",
                 "data": { "queries": [
-                  { "id": "added", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.lines_of_code.count\", type=\"added\"})", "step": 60, "label": "Added" },
-                  { "id": "removed", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.lines_of_code.count\", type=\"removed\"})", "step": 60, "label": "Removed" }
+                  { "id": "added", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.lines_of_code.count\", type=\"added\", \"@resource.service.name\"=\"claude-code\"})", "step": 60, "label": "Added" },
+                  { "id": "removed", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.lines_of_code.count\", type=\"removed\", \"@resource.service.name\"=\"claude-code\"})", "step": 60, "label": "Removed" }
                 ] },
-                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false } } }
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
@@ -182,9 +182,9 @@ Resources:
                 "view": "line",
                 "region": "${MetricsRegion}",
                 "data": { "queries": [
-                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.commit.count\"})", "step": 60, "label": "Commits" }
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.commit.count\", \"@resource.service.name\"=\"claude-code\"})", "step": 60, "label": "Commits" }
                 ] },
-                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": false, "width": 2, "pattern": "solid", "spline": false } } }
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
@@ -195,9 +195,9 @@ Resources:
                 "view": "line",
                 "region": "${MetricsRegion}",
                 "data": { "queries": [
-                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.active_time.total\"}) / 3600", "step": 60, "label": "Hours" }
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.active_time.total\", \"@resource.service.name\"=\"claude-code\"}) / 3600", "step": 60, "label": "Hours" }
                 ] },
-                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": false, "width": 2, "pattern": "solid", "spline": false } } }
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
@@ -208,9 +208,9 @@ Resources:
                 "view": "line",
                 "region": "${MetricsRegion}",
                 "data": { "queries": [
-                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.pull_request.count\"})", "step": 60, "label": "PRs" }
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.pull_request.count\", \"@resource.service.name\"=\"claude-code\"})", "step": 60, "label": "PRs" }
                 ] },
-                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": false, "width": 2, "pattern": "solid", "spline": false } } }
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
@@ -221,9 +221,9 @@ Resources:
                 "view": "pie",
                 "region": "${MetricsRegion}",
                 "data": { "queries": [
-                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (language)({\"claude_code.code_edit_tool.decision\"}))", "step": 60 }
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (language)({\"claude_code.code_edit_tool.decision\", \"@resource.service.name\"=\"claude-code\"}))", "step": 60 }
                 ] },
-                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": true, "width": 2, "pattern": "solid", "spline": false } } }
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": true, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
@@ -234,9 +234,9 @@ Resources:
                 "view": "line",
                 "region": "${MetricsRegion}",
                 "data": { "queries": [
-                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (decision)({\"claude_code.code_edit_tool.decision\"}))", "step": 60 }
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (decision)({\"claude_code.code_edit_tool.decision\", \"@resource.service.name\"=\"claude-code\"}))", "step": 60 }
                 ] },
-                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false } } }
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
@@ -247,9 +247,9 @@ Resources:
                 "view": "line",
                 "region": "${MetricsRegion}",
                 "data": { "queries": [
-                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (tool_name)({\"claude_code.code_edit_tool.decision\"}))", "step": 60 }
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (tool_name)({\"claude_code.code_edit_tool.decision\", \"@resource.service.name\"=\"claude-code\"}))", "step": 60 }
                 ] },
-                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false } } }
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
@@ -265,9 +265,9 @@ Resources:
                 "view": "line",
                 "region": "${MetricsRegion}",
                 "data": { "queries": [
-                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (department)({\"claude_code.token.usage\"}))", "step": 60 }
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (department)({\"claude_code.token.usage\", \"@resource.service.name\"=\"claude-code\"}))", "step": 60 }
                 ] },
-                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": true, "width": 2, "pattern": "solid", "spline": false } } }
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": true, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
@@ -278,9 +278,9 @@ Resources:
                 "view": "line",
                 "region": "${MetricsRegion}",
                 "data": { "queries": [
-                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (\"team.id\")({\"claude_code.token.usage\"}))", "step": 60 }
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (\"team.id\")({\"claude_code.token.usage\", \"@resource.service.name\"=\"claude-code\"}))", "step": 60 }
                 ] },
-                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": true, "width": 2, "pattern": "solid", "spline": false } } }
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": true, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {

--- a/deployment/infrastructure/cowork-dashboard.yaml
+++ b/deployment/infrastructure/cowork-dashboard.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'CloudWatch dashboard for Claude CoWork usage metrics'
+Description: 'CloudWatch dashboard for Claude CoWork usage metrics using native PromQL widgets over OTLP-ingested metrics'
 
 Parameters:
   DashboardName:
@@ -7,15 +7,10 @@ Parameters:
     Default: ClaudeCoWorkDashboard
     Description: Name for the CloudWatch dashboard
 
-  MetricsLogGroup:
-    Type: String
-    Default: /aws/claude-code/metrics
-    Description: CloudWatch Log Group containing CoWork metrics
-
   MetricsRegion:
     Type: String
     Default: us-east-1
-    Description: Region where metrics log group exists
+    Description: Region where OTLP metrics are ingested
 
 Resources:
   Dashboard:
@@ -25,200 +20,203 @@ Resources:
       DashboardBody: !Sub |
         {
           "widgets": [
-
             {
               "type": "text",
               "x": 0, "y": 0, "width": 24, "height": 2,
-              "properties": {
-                "markdown": "# 📊 Claude CoWork Dashboard\n\nAggregate usage and cost metrics for Claude CoWork (Claude Desktop) sessions via Amazon Bedrock.",
-                "background": "transparent"
-              }
+              "properties": { "markdown": "## Overview", "background": "transparent" }
             },
-
             {
-              "type": "log",
+              "type": "chart",
               "x": 0, "y": 2, "width": 6, "height": 4,
               "properties": {
-                "query": "SOURCE '${MetricsLogGroup}' | filter `service.name` = \"cowork\" and `claude_code.token.usage` > 0 | stats round(sum(`claude_code.token.usage`) / 1000000, 2) as Tokens_M",
-                "region": "${MetricsRegion}",
                 "title": "Total Tokens Used",
-                "queryLanguage": "cwli",
-                "view": "singleValue"
+                "view": "number",
+                "region": "${MetricsRegion}",
+                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.token.usage\", \"@resource.service.name\"=\"cowork\"})", "step": 60, "label": "Tokens" }] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
-              "type": "log",
+              "type": "chart",
               "x": 6, "y": 2, "width": 6, "height": 4,
               "properties": {
-                "query": "SOURCE '${MetricsLogGroup}' | filter `service.name` = \"cowork\" and `claude_code.session.count` > 0 | stats count_distinct(`user.id`) as Users",
-                "region": "${MetricsRegion}",
                 "title": "Active Users",
-                "queryLanguage": "cwli",
-                "view": "singleValue"
+                "view": "number",
+                "region": "${MetricsRegion}",
+                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "count(group by (\"user.id\")({\"claude_code.session.count\", \"@resource.service.name\"=\"cowork\"}))", "step": 60, "label": "Users" }] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
-              "type": "log",
+              "type": "chart",
               "x": 12, "y": 2, "width": 6, "height": 4,
               "properties": {
-                "query": "SOURCE '${MetricsLogGroup}' | filter `service.name` = \"cowork\" and `claude_code.session.count` > 0 | stats sum(`claude_code.session.count`) as Sessions",
-                "region": "${MetricsRegion}",
                 "title": "Total Sessions",
-                "queryLanguage": "cwli",
-                "view": "singleValue"
+                "view": "number",
+                "region": "${MetricsRegion}",
+                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.session.count\", \"@resource.service.name\"=\"cowork\"})", "step": 60, "label": "Sessions" }] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
-              "type": "log",
+              "type": "chart",
               "x": 18, "y": 2, "width": 6, "height": 4,
               "properties": {
-                "query": "SOURCE '${MetricsLogGroup}' | filter `service.name` = \"cowork\" and `claude_code.cost.usage` > 0 | stats round(sum(`claude_code.cost.usage`), 2) as Cost",
-                "region": "${MetricsRegion}",
                 "title": "Total Cost (USD)",
-                "queryLanguage": "cwli",
-                "view": "singleValue"
+                "view": "number",
+                "region": "${MetricsRegion}",
+                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.cost.usage\", \"@resource.service.name\"=\"cowork\"})", "step": 60, "label": "USD" }] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
+              }
+            },
+
+            {
+              "type": "text",
+              "x": 0, "y": 6, "width": 24, "height": 2,
+              "properties": { "markdown": "## Usage Over Time", "background": "transparent" }
+            },
+            {
+              "type": "chart",
+              "x": 0, "y": 8, "width": 12, "height": 6,
+              "properties": {
+                "title": "Token Usage Over Time",
+                "view": "line",
+                "region": "${MetricsRegion}",
+                "data": { "queries": [
+                  { "id": "total", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.token.usage\", \"@resource.service.name\"=\"cowork\"})", "step": 60, "label": "Total Tokens" }
+                ] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
-              "type": "log",
-              "x": 0, "y": 6, "width": 12, "height": 6,
+              "type": "chart",
+              "x": 12, "y": 8, "width": 12, "height": 6,
               "properties": {
-                "query": "SOURCE '${MetricsLogGroup}' | filter `service.name` = \"cowork\" and `claude_code.token.usage` > 0 | stats sum(`claude_code.token.usage`) / 1000 as Tokens_K by bin(5m)",
-                "region": "${MetricsRegion}",
-                "title": "Token Usage Over Time (thousands)",
-                "queryLanguage": "cwli",
-                "view": "timeSeries",
-                "stacked": false,
-                "yAxis": { "left": { "min": 0 } }
-              }
-            },
-            {
-              "type": "log",
-              "x": 12, "y": 6, "width": 12, "height": 6,
-              "properties": {
-                "query": "SOURCE '${MetricsLogGroup}' | filter `service.name` = \"cowork\" and `claude_code.cost.usage` > 0 | stats sum(`claude_code.cost.usage`) as Cost by bin(5m)",
-                "region": "${MetricsRegion}",
                 "title": "Cost Over Time (USD)",
-                "queryLanguage": "cwli",
-                "view": "timeSeries",
-                "stacked": false,
-                "yAxis": { "left": { "min": 0 } }
-              }
-            },
-
-            {
-              "type": "log",
-              "x": 0, "y": 12, "width": 12, "height": 6,
-              "properties": {
-                "query": "SOURCE '${MetricsLogGroup}' | filter `service.name` = \"cowork\" and `claude_code.token.usage` > 0 | parse @message /\"model\":\"(?<model>[^\"]+)\"/ | fields bin(5m) as time, if(model like /sonnet-4-5/, `claude_code.token.usage`, 0) as sonnet_4_5, if(model like /opus-4-6/, `claude_code.token.usage`, 0) as opus_4_6, if(model like /opus-4-7/, `claude_code.token.usage`, 0) as opus_4_7, if(model like /sonnet-4-20250514/, `claude_code.token.usage`, 0) as sonnet_4, if(model like /haiku-4-5/, `claude_code.token.usage`, 0) as haiku_4_5 | stats sum(opus_4_7) / 1000 as Opus_4_7, sum(opus_4_6) / 1000 as Opus_4_6, sum(sonnet_4_5) / 1000 as Sonnet_4_5, sum(sonnet_4) / 1000 as Sonnet_4, sum(haiku_4_5) / 1000 as Haiku_4_5 by time",
+                "view": "line",
                 "region": "${MetricsRegion}",
-                "title": "Token Usage by Model Over Time (thousands)",
-                "queryLanguage": "cwli",
-                "view": "timeSeries",
-                "stacked": false,
-                "yAxis": { "left": { "min": 0 } }
+                "data": { "queries": [
+                  { "id": "cost", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.cost.usage\", \"@resource.service.name\"=\"cowork\"})", "step": 60, "label": "Cost (USD)" }
+                ] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
-              "type": "log",
-              "x": 12, "y": 12, "width": 12, "height": 6,
+              "type": "chart",
+              "x": 0, "y": 14, "width": 12, "height": 6,
               "properties": {
-                "query": "SOURCE '${MetricsLogGroup}' | filter `service.name` = \"cowork\" and `claude_code.session.count` > 0 | stats sum(`claude_code.session.count`) as Sessions by bin(5m)",
-                "region": "${MetricsRegion}",
-                "title": "Active Sessions Over Time",
-                "queryLanguage": "cwli",
-                "view": "timeSeries",
-                "stacked": false,
-                "yAxis": { "left": { "min": 0 } }
-              }
-            },
-
-            {
-              "type": "text",
-              "x": 0, "y": 18, "width": 24, "height": 2,
-              "properties": {
-                "markdown": "## 📈 Model & Token Breakdown",
-                "background": "transparent"
-              }
-            },
-
-            {
-              "type": "log",
-              "x": 0, "y": 20, "width": 8, "height": 6,
-              "properties": {
-                "query": "SOURCE '${MetricsLogGroup}' | filter `service.name` = \"cowork\" and `claude_code.token.usage` > 0 | parse @message /\"model\":\"(?<model>[^\"]+)\"/ | stats round(sum(`claude_code.token.usage`) / 1000, 0) as Tokens_K by model | sort Tokens_K desc | limit 10",
-                "region": "${MetricsRegion}",
                 "title": "Token Usage by Model",
-                "queryLanguage": "cwli",
-                "view": "pie"
+                "view": "line",
+                "region": "${MetricsRegion}",
+                "data": { "queries": [
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (model)({\"claude_code.token.usage\", \"@resource.service.name\"=\"cowork\"}))", "step": 60 }
+                ] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": true, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
-              "type": "log",
-              "x": 8, "y": 20, "width": 8, "height": 6,
+              "type": "chart",
+              "x": 12, "y": 14, "width": 12, "height": 6,
               "properties": {
-                "query": "SOURCE '${MetricsLogGroup}' | filter `service.name` = \"cowork\" and `claude_code.cost.usage` > 0 | parse @message /\"model\":\"(?<model>[^\"]+)\"/ | stats round(sum(`claude_code.cost.usage`), 2) as Cost by model | sort Cost desc | limit 10",
+                "title": "Active Sessions Over Time",
+                "view": "line",
                 "region": "${MetricsRegion}",
-                "title": "Cost by Model (USD)",
-                "queryLanguage": "cwli",
-                "view": "pie"
-              }
-            },
-            {
-              "type": "log",
-              "x": 16, "y": 20, "width": 8, "height": 6,
-              "properties": {
-                "query": "SOURCE '${MetricsLogGroup}' | filter `service.name` = \"cowork\" and `claude_code.token.usage` > 0 | stats round(sum(`claude_code.token.usage`) / 1000, 0) as Tokens_K by `type` | sort Tokens_K desc",
-                "region": "${MetricsRegion}",
-                "title": "Token Usage by Type",
-                "queryLanguage": "cwli",
-                "view": "pie"
+                "data": { "queries": [
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.session.count\", \"@resource.service.name\"=\"cowork\"})", "step": 60, "label": "Sessions" }
+                ] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
 
             {
               "type": "text",
-              "x": 0, "y": 26, "width": 24, "height": 2,
+              "x": 0, "y": 20, "width": 24, "height": 2,
+              "properties": { "markdown": "## Model & Token Breakdown", "background": "transparent" }
+            },
+            {
+              "type": "chart",
+              "x": 0, "y": 22, "width": 8, "height": 6,
               "properties": {
-                "markdown": "## 💻 Platform & Environment",
-                "background": "transparent"
+                "title": "Token Usage by Model",
+                "view": "pie",
+                "region": "${MetricsRegion}",
+                "data": { "queries": [
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (model)({\"claude_code.token.usage\", \"@resource.service.name\"=\"cowork\"}))", "step": 60 }
+                ] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": true, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
+              }
+            },
+            {
+              "type": "chart",
+              "x": 8, "y": 22, "width": 8, "height": 6,
+              "properties": {
+                "title": "Cost by Model (USD)",
+                "view": "pie",
+                "region": "${MetricsRegion}",
+                "data": { "queries": [
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (model)({\"claude_code.cost.usage\", \"@resource.service.name\"=\"cowork\"}))", "step": 60 }
+                ] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": true, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
+              }
+            },
+            {
+              "type": "chart",
+              "x": 16, "y": 22, "width": 8, "height": 6,
+              "properties": {
+                "title": "Token Usage by Type",
+                "view": "pie",
+                "region": "${MetricsRegion}",
+                "data": { "queries": [
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (type)({\"claude_code.token.usage\", \"@resource.service.name\"=\"cowork\"}))", "step": 60 }
+                ] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": true, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
 
             {
-              "type": "log",
-              "x": 0, "y": 28, "width": 8, "height": 6,
+              "type": "text",
+              "x": 0, "y": 28, "width": 24, "height": 2,
+              "properties": { "markdown": "## Platform & Environment", "background": "transparent" }
+            },
+            {
+              "type": "chart",
+              "x": 0, "y": 30, "width": 8, "height": 6,
               "properties": {
-                "query": "SOURCE '${MetricsLogGroup}' | filter `service.name` = \"cowork\" and `claude_code.session.count` > 0 | stats sum(`claude_code.session.count`) as Sessions by `os.type` | sort Sessions desc",
-                "region": "${MetricsRegion}",
                 "title": "Sessions by Operating System",
-                "queryLanguage": "cwli",
-                "view": "pie"
+                "view": "pie",
+                "region": "${MetricsRegion}",
+                "data": { "queries": [
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (\"@resource.os.type\")({\"claude_code.session.count\", \"@resource.service.name\"=\"cowork\"}))", "step": 60 }
+                ] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": true, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
-              "type": "log",
-              "x": 8, "y": 28, "width": 8, "height": 6,
+              "type": "chart",
+              "x": 8, "y": 30, "width": 8, "height": 6,
               "properties": {
-                "query": "SOURCE '${MetricsLogGroup}' | filter `service.name` = \"cowork\" and `claude_code.session.count` > 0 | stats sum(`claude_code.session.count`) as Sessions by `service.version` | sort Sessions desc | limit 10",
-                "region": "${MetricsRegion}",
                 "title": "CoWork Versions in Use",
-                "queryLanguage": "cwli",
-                "view": "table"
+                "view": "pie",
+                "region": "${MetricsRegion}",
+                "data": { "queries": [
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (\"@resource.service.version\")({\"claude_code.session.count\", \"@resource.service.name\"=\"cowork\"}))", "step": 60 }
+                ] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": true, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
-              "type": "log",
-              "x": 16, "y": 28, "width": 8, "height": 6,
+              "type": "chart",
+              "x": 16, "y": 30, "width": 8, "height": 6,
               "properties": {
-                "query": "SOURCE '${MetricsLogGroup}' | filter `service.name` = \"cowork\" and `claude_code.session.count` > 0 | stats sum(`claude_code.session.count`) as Sessions by `host.arch` | sort Sessions desc",
-                "region": "${MetricsRegion}",
                 "title": "Sessions by Architecture",
-                "queryLanguage": "cwli",
-                "view": "pie"
+                "view": "pie",
+                "region": "${MetricsRegion}",
+                "data": { "queries": [
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (\"@resource.host.arch\")({\"claude_code.session.count\", \"@resource.service.name\"=\"cowork\"}))", "step": 60 }
+                ] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": true, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             }
-
           ]
         }
 
@@ -226,7 +224,3 @@ Outputs:
   DashboardURL:
     Description: Direct URL to the CoWork CloudWatch dashboard
     Value: !Sub 'https://console.aws.amazon.com/cloudwatch/home?region=${AWS::Region}#dashboards:name=${DashboardName}'
-
-  LogsInsightsURL:
-    Description: URL to CloudWatch Logs Insights
-    Value: !Sub 'https://console.aws.amazon.com/cloudwatch/home?region=${AWS::Region}#logsV2:logs-insights'

--- a/deployment/infrastructure/otel-collector.yaml
+++ b/deployment/infrastructure/otel-collector.yaml
@@ -52,7 +52,6 @@ Conditions:
   HasJwtAuth: !Not [!Equals [!Ref OidcIssuerUrl, '']]
   HasOidcClientId: !Not [!Equals [!Ref OidcClientId, '']]
   AnalyticsEnabled: !Equals [!Ref EnableAnalytics, 'true']
-  AnalyticsDisabled: !Not [!Equals [!Ref EnableAnalytics, 'true']]
 
 # Rules section removed - validation handled by deployment script
 
@@ -330,223 +329,218 @@ Resources:
                 Resource:
                   - !Sub 'arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/claude-code-otel-config'
 
-  # SSM Parameter for Configuration — OTLP-only (no analytics)
-  OTelConfigOtlpOnly:
+  # SSM Parameter for Configuration — single resource with conditional value
+  # to avoid delete+create race during stack updates between analytics modes.
+  OTelConfig:
     Type: AWS::SSM::Parameter
-    Condition: AnalyticsDisabled
     Properties:
       Name: claude-code-otel-config
       Type: String
       Tier: Advanced
-      Description: OpenTelemetry configuration - OTLP export only
-      Value: !Sub |
-        extensions:
-          health_check:
-            endpoint: 0.0.0.0:13133
-            path: /
-          sigv4auth:
-            service: "monitoring"
-            region: "${AWS::Region}"
+      Description: !If
+        - AnalyticsEnabled
+        - "OpenTelemetry configuration - dual export (OTLP + EMF)"
+        - "OpenTelemetry configuration - OTLP export only"
+      Value: !If
+        - AnalyticsEnabled
+        - !Sub |
+            extensions:
+              health_check:
+                endpoint: 0.0.0.0:13133
+                path: /
+              sigv4auth:
+                service: "monitoring"
+                region: "${AWS::Region}"
 
-        receivers:
-          otlp:
-            protocols:
-              grpc:
-                endpoint: 0.0.0.0:4317
-                include_metadata: true
-              http:
-                endpoint: 0.0.0.0:4318
-                include_metadata: true
+            receivers:
+              otlp:
+                protocols:
+                  grpc:
+                    endpoint: 0.0.0.0:4317
+                    include_metadata: true
+                  http:
+                    endpoint: 0.0.0.0:4318
+                    include_metadata: true
 
-        processors:
-          batch/metrics:
-            timeout: 60s
-          attributes:
-            actions:
-              - key: user.email
-                from_context: metadata.x-user-email
-                action: upsert
-              - key: user.id
-                from_context: metadata.x-user-id
-                action: upsert
-              - key: user.name
-                from_context: metadata.x-user-name
-                action: upsert
-              - key: department
-                from_context: metadata.x-department
-                action: upsert
-              - key: team.id
-                from_context: metadata.x-team-id
-                action: upsert
-              - key: cost_center
-                from_context: metadata.x-cost-center
-                action: upsert
-              - key: organization
-                from_context: metadata.x-organization
-                action: upsert
-              - key: location
-                from_context: metadata.x-location
-                action: upsert
-              - key: role
-                from_context: metadata.x-role
-                action: upsert
-              - key: manager
-                from_context: metadata.x-manager
-                action: upsert
-          resource:
-            attributes:
-              - key: aws.account_id
-                value: "${AWS::AccountId}"
-                action: insert
-              - key: deployment.environment
-                value: "production"
-                action: insert
+            processors:
+              batch/metrics:
+                timeout: 60s
+              attributes:
+                actions:
+                  - key: user.email
+                    from_context: metadata.x-user-email
+                    action: upsert
+                  - key: user.id
+                    from_context: metadata.x-user-id
+                    action: upsert
+                  - key: user.name
+                    from_context: metadata.x-user-name
+                    action: upsert
+                  - key: department
+                    from_context: metadata.x-department
+                    action: upsert
+                  - key: team.id
+                    from_context: metadata.x-team-id
+                    action: upsert
+                  - key: cost_center
+                    from_context: metadata.x-cost-center
+                    action: upsert
+                  - key: organization
+                    from_context: metadata.x-organization
+                    action: upsert
+                  - key: location
+                    from_context: metadata.x-location
+                    action: upsert
+                  - key: role
+                    from_context: metadata.x-role
+                    action: upsert
+                  - key: manager
+                    from_context: metadata.x-manager
+                    action: upsert
+              resource:
+                attributes:
+                  - key: aws.account_id
+                    value: "${AWS::AccountId}"
+                    action: insert
+                  - key: deployment.environment
+                    value: "production"
+                    action: insert
 
-        exporters:
-          otlphttp:
-            tls:
-              insecure: false
-            endpoint: "https://monitoring.${AWS::Region}.amazonaws.com"
-            auth:
-              authenticator: sigv4auth
+            exporters:
+              otlphttp:
+                tls:
+                  insecure: false
+                endpoint: "https://monitoring.${AWS::Region}.amazonaws.com"
+                auth:
+                  authenticator: sigv4auth
 
-        service:
-          extensions: [health_check, sigv4auth]
-          telemetry:
-            logs:
-              level: info
-              development: false
-              encoding: json
-              output_paths: [stdout]
-          pipelines:
-            metrics:
-              receivers: [otlp]
-              processors: [attributes, resource, batch/metrics]
-              exporters: [otlphttp]
+              awsemf:
+                namespace: ClaudeCode
+                log_group_name: /aws/claude-code/metrics
+                region: ${AWS::Region}
+                output_destination: cloudwatch
+                log_retention: 7
+                resource_to_telemetry_conversion:
+                  enabled: true
+                metric_declarations:
+                  - dimensions: [[OTelLib]]
+                    metric_name_selectors: [".*"]
+                  - dimensions: [[department, OTelLib]]
+                    metric_name_selectors: [".*"]
+                  - dimensions: [[team.id, OTelLib]]
+                    metric_name_selectors: [".*"]
+                  - dimensions: [[organization, OTelLib]]
+                    metric_name_selectors: [".*"]
+                  - dimensions: [[model, OTelLib]]
+                    metric_name_selectors: [".*"]
+                  - dimensions: [[cost_center, OTelLib]]
+                    metric_name_selectors: ["claude_code.cost.usage", "claude_code.token.usage"]
+                  - dimensions: [[type, OTelLib]]
+                    metric_name_selectors: ["claude_code.token.usage", "claude_code.lines_of_code.count"]
+                  - dimensions: [[tool_name, OTelLib]]
+                    metric_name_selectors: ["claude_code.code_edit_tool.*"]
+                  - dimensions: [[language, OTelLib]]
+                    metric_name_selectors: ["claude_code.code_edit_tool.*"]
+                  - dimensions: [[decision, OTelLib]]
+                    metric_name_selectors: ["claude_code.code_edit_tool.decision"]
 
-  # SSM Parameter for Configuration — dual-export (OTLP + EMF for analytics)
-  OTelConfigDualExport:
-    Type: AWS::SSM::Parameter
-    Condition: AnalyticsEnabled
-    Properties:
-      Name: claude-code-otel-config
-      Type: String
-      Tier: Advanced
-      Description: OpenTelemetry configuration - dual export (OTLP + EMF)
-      Value: !Sub |
-        extensions:
-          health_check:
-            endpoint: 0.0.0.0:13133
-            path: /
-          sigv4auth:
-            service: "monitoring"
-            region: "${AWS::Region}"
+            service:
+              extensions: [health_check, sigv4auth]
+              telemetry:
+                logs:
+                  level: info
+                  development: false
+                  encoding: json
+                  output_paths: [stdout]
+              pipelines:
+                metrics:
+                  receivers: [otlp]
+                  processors: [attributes, resource, batch/metrics]
+                  exporters: [otlphttp, awsemf]
+        - !Sub |
+            extensions:
+              health_check:
+                endpoint: 0.0.0.0:13133
+                path: /
+              sigv4auth:
+                service: "monitoring"
+                region: "${AWS::Region}"
 
-        receivers:
-          otlp:
-            protocols:
-              grpc:
-                endpoint: 0.0.0.0:4317
-                include_metadata: true
-              http:
-                endpoint: 0.0.0.0:4318
-                include_metadata: true
+            receivers:
+              otlp:
+                protocols:
+                  grpc:
+                    endpoint: 0.0.0.0:4317
+                    include_metadata: true
+                  http:
+                    endpoint: 0.0.0.0:4318
+                    include_metadata: true
 
-        processors:
-          batch/metrics:
-            timeout: 60s
-          attributes:
-            actions:
-              - key: user.email
-                from_context: metadata.x-user-email
-                action: upsert
-              - key: user.id
-                from_context: metadata.x-user-id
-                action: upsert
-              - key: user.name
-                from_context: metadata.x-user-name
-                action: upsert
-              - key: department
-                from_context: metadata.x-department
-                action: upsert
-              - key: team.id
-                from_context: metadata.x-team-id
-                action: upsert
-              - key: cost_center
-                from_context: metadata.x-cost-center
-                action: upsert
-              - key: organization
-                from_context: metadata.x-organization
-                action: upsert
-              - key: location
-                from_context: metadata.x-location
-                action: upsert
-              - key: role
-                from_context: metadata.x-role
-                action: upsert
-              - key: manager
-                from_context: metadata.x-manager
-                action: upsert
-          resource:
-            attributes:
-              - key: aws.account_id
-                value: "${AWS::AccountId}"
-                action: insert
-              - key: deployment.environment
-                value: "production"
-                action: insert
+            processors:
+              batch/metrics:
+                timeout: 60s
+              attributes:
+                actions:
+                  - key: user.email
+                    from_context: metadata.x-user-email
+                    action: upsert
+                  - key: user.id
+                    from_context: metadata.x-user-id
+                    action: upsert
+                  - key: user.name
+                    from_context: metadata.x-user-name
+                    action: upsert
+                  - key: department
+                    from_context: metadata.x-department
+                    action: upsert
+                  - key: team.id
+                    from_context: metadata.x-team-id
+                    action: upsert
+                  - key: cost_center
+                    from_context: metadata.x-cost-center
+                    action: upsert
+                  - key: organization
+                    from_context: metadata.x-organization
+                    action: upsert
+                  - key: location
+                    from_context: metadata.x-location
+                    action: upsert
+                  - key: role
+                    from_context: metadata.x-role
+                    action: upsert
+                  - key: manager
+                    from_context: metadata.x-manager
+                    action: upsert
+              resource:
+                attributes:
+                  - key: aws.account_id
+                    value: "${AWS::AccountId}"
+                    action: insert
+                  - key: deployment.environment
+                    value: "production"
+                    action: insert
 
-        exporters:
-          otlphttp:
-            tls:
-              insecure: false
-            endpoint: "https://monitoring.${AWS::Region}.amazonaws.com"
-            auth:
-              authenticator: sigv4auth
+            exporters:
+              otlphttp:
+                tls:
+                  insecure: false
+                endpoint: "https://monitoring.${AWS::Region}.amazonaws.com"
+                auth:
+                  authenticator: sigv4auth
 
-          awsemf:
-            namespace: ClaudeCode
-            log_group_name: /aws/claude-code/metrics
-            region: ${AWS::Region}
-            output_destination: cloudwatch
-            log_retention: 7
-            resource_to_telemetry_conversion:
-              enabled: true
-            metric_declarations:
-              - dimensions: [[OTelLib]]
-                metric_name_selectors: [".*"]
-              - dimensions: [[department, OTelLib]]
-                metric_name_selectors: [".*"]
-              - dimensions: [[team.id, OTelLib]]
-                metric_name_selectors: [".*"]
-              - dimensions: [[organization, OTelLib]]
-                metric_name_selectors: [".*"]
-              - dimensions: [[model, OTelLib]]
-                metric_name_selectors: [".*"]
-              - dimensions: [[cost_center, OTelLib]]
-                metric_name_selectors: ["claude_code.cost.usage", "claude_code.token.usage"]
-              - dimensions: [[type, OTelLib]]
-                metric_name_selectors: ["claude_code.token.usage", "claude_code.lines_of_code.count"]
-              - dimensions: [[tool_name, OTelLib]]
-                metric_name_selectors: ["claude_code.code_edit_tool.*"]
-              - dimensions: [[language, OTelLib]]
-                metric_name_selectors: ["claude_code.code_edit_tool.*"]
-              - dimensions: [[decision, OTelLib]]
-                metric_name_selectors: ["claude_code.code_edit_tool.decision"]
-
-        service:
-          extensions: [health_check, sigv4auth]
-          telemetry:
-            logs:
-              level: info
-              development: false
-              encoding: json
-              output_paths: [stdout]
-          pipelines:
-            metrics:
-              receivers: [otlp]
-              processors: [attributes, resource, batch/metrics]
-              exporters: [otlphttp, awsemf]
+            service:
+              extensions: [health_check, sigv4auth]
+              telemetry:
+                logs:
+                  level: info
+                  development: false
+                  encoding: json
+                  output_paths: [stdout]
+              pipelines:
+                metrics:
+                  receivers: [otlp]
+                  processors: [attributes, resource, batch/metrics]
+                  exporters: [otlphttp]
 
   # ECS Task Definition
   TaskDefinition:
@@ -567,10 +561,7 @@ Resources:
           Memory: 512
           Secrets:
             - Name: AOT_CONFIG_CONTENT
-              ValueFrom: !If
-                - AnalyticsEnabled
-                - !Ref OTelConfigDualExport
-                - !Ref OTelConfigOtlpOnly
+              ValueFrom: !Ref OTelConfig
           PortMappings:
             - ContainerPort: 4317
               Protocol: tcp
@@ -693,10 +684,7 @@ Outputs:
 
   ConfigParameterName:
     Description: SSM Parameter containing collector configuration
-    Value: !If
-      - AnalyticsEnabled
-      - !Ref OTelConfigDualExport
-      - !Ref OTelConfigOtlpOnly
+    Value: !Ref OTelConfig
 
   LogGroupName:
     Description: CloudWatch Log Group for metrics (only when analytics enabled)

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -119,11 +119,13 @@ class DeployCommand(Command):
                     console.print("[yellow]Monitoring is not enabled in your configuration.[/yellow]")
                     return 1
             elif stack_arg == "cowork-dashboard":
-                if profile.monitoring_enabled:
-                    stacks_to_deploy.append(("cowork-dashboard", "CoWork CloudWatch Dashboard"))
-                else:
+                if not profile.monitoring_enabled:
                     console.print("[yellow]Monitoring is not enabled in your configuration.[/yellow]")
                     return 1
+                if getattr(profile, "monitoring_mode", "central") == "sidecar":
+                    console.print("[yellow]CoWork dashboard requires central monitoring mode (Cowork cannot export telemetry in sidecar mode).[/yellow]")
+                    return 1
+                stacks_to_deploy.append(("cowork-dashboard", "CoWork CloudWatch Dashboard"))
             elif stack_arg == "analytics":
                 if profile.monitoring_enabled:
                     stacks_to_deploy.append(("analytics", "Analytics Pipeline (Kinesis Firehose + Athena)"))
@@ -236,7 +238,8 @@ class DeployCommand(Command):
 
             if should_delete:
                 console.print("\n[bold]Cleaning up orphaned stacks...[/bold]\n")
-                for stack_type, stack_name, _status in orphaned_stacks:
+                # Delete in reverse deployment order (dependents first)
+                for stack_type, stack_name, _status in reversed(orphaned_stacks):
                     try:
                         console.print(f"[yellow]Deleting {stack_type} stack: {stack_name}...[/yellow]")
                         cf_manager.delete_stack(stack_name)
@@ -719,7 +722,6 @@ class DeployCommand(Command):
                     "cowork-dashboard", f"{profile.identity_pool_name}-cowork-dashboard"
                 )
                 params = [
-                    f"MetricsLogGroup={profile.metrics_log_group}",
                     f"MetricsRegion={profile.aws_region}",
                 ]
                 return deploy_with_cf(
@@ -999,7 +1001,6 @@ class DeployCommand(Command):
             template = project_root / "deployment" / "infrastructure" / "cowork-dashboard.yaml"
             stack_name = profile.stack_names.get("cowork-dashboard", f"{profile.identity_pool_name}-cowork-dashboard")
             params = [
-                f"MetricsLogGroup={profile.metrics_log_group}",
                 f"MetricsRegion={region}",
             ]
             print_deploy_cmd(template, stack_name, params)
@@ -1175,6 +1176,7 @@ class DeployCommand(Command):
             "networking": "VPC Networking",
             "monitoring": "OpenTelemetry Collector",
             "dashboard": "CloudWatch Dashboard",
+            "cowork-dashboard": "CoWork CloudWatch Dashboard",
             "analytics": "Analytics Pipeline",
             "quota": "Quota Monitoring",
             "codebuild": "CodeBuild",

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -848,11 +848,13 @@ class InitCommand(Command):
                     "  [green]+[/green] Works offline — each dev machine runs its own collector\n"
                     "  [yellow]-[/yellow] No Athena SQL query pipeline (PromQL dashboards still included)\n"
                     "  [yellow]-[/yellow] Each machine manages its own collector process\n"
+                    "  [yellow]-[/yellow] Claude Cowork (desktop) telemetry not supported (cannot reach localhost collector)\n"
                 )
                 console.print(
                     "[cyan]Central:[/cyan]\n"
                     "  [green]+[/green] Optional Athena SQL pipeline (EMF → Firehose → S3 → Athena)\n"
                     "  [green]+[/green] Single collector for all users — centralized management\n"
+                    "  [green]+[/green] Supports Claude Cowork (desktop) telemetry\n"
                     "  [green]+[/green] Recommended if IT policies prevent users running a local OTel collector on localhost\n"
                     "  [yellow]-[/yellow] Requires VPC/ECS Fargate infrastructure\n"
                     "  [yellow]-[/yellow] Higher cost (ECS tasks, NAT gateways, load balancer)\n"

--- a/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
+++ b/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
@@ -71,21 +71,28 @@ def add_monitoring_config(mdm_config: dict, profile, console: Console) -> None:
     if not profile.monitoring_enabled:
         return
 
+    monitoring_mode = getattr(profile, "monitoring_mode", "central")
+
+    if monitoring_mode == "sidecar":
+        console.print("[dim]Sidecar mode — Cowork telemetry not supported, skipping OTLP config[/dim]")
+        return
+
     monitoring_stack = profile.stack_names.get(
         "monitoring", f"{profile.identity_pool_name}-otel-collector"
     )
-
     try:
         outputs = get_stack_outputs(monitoring_stack, profile.aws_region)
         endpoint = outputs.get("CollectorEndpoint")
-        if endpoint:
-            mdm_config["otlpEndpoint"] = endpoint
-            mdm_config["otlpProtocol"] = "http/protobuf"
-            console.print(f"[dim]OTLP endpoint: {endpoint}[/dim]")
-        else:
-            console.print("[dim]Monitoring stack not found — skipping OTLP config[/dim]")
     except Exception:
         console.print("[dim]Could not query monitoring stack — skipping OTLP config[/dim]")
+        return
+
+    if endpoint:
+        mdm_config["otlpEndpoint"] = endpoint
+        mdm_config["otlpProtocol"] = "http/protobuf"
+        console.print(f"[dim]OTLP endpoint: {endpoint}[/dim]")
+    else:
+        console.print("[dim]Monitoring endpoint not found — skipping OTLP config[/dim]")
 
 
 def _mdm_keys(config: dict) -> dict:

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -23,7 +23,7 @@ class Profile:
     schema_version: str = "2.0"  # Configuration schema version
     stack_names: dict[str, str] = field(default_factory=dict)
     monitoring_enabled: bool = True
-    monitoring_mode: str = "sidecar"  # "sidecar" (local collector) or "central" (ECS Fargate)
+    monitoring_mode: str = "central"  # "sidecar" (local collector) or "central" (ECS Fargate)
     monitoring_config: dict[str, Any] = field(default_factory=dict)
     analytics_enabled: bool = True  # Analytics pipeline for user metrics
     metrics_log_group: str = "/aws/claude-code/metrics"
@@ -181,6 +181,11 @@ class Profile:
             # If distribution was enabled but no type specified, default to presigned-s3
             if "distribution_type" not in data or data["distribution_type"] is None:
                 data["distribution_type"] = "presigned-s3"
+
+        # Ensure monitoring_mode defaults to "central" for existing profiles
+        # (new profiles created via init will explicitly set "sidecar")
+        if "monitoring_mode" not in data:
+            data["monitoring_mode"] = "central"
 
         # Set default cross-region profile if not present
         if "cross_region_profile" not in data:


### PR DESCRIPTION
## Description

Hardens the sidecar monitoring mode by fixing backward compatibility for existing profiles, adding Cowork telemetry guardrails, and migrating the CoWork dashboard to PromQL. Ensures that customers upgrading without re-running `ccwb init` continue operating in central mode, and that sidecar mode clearly communicates (and enforces) that Claude Cowork desktop telemetry is not supported.

## Why is this change needed

The recently introduced "sidecar" vs "central" monitoring mode had several issues:
1. Existing profiles missing the `monitoring_mode` field would incorrectly default to "sidecar" due to the dataclass default, breaking their deployments
2. Claude Cowork (desktop app) cannot send OTLP to a localhost collector, but the MDM config was emitting `otlpEndpoint: http://localhost:4318` in sidecar mode
3. The CoWork dashboard could still be deployed in sidecar mode despite having no data source
4. Orphaned stack cleanup deleted stacks in deployment order instead of reverse, causing dependency failures

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Infrastructure/deployment change
- [ ] Dependency update
- [ ] CI/CD changes

## Changes Made

- **Config**: Default `monitoring_mode` to "central" for existing profiles (backward compat) with explicit migration in `Profile.from_dict()`
- **Init wizard**: Add Cowork telemetry limitation warning to sidecar description; add Cowork telemetry support as a PRO for central mode
- **CoWork MDM generation**: Skip OTLP config entirely in sidecar mode; central mode correctly resolves endpoint from CloudFormation outputs
- **Deploy**: Block cowork-dashboard deployment in sidecar mode; delete orphaned stacks in reverse order; add cowork-dashboard to orphaned stack detection; remove unused MetricsLogGroup parameter
- **CloudFormation**: Migrate CoWork dashboard to PromQL with service.name filtering; consolidate SSM parameter to single resource for safe stack updates
- **Changelog**: Tag as v2.4.0 with all changes documented

## Additional Notes

- Existing customers who upgrade without re-running `init` will continue operating in "central" mode with no behavior change
- New customers running `init` for the first time will be offered "sidecar" as the recommended default
- The init wizard now clearly communicates the Cowork telemetry limitation for sidecar mode

---

## Testing Checklist

### What was tested

- [x] CLI commands tested (`ccwb init/deploy/build/package/test`)
- [x] CloudFormation templates deployed successfully
- [x] Unit/integration tests pass (`ccwb test`)
- [x] Binary installation tested (`install.sh` / `install.bat`)
- [x] End-to-end authentication flow tested

### Special cases

- [ ] This PR only modifies GitHub workflows (auto-exempt from testing validation)
- [ ] This is a documentation-only change (exempt from testing validation)
- [ ] This PR needs `skip-testing-validation` label (explain why below)

## Testing Evidence

**Test Environment:** us-east-1, Python 3.12, macOS

**Test Results:**

```text
- Verified ccwb init displays updated sidecar/central descriptions with Cowork telemetry notes
- Verified ccwb deploy --stack cowork-dashboard rejects with clear message in sidecar mode
- Verified ccwb cowork generate with sidecar profile produces MDM config without otlpEndpoint/otlpProtocol
- Verified ccwb cowork generate with central profile correctly resolves OTLP endpoint from CloudFormation
- Verified existing profile without monitoring_mode field loads as "central"
- Verified orphaned stack deletion proceeds in reverse order (monitoring before networking)
```
