### PR TITLE
feat: enable quota enforcement for IAM Identity Center users

### DIFF
--- a/deployment/infrastructure/lambda-functions/quota_check/index.py
+++ b/deployment/infrastructure/lambda-functions/quota_check/index.py
@@ -1,6 +1,6 @@
 # ABOUTME: Lambda function for real-time quota checking before credential issuance
 # ABOUTME: Returns allowed/blocked status based on user quota policy and current usage
-# ABOUTME: Requires JWT authentication - extracts user identity from API Gateway JWT Authorizer claims
+# ABOUTME: Extracts user identity from JWT claims (OIDC) or IAM caller ARN (IDC) for quota enforcement
 
 import json
 import boto3
@@ -54,27 +54,38 @@ def lambda_handler(event, context):
         JSON response with allowed status and usage details
     """
     try:
-        # Extract validated claims from API Gateway JWT Authorizer
-        # The JWT Authorizer validates the token before Lambda is invoked
+        # Extract user identity from either JWT claims (OIDC) or IAM caller identity (IDC)
+        email = None
+        groups = []
+
+        # Path 1: JWT Authorizer (OIDC users)
         authorizer_context = event.get("requestContext", {}).get("authorizer", {})
         jwt_claims = authorizer_context.get("jwt", {}).get("claims", {})
 
-        # Email from validated JWT claims (secure - no parameter tampering possible)
-        email = jwt_claims.get("email")
+        if jwt_claims:
+            email = jwt_claims.get("email")
+            groups = extract_groups_from_claims(jwt_claims)
 
-        # Extract groups from various possible JWT claims
-        groups = extract_groups_from_claims(jwt_claims)
+        # Path 2: IAM identity (IDC users) — extract email from caller ARN
+        # ARN format: arn:aws:sts::ACCOUNT:assumed-role/AWSReservedSSO_.../user@company.com
+        if not email:
+            identity = event.get("requestContext", {}).get("identity", {})
+            caller_arn = identity.get("caller", "") or identity.get("userArn", "")
+            if "/" in caller_arn:
+                session_name = caller_arn.split("/")[-1]
+                if "@" in session_name:
+                    email = session_name
+                    print(f"Identity resolved from IAM ARN: {email}")
 
         if not email:
-            # JWT is valid but missing email claim
-            # Security: Default to fail-closed (block) unless explicitly configured to allow
-            print(f"JWT missing email claim. Available claims: {list(jwt_claims.keys())}")
+            # Neither JWT nor IAM identity resolved
+            print(f"No user identity found. JWT claims: {list(jwt_claims.keys())}")
             allow_missing_email = MISSING_EMAIL_ENFORCEMENT != "block"
             return build_response(200, {
-                "error": "No email claim in JWT token",
+                "error": "No user identity found (no JWT email claim or IAM session name)",
                 "allowed": allow_missing_email,
-                "reason": "missing_email_claim",
-                "message": "JWT token does not contain email claim" + (" - quota check skipped" if allow_missing_email else " - access denied for security")
+                "reason": "missing_identity",
+                "message": "Could not resolve user identity" + (" - quota check skipped" if allow_missing_email else " - access denied for security")
             })
 
         # 1. Resolve the effective quota policy for this user

--- a/deployment/infrastructure/quota-monitoring.yaml
+++ b/deployment/infrastructure/quota-monitoring.yaml
@@ -301,6 +301,7 @@ Resources:
 
   # JWT Authorizer for OIDC token validation (only when SSO is enabled)
   QuotaCheckAuthorizer:
+    Condition: HasJwtAuth
     Type: AWS::ApiGatewayV2::Authorizer
     Condition: HasJwtAuth
     Properties:
@@ -323,7 +324,7 @@ Resources:
       IntegrationUri: !GetAtt QuotaCheckFunction.Arn
       PayloadFormatVersion: '2.0'
 
-  # Route for GET /check (JWT authenticated when SSO enabled, open when disabled)
+  # Route for GET /check — JWT when OIDC configured, IAM auth when IDC/none
   QuotaCheckRouteWithAuth:
     Type: AWS::ApiGatewayV2::Route
     Condition: HasJwtAuth
@@ -334,13 +335,14 @@ Resources:
       AuthorizerId: !Ref QuotaCheckAuthorizer
       AuthorizationType: JWT
 
-  QuotaCheckRouteNoAuth:
+  QuotaCheckRouteIAM:
     Type: AWS::ApiGatewayV2::Route
     Condition: NoJwtAuth
     Properties:
       ApiId: !Ref QuotaCheckApi
       RouteKey: 'GET /check'
       Target: !Sub 'integrations/${QuotaCheckIntegration}'
+      AuthorizationType: AWS_IAM
 
   # Default stage with auto-deploy
   QuotaCheckStage:

--- a/source/credential_provider/__main__.py
+++ b/source/credential_provider/__main__.py
@@ -1772,12 +1772,17 @@ class MultiProviderAuth:
 
         return list(set(groups))  # Remove duplicates
 
-    def _check_quota(self, token_claims: dict, id_token: str) -> dict:
+    def _check_quota(self, token_claims: dict, id_token: str = None) -> dict:
         """Check user quota via the quota check API.
 
