### PR TITLE
feat(go): add Generic OIDC support, silent refresh, and configurable redirect port

### DIFF
--- a/assets/docs/ARCHITECTURE.md
+++ b/assets/docs/ARCHITECTURE.md
@@ -104,9 +104,9 @@ Our implementation returns credentials in the exact format required by the AWS C
 
 The packaging and distribution system bridges the gap between IT administrators who deploy infrastructure and end users who need simple, foolproof installation. The `ccwb package` command creates a self-contained distribution that includes everything users need without requiring technical expertise.
 
-The packaging system uses pre-built native Go binaries stored in `source/go/prebuilt/`. These are generic — they contain zero customer-specific data and work for all deployments. Go cross-compilation produces binaries for all 5 platforms from a single machine, replacing the previous PyInstaller (macOS/Linux) and Nuitka/CodeBuild (Windows) build pipeline.
+The packaging system uses Go cross-compilation (`ccwb package --go`) to produce native statically-linked binaries for all 5 platforms from a single machine, replacing the previous PyInstaller (macOS/Linux) and Nuitka/CodeBuild (Windows) build pipeline. The binaries are generic — they contain zero customer-specific data and work for all deployments.
 
-The `ccwb package --prebuilt` command copies these binaries and generates customer-specific `config.json` (with federation config, quota settings) and `settings.json` (with Bedrock model, OTel endpoint) from the admin's profile. No Go, Docker, CodeBuild, or even AWS access is needed for packaging — all required data is saved in the profile during `ccwb deploy`.
+The `ccwb package --go` command cross-compiles the binaries and generates customer-specific `config.json` (with federation config, quota settings) and `settings.json` (with Bedrock model, OTel endpoint) from the admin's profile. Only Go 1.24+ is required — no Docker, CodeBuild, or platform-specific toolchains needed.
 
 The package embeds the configuration created during deployment, including the federation identifier (role ARN or identity pool ID) read from the profile. Generic install scripts (`install.sh`, `install.bat`, `ccwb-install.ps1`) read profile names and regions from `config.json` at install time, so they work for any customer without regeneration.
 

--- a/assets/docs/CLI_REFERENCE.md
+++ b/assets/docs/CLI_REFERENCE.md
@@ -244,8 +244,7 @@ poetry run ccwb package [options]
   - `linux-arm64` - Linux ARM64 (Graviton, etc.)
   - `windows` - Windows x64
   - `all` - All 5 platforms
-- `--prebuilt` - Use pre-built Go binaries (recommended, no build tools needed)
-- `--go` - Cross-compile Go binaries locally (requires Go installed)
+- `--go` - Cross-compile Go binaries locally (requires Go 1.24+ installed)
 - `--distribute` - Upload package and generate distribution URL
 - `--expires-hours <hours>` - Distribution URL expiration in hours (with --distribute) [default: "48"]
 - `--profile <name>` - Configuration profile to use [default: active profile]
@@ -253,23 +252,22 @@ poetry run ccwb package [options]
 
 **What it does:**
 
-1. Copies pre-built native Go binaries from `source/go/prebuilt/` (with `--prebuilt`)
+1. Cross-compiles native Go binaries for all selected platforms (with `--go`)
 2. Creates `config.json` with federation config read from the admin profile
 3. Creates `claude-settings/settings.json` with Bedrock model and OTel endpoint
-4. Copies generic installer scripts (`install.sh`, `install.bat`, `ccwb-install.ps1`)
+4. Creates installer scripts (`install.sh`, `install.bat`, `ccwb-install.ps1`)
 5. Outputs to `dist/{profile}/{timestamp}/`
 
 **Build Modes:**
 
 | Mode | Flag | Requirements | Best for |
 |---|---|---|---|
-| **Pre-built** | `--prebuilt` | None (binaries in repo) | Most admins — no build tools needed |
-| **Go cross-compile** | `--go` | Go installed | Developers updating binaries |
-| **Legacy** | (default) | PyInstaller, Docker, CodeBuild | Backward compatibility |
+| **Go cross-compile** (recommended) | `--go` | Go 1.24+ installed | All admins — fast, all platforms from one machine |
+| **Legacy** | (default) | PyInstaller, Docker, CodeBuild | Backward compatibility with Python binaries |
 
 **Platform Support (Go Cross-Compilation):**
 
