### PR TITLE
docs: add per-stack AWS resource inventory for SCP planning

### DIFF
--- a/assets/docs/RESOURCE_INVENTORY.md
+++ b/assets/docs/RESOURCE_INVENTORY.md
@@ -1,6 +1,6 @@
 # AWS Resource Inventory Per Stack
 
-> **Last updated:** 2026-05-29
+> **Last updated:** 2026-07-03
 
 > **Purpose:** Pre-deployment reference for customers under restrictive SCPs.
 > Use this to plan IAM/SCP exemptions or decide which stacks to skip before running `ccwb deploy`.
@@ -9,7 +9,7 @@
 ## Stack Deployment Order
 
 ```
-auth → networking → s3bucket → monitoring → dashboard → analytics → quota → [codebuild] → [distribution]
+auth → networking → s3bucket → monitoring → dashboard → analytics → quota → [codebuild] → [distribution] → [bootstrap] → [websearch]
 ```
 
 Stacks in `[]` are optional. Only `auth` is strictly required for basic Claude Code access.
@@ -285,6 +285,115 @@ Stacks in `[]` are optional. Only `auth` is strictly required for basic Claude C
 
 ---
 
+## bootstrap (device-code)
+
+**Template:** `bootstrap-device-code.yaml`
+**Required:** No (optional, for Claude Desktop dynamic config delivery via RFC 8628 device-code flow)
+
+| Resource Type | Service Namespace | Count |
+|---|---|---|
+| `AWS::ApiGateway::RestApi` | `apigateway` | 1 |
+| `AWS::ApiGateway::Resource` | `apigateway` | 5 |
+| `AWS::ApiGateway::Method` | `apigateway` | 5 |
+| `AWS::ApiGateway::Deployment` | `apigateway` | 1 |
+| `AWS::ApiGateway::Stage` | `apigateway` | 1 |
+| `AWS::ApiGateway::Authorizer` | `apigateway` | 1 |
+| `AWS::DynamoDB::Table` | `dynamodb` | 1 |
+| `AWS::IAM::Role` | `iam` | 2 |
+| `AWS::Lambda::Function` | `lambda` | 2 |
+| `AWS::Lambda::Permission` | `lambda` | 2 |
+| `AWS::WAFv2::IPSet` | `wafv2` | 1 (conditional) |
+| `AWS::WAFv2::WebACL` | `wafv2` | 1 (conditional) |
+| `AWS::WAFv2::WebACLAssociation` | `wafv2` | 1 (conditional) |
+
+**IAM actions required for deployment:**
+- `apigateway:CreateRestApi`, `apigateway:CreateResource`, `apigateway:PutMethod`, `apigateway:CreateDeployment`, `apigateway:CreateStage`, `apigateway:CreateAuthorizer`
+- `dynamodb:CreateTable`, `dynamodb:DescribeTable`
+- `iam:CreateRole`, `iam:PutRolePolicy`, `iam:PassRole`
+- `lambda:CreateFunction`, `lambda:AddPermission`
+- `wafv2:CreateIPSet`, `wafv2:CreateWebACL`, `wafv2:AssociateWebACL` (if WAF enabled)
+
+---
+
+## bootstrap (oidc-bearer)
+
+**Template:** `bootstrap-oidc-bearer.yaml`
+**Required:** No (optional, lightweight config-only delivery without plugins)
+
+| Resource Type | Service Namespace | Count |
+|---|---|---|
+| `AWS::ApiGatewayV2::Api` | `apigateway` | 1 |
+| `AWS::ApiGatewayV2::Integration` | `apigateway` | 1 |
+| `AWS::ApiGatewayV2::Route` | `apigateway` | 1 |
+| `AWS::ApiGatewayV2::Stage` | `apigateway` | 1 |
+| `AWS::IAM::Role` | `iam` | 1 |
+| `AWS::Lambda::Function` | `lambda` | 1 |
+| `AWS::Lambda::Permission` | `lambda` | 1 |
+
+**IAM actions required for deployment:**
+- `apigateway:CreateApi`, `apigateway:CreateIntegration`, `apigateway:CreateRoute`, `apigateway:CreateStage`
+- `iam:CreateRole`, `iam:PutRolePolicy`, `iam:PassRole`
+- `lambda:CreateFunction`, `lambda:AddPermission`
+
+---
+
+## websearch
+
+**Template:** `bedrock-agentcore-gateway.yaml`
+**Required:** No (optional, for MCP web search tool via Bedrock AgentCore)
+**Region restriction:** us-east-1 only (managed connector availability)
+
+| Resource Type | Service Namespace | Count |
+|---|---|---|
+| `AWS::BedrockAgentCore::Gateway` | `bedrock-agentcore` | 1 |
+| `AWS::BedrockAgentCore::GatewayTarget` | `bedrock-agentcore` | 1 |
+| `AWS::IAM::Role` | `iam` | 1 |
+
+**IAM actions required for deployment:**
+- `bedrock-agentcore:CreateGateway`, `bedrock-agentcore:CreateGatewayTarget`
+- `iam:CreateRole`, `iam:PutRolePolicy`, `iam:PassRole`
+
+---
+
+## auth (idc)
+
+**Template:** `bedrock-auth-idc.yaml`
+**Required:** Alternative to OIDC auth (for IAM Identity Center users)
+
+| Resource Type | Service Namespace | Count |
+|---|---|---|
+| *(No AWS resources)* | — | 0 |
+
+IAM Identity Center handles authentication natively — no additional CloudFormation resources are provisioned.
+
+**IAM actions required for deployment:**
+- `cloudformation:CreateStack` (deploys empty stack as marker)
+
+---
+
+## cognito-user-pool
+
+**Template:** `cognito-user-pool-setup.yaml`
+**Required:** No (optional, built-in user directory)
+
+| Resource Type | Service Namespace | Count |
+|---|---|---|
+| `AWS::Cognito::UserPool` | `cognito-idp` | 1 |
+| `AWS::Cognito::UserPoolClient` | `cognito-idp` | 1 |
+| `AWS::Cognito::UserPoolDomain` | `cognito-idp` | 1 |
+| `AWS::Cognito::UserPoolIdentityProvider` | `cognito-idp` | 1 (conditional) |
+| `AWS::IAM::Role` | `iam` | 1 |
+| `AWS::Lambda::Function` | `lambda` | 1 |
+| `AWS::Lambda::Permission` | `lambda` | 1 |
+| `AWS::CloudFormation::CustomResource` | `cloudformation` | 1 |
+
+**IAM actions required for deployment:**
+- `cognito-idp:CreateUserPool`, `cognito-idp:CreateUserPoolClient`, `cognito-idp:CreateUserPoolDomain`
+- `iam:CreateRole`, `iam:PutRolePolicy`, `iam:PassRole`
+- `lambda:CreateFunction`, `lambda:AddPermission`
+
+---
+
 ## SCP Service Namespace Summary
 
 Minimum services required for **basic deployment** (auth only):