+        Supports two auth modes:
+        - OIDC: sends JWT in Authorization header (API Gateway JWT Authorizer)
+        - IDC/IAM: sends SigV4-signed request (API Gateway IAM auth)
+
         Args:
-            token_claims: JWT token claims containing user info (for logging/fallback)
-            id_token: Raw JWT token to send in Authorization header for API Gateway validation
+            token_claims: JWT token claims containing user info (for logging/fallback).
+                          For IDC, may be empty — email is resolved from IAM ARN server-side.
+            id_token: Raw JWT token for OIDC path. None for IDC path.
 
         Returns:
             Quota check result dict with 'allowed' key
@@ -1786,22 +1791,44 @@ class MultiProviderAuth:
         fail_mode = self.config.get("quota_fail_mode", "open")
         timeout = self.config.get("quota_check_timeout", 5)
 
-        email = token_claims.get("email")
-        if not email:
+        email = token_claims.get("email") if token_claims else None
+        if not email and not id_token:
+            # IDC path: email will be resolved server-side from IAM ARN
+            self._debug_print("IDC mode: email will be resolved from IAM ARN by quota Lambda")
+        elif not email:
             self._debug_print("No email in token claims, skipping quota check")
             return {"allowed": True, "reason": "no_email"}
 
-        groups = self._extract_groups(token_claims)
-        self._debug_print(f"Checking quota for {email} (groups: {groups})")
+        if email:
+            groups = self._extract_groups(token_claims)
+            self._debug_print(f"Checking quota for {email} (groups: {groups})")
+        else:
+            self._debug_print("Checking quota via IAM identity")
 
         try:
-            # Send JWT token in Authorization header for API Gateway JWT Authorizer validation
-            # The API extracts email/groups from validated JWT claims, not query params
-            response = requests.get(
-                f"{quota_api_endpoint}/check",
-                headers={"Authorization": f"Bearer {id_token}"},
-                timeout=timeout
-            )
+            if id_token:
+                # OIDC path: JWT in Authorization header
+                response = requests.get(
+                    f"{quota_api_endpoint}/check",
+                    headers={"Authorization": f"Bearer {id_token}"},
+                    timeout=timeout
+                )
+            else:
+                # IDC/IAM path: SigV4-signed request using current AWS credentials
+                import botocore.session
+                from botocore.auth import SigV4Auth
+                from botocore.awsrequest import AWSRequest
+
+                session = botocore.session.get_session()
+                credentials = session.get_credentials().get_frozen_credentials()
+                url = f"{quota_api_endpoint}/check"
+                request = AWSRequest(method="GET", url=url)
+                SigV4Auth(credentials, "execute-api", self.config.get("aws_region", "us-east-1")).add_auth(request)
+                response = requests.get(
+                    url,
+                    headers=dict(request.headers),
+                    timeout=timeout
+                )
 
             if response.status_code == 200:
                 result = response.json()
@@ -2228,6 +2255,7 @@ class MultiProviderAuth:
                     id_token = self.get_monitoring_token()
                     token_claims = self._get_cached_token_claims()
                     if id_token and token_claims:
+                        # OIDC path: check with JWT
                         quota_result = self._check_quota(token_claims, id_token)
                         self._save_quota_check_timestamp()
                         if not quota_result.get("allowed", True):
@@ -2235,7 +2263,14 @@ class MultiProviderAuth:
                         else:
                             self._handle_quota_warning(quota_result)
                     else:
-                        self._debug_print("No cached token for quota re-check, skipping")
+                        # IDC/IAM path: check with SigV4 (no JWT needed)
+                        self._debug_print("No JWT token — using IAM identity for quota check")
+                        quota_result = self._check_quota({}, None)
+                        self._save_quota_check_timestamp()
+                        if not quota_result.get("allowed", True):
+                            return self._handle_quota_blocked(quota_result)
+                        else:
+                            self._handle_quota_warning(quota_result)
 
                 # Output cached credentials (intended behavior for AWS CLI)
                 print(json.dumps(cached))  # noqa: S105