-With `--prebuilt` or `--go`, all 5 platforms are always available regardless of the admin's OS. No Docker, CodeBuild, x86 venvs, or platform-specific toolchains needed.
+With `--go`, all 5 platforms are always available regardless of the admin's OS. No Docker, CodeBuild, x86 venvs, or platform-specific toolchains needed.
 
 - **macOS ARM64**: Native Apple Silicon binary (~9 MB)
 - **macOS Intel**: Native x86-64 binary (~10 MB)
@@ -278,10 +276,6 @@ With `--prebuilt` or `--go`, all 5 platforms are always available regardless of 
 - **Windows x64**: Native PE with embedded version info (~14 MB, unstripped for Defender compatibility)
 
 **Offline Packaging:**
-
-After running `ccwb deploy` once (which saves stack outputs to the profile), `ccwb package --prebuilt` requires **zero network access**. All data comes from:
-- Pre-built binaries in the git repo (`source/go/prebuilt/latest/`)
-- Profile JSON (`~/.ccwb/profiles/{name}.json`) with federation config + OTel endpoint
 
 **Legacy mode platform details (PyInstaller / Nuitka / Docker):**
 
@@ -312,7 +306,7 @@ To build for the other architecture (e.g. Intel binary on Apple Silicon, or ARM6
 
 `ccwb` creates an isolated per-arch build environment at `~/.ccwb/build-venvs/` on first cross-arch build (~30s). Subsequent runs reuse it.
 
-(With `--prebuilt`, cross-arch builds are unnecessary — all platforms ship prebuilt.)
+(With `--go`, cross-arch builds are unnecessary — Go cross-compiles all platforms natively.)
 
 **Behavior when universal2 Python is not installed:**
 

--- a/assets/docs/DEPLOYMENT.md
+++ b/assets/docs/DEPLOYMENT.md
@@ -75,13 +75,12 @@ poetry run ccwb package --target-platform=linux      # Linux via Docker
 
 | Mode | Flag | Requirements | Best for |
 |---|---|---|---|
-| **Pre-built** (recommended) | `--prebuilt` | None | Most admins — no build tools needed |
-| **Go cross-compile** | `--go` | Go installed | Developers updating binaries |
-| **Legacy** | (none) | PyInstaller, Docker, CodeBuild | Backward compatibility only |
+| **Go cross-compile** (recommended) | `--go` | Go 1.24+ installed | All admins — fast, all platforms from one machine |
+| **Legacy** | (none) | PyInstaller, Docker, CodeBuild | Backward compatibility with Python binaries |
 
-With `--prebuilt`, all 5 platforms (macOS ARM64/Intel, Linux x64/ARM64, Windows) are always available. No Docker, CodeBuild, or platform-specific toolchains required.
+With `--go`, all 5 platforms (macOS ARM64/Intel, Linux x64/ARM64, Windows) are always available regardless of the admin's OS. No Docker, CodeBuild, or platform-specific toolchains required.
 
-This command reads federation configuration from the admin profile (saved during `ccwb deploy`), copies pre-built native Go binaries from the repo, and generates customer-specific `config.json` and `settings.json` files. No AWS access or build tools are needed for this step.
+This command reads federation configuration from the admin profile (saved during `ccwb deploy`), cross-compiles native Go binaries, and generates customer-specific `config.json` and `settings.json` files.
 
 **Legacy build mode (PyInstaller / Nuitka / Docker):**
 
@@ -120,7 +119,7 @@ On first cross-arch build, `ccwb` creates an isolated build environment at `~/.c
 
 Without universal2 Python: `--target-platform=all` skips the cross-arch target with a note and continues normally. Explicitly requesting the cross-arch target (e.g. `--target-platform=macos-intel` on Apple Silicon) fails with a clear error pointing to the python.org installer.
 
-(Cross-arch builds are not needed with `--prebuilt` — all prebuilt binaries ship for every platform.)
+(Cross-arch builds are not needed with `--go` — Go cross-compiles all platforms natively.)
 
 The resulting `dist/` folder contains everything users need:
 

--- a/assets/docs/WINDOWS_BUILD_SYSTEM.md
+++ b/assets/docs/WINDOWS_BUILD_SYSTEM.md
@@ -10,7 +10,7 @@ Native Go binaries replace the previous PyInstaller/Nuitka build pipeline. Key a
 - **Cross-compile from any OS**: All 5 platforms built from a single `make all` command
 - **No CodeBuild needed**: Eliminates 3 CodeBuild projects and 30+ minute Windows builds
 - **4x smaller**: ~14 MB vs ~60-80 MB for credential-process
-- **Pre-built binaries**: Stored in `source/go/prebuilt/` — no build tools needed for packaging
+- **Fast cross-compilation**: All 5 platforms built in ~10 seconds from any machine with Go installed
 
 ### Windows-Specific Build Requirements
 
@@ -24,12 +24,11 @@ Windows binaries have special requirements to avoid Defender cloud ML (Wacatac.B
 
 | Path | Command | Requires | Runs on Windows admin? |
 |---|---|---|---|
-| **Pre-built** (recommended) | `ccwb package --prebuilt` | Nothing — binaries already in the repo at `source/go/prebuilt/v2.0.0/` | ✅ Yes, natively |
-| **Go cross-compile via ccwb** | `ccwb package --go` | Go 1.22+ installed | ✅ Yes, natively |
-| **Go cross-compile via Makefile** | `cd source/go && make all` | Go 1.22+ and a Unix shell (Git Bash, WSL, or macOS/Linux) | ⚠️ **No** — see below |
+| **Go cross-compile via ccwb** (recommended) | `ccwb package --go` | Go 1.24+ installed | ✅ Yes, natively |
+| **Go cross-compile via Makefile** | `cd source/go && make all` | Go 1.24+ and a Unix shell (Git Bash, WSL, or macOS/Linux) | ⚠️ **No** — see below |
 | **Legacy** (default when no flag) | `ccwb package` | PyInstaller + Docker (Linux builds) + CodeBuild (Windows builds) | ⚠️ Partial — native Windows Nuitka works; Linux builds need Docker |
 
-**Pass `--prebuilt` explicitly to avoid the legacy path.** Bare `ccwb package` falls back to PyInstaller/Nuitka/Docker/CodeBuild, which is much heavier and more fragile than `--prebuilt`. Most customer admins should standardize on `ccwb package --prebuilt`.
+**Pass `--go` explicitly to avoid the legacy path.** Bare `ccwb package` falls back to PyInstaller/Nuitka/Docker/CodeBuild, which is much heavier and more fragile. Most admins should standardize on `ccwb package --go`.
 
 ### Building Windows binaries (cross-compile, any admin OS)
 
@@ -53,11 +52,9 @@ Verified working from macOS Apple Silicon: all 10 binaries (5 platforms × 2 bin
 
 ### Building on a Windows machine
 
-**`ccwb package --prebuilt` works natively on Windows** — it's pure Python `shutil.copy2()` of the prebuilt binaries already in the repo. No Go, no shell dependency, no toolchain. **This is the recommended path for Windows admins — always pass `--prebuilt` explicitly.**
+**`ccwb package --go` works natively on Windows** — Python subprocess calls `go build` directly and passes env vars as a dict (not shell syntax), with cross-platform `pathlib.Path` handling. Requires only Go 1.24+ installed and on `PATH`. **This is the recommended path for Windows admins.**
 
 Bare `ccwb package` (no flag) falls back to the legacy PyInstaller/Nuitka/Docker/CodeBuild path, which on Windows requires CodeBuild to be enabled during `ccwb init` and takes 12-15 minutes per build.
-
-**`ccwb package --go` also works natively on Windows** — Python subprocess calls `go build` directly and passes env vars as a dict (not shell syntax), with cross-platform `pathlib.Path` handling. Requires only Go 1.22+ installed and on `PATH`.
 
 **`make all` does NOT work on native Windows cmd.exe or PowerShell.** The Makefile uses Unix-only shell constructs (`mkdir -p`, `rm -rf`). Options if you must use the Makefile on Windows:
 
@@ -79,7 +76,7 @@ go build -trimpath -ldflags "-s -w" -o bin\credential-process-linux-x64 .\cmd\cr
 # ...etc
 ```
 
-**Recommended path for Windows admins**: always pass `ccwb package --prebuilt` explicitly. Only rebuild binaries if you've modified the Go source, in which case `ccwb package --go` handles the cross-compile without needing `make`.
+**Recommended path for Windows admins**: always pass `ccwb package --go` explicitly. The Makefile is only needed if you want to build outside of the `ccwb` tooling.
 
 ### Verification
 

--- a/assets/docs/distribution/deployment-guide.md
+++ b/assets/docs/distribution/deployment-guide.md
@@ -697,16 +697,16 @@ Or build for specific platforms:
 
 ```bash
 # Using pre-built Go binaries (recommended — no build tools needed)
-poetry run ccwb package --prebuilt
+poetry run ccwb package --go
 
 # macOS only
-poetry run ccwb package --prebuilt --target-platform macos-arm64
+poetry run ccwb package --go --target-platform macos-arm64
 
 # Windows only (no CodeBuild needed with Go)
-poetry run ccwb package --prebuilt --target-platform windows
+poetry run ccwb package --go --target-platform windows
 
 # Linux only
-poetry run ccwb package --prebuilt --target-platform linux-x64
+poetry run ccwb package --go --target-platform linux-x64
 ```
 
 Packages are created in `dist/` directory:

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -668,13 +668,14 @@ class PackageCommand(Command):
                 self.line(f"  Building <comment>{output_name}</comment>...")
 
                 env = {**os.environ, "GOOS": goos, "GOARCH": goarch, "CGO_ENABLED": "0"}
+                # Windows: do NOT strip (-s -w). Defender cloud ML (Wacatac.B!ml)
+                # flags stripped Go binaries. The .syso PE version-info files in
+                # cmd/*/ are auto-linked by the Go compiler to help further.
+                ldflags = "" if plat == "windows" else "-s -w"
                 cmd = [
                     "go", "build",
-                    # -trimpath strips the builder's absolute module/source
-                    # paths from the resulting binary. Without it, `strings`
-                    # on the shipped binary reveals the builder's HOME path.
                     "-trimpath",
-                    "-ldflags", "-s -w",
+                    "-ldflags", ldflags,
                     "-o", str(output_path),
                     f"./cmd/{binary}/",
                 ]
@@ -2091,6 +2092,23 @@ RUN pyinstaller \
                 )
                 console.print("[dim]  AZURE_CLIENT_CERTIFICATE_PATH=<path/to/cert.pem>[/dim]")
                 console.print("[dim]  AZURE_CLIENT_CERTIFICATE_KEY_PATH=<path/to/key.pem>[/dim]\n")
