### PR TITLE
feat: add cache read disclosure to quota CLI commands

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1058,6 +1058,13 @@ class InitCommand(Command):
                     if custom_daily:
                         console.print(f"  → Using custom daily limit: {daily_limit:,} tokens")
 
+                    console.print(
+                        "\n[dim]Note: Limits include all token types including cache reads.\n"
+                        "Typical Claude Code usage has ~80% cache hit ratio — multiply\n"
+                        "your desired inference-only limit by 5x to account for cached\n"
+                        "token volume.[/dim]"
+                    )
+
                     # Enforcement mode configuration
                     console.print("\n[bold]Enforcement Modes[/bold]")
                     console.print("Choose how limits are enforced:")

--- a/source/claude_code_with_bedrock/cli/commands/quota.py
+++ b/source/claude_code_with_bedrock/cli/commands/quota.py
@@ -82,6 +82,26 @@ def _get_quota_manager(profile) -> QuotaPolicyManager:
     return QuotaPolicyManager(table_name, profile.aws_region)
 
 
+# Disclosure text shown when setting or viewing quotas
+CACHE_READ_DISCLOSURE = (
+    "\n[dim]Note: Limits include all token types including cache reads.\n"
+    "Typical Claude Code usage has ~80% cache hit ratio — multiply\n"
+    "your desired inference-only limit by 5x to account for cached\n"
+    "token volume.\n"
+    "\n"
+    "  Cache hit ratio guide:\n"
+    "    multiplier = 1 / (1 - cache_hit_ratio)\n"
+    "    75% cache hits → multiply by 4x\n"
+    "    80% cache hits → multiply by 5x\n"
+    "    90% cache hits → multiply by 10x[/dim]"
+)
+
+
+def _print_cache_read_disclosure(console: Console) -> None:
+    """Print cache read disclosure note."""
+    console.print(CACHE_READ_DISCLOSURE)
+
+
 def _format_tokens(tokens: int) -> str:
     """Format token count for display.
 
@@ -212,6 +232,7 @@ class QuotaSetUserCommand(Command):
             if policy.daily_token_limit:
                 console.print(f"  Daily limit: {_format_tokens(policy.daily_token_limit)}")
             console.print(f"  Enforcement: {policy.enforcement_mode.value}")
+            _print_cache_read_disclosure(console)
             return 0
 
         except PolicyAlreadyExistsError:
@@ -230,6 +251,7 @@ class QuotaSetUserCommand(Command):
                 if policy.daily_token_limit:
                     console.print(f"  Daily limit: {_format_tokens(policy.daily_token_limit)}")
                 console.print(f"  Enforcement: {policy.enforcement_mode.value}")
+                _print_cache_read_disclosure(console)
                 return 0
             except QuotaPolicyError as e:
                 console.print(f"[red]Failed to update policy: {e}[/red]")
@@ -319,6 +341,7 @@ class QuotaSetGroupCommand(Command):
             if policy.daily_token_limit:
                 console.print(f"  Daily limit: {_format_tokens(policy.daily_token_limit)}")
             console.print(f"  Enforcement: {policy.enforcement_mode.value}")
+            _print_cache_read_disclosure(console)
             return 0
 
         except PolicyAlreadyExistsError:
@@ -337,6 +360,7 @@ class QuotaSetGroupCommand(Command):
                 if policy.daily_token_limit:
                     console.print(f"  Daily limit: {_format_tokens(policy.daily_token_limit)}")
                 console.print(f"  Enforcement: {policy.enforcement_mode.value}")
+                _print_cache_read_disclosure(console)
                 return 0
             except QuotaPolicyError as e:
                 console.print(f"[red]Failed to update policy: {e}[/red]")
@@ -421,6 +445,7 @@ class QuotaSetDefaultCommand(Command):
             if policy.daily_token_limit:
                 console.print(f"  Daily limit: {_format_tokens(policy.daily_token_limit)}")
             console.print(f"  Enforcement: {policy.enforcement_mode.value}")
+            _print_cache_read_disclosure(console)
             return 0
 
         except PolicyAlreadyExistsError:
@@ -439,6 +464,7 @@ class QuotaSetDefaultCommand(Command):
                 if policy.daily_token_limit:
                     console.print(f"  Daily limit: {_format_tokens(policy.daily_token_limit)}")
                 console.print(f"  Enforcement: {policy.enforcement_mode.value}")
+                _print_cache_read_disclosure(console)
                 return 0
             except QuotaPolicyError as e:
                 console.print(f"[red]Failed to update policy: {e}[/red]")
@@ -652,6 +678,7 @@ class QuotaShowCommand(Command):
             table.add_row("Critical (90%)", _format_tokens(policy.warning_threshold_90))
 
             console.print(table)
+            console.print("\n[dim]Token limits include all token types (includes cache reads)[/dim]")
 
             if groups:
                 console.print(f"\n[dim]Groups evaluated: {', '.join(groups)}[/dim]")
@@ -759,6 +786,7 @@ class QuotaUsageCommand(Command):
                 )
 
             console.print(table)
+            console.print("\n[dim]Token usage includes all token types (includes cache reads)[/dim]")
 
             # Show warning if near/over quota
             if monthly_pct >= 100:

--- a/source/tests/cli/commands/test_quota_disclosure.py
+++ b/source/tests/cli/commands/test_quota_disclosure.py
@@ -1,0 +1,51 @@
+# ABOUTME: Tests for cache read disclosure in quota CLI commands
+# ABOUTME: Verifies the disclosure note appears in quota set/show/usage output
+
+"""Tests for quota cache read disclosure feature (#403)."""
+
+from io import StringIO
+from unittest.mock import patch
+
+from rich.console import Console
+
+from claude_code_with_bedrock.cli.commands.quota import (
+    CACHE_READ_DISCLOSURE,
+    _print_cache_read_disclosure,
+)
+
+
+class TestCacheReadDisclosure:
+    """Tests for cache read disclosure in quota commands."""
+
+    def test_cache_read_disclosure_constant_exists(self):
+        """CACHE_READ_DISCLOSURE constant is defined and non-empty."""
+        assert CACHE_READ_DISCLOSURE
+        assert "cache reads" in CACHE_READ_DISCLOSURE.lower() or "cache" in CACHE_READ_DISCLOSURE.lower()
+
+    def test_cache_read_disclosure_mentions_multiplier(self):
+        """Disclosure mentions the 5x multiplier for 80% cache hit ratio."""
+        assert "5x" in CACHE_READ_DISCLOSURE
+        assert "80%" in CACHE_READ_DISCLOSURE
+
+    def test_cache_read_disclosure_mentions_formula(self):
+        """Disclosure includes the cache hit ratio formula."""
+        assert "1 / (1 - cache_hit_ratio)" in CACHE_READ_DISCLOSURE
+
+    def test_cache_read_disclosure_mentions_ratios(self):
+        """Disclosure shows cache hit ratio guide with 75%, 80%, 90%."""
+        assert "75%" in CACHE_READ_DISCLOSURE
+        assert "80%" in CACHE_READ_DISCLOSURE
+        assert "90%" in CACHE_READ_DISCLOSURE
+        assert "4x" in CACHE_READ_DISCLOSURE
+        assert "5x" in CACHE_READ_DISCLOSURE
+        assert "10x" in CACHE_READ_DISCLOSURE
+
+    def test_print_cache_read_disclosure_outputs(self):
+        """_print_cache_read_disclosure prints to console."""
+        output = StringIO()
+        console = Console(file=output, force_terminal=True)
+        _print_cache_read_disclosure(console)
+        rendered = output.getvalue()
+        # Rich strips markup, check plain text content
+        assert "cache" in rendered.lower()
+        assert "5x" in rendered


### PR DESCRIPTION
## Summary

Adds disclosure notes when setting or viewing quotas to inform admins that token limits include all token types including cache reads.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Problem

With prompt caching enabled (typical ~80% cache hit ratio in Claude Code), cache reads dominate reported token volume. Users see quota usage at 191% when their actual inference work is minimal — the bulk is cache reads which represent minimal cost. Admins need to know this when setting limits.

## Changes

Disclosure added to:
- `ccwb quota set-default` / `set-user` / `set-group` — full guide with cache hit ratio formula
- `ccwb quota show` — inline note: "Token limits include all token types (includes cache reads)"
- `ccwb quota usage` — inline note: "Token usage includes all token types (includes cache reads)"
- `ccwb init` wizard — note after daily limit configuration

## Testing Evidence

### Test Environment

**AWS Region:** <!-- region --> us-east-1
**Python Version:** <!-- version --> 3.12.3
**Operating System:** <!-- os --> Linux (Ubuntu 24.04)

### CLI Testing

- [x] **`ccwb quota set-default`** displays cache read disclosure after setting limits
- [x] **`ccwb quota show`** displays inline note about cache reads
- [x] All existing tests pass locally

### Unit Tests

- [x] All existing tests pass locally
- 5 new tests in `test_quota_disclosure.py`

### Test Results

```
tests/cli/commands/test_quota_disclosure.py::TestCacheReadDisclosure::test_cache_read_disclosure_constant_exists PASSED
tests/cli/commands/test_quota_disclosure.py::TestCacheReadDisclosure::test_cache_read_disclosure_mentions_multiplier PASSED
tests/cli/commands/test_quota_disclosure.py::TestCacheReadDisclosure::test_cache_read_disclosure_mentions_formula PASSED
tests/cli/commands/test_quota_disclosure.py::TestCacheReadDisclosure::test_cache_read_disclosure_mentions_ratios PASSED
tests/cli/commands/test_quota_disclosure.py::TestCacheReadDisclosure::test_print_cache_read_disclosure_outputs PASSED

5 passed in 0.46s

All 23 existing quota tests also pass:
23 passed, 254 deselected in 0.67s
```

Closes #403