--- a/source/tests/test_quota_idc_auth.py
+++ b/source/tests/test_quota_idc_auth.py
@@ -1,0 +1,159 @@
+# ABOUTME: Tests for dual-auth quota check (JWT + IAM Identity Center)
+# ABOUTME: Verifies identity resolution from both OIDC JWT claims and IAM caller ARN
+
+"""Tests for quota_check Lambda dual identity resolution.
+
+These tests verify the identity extraction logic ONLY — they don't test
+the full quota calculation flow (that's tested in test_quota_check_lambda.py).
+"""
+
+import json
+import os
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+# Add the lambda function to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "deployment", "infrastructure", "lambda-functions", "quota_check"))
+
+import index
+
+
+class TestIdentityResolution:
+    """Test that the Lambda correctly extracts user identity from JWT or IAM ARN."""
+
+    def _make_event(self, jwt_claims=None, caller_arn=None):
+        """Build a mock API Gateway event."""
+        event = {"requestContext": {}}
+        if jwt_claims:
+            event["requestContext"]["authorizer"] = {"jwt": {"claims": jwt_claims}}
+        if caller_arn:
+            event["requestContext"]["identity"] = {"caller": caller_arn, "userArn": caller_arn}
+        return event
+
+    def test_oidc_user_with_email_claim(self):
+        """OIDC user: identity resolved from JWT email claim."""
+        event = self._make_event(jwt_claims={"email": "alice@company.com", "sub": "abc123"})
+
+        with patch.object(index, "resolve_quota_for_user") as mock_resolve, \
+             patch.object(index, "get_unblock_status", return_value=None), \
+             patch.object(index, "get_user_usage_summary", return_value={}):
+            mock_resolve.return_value = {
+                "monthly_limit": 225000000,
+                "daily_limit": 0,
+                "enforcement_mode": "alert",
+                "enabled": True,
+                "warning_threshold_80": 180000000,
+                "warning_threshold_90": 202500000,
+            }
+
+            result = index.lambda_handler(event, None)
+            body = json.loads(result["body"])
+
+            mock_resolve.assert_called_once_with("alice@company.com", [])
+            assert body["allowed"] is True
+
+    def test_idc_user_with_email_in_arn(self):
+        """IDC user: identity resolved from assumed-role ARN session name."""
+        event = self._make_event(
+            caller_arn="arn:aws:sts::123456789012:assumed-role/AWSReservedSSO_BedrockAccess_abc123/bob@company.com"
+        )
+
+        with patch.object(index, "resolve_quota_for_user") as mock_resolve, \
+             patch.object(index, "get_unblock_status", return_value=None), \
+             patch.object(index, "get_user_usage_summary", return_value={}):
+            mock_resolve.return_value = {
+                "monthly_limit": 225000000,
+                "daily_limit": 0,
+                "enforcement_mode": "alert",
+                "enabled": True,
+                "warning_threshold_80": 180000000,
+                "warning_threshold_90": 202500000,
+            }
+
+            result = index.lambda_handler(event, None)
+            body = json.loads(result["body"])
+
+            mock_resolve.assert_called_once_with("bob@company.com", [])
+            assert body["allowed"] is True
+
+    def test_idc_user_arn_without_email(self):
+        """IDC user with ARN that has no email in session name — missing identity."""
+        event = self._make_event(
+            caller_arn="arn:aws:sts::123456789012:assumed-role/AWSReservedSSO_BedrockAccess_abc123/session123"
+        )
+
+        result = index.lambda_handler(event, None)
+        body = json.loads(result["body"])
+
+        assert body["reason"] == "missing_identity"
+
+    def test_no_auth_at_all(self):
+        """No JWT claims and no IAM identity — missing identity."""
+        event = self._make_event()
+
+        result = index.lambda_handler(event, None)
+        body = json.loads(result["body"])
+
+        assert body["reason"] == "missing_identity"
+
+    def test_jwt_without_email_falls_through_to_arn(self):
+        """JWT present but missing email claim — falls through to IAM ARN."""
+        event = self._make_event(
+            jwt_claims={"sub": "abc123"},  # no email
+            caller_arn="arn:aws:sts::123456789012:assumed-role/Role/carol@company.com"
+        )
+
+        with patch.object(index, "resolve_quota_for_user") as mock_resolve, \
+             patch.object(index, "get_unblock_status", return_value=None), \
+             patch.object(index, "get_user_usage_summary", return_value={}):
+            mock_resolve.return_value = {
+                "monthly_limit": 225000000,
+                "daily_limit": 0,
+                "enforcement_mode": "alert",
+                "enabled": True,
+                "warning_threshold_80": 180000000,
+                "warning_threshold_90": 202500000,
+            }
+
+            result = index.lambda_handler(event, None)
+            body = json.loads(result["body"])
+
+            mock_resolve.assert_called_once_with("carol@company.com", [])
+            assert body["allowed"] is True
+
+    def test_malformed_arn_no_slash(self):
+        """Malformed ARN without slashes — should not crash."""
+        event = self._make_event(caller_arn="not-a-valid-arn")
+
+        result = index.lambda_handler(event, None)
+        body = json.loads(result["body"])
+
+        # "not-a-valid-arn" split by "/" gives ["not-a-valid-arn"] — no @ → missing identity
+        assert body["reason"] == "missing_identity"
+
+    def test_jwt_preferred_over_arn_when_both_present(self):
+        """When both JWT email and ARN are available, JWT takes priority."""
+        event = self._make_event(
+            jwt_claims={"email": "jwt-user@company.com", "sub": "abc"},
+            caller_arn="arn:aws:sts::123456789012:assumed-role/Role/arn-user@company.com"
+        )
+
+        with patch.object(index, "resolve_quota_for_user") as mock_resolve, \
+             patch.object(index, "get_unblock_status", return_value=None), \
+             patch.object(index, "get_user_usage_summary", return_value={}):
+            mock_resolve.return_value = {
+                "monthly_limit": 225000000,
+                "daily_limit": 0,
+                "enforcement_mode": "alert",
+                "enabled": True,
+                "warning_threshold_80": 180000000,
+                "warning_threshold_90": 202500000,
+            }
+
+            result = index.lambda_handler(event, None)
+            body = json.loads(result["body"])
+
+            # JWT email takes priority
+            mock_resolve.assert_called_once_with("jwt-user@company.com", [])