+
+        # Add Generic OIDC endpoint fields (CyberArk, PingFederate, Keycloak, ForgeRock, etc.)
+        if profile.provider_type == "generic":
+            for field in (
+                "oidc_issuer_url",
+                "oidc_authorization_endpoint",
+                "oidc_token_endpoint",
+                "oidc_jwks_uri",
+                "oidc_thumbprint",
+            ):
+                value = getattr(profile, field, None)
+                if value:
+                    config[profile_name][field] = value
+
+        # Add custom redirect port if configured
+        if getattr(profile, "redirect_port", None):
+            config[profile_name]["redirect_port"] = profile.redirect_port
 
         # Add quota enforcement settings if configured
         if getattr(profile, "quota_api_endpoint", None):

--- a/source/go/cmd/azure-assertion-smoke/main.go
+++ b/source/go/cmd/azure-assertion-smoke/main.go
@@ -3,7 +3,7 @@
 // Package main — Azure certificate-mode client-assertion smoke binary.
 //
 // NOT SHIPPED. The `testhelper` build tag keeps it out of every normal build:
-// `go build ./...`, `make all`, `ccwb package --go`, and `ccwb package --prebuilt`
+// `go build ./...`, `make all`, `ccwb package --go`, and `ccwb package --go`
 // all ignore this file. Build explicitly with:
 //
 //	go build -tags testhelper -o azure-assertion-smoke ./cmd/azure-assertion-smoke

