### PR TITLE
fix: Route53 docs, Windows CodeBuild region validation, ECS SLR docs

### DIFF
--- a/assets/docs/MONITORING.md
+++ b/assets/docs/MONITORING.md
@@ -11,6 +11,7 @@ When you enable monitoring during deployment, the system collects and visualizes
 - Server-side OpenTelemetry collector running on ECS Fargate behind an ALB
 - Supports optional Athena SQL pipeline (EMF logs → Kinesis Firehose → S3 → Athena) for ad-hoc SQL queries
 - Requires VPC and networking infrastructure
+- Requires the `AWSServiceRoleForECS` service-linked role (created automatically by `ccwb deploy`; if deploying templates manually, create it first: `aws iam create-service-linked-role --aws-service-name ecs.amazonaws.com`)
 - ~$30-50/month server cost
 - Best for: organizations wanting centralized metrics aggregation, IT-managed collector, or ad-hoc SQL queries via Athena
 

--- a/assets/docs/distribution/deployment-guide.md
+++ b/assets/docs/distribution/deployment-guide.md
@@ -55,6 +55,11 @@ User → ALB (HTTPS) → OIDC Authentication (IdP) → Lambda → S3 (presigned 
   - Private subnets in 2+ availability zones (for Lambda)
   - Can be created via `ccwb deploy networking` or use existing VPC
 
+- **Route53 Hosted Zone (if using custom domain)**:
+
+  - Must be in the **same AWS account** as the deployment (ACM certificate validation creates DNS records directly)
+  - If your zone is in a separate account (e.g., Control Tower shared networking), migrate or delegate it to the deployment account first
+
 - **IdP Account with Admin Access**:
 
   - Ability to create web applications (OAuth2 confidential clients)

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -879,6 +879,19 @@ class DeployCommand(Command):
                             pass
 
             elif stack_type == "codebuild":
+                # WINDOWS_SERVER_2022_CONTAINER is only available in select regions
+                codebuild_supported_regions = [
+                    "us-east-1", "us-east-2", "us-west-2",
+                    "eu-central-1", "eu-west-1",
+                    "ap-northeast-1", "ap-southeast-2",
+                    "sa-east-1",
+                ]
+                if profile.aws_region not in codebuild_supported_regions:
+                    console.print(
+                        f"[red]Windows CodeBuild is not available in {profile.aws_region}.[/red]\n"
+                        f"Supported regions: {', '.join(codebuild_supported_regions)}"
+                    )
+                    return 1
                 template = project_root / "deployment" / "infrastructure" / "codebuild-windows.yaml"
                 stack_name = profile.stack_names.get("codebuild", f"{profile.identity_pool_name}-codebuild")
                 params = [f"ProjectNamePrefix={profile.identity_pool_name}"]


### PR DESCRIPTION
## Summary

Batch of 3 small fixes consolidated from stale PRs, **retargeted to beta** for lower-risk merge.

### Changes

1. **docs: Route53 same-account requirement** (from #219, fixes #216)
   - Documents that ACM certificate validation requires the Route53 hosted zone in the same AWS account
   - Added to distribution deployment guide prerequisites

2. **fix(deploy): validate region before Windows CodeBuild** (from #222, fixes #213)
   - `WINDOWS_SERVER_2022_CONTAINER` is only available in 5 regions
   - Adds region check before deploying codebuild stack, with clear error message

3. **docs: ECS service-linked role prerequisite** (from #247, fixes #236)
   - Documents that `AWSServiceRoleForECS` is required for central collector
   - `ccwb deploy` creates it automatically, but manual template deploys need it first

## Why beta?

These are retargeted from main to beta to reduce risk. All are small, additive changes (docs + one validation check). 3 files changed, +16 lines.

## Supersedes

Closing the original stale PRs (#219, #222, #247) in favour of this consolidated PR.

@dineshSajwan low-risk merge — docs and one pre-deploy validation.