### PR DESCRIPTION
Fixes #401. Also addresses the limitation noted in PR #312 (`iam-identity-center-setup.md`):

> Quota enforcement not available: The `_check_quota()` function requires an OIDC ID token. IAM Identity Center does not produce an OIDC ID token. Per-user token quota limits cannot be enforced on the IDC path.

This PR removes that limitation.

## Solution

End-to-end quota enforcement for IDC users using IAM identity (no JWT required):

### 1. Quota Lambda — dual identity resolution

Extracts user email from either JWT claims (OIDC) or IAM caller ARN (IDC):
```
OIDC: JWT claims → email
IDC:  arn:aws:sts::ACCOUNT:assumed-role/AWSReservedSSO_.../alice@company.com → alice@company.com
```

### 2. API Gateway — conditional auth

- OIDC configured → JWT Authorizer route
- No OIDC → AWS_IAM route (SigV4-signed requests)

### 3. Credential process — complete client-side trigger

When no JWT is available (IDC path), the credential-process:
- Signs the quota API request with SigV4 using the user's AWS credentials
- The Lambda resolves identity from the IAM caller ARN
- Blocking/warning works identically to the OIDC path

Previously, the `else` branch logged "No cached token for quota re-check, skipping" — now it checks quota via IAM identity instead of skipping.

## Changes

| File | Change |
|------|--------|
| `quota_check/index.py` | Dual identity resolution (JWT or IAM ARN) |
| `quota-monitoring.yaml` | Conditional routes (JWT or IAM) + conditional Authorizer |
| `credential_provider/__main__.py` | SigV4 fallback + IDC quota trigger in cached-credentials path |
| `tests/test_quota_idc_auth.py` | 5 unit tests covering all identity resolution paths |

4 files, +211/-30 lines.

## Testing

| # | Scenario | Expected |
|---|----------|----------|
| 1 | OIDC user with JWT containing email | Identity from JWT, quota enforced |
| 2 | IDC user with SigV4, ARN has email | Identity from ARN, quota enforced |
| 3 | IDC user, ARN has no email | Missing identity response |
| 4 | No auth provided | Missing identity response |
| 5 | JWT present but missing email, ARN has email | Falls through to ARN |

## Backward compatible

- OIDC: unchanged (JWT route + Bearer token + JWT identity)
- IDC: new IAM route + SigV4 + ARN identity
- No new infrastructure