### PR TITLE
fix: monitoring stack update fails on existing deployments (SSM parameter conflict)

### DIFF
--- a/deployment/infrastructure/otel-collector.yaml
+++ b/deployment/infrastructure/otel-collector.yaml
@@ -331,8 +331,10 @@ Resources:
                   - !Sub 'arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/claude-code-otel-config'
 
   # SSM Parameter for Configuration — OTLP-only (no analytics)
-  OTelConfigOtlpOnly:
+  OTelConfig:
     Type: AWS::SSM::Parameter
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Condition: AnalyticsDisabled
     Properties:
       Name: claude-code-otel-config
@@ -427,6 +429,8 @@ Resources:
   # SSM Parameter for Configuration — dual-export (OTLP + EMF for analytics)
   OTelConfigDualExport:
     Type: AWS::SSM::Parameter
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Condition: AnalyticsEnabled
     Properties:
       Name: claude-code-otel-config
@@ -570,7 +574,7 @@ Resources:
               ValueFrom: !If
                 - AnalyticsEnabled
                 - !Ref OTelConfigDualExport
-                - !Ref OTelConfigOtlpOnly
+                - !Ref OTelConfig
           PortMappings:
             - ContainerPort: 4317
               Protocol: tcp
@@ -696,7 +700,7 @@ Outputs:
     Value: !If
       - AnalyticsEnabled
       - !Ref OTelConfigDualExport
-      - !Ref OTelConfigOtlpOnly
+      - !Ref OTelConfig
 
   LogGroupName:
     Description: CloudWatch Log Group for metrics (only when analytics enabled)


### PR DESCRIPTION
Fixes #398

## Problem

After PR #387 merged to main, existing monitoring deployments cannot be updated:

```
AWS::SSM::Parameter (OTelConfigDualExport):
claude-code-otel-config already exists in stack
```

PR #387 renamed the logical resource `OTelConfig` → `OTelConfigOtlpOnly` + `OTelConfigDualExport`. Existing stacks have the physical parameter under the original logical name. CloudFormation cannot create a new logical resource that maps to an already-existing physical resource.

## Fix

1. **Rename `OTelConfigOtlpOnly` back to `OTelConfig`** (the original logical name). CloudFormation sees this as an update to the existing resource rather than delete + create.

2. **Add `DeletionPolicy: Retain` + `UpdateReplacePolicy: Retain`** to both SSM parameters. Prevents accidental deletion if logical names change again in the future.

## Why target main

PR #387 merged directly to main (not beta). The regression is live on main and blocks all existing monitoring stack updates. This fix must land on main to unblock affected deployments.

## Why this works

| Scenario | Before (broken) | After (fixed) |
|----------|-----------------|---------------|
| Existing stack update (pre-#387) | CF deletes `OTelConfig`, tries to create `OTelConfigOtlpOnly` → **conflict** | CF updates `OTelConfig` in-place → **success** |
| New deployment | Creates resources fresh | Same — works |
| Analytics enabled | Creates `OTelConfigDualExport` | Same — unchanged |

## Note: fresh deployments made after #387 merged (May 20-23)

If anyone deployed the monitoring stack **fresh** (not an update) during the 3 days since #387 merged, their stack has `OTelConfigOtlpOnly` as the logical name. Updating to this fix would cause the reverse conflict. This is expected to be rare since:
- Most users are updating existing stacks (which is what broke and triggered #398)
- Fresh deploys during a 3-day window are uncommon

**Workaround for fresh #387 deployers:** Delete the SSM parameter before re-deploying:
```bash
aws ssm delete-parameter --name claude-code-otel-config
ccwb deploy monitoring
```

## Changes

One file, +7/-3 lines.

## Testing Evidence

### CloudFormation Template Validation

Template validates successfully with the renamed resource.

### Logical Resource Verification

```bash
$ grep -c "OTelConfigOtlpOnly" deployment/infrastructure/otel-collector.yaml
0  # Fully removed

$ grep "OTelConfig:" deployment/infrastructure/otel-collector.yaml
  OTelConfig:  # Original logical name restored

$ grep "DeletionPolicy" deployment/infrastructure/otel-collector.yaml
    DeletionPolicy: Retain
    DeletionPolicy: Retain
```

### Backward Compatibility Check

- [x] Original logical name `OTelConfig` is preserved — existing stacks will see an in-place UPDATE not DELETE+CREATE
- [x] `OTelConfigDualExport` retains its name (new resource, only for analytics-enabled deployments)
- [x] All `!Ref` and `!If` references updated to use `OTelConfig` instead of `OTelConfigOtlpOnly`
- [x] `DeletionPolicy: Retain` prevents physical resource deletion on future logical name changes
- [x] No Python code changes — infrastructure-only
- [x] No test changes needed