@@ -297,7 +406,7 @@ Full deployment adds:
 ec2, ecs, elasticloadbalancing, s3, ssm, acm, route53,
 application-autoscaling, cloudwatch, dynamodb, lambda,
 sns, events, apigateway, athena, glue, firehose, codebuild,
-secretsmanager
+secretsmanager, wafv2, bedrock-agentcore, cognito-idp
 ```
 
 **CloudFormation itself** always requires:

--- a/assets/docs/RESOURCE_INVENTORY.md
+++ b/assets/docs/RESOURCE_INVENTORY.md
@@ -1,0 +1,307 @@
+# AWS Resource Inventory Per Stack
+
+> **Last updated:** 2026-05-29
+
+> **Purpose:** Pre-deployment reference for customers under restrictive SCPs.
+> Use this to plan IAM/SCP exemptions or decide which stacks to skip before running `ccwb deploy`.
+> This is a static point-in-time list — verify against the actual templates if your deployment uses a newer version.
+
+## Stack Deployment Order
+
+```
+auth → networking → s3bucket → monitoring → dashboard → analytics → quota → [codebuild] → [distribution]
+```
+
+Stacks in `[]` are optional. Only `auth` is strictly required for basic Claude Code access.
+
+---
+
+## auth (bedrock-auth-{provider})
+
+**Template:** `bedrock-auth-{cognito-pool|okta|azure|auth0|generic}.yaml`
+**Required:** Yes (core authentication)
+
+| Resource Type | Service Namespace | Count |
+|---|---|---|
+| `AWS::Cognito::IdentityPool` | `cognito-identity` | 1 |
+| `AWS::Cognito::IdentityPoolRoleAttachment` | `cognito-identity` | 1 |
+| `AWS::Cognito::IdentityPoolPrincipalTag` | `cognito-identity` | 1 |
+| `AWS::IAM::OIDCProvider` | `iam` | 1 |
+| `AWS::IAM::ManagedPolicy` | `iam` | 1 |
+| `AWS::IAM::Role` | `iam` | 3 |
+| `AWS::Logs::LogGroup` | `logs` | 1 |
+
+**IAM actions required for deployment:**
+- `cognito-identity:*`
+- `iam:CreateRole`, `iam:PutRolePolicy`, `iam:AttachRolePolicy`, `iam:CreateOpenIDConnectProvider`, `iam:CreatePolicy`
+- `logs:CreateLogGroup`, `logs:PutRetentionPolicy`
+
+---
+
+## networking
+
+**Template:** `networking.yaml`
+**Required:** Only for central monitoring mode
+
+| Resource Type | Service Namespace | Count |
+|---|---|---|
+| `AWS::EC2::VPC` | `ec2` | 1 |
+| `AWS::EC2::InternetGateway` | `ec2` | 1 |
+| `AWS::EC2::VPCGatewayAttachment` | `ec2` | 1 |
+| `AWS::EC2::Subnet` | `ec2` | 2 |
+| `AWS::EC2::RouteTable` | `ec2` | 1 |
+| `AWS::EC2::Route` | `ec2` | 1 |
+| `AWS::EC2::SubnetRouteTableAssociation` | `ec2` | 2 |
+
+**IAM actions required for deployment:**
+- `ec2:CreateVpc`, `ec2:CreateSubnet`, `ec2:CreateInternetGateway`, `ec2:AttachInternetGateway`
+- `ec2:CreateRouteTable`, `ec2:CreateRoute`, `ec2:AssociateRouteTable`
+- `ec2:DescribeVpcs`, `ec2:DescribeSubnets`, `ec2:DescribeRouteTables`
+
+---
+
+## s3bucket
+
+**Template:** `s3bucket.yaml`
+**Required:** For central monitoring + quota (Lambda packaging)
+
+| Resource Type | Service Namespace | Count |
+|---|---|---|
+| `AWS::S3::Bucket` | `s3` | 1 |
+
+**IAM actions required for deployment:**
+- `s3:CreateBucket`, `s3:PutBucketPolicy`, `s3:PutEncryptionConfiguration`
+
+---
+
+## monitoring (otel-collector)
+
+**Template:** `otel-collector.yaml`
+**Required:** For usage tracking and dashboards
+
+| Resource Type | Service Namespace | Count |
+|---|---|---|
+| `AWS::ECS::Cluster` | `ecs` | 1 |
+| `AWS::ECS::Service` | `ecs` | 2 |
+| `AWS::ECS::TaskDefinition` | `ecs` | 1 |
+| `AWS::EC2::SecurityGroup` | `ec2` | 2 |
+| `AWS::ElasticLoadBalancingV2::LoadBalancer` | `elasticloadbalancing` | 1 |
+| `AWS::ElasticLoadBalancingV2::Listener` | `elasticloadbalancing` | 2 |
+| `AWS::ElasticLoadBalancingV2::TargetGroup` | `elasticloadbalancing` | 1 |
+| `AWS::IAM::Role` | `iam` | 2 |
+| `AWS::Logs::LogGroup` | `logs` | 2 |
+| `AWS::SSM::Parameter` | `ssm` | 2 |
+| `AWS::CertificateManager::Certificate` | `acm` | 1 (conditional) |
+| `AWS::Route53::RecordSet` | `route53` | 1 (conditional) |
+| `AWS::ApplicationAutoScaling::ScalableTarget` | `application-autoscaling` | 1 |
+| `AWS::ApplicationAutoScaling::ScalingPolicy` | `application-autoscaling` | 1 |
+
+**IAM actions required for deployment:**
+- `ecs:CreateCluster`, `ecs:CreateService`, `ecs:RegisterTaskDefinition`
+- `ec2:CreateSecurityGroup`, `ec2:AuthorizeSecurityGroupIngress`
+- `elasticloadbalancing:CreateLoadBalancer`, `elasticloadbalancing:CreateTargetGroup`, `elasticloadbalancing:CreateListener`
+- `iam:CreateRole`, `iam:PutRolePolicy`, `iam:PassRole`
+- `logs:CreateLogGroup`
+- `ssm:PutParameter`
+- `acm:RequestCertificate` (if custom domain)
+- `route53:ChangeResourceRecordSets` (if custom domain)
+- `application-autoscaling:RegisterScalableTarget`, `application-autoscaling:PutScalingPolicy`
+
+**Runtime service-linked role required:**
+- `AWSServiceRoleForECS` (created automatically by `ccwb deploy`, or manually: `aws iam create-service-linked-role --aws-service-name ecs.amazonaws.com`)
+
+---
+
+## dashboard
+
+**Template:** `claude-code-dashboard.yaml`
+**Required:** No (optional visualization)
+
+| Resource Type | Service Namespace | Count |
+|---|---|---|
+| `AWS::CloudWatch::Dashboard` | `cloudwatch` | 1 |
+
+**IAM actions required for deployment:**
+- `cloudwatch:PutDashboard`
+
+---
+
+## cowork-dashboard
+
+**Template:** `cowork-dashboard.yaml`
+**Required:** No (optional, CoWork-specific)
+
+| Resource Type | Service Namespace | Count |
+|---|---|---|
+| `AWS::CloudWatch::Dashboard` | `cloudwatch` | 1 |
+
+**IAM actions required for deployment:**
+- `cloudwatch:PutDashboard`
+
+---
+
+## analytics
+
+**Template:** `analytics-pipeline.yaml`
+**Required:** No (optional, for SQL queries on usage data)
+
+| Resource Type | Service Namespace | Count |
+|---|---|---|
+| `AWS::S3::Bucket` | `s3` | 2 |
+| `AWS::IAM::Role` | `iam` | 3 |
+| `AWS::Lambda::Function` | `lambda` | 1 |
+| `AWS::KinesisFirehose::DeliveryStream` | `firehose` | 1 |
+| `AWS::Logs::SubscriptionFilter` | `logs` | 1 |
+| `AWS::Glue::Database` | `glue` | 1 |
+| `AWS::Glue::Table` | `glue` | 1 |
+| `AWS::Athena::WorkGroup` | `athena` | 1 |
+| `AWS::Athena::NamedQuery` | `athena` | 10 |
+
+**IAM actions required for deployment:**
+- `s3:CreateBucket`
+- `iam:CreateRole`, `iam:PutRolePolicy`, `iam:PassRole`
+- `lambda:CreateFunction`, `lambda:AddPermission`
+- `firehose:CreateDeliveryStream`
+- `logs:PutSubscriptionFilter`
+- `glue:CreateDatabase`, `glue:CreateTable`
+- `athena:CreateWorkGroup`, `athena:CreateNamedQuery`
+
+---
+
+## quota
+
+**Template:** `quota-monitoring.yaml`
+**Required:** No (optional, for per-user token limits)
+
+| Resource Type | Service Namespace | Count |
+|---|---|---|
+| `AWS::DynamoDB::Table` | `dynamodb` | 2 |
+| `AWS::Lambda::Function` | `lambda` | 2 |
+| `AWS::Lambda::Permission` | `lambda` | 2 |
+| `AWS::IAM::Role` | `iam` | 2 |
+| `AWS::SNS::Topic` | `sns` | 1 |
+| `AWS::Events::Rule` | `events` | 1 |
+| `AWS::ApiGatewayV2::Api` | `apigateway` | 1 |
+| `AWS::ApiGatewayV2::Authorizer` | `apigateway` | 1 |
+| `AWS::ApiGatewayV2::Integration` | `apigateway` | 1 |
+| `AWS::ApiGatewayV2::Route` | `apigateway` | 1 |
+| `AWS::ApiGatewayV2::Stage` | `apigateway` | 1 |
+
+**IAM actions required for deployment:**
+- `dynamodb:CreateTable`, `dynamodb:DescribeTable`
+- `lambda:CreateFunction`, `lambda:AddPermission`
+- `iam:CreateRole`, `iam:PutRolePolicy`, `iam:PassRole`
+- `sns:CreateTopic`
+- `events:PutRule`, `events:PutTargets`
+- `apigateway:CreateApi`, `apigateway:CreateRoute`, `apigateway:CreateIntegration`, `apigateway:CreateStage`, `apigateway:CreateAuthorizer`
+
+---
+
+## codebuild
+
+**Template:** `codebuild-windows.yaml`
+**Required:** No (optional, for Windows binary builds)
+**Region restriction:** us-east-1, us-east-2, us-west-2, eu-west-1, ap-southeast-2 only
+
+| Resource Type | Service Namespace | Count |
+|---|---|---|
+| `AWS::S3::Bucket` | `s3` | 2 |
+| `AWS::IAM::Role` | `iam` | 1 |
+| `AWS::Logs::LogGroup` | `logs` | 1 |
+| `AWS::CodeBuild::Project` | `codebuild` | 1 |
+
+**IAM actions required for deployment:**
+- `s3:CreateBucket`
+- `iam:CreateRole`, `iam:PutRolePolicy`, `iam:PassRole`
+- `logs:CreateLogGroup`
+- `codebuild:CreateProject`
+
+---
+
+## distribution (presigned-s3)
+
+**Template:** `presigned-s3-distribution.yaml`
+**Required:** No (optional, for binary distribution via presigned URLs)
+
+| Resource Type | Service Namespace | Count |
+|---|---|---|
+| `AWS::S3::Bucket` | `s3` | 2 |
+| `AWS::IAM::User` | `iam` | 1 |
+| `AWS::IAM::AccessKey` | `iam` | 1 |
+| `AWS::IAM::Policy` | `iam` | 1 |
+| `AWS::SecretsManager::Secret` | `secretsmanager` | 1 |
+
+**IAM actions required for deployment:**
+- `s3:CreateBucket`
+- `iam:CreateUser`, `iam:CreateAccessKey`, `iam:PutUserPolicy`
+- `secretsmanager:CreateSecret`
+
+---
+
+## distribution (landing-page)
+
+**Template:** `landing-page-distribution.yaml`
+**Required:** No (optional, ALB-based landing page with IdP auth)
+
+| Resource Type | Service Namespace | Count |
+|---|---|---|
+| `AWS::S3::Bucket` | `s3` | 2 |
+| `AWS::S3::BucketPolicy` | `s3` | 1 |
+| `AWS::EC2::SecurityGroup` | `ec2` | 1 |
+| `AWS::ElasticLoadBalancingV2::LoadBalancer` | `elasticloadbalancing` | 1 |
+| `AWS::ElasticLoadBalancingV2::Listener` | `elasticloadbalancing` | 1 |
+| `AWS::ElasticLoadBalancingV2::TargetGroup` | `elasticloadbalancing` | 1 |
+| `AWS::Lambda::Function` | `lambda` | 2 |
+| `AWS::Lambda::Permission` | `lambda` | 1 |
+| `AWS::IAM::Role` | `iam` | 2 |
+| `AWS::Logs::LogGroup` | `logs` | 1 |
+| `AWS::CertificateManager::Certificate` | `acm` | 1 |
+| `AWS::Route53::RecordSet` | `route53` | 1 |
+| `AWS::CloudFormation::CustomResource` | `cloudformation` | 1 |
+
+**IAM actions required for deployment:**
+- `s3:CreateBucket`, `s3:PutBucketPolicy`
+- `ec2:CreateSecurityGroup`, `ec2:AuthorizeSecurityGroupIngress`
+- `elasticloadbalancing:CreateLoadBalancer`, `elasticloadbalancing:CreateTargetGroup`, `elasticloadbalancing:CreateListener`
+- `lambda:CreateFunction`, `lambda:AddPermission`
+- `iam:CreateRole`, `iam:PutRolePolicy`, `iam:PassRole`
+- `logs:CreateLogGroup`
+- `acm:RequestCertificate`
+- `route53:ChangeResourceRecordSets`
+
+---
+
+## logs-insights-queries
+
+**Template:** `logs-insights-queries.yaml`
+**Required:** No (optional, pre-built CloudWatch Insights queries)
+
+| Resource Type | Service Namespace | Count |
+|---|---|---|
+| `AWS::Logs::QueryDefinition` | `logs` | 19 |
+
+**IAM actions required for deployment:**
+- `logs:PutQueryDefinition`
+
+---
+
+## SCP Service Namespace Summary
+
+Minimum services required for **basic deployment** (auth only):
+```
+cognito-identity, iam, logs, cloudformation, sts
+```
+
+Full deployment adds:
+```
+ec2, ecs, elasticloadbalancing, s3, ssm, acm, route53,
+application-autoscaling, cloudwatch, dynamodb, lambda,
+sns, events, apigateway, athena, glue, firehose, codebuild,
+secretsmanager
+```
+
+**CloudFormation itself** always requires:
+```
+cloudformation:CreateStack, cloudformation:UpdateStack, cloudformation:DescribeStacks,
+cloudformation:DescribeStackEvents, cloudformation:GetTemplate
+```


### PR DESCRIPTION
## Summary

Adds a static resource inventory (`assets/docs/RESOURCE_INVENTORY.md`) documenting all AWS resource types, service namespaces, and IAM actions required per CloudFormation stack.

## Type of Change

- [x] Documentation update

## Problem

Customers under restrictive SCPs cannot get past `ccwb deploy` because their policies block resources the templates create. Today there's no way to know upfront which stack creates what — customers must inspect each CloudFormation template manually.

## Solution

A single reference document listing per stack:
- All AWS resource types created
- Service namespace required in SCPs
- IAM actions needed for deployment
- Whether the stack is required or optional
- Minimum SCP allowlist for basic deployment

## Contents

| Stack | Resources | Required? |
|---|---|---|
| auth | 9 | Yes |
| networking | 9 | Central mode only |
| s3bucket | 1 | Central + quota |
| monitoring | 22 | For usage tracking |
| dashboard | 1 | Optional |
| analytics | 21 | Optional |
| quota | 15 | Optional |
| codebuild | 5 | Optional |
| distribution | 6-18 | Optional |

## Testing Evidence

### Test Environment

**AWS Region:** <!-- region --> N/A (documentation only)
**Python Version:** <!-- version --> N/A
**Operating System:** <!-- os --> N/A

### CLI Testing

- [x] **Documentation update** — no code changes

### Test Results

```
Documentation-only PR. Resource types extracted directly from CloudFormation templates
using: grep "Type: AWS::" deployment/infrastructure/*.yaml
All resource types verified against actual template content.
```