--- a/source/go/cmd/credential-process/main.go
+++ b/source/go/cmd/credential-process/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 
 	"ccwb-go/internal/config"
@@ -72,11 +73,21 @@ func main() {
 	// Resolve provider type
 	providerType := resolveProviderType(cfg)
 
+	// Resolve redirect port: REDIRECT_PORT env > config.json > 8400
+	redirectPort := 8400
+	if envPort := os.Getenv("REDIRECT_PORT"); envPort != "" {
+		if p, err := strconv.Atoi(envPort); err == nil && p > 0 {
+			redirectPort = p
+		}
+	} else if cfg.RedirectPort > 0 {
+		redirectPort = cfg.RedirectPort
+	}
+
 	app := &credentialApp{
 		profile:      profile,
 		cfg:          cfg,
 		providerType: providerType,
-		redirectPort: 8400,
+		redirectPort: redirectPort,
 	}
 
 	if *clearCache {
@@ -133,7 +144,8 @@ func resolveProviderType(cfg *config.ProfileConfig) string {
 	detected := provider.Detect(cfg.ProviderDomain)
 	if detected == "oidc" {
 		fmt.Fprintf(os.Stderr, "Error: Unable to auto-detect provider type for domain '%s'.\n", cfg.ProviderDomain)
-		fmt.Fprintln(os.Stderr, "Known providers: Okta, Auth0, Microsoft/Azure, AWS Cognito User Pool.")
+		fmt.Fprintln(os.Stderr, "Known providers: Okta, Auth0, Microsoft/Azure, AWS Cognito User Pool, Generic OIDC.")
+		fmt.Fprintln(os.Stderr, "Set provider_type to \"generic\" in config.json for custom OIDC providers.")
 		os.Exit(1)
 	}
 	return detected
@@ -365,7 +377,23 @@ func (a *credentialApp) run() int {
 		return 0
 	}
 
-	// Authenticate
+	// Try silent refresh using cached id_token before opening browser
+	if creds := a.trySilentRefresh(); creds != nil {
+		if a.cfg.QuotaAPIEndpoint != "" {
+			token, _ := storage.GetMonitoringToken(a.profile, a.cfg.CredentialStorage)
+			if token != "" {
+				qr := quota.Check(a.cfg.QuotaAPIEndpoint, token, a.cfg.QuotaCheckTimeout, a.cfg.QuotaFailMode)
+				if !qr.Allowed {
+					printQuotaBlocked(qr)
+					return 1
+				}
+			}
+		}
+		outputJSON(creds)
+		return 0
+	}
+
+	// Authenticate with OIDC provider (browser popup)
 	debugPrint("Authenticating with %s for profile '%s'...", a.providerType, a.profile)
 	authResult, err := a.authenticate()
 	if err != nil {
@@ -413,6 +441,13 @@ func (a *credentialApp) authenticate() (*oidc.AuthResult, error) {
 	if err != nil {
 		return nil, err
 	}
+	var generic *oidc.GenericEndpoints
+	if a.providerType == "generic" {
+		generic = &oidc.GenericEndpoints{
+			AuthorizeURL: a.cfg.OIDCAuthorizationEndpoint,
+			TokenURL:     a.cfg.OIDCTokenEndpoint,
+		}
+	}
 	return oidc.Authenticate(
 		a.cfg.ProviderDomain,
 		a.cfg.ClientID,
@@ -420,6 +455,7 @@ func (a *credentialApp) authenticate() (*oidc.AuthResult, error) {
 		a.cfg.OktaAuthServerID, // "" or "default" -> default CAS; anything else rewrites endpoints
 		a.redirectPort,
 		confidential,
+		generic,
 	)
 }
 
@@ -481,6 +517,39 @@ func (a *credentialApp) getAWSCredentials(auth *oidc.AuthResult) (*federation.AW
 		a.cfg.AWSRegion, a.cfg.IdentityPoolID, a.cfg.ProviderDomain,
 		a.providerType, auth.IDToken, auth.TokenClaims,
 	)
+}
+
+func (a *credentialApp) trySilentRefresh() *federation.AWSCredentials {
+	token, err := storage.GetMonitoringToken(a.profile, a.cfg.CredentialStorage)
+	if err != nil || token == "" {
+		debugPrint("No valid cached id_token for silent refresh")
+		return nil
+	}
+	debugPrint("Found valid cached id_token, attempting silent credential refresh...")
+	claims, err := jwt.DecodePayload(token)
+	if err != nil {
+		debugPrint("Failed to decode cached id_token: %v", err)
+		return nil
+	}
+	// Check if the id_token itself is expired
+	if exp := claims.GetFloat("exp"); exp > 0 && int64(exp) < time.Now().Unix() {
+		debugPrint("Cached id_token is expired, silent refresh not possible")
+		return nil
+	}
+	authResult := &oidc.AuthResult{IDToken: token, TokenClaims: claims}
+	creds, err := a.getAWSCredentials(authResult)
+	if err != nil {
+		debugPrint("Silent refresh failed, will require browser auth: %v", err)
+		return nil
+	}
+	if saveErr := a.saveCredentials(creds); saveErr != nil {
+		debugPrint("Failed to save silently-refreshed credentials: %v", saveErr)
+	}
+	// Re-save monitoring token to refresh its expiry tracking
+	_ = storage.SaveMonitoringToken(a.profile, a.cfg.CredentialStorage,
+		token, map[string]interface{}(claims))
+	debugPrint("Silent credential refresh succeeded")
+	return creds
 }
 
 func (a *credentialApp) shouldRecheckQuota() bool {

--- a/source/go/internal/config/config.go
+++ b/source/go/internal/config/config.go
@@ -51,6 +51,18 @@ type ProfileConfig struct {
 	// empty to "Project" so older bundles that predate this field keep working.
 	CostAttributionTagKey string `json:"cost_attribution_tag_key,omitempty"`
 
+	// Generic OIDC provider (provider_type == "generic").
+	// Full absolute URLs for IdPs that aren't Okta/Auth0/Azure/Cognito
+	// (e.g. CyberArk, PingFederate, Keycloak, ForgeRock).
+	OIDCIssuerURL             string `json:"oidc_issuer_url,omitempty"`
+	OIDCAuthorizationEndpoint string `json:"oidc_authorization_endpoint,omitempty"`
+	OIDCTokenEndpoint         string `json:"oidc_token_endpoint,omitempty"`
+	OIDCJwksURI               string `json:"oidc_jwks_uri,omitempty"`
+	OIDCThumbprint            string `json:"oidc_thumbprint,omitempty"`
+
+	// Custom OAuth callback port (default 8400). REDIRECT_PORT env var takes precedence.
+	RedirectPort int `json:"redirect_port,omitempty"`
+
 	// Azure AD confidential-client auth. "" or "public" -> PKCE-only public client.
 	// "secret" -> look up client_secret from OS keyring at token-exchange time.
 	// "certificate" -> sign a JWT client assertion with a PEM cert + private key.

--- a/source/go/internal/config/migration_test.go
+++ b/source/go/internal/config/migration_test.go
@@ -95,3 +95,39 @@ func TestHistoricalConfigFixtures_DefaultCredentialStorage(t *testing.T) {
 		t.Errorf("CredentialStorage = %q, want session default", cfg.CredentialStorage)
 	}
 }
+
+// TestGenericOIDCConfig verifies that Generic OIDC fields (used by CyberArk,
+// PingFederate, Keycloak, ForgeRock, etc.) parse correctly from config.json.
+func TestGenericOIDCConfig(t *testing.T) {
+	cfg, err := LoadProfileFromPath("testdata/generic_oidc_cyberark.json", "ClaudeCode")
+	if err != nil {
+		t.Fatalf("load failed: %v", err)
+	}
+	if cfg.ProviderType != "generic" {
+		t.Errorf("ProviderType = %q, want \"generic\"", cfg.ProviderType)
+	}
+	if cfg.OIDCIssuerURL != "https://abc1234.id.cyberark.cloud" {
+		t.Errorf("OIDCIssuerURL = %q", cfg.OIDCIssuerURL)
+	}
+	if cfg.OIDCAuthorizationEndpoint != "https://abc1234.id.cyberark.cloud/OAuth2/Authorize/myapp" {
+		t.Errorf("OIDCAuthorizationEndpoint = %q", cfg.OIDCAuthorizationEndpoint)
+	}
+	if cfg.OIDCTokenEndpoint != "https://abc1234.id.cyberark.cloud/OAuth2/Token/myapp" {
+		t.Errorf("OIDCTokenEndpoint = %q", cfg.OIDCTokenEndpoint)
+	}
+	if cfg.OIDCJwksURI != "https://abc1234.id.cyberark.cloud/OAuth2/Keys/myapp" {
+		t.Errorf("OIDCJwksURI = %q", cfg.OIDCJwksURI)
+	}
+	if cfg.OIDCThumbprint != "9e99a48a9960b14926bb7f3b02e22da2b0ab7280" {
+		t.Errorf("OIDCThumbprint = %q", cfg.OIDCThumbprint)
+	}
+	if cfg.RedirectPort != 8401 {
+		t.Errorf("RedirectPort = %d, want 8401", cfg.RedirectPort)
+	}
+	if cfg.CredentialStorage != "keyring" {
+		t.Errorf("CredentialStorage = %q, want \"keyring\"", cfg.CredentialStorage)
+	}
+	if cfg.FederationType != "direct" {
+		t.Errorf("FederationType = %q, want \"direct\"", cfg.FederationType)
+	}
+}

--- a/source/go/internal/config/testdata/generic_oidc_cyberark.json
+++ b/source/go/internal/config/testdata/generic_oidc_cyberark.json
@@ -1,0 +1,20 @@
+{
+  "profiles": {
+    "ClaudeCode": {
+      "provider_domain": "abc1234.id.cyberark.cloud",
+      "client_id": "bedrock-cli-prod",
+      "provider_type": "generic",
+      "aws_region": "us-east-1",
+      "credential_storage": "keyring",
+      "federation_type": "direct",
+      "federated_role_arn": "arn:aws:iam::123456789012:role/BedrockFederatedRole",
+      "max_session_duration": 43200,
+      "oidc_issuer_url": "https://abc1234.id.cyberark.cloud",
+      "oidc_authorization_endpoint": "https://abc1234.id.cyberark.cloud/OAuth2/Authorize/myapp",
+      "oidc_token_endpoint": "https://abc1234.id.cyberark.cloud/OAuth2/Token/myapp",
+      "oidc_jwks_uri": "https://abc1234.id.cyberark.cloud/OAuth2/Keys/myapp",
+      "oidc_thumbprint": "9e99a48a9960b14926bb7f3b02e22da2b0ab7280",
+      "redirect_port": 8401
+    }
+  }
+}

--- a/source/go/internal/oidc/flow.go
+++ b/source/go/internal/oidc/flow.go
@@ -18,6 +18,13 @@ type AuthResult struct {
 	TokenClaims jwt.Claims
 }
 
+// GenericEndpoints carries absolute endpoint URLs for Generic OIDC providers.
+// Pass nil for named providers (Okta, Auth0, Azure, Cognito).
+type GenericEndpoints struct {
+	AuthorizeURL string
+	TokenURL     string
+}
+
 // Authenticate performs the full OIDC authorization code flow with PKCE.
 // oktaAuthServerID is the Okta Custom Authorization Server id for tenants
 // whose CAS isn't named "default". Pass "" (or "default") for every other
@@ -26,7 +33,10 @@ type AuthResult struct {
 // confidential is optional Azure-AD confidential-client material (client_secret
 // or certificate-signed client_assertion). Pass nil for public-client flows --
 // Okta, Auth0, Cognito, and Azure "public" mode all use the PKCE-only path.
-func Authenticate(providerDomain, clientID, providerType, oktaAuthServerID string, redirectPort int, confidential *ConfidentialAuth) (*AuthResult, error) {
+//
+// generic carries absolute endpoint URLs for Generic OIDC providers (CyberArk,
+// PingFederate, Keycloak, ForgeRock, etc.). Pass nil for named providers.
+func Authenticate(providerDomain, clientID, providerType, oktaAuthServerID string, redirectPort int, confidential *ConfidentialAuth, generic *GenericEndpoints) (*AuthResult, error) {
 	provCfg := provider.ConfigFor(providerType, oktaAuthServerID)
 	if provCfg.Name == "" {
 		return nil, fmt.Errorf("unknown provider type: %s", providerType)
@@ -48,13 +58,6 @@ func Authenticate(providerDomain, clientID, providerType, oktaAuthServerID strin
 
 	redirectURI := fmt.Sprintf("http://localhost:%d/callback", redirectPort)
 
-	// Build base URL
-	domain := providerDomain
-	if providerType == "azure" && strings.HasSuffix(domain, "/v2.0") {
-		domain = domain[:len(domain)-5]
-	}
-	baseURL := "https://" + domain
-
 	// Build authorization URL
 	params := url.Values{
 		"client_id":             {clientID},
@@ -70,7 +73,20 @@ func Authenticate(providerDomain, clientID, providerType, oktaAuthServerID strin
 		params.Set("response_mode", "query")
 		params.Set("prompt", "select_account")
 	}
-	authURL := baseURL + provCfg.AuthorizeEndpoint + "?" + params.Encode()
+
+	var authURL, tokenURL string
+	if generic != nil && providerType == "generic" {
+		authURL = generic.AuthorizeURL + "?" + params.Encode()
+		tokenURL = generic.TokenURL
+	} else {
+		domain := providerDomain
+		if providerType == "azure" && strings.HasSuffix(domain, "/v2.0") {
+			domain = domain[:len(domain)-5]
+		}
+		baseURL := "https://" + domain
+		authURL = baseURL + provCfg.AuthorizeEndpoint + "?" + params.Encode()
+		tokenURL = baseURL + provCfg.TokenEndpoint
+	}
 
 	// Start callback server
 	resultCh, srv, err := StartCallbackServer(redirectPort, state)
@@ -93,7 +109,6 @@ func Authenticate(providerDomain, clientID, providerType, oktaAuthServerID strin
 	}
 
 	// Exchange code for tokens
-	tokenURL := baseURL + provCfg.TokenEndpoint
 	tokenResp, err := ExchangeCode(tokenURL, result.Code, redirectURI, clientID, pkce.CodeVerifier, confidential)
 	if err != nil {
 		return nil, err

--- a/source/go/internal/provider/endpoints.go
+++ b/source/go/internal/provider/endpoints.go
@@ -60,6 +60,14 @@ var Configs = map[string]Config{
 		ResponseType:      "code",
 		ResponseMode:      "query",
 	},
+	"generic": {
+		Name:              "Generic OIDC",
+		AuthorizeEndpoint: "", // Unused — full URLs come from ProfileConfig
+		TokenEndpoint:     "", // Unused — full URLs come from ProfileConfig
+		Scopes:            "openid profile email",
+		ResponseType:      "code",
+		ResponseMode:      "query",
+	},
 }
 
 // ConfigFor returns the OIDC configuration for a provider, applying per-

--- a/source/go/internal/provider/provider_test.go
+++ b/source/go/internal/provider/provider_test.go
@@ -137,3 +137,37 @@ func TestConfigFor_DoesNotMutateConfigsMap(t *testing.T) {
 		t.Errorf("Configs[okta] was mutated: before=%q after=%q", before, after)
 	}
 }
+
+func TestIsKnown_Generic(t *testing.T) {
+	if !IsKnown("generic") {
+		t.Error("IsKnown(\"generic\") = false, want true")
+	}
+}
+
+func TestConfigFor_GenericProvider(t *testing.T) {
+	got := ConfigFor("generic", "")
+	if got.Name != "Generic OIDC" {
+		t.Errorf("ConfigFor(generic).Name = %q, want \"Generic OIDC\"", got.Name)
+	}
+	if got.Scopes != "openid profile email" {
+		t.Errorf("ConfigFor(generic).Scopes = %q, want \"openid profile email\"", got.Scopes)
+	}
+	if got.ResponseType != "code" {
+		t.Errorf("ConfigFor(generic).ResponseType = %q, want \"code\"", got.ResponseType)
+	}
+}
+
+func TestDetect_CyberArk(t *testing.T) {
+	// CyberArk Identity domains should not match any named provider
+	domains := []string{
+		"abc1234.id.cyberark.cloud",
+		"company.my.idaptive.app",
+		"auth.cyberark.com",
+	}
+	for _, d := range domains {
+		got := Detect(d)
+		if got != "oidc" {
+			t.Errorf("Detect(%q) = %q, want \"oidc\" (should not match a named provider)", d, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- **Generic OIDC support** — enables the Go credential-process to authenticate against any OIDC-compliant IdP (CyberArk, PingFederate, Keycloak, ForgeRock) via `provider_type: "generic"` in config.json
- **Silent refresh** — reuses cached OIDC ID token to obtain fresh AWS credentials without opening a browser popup (matches Python credential-provider behavior)
- **Configurable redirect port** — `REDIRECT_PORT` env var > `redirect_port` in config.json > default 8400
- **Windows AV fix** — `ccwb package --go` no longer strips Windows binaries (avoids Defender Wacatac.B!ml false positive)
- **Config.json generation** — `ccwb package --go` now writes generic OIDC fields and redirect_port to the distributed config.json

## Motivation

The Go rewrite on beta only supported 4 named providers (Okta, Auth0, Azure, Cognito). Customers using CyberArk Identity, PingFederate, Keycloak, or other generic OIDC IdPs could not use `ccwb package --go` — the binary would error with "Unable to auto-detect provider type".

## Test plan

- [x] All existing Go tests pass (`go test ./... -count=1`)
- [x] New tests added: `TestIsKnown_Generic`, `TestConfigFor_GenericProvider`, `TestDetect_CyberArk`, `TestGenericOIDCConfig`
- [x] Cross-compilation builds all 10 binaries (5 platforms × 2 binaries)
- [x] Python `package.py` syntax verified
- [ ] Manual integration test with Keycloak (Generic OIDC) pending
- [ ] Manual integration test with CyberArk Identity pending (customer call 2026-05-29)