### PR TITLE
fix: eu-south-2 duplicated where eu-south-1 (Milan) intended in Sonnet 4.5 CRIS profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - OTLP-First Metrics
+## [2.4.0] - 2026-05-22 - OTLP-First Metrics
+
+### Added
+
+- **Sidecar monitoring mode**: New "sidecar" collector option during `ccwb init` — runs a local OTel collector on each dev machine, no ECS/VPC infrastructure needed
+- **Monitoring mode backward compatibility**: Existing profiles without `monitoring_mode` default to "central", preserving current behavior on upgrade without re-running init
 
 ### Changed
 
@@ -14,6 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Quota monitoring**: Quota monitor Lambda now queries CloudWatch Prometheus-compatible API (`/api/v1/query`) for usage data instead of relying on MetricsAggregator
 - **Auth templates**: Removed `cloudwatch:namespace` IAM conditions (OTLP metrics don't use CW namespaces)
 - **Dashboard deployment**: No longer requires S3 packaging (no Lambda functions to package)
+- **Init wizard**: Sidecar mode description now clearly states that Claude Cowork (desktop) telemetry is not supported
+- **CoWork MDM generation**: Sidecar mode no longer emits `otlpEndpoint`/`otlpProtocol` in MDM config files
+
+### Fixed
+
+- **Orphaned stack deletion order**: Stacks are now deleted in reverse deployment order, respecting dependencies (e.g., monitoring before networking)
+- **CoWork MDM OTLP endpoint**: Central mode correctly resolves the collector endpoint from CloudFormation stack outputs
+- **CoWork dashboard in sidecar mode**: Blocked deployment of CoWork dashboard when in sidecar mode (Cowork desktop cannot reach localhost collector)
+- **Orphaned stack detection**: Added `cowork-dashboard` to orphaned stack detection so it is offered for cleanup when switching from central to sidecar
 
 ### Removed
 

--- a/deployment/infrastructure/claude-code-dashboard.yaml
+++ b/deployment/infrastructure/claude-code-dashboard.yaml
@@ -32,7 +32,7 @@ Resources:
                 "title": "Total Tokens Used",
                 "view": "number",
                 "region": "${MetricsRegion}",
-                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.token.usage\"})", "step": 60, "label": "Tokens" }] },
+                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.token.usage\", \"@resource.service.name\"=\"claude-code\"})", "step": 60, "label": "Tokens" }] },
                 "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
@@ -43,7 +43,7 @@ Resources:
                 "title": "Active Users",
                 "view": "number",
                 "region": "${MetricsRegion}",
-                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "count(group by (\"user.email\")({\"claude_code.session.count\"}))", "step": 60, "label": "Users" }] },
+                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "count(group by (\"user.email\")({\"claude_code.session.count\", \"@resource.service.name\"=\"claude-code\"}))", "step": 60, "label": "Users" }] },
                 "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
@@ -54,7 +54,7 @@ Resources:
                 "title": "Sessions",
                 "view": "number",
                 "region": "${MetricsRegion}",
-                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.session.count\"})", "step": 60, "label": "Sessions" }] },
+                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.session.count\", \"@resource.service.name\"=\"claude-code\"})", "step": 60, "label": "Sessions" }] },
                 "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
@@ -65,7 +65,7 @@ Resources:
                 "title": "Cache Hit Rate",
                 "view": "number",
                 "region": "${MetricsRegion}",
-                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.token.usage\", type=\"cacheRead\"}) / sum({\"claude_code.token.usage\"}) * 100", "step": 60, "label": "%" }] },
+                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.token.usage\", type=\"cacheRead\", \"@resource.service.name\"=\"claude-code\"}) / sum({\"claude_code.token.usage\", \"@resource.service.name\"=\"claude-code\"}) * 100", "step": 60, "label": "%" }] },
                 "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
@@ -82,9 +82,9 @@ Resources:
                 "view": "line",
                 "region": "${MetricsRegion}",
                 "data": { "queries": [
-                  { "id": "total", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.token.usage\"})", "step": 60, "label": "Total Tokens" }
+                  { "id": "total", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.token.usage\", \"@resource.service.name\"=\"claude-code\"})", "step": 60, "label": "Total Tokens" }
                 ] },
-                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": false, "width": 2, "pattern": "solid", "spline": false } } }
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
@@ -95,12 +95,12 @@ Resources:
                 "view": "line",
                 "region": "${MetricsRegion}",
                 "data": { "queries": [
-                  { "id": "input", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.token.usage\", type=\"input\"})", "step": 60, "label": "Input" },
-                  { "id": "output", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.token.usage\", type=\"output\"})", "step": 60, "label": "Output" },
-                  { "id": "cache", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.token.usage\", type=\"cacheRead\"})", "step": 60, "label": "Cache Read" },
-                  { "id": "cacheCreate", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.token.usage\", type=\"cacheCreation\"})", "step": 60, "label": "Cache Creation" }
+                  { "id": "input", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.token.usage\", type=\"input\", \"@resource.service.name\"=\"claude-code\"})", "step": 60, "label": "Input" },
+                  { "id": "output", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.token.usage\", type=\"output\", \"@resource.service.name\"=\"claude-code\"})", "step": 60, "label": "Output" },
+                  { "id": "cache", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.token.usage\", type=\"cacheRead\", \"@resource.service.name\"=\"claude-code\"})", "step": 60, "label": "Cache Read" },
+                  { "id": "cacheCreate", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.token.usage\", type=\"cacheCreation\", \"@resource.service.name\"=\"claude-code\"})", "step": 60, "label": "Cache Creation" }
                 ] },
-                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false } } }
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
@@ -111,9 +111,9 @@ Resources:
                 "view": "line",
                 "region": "${MetricsRegion}",
                 "data": { "queries": [
-                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (model)({\"claude_code.token.usage\"}))", "step": 60 }
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (model)({\"claude_code.token.usage\", \"@resource.service.name\"=\"claude-code\"}))", "step": 60 }
                 ] },
-                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": true, "width": 2, "pattern": "solid", "spline": false } } }
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": true, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
@@ -124,9 +124,9 @@ Resources:
                 "view": "line",
                 "region": "${MetricsRegion}",
                 "data": { "queries": [
-                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (\"user.email\")({\"claude_code.token.usage\"}))", "step": 60 }
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (\"user.email\")({\"claude_code.token.usage\", \"@resource.service.name\"=\"claude-code\"}))", "step": 60 }
                 ] },
-                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false } } }
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
@@ -137,9 +137,9 @@ Resources:
                 "view": "line",
                 "region": "${MetricsRegion}",
                 "data": { "queries": [
-                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (\"user.email\")({\"claude_code.cost.usage\"}))", "step": 60 }
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (\"user.email\")({\"claude_code.cost.usage\", \"@resource.service.name\"=\"claude-code\"}))", "step": 60 }
                 ] },
-                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false } } }
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
@@ -150,9 +150,9 @@ Resources:
                 "view": "line",
                 "region": "${MetricsRegion}",
                 "data": { "queries": [
-                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "count(group by (\"user.email\")({\"claude_code.session.count\"}))", "step": 60, "label": "Active Users" }
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "count(group by (\"user.email\")({\"claude_code.session.count\", \"@resource.service.name\"=\"claude-code\"}))", "step": 60, "label": "Active Users" }
                 ] },
-                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": false, "width": 2, "pattern": "solid", "spline": false } } }
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
@@ -168,10 +168,10 @@ Resources:
                 "view": "line",
                 "region": "${MetricsRegion}",
                 "data": { "queries": [
-                  { "id": "added", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.lines_of_code.count\", type=\"added\"})", "step": 60, "label": "Added" },
-                  { "id": "removed", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.lines_of_code.count\", type=\"removed\"})", "step": 60, "label": "Removed" }
+                  { "id": "added", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.lines_of_code.count\", type=\"added\", \"@resource.service.name\"=\"claude-code\"})", "step": 60, "label": "Added" },
+                  { "id": "removed", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.lines_of_code.count\", type=\"removed\", \"@resource.service.name\"=\"claude-code\"})", "step": 60, "label": "Removed" }
                 ] },
-                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false } } }
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
@@ -182,9 +182,9 @@ Resources:
                 "view": "line",
                 "region": "${MetricsRegion}",
                 "data": { "queries": [
-                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.commit.count\"})", "step": 60, "label": "Commits" }
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.commit.count\", \"@resource.service.name\"=\"claude-code\"})", "step": 60, "label": "Commits" }
                 ] },
-                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": false, "width": 2, "pattern": "solid", "spline": false } } }
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
@@ -195,9 +195,9 @@ Resources:
                 "view": "line",
                 "region": "${MetricsRegion}",
                 "data": { "queries": [
-                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.active_time.total\"}) / 3600", "step": 60, "label": "Hours" }
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.active_time.total\", \"@resource.service.name\"=\"claude-code\"}) / 3600", "step": 60, "label": "Hours" }
                 ] },
-                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": false, "width": 2, "pattern": "solid", "spline": false } } }
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
@@ -208,9 +208,9 @@ Resources:
                 "view": "line",
                 "region": "${MetricsRegion}",
                 "data": { "queries": [
-                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.pull_request.count\"})", "step": 60, "label": "PRs" }
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.pull_request.count\", \"@resource.service.name\"=\"claude-code\"})", "step": 60, "label": "PRs" }
                 ] },
-                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": false, "width": 2, "pattern": "solid", "spline": false } } }
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
@@ -221,9 +221,9 @@ Resources:
                 "view": "pie",
                 "region": "${MetricsRegion}",
                 "data": { "queries": [
-                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (language)({\"claude_code.code_edit_tool.decision\"}))", "step": 60 }
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (language)({\"claude_code.code_edit_tool.decision\", \"@resource.service.name\"=\"claude-code\"}))", "step": 60 }
                 ] },
-                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": true, "width": 2, "pattern": "solid", "spline": false } } }
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": true, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
@@ -234,9 +234,9 @@ Resources:
                 "view": "line",
                 "region": "${MetricsRegion}",
                 "data": { "queries": [
-                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (decision)({\"claude_code.code_edit_tool.decision\"}))", "step": 60 }
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (decision)({\"claude_code.code_edit_tool.decision\", \"@resource.service.name\"=\"claude-code\"}))", "step": 60 }
                 ] },
-                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false } } }
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
@@ -247,9 +247,9 @@ Resources:
                 "view": "line",
                 "region": "${MetricsRegion}",
                 "data": { "queries": [
-                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (tool_name)({\"claude_code.code_edit_tool.decision\"}))", "step": 60 }
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (tool_name)({\"claude_code.code_edit_tool.decision\", \"@resource.service.name\"=\"claude-code\"}))", "step": 60 }
                 ] },
-                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false } } }
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
@@ -265,9 +265,9 @@ Resources:
                 "view": "line",
                 "region": "${MetricsRegion}",
                 "data": { "queries": [
-                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (department)({\"claude_code.token.usage\"}))", "step": 60 }
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (department)({\"claude_code.token.usage\", \"@resource.service.name\"=\"claude-code\"}))", "step": 60 }
                 ] },
-                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": true, "width": 2, "pattern": "solid", "spline": false } } }
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": true, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
@@ -278,9 +278,9 @@ Resources:
                 "view": "line",
                 "region": "${MetricsRegion}",
                 "data": { "queries": [
-                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (\"team.id\")({\"claude_code.token.usage\"}))", "step": 60 }
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (\"team.id\")({\"claude_code.token.usage\", \"@resource.service.name\"=\"claude-code\"}))", "step": 60 }
                 ] },
-                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": true, "width": 2, "pattern": "solid", "spline": false } } }
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": true, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {

--- a/deployment/infrastructure/cowork-dashboard.yaml
+++ b/deployment/infrastructure/cowork-dashboard.yaml
@@ -1,5 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'CloudWatch dashboard for Claude CoWork usage metrics'
+Description: 'CloudWatch dashboard for Claude CoWork usage metrics using native PromQL widgets over OTLP-ingested metrics'
 
 Parameters:
   DashboardName:
@@ -7,15 +7,10 @@ Parameters:
     Default: ClaudeCoWorkDashboard
     Description: Name for the CloudWatch dashboard
 
-  MetricsLogGroup:
-    Type: String
-    Default: /aws/claude-code/metrics
-    Description: CloudWatch Log Group containing CoWork metrics
-
   MetricsRegion:
     Type: String
     Default: us-east-1
-    Description: Region where metrics log group exists
+    Description: Region where OTLP metrics are ingested
 
 Resources:
   Dashboard:
@@ -25,200 +20,203 @@ Resources:
       DashboardBody: !Sub |
         {
           "widgets": [
-
             {
               "type": "text",
               "x": 0, "y": 0, "width": 24, "height": 2,
-              "properties": {
-                "markdown": "# 📊 Claude CoWork Dashboard\n\nAggregate usage and cost metrics for Claude CoWork (Claude Desktop) sessions via Amazon Bedrock.",
-                "background": "transparent"
-              }
+              "properties": { "markdown": "## Overview", "background": "transparent" }
             },
-
             {
-              "type": "log",
+              "type": "chart",
               "x": 0, "y": 2, "width": 6, "height": 4,
               "properties": {
-                "query": "SOURCE '${MetricsLogGroup}' | filter `service.name` = \"cowork\" and `claude_code.token.usage` > 0 | stats round(sum(`claude_code.token.usage`) / 1000000, 2) as Tokens_M",
-                "region": "${MetricsRegion}",
                 "title": "Total Tokens Used",
-                "queryLanguage": "cwli",
-                "view": "singleValue"
+                "view": "number",
+                "region": "${MetricsRegion}",
+                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.token.usage\", \"@resource.service.name\"=\"cowork\"})", "step": 60, "label": "Tokens" }] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
-              "type": "log",
+              "type": "chart",
               "x": 6, "y": 2, "width": 6, "height": 4,
               "properties": {
-                "query": "SOURCE '${MetricsLogGroup}' | filter `service.name` = \"cowork\" and `claude_code.session.count` > 0 | stats count_distinct(`user.id`) as Users",
-                "region": "${MetricsRegion}",
                 "title": "Active Users",
-                "queryLanguage": "cwli",
-                "view": "singleValue"
+                "view": "number",
+                "region": "${MetricsRegion}",
+                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "count(group by (\"user.id\")({\"claude_code.session.count\", \"@resource.service.name\"=\"cowork\"}))", "step": 60, "label": "Users" }] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
-              "type": "log",
+              "type": "chart",
               "x": 12, "y": 2, "width": 6, "height": 4,
               "properties": {
-                "query": "SOURCE '${MetricsLogGroup}' | filter `service.name` = \"cowork\" and `claude_code.session.count` > 0 | stats sum(`claude_code.session.count`) as Sessions",
-                "region": "${MetricsRegion}",
                 "title": "Total Sessions",
-                "queryLanguage": "cwli",
-                "view": "singleValue"
+                "view": "number",
+                "region": "${MetricsRegion}",
+                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.session.count\", \"@resource.service.name\"=\"cowork\"})", "step": 60, "label": "Sessions" }] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
-              "type": "log",
+              "type": "chart",
               "x": 18, "y": 2, "width": 6, "height": 4,
               "properties": {
-                "query": "SOURCE '${MetricsLogGroup}' | filter `service.name` = \"cowork\" and `claude_code.cost.usage` > 0 | stats round(sum(`claude_code.cost.usage`), 2) as Cost",
-                "region": "${MetricsRegion}",
                 "title": "Total Cost (USD)",
-                "queryLanguage": "cwli",
-                "view": "singleValue"
+                "view": "number",
+                "region": "${MetricsRegion}",
+                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.cost.usage\", \"@resource.service.name\"=\"cowork\"})", "step": 60, "label": "USD" }] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
+              }
+            },
+
+            {
+              "type": "text",
+              "x": 0, "y": 6, "width": 24, "height": 2,
+              "properties": { "markdown": "## Usage Over Time", "background": "transparent" }
+            },
+            {
+              "type": "chart",
+              "x": 0, "y": 8, "width": 12, "height": 6,
+              "properties": {
+                "title": "Token Usage Over Time",
+                "view": "line",
+                "region": "${MetricsRegion}",
+                "data": { "queries": [
+                  { "id": "total", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.token.usage\", \"@resource.service.name\"=\"cowork\"})", "step": 60, "label": "Total Tokens" }
+                ] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
-              "type": "log",
-              "x": 0, "y": 6, "width": 12, "height": 6,
+              "type": "chart",
+              "x": 12, "y": 8, "width": 12, "height": 6,
               "properties": {
-                "query": "SOURCE '${MetricsLogGroup}' | filter `service.name` = \"cowork\" and `claude_code.token.usage` > 0 | stats sum(`claude_code.token.usage`) / 1000 as Tokens_K by bin(5m)",
-                "region": "${MetricsRegion}",
-                "title": "Token Usage Over Time (thousands)",
-                "queryLanguage": "cwli",
-                "view": "timeSeries",
-                "stacked": false,
-                "yAxis": { "left": { "min": 0 } }
-              }
-            },
-            {
-              "type": "log",
-              "x": 12, "y": 6, "width": 12, "height": 6,
-              "properties": {
-                "query": "SOURCE '${MetricsLogGroup}' | filter `service.name` = \"cowork\" and `claude_code.cost.usage` > 0 | stats sum(`claude_code.cost.usage`) as Cost by bin(5m)",
-                "region": "${MetricsRegion}",
                 "title": "Cost Over Time (USD)",
-                "queryLanguage": "cwli",
-                "view": "timeSeries",
-                "stacked": false,
-                "yAxis": { "left": { "min": 0 } }
-              }
-            },
-
-            {
-              "type": "log",
-              "x": 0, "y": 12, "width": 12, "height": 6,
-              "properties": {
-                "query": "SOURCE '${MetricsLogGroup}' | filter `service.name` = \"cowork\" and `claude_code.token.usage` > 0 | parse @message /\"model\":\"(?<model>[^\"]+)\"/ | fields bin(5m) as time, if(model like /sonnet-4-5/, `claude_code.token.usage`, 0) as sonnet_4_5, if(model like /opus-4-6/, `claude_code.token.usage`, 0) as opus_4_6, if(model like /opus-4-7/, `claude_code.token.usage`, 0) as opus_4_7, if(model like /sonnet-4-20250514/, `claude_code.token.usage`, 0) as sonnet_4, if(model like /haiku-4-5/, `claude_code.token.usage`, 0) as haiku_4_5 | stats sum(opus_4_7) / 1000 as Opus_4_7, sum(opus_4_6) / 1000 as Opus_4_6, sum(sonnet_4_5) / 1000 as Sonnet_4_5, sum(sonnet_4) / 1000 as Sonnet_4, sum(haiku_4_5) / 1000 as Haiku_4_5 by time",
+                "view": "line",
                 "region": "${MetricsRegion}",
-                "title": "Token Usage by Model Over Time (thousands)",
-                "queryLanguage": "cwli",
-                "view": "timeSeries",
-                "stacked": false,
-                "yAxis": { "left": { "min": 0 } }
+                "data": { "queries": [
+                  { "id": "cost", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.cost.usage\", \"@resource.service.name\"=\"cowork\"})", "step": 60, "label": "Cost (USD)" }
+                ] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
-              "type": "log",
-              "x": 12, "y": 12, "width": 12, "height": 6,
+              "type": "chart",
+              "x": 0, "y": 14, "width": 12, "height": 6,
               "properties": {
-                "query": "SOURCE '${MetricsLogGroup}' | filter `service.name` = \"cowork\" and `claude_code.session.count` > 0 | stats sum(`claude_code.session.count`) as Sessions by bin(5m)",
-                "region": "${MetricsRegion}",
-                "title": "Active Sessions Over Time",
-                "queryLanguage": "cwli",
-                "view": "timeSeries",
-                "stacked": false,
-                "yAxis": { "left": { "min": 0 } }
-              }
-            },
-
-            {
-              "type": "text",
-              "x": 0, "y": 18, "width": 24, "height": 2,
-              "properties": {
-                "markdown": "## 📈 Model & Token Breakdown",
-                "background": "transparent"
-              }
-            },
-
-            {
-              "type": "log",
-              "x": 0, "y": 20, "width": 8, "height": 6,
-              "properties": {
-                "query": "SOURCE '${MetricsLogGroup}' | filter `service.name` = \"cowork\" and `claude_code.token.usage` > 0 | parse @message /\"model\":\"(?<model>[^\"]+)\"/ | stats round(sum(`claude_code.token.usage`) / 1000, 0) as Tokens_K by model | sort Tokens_K desc | limit 10",
-                "region": "${MetricsRegion}",
                 "title": "Token Usage by Model",
-                "queryLanguage": "cwli",
-                "view": "pie"
+                "view": "line",
+                "region": "${MetricsRegion}",
+                "data": { "queries": [
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (model)({\"claude_code.token.usage\", \"@resource.service.name\"=\"cowork\"}))", "step": 60 }
+                ] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": true, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
-              "type": "log",
-              "x": 8, "y": 20, "width": 8, "height": 6,
+              "type": "chart",
+              "x": 12, "y": 14, "width": 12, "height": 6,
               "properties": {
-                "query": "SOURCE '${MetricsLogGroup}' | filter `service.name` = \"cowork\" and `claude_code.cost.usage` > 0 | parse @message /\"model\":\"(?<model>[^\"]+)\"/ | stats round(sum(`claude_code.cost.usage`), 2) as Cost by model | sort Cost desc | limit 10",
+                "title": "Active Sessions Over Time",
+                "view": "line",
                 "region": "${MetricsRegion}",
-                "title": "Cost by Model (USD)",
-                "queryLanguage": "cwli",
-                "view": "pie"
-              }
-            },
-            {
-              "type": "log",
-              "x": 16, "y": 20, "width": 8, "height": 6,
-              "properties": {
-                "query": "SOURCE '${MetricsLogGroup}' | filter `service.name` = \"cowork\" and `claude_code.token.usage` > 0 | stats round(sum(`claude_code.token.usage`) / 1000, 0) as Tokens_K by `type` | sort Tokens_K desc",
-                "region": "${MetricsRegion}",
-                "title": "Token Usage by Type",
-                "queryLanguage": "cwli",
-                "view": "pie"
+                "data": { "queries": [
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.session.count\", \"@resource.service.name\"=\"cowork\"})", "step": 60, "label": "Sessions" }
+                ] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
 
             {
               "type": "text",
-              "x": 0, "y": 26, "width": 24, "height": 2,
+              "x": 0, "y": 20, "width": 24, "height": 2,
+              "properties": { "markdown": "## Model & Token Breakdown", "background": "transparent" }
+            },
+            {
+              "type": "chart",
+              "x": 0, "y": 22, "width": 8, "height": 6,
               "properties": {
-                "markdown": "## 💻 Platform & Environment",
-                "background": "transparent"
+                "title": "Token Usage by Model",
+                "view": "pie",
+                "region": "${MetricsRegion}",
+                "data": { "queries": [
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (model)({\"claude_code.token.usage\", \"@resource.service.name\"=\"cowork\"}))", "step": 60 }
+                ] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": true, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
+              }
+            },
+            {
+              "type": "chart",
+              "x": 8, "y": 22, "width": 8, "height": 6,
+              "properties": {
+                "title": "Cost by Model (USD)",
+                "view": "pie",
+                "region": "${MetricsRegion}",
+                "data": { "queries": [
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (model)({\"claude_code.cost.usage\", \"@resource.service.name\"=\"cowork\"}))", "step": 60 }
+                ] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": true, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
+              }
+            },
+            {
+              "type": "chart",
+              "x": 16, "y": 22, "width": 8, "height": 6,
+              "properties": {
+                "title": "Token Usage by Type",
+                "view": "pie",
+                "region": "${MetricsRegion}",
+                "data": { "queries": [
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (type)({\"claude_code.token.usage\", \"@resource.service.name\"=\"cowork\"}))", "step": 60 }
+                ] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": true, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
 
             {
-              "type": "log",
-              "x": 0, "y": 28, "width": 8, "height": 6,
+              "type": "text",
+              "x": 0, "y": 28, "width": 24, "height": 2,
+              "properties": { "markdown": "## Platform & Environment", "background": "transparent" }
+            },
+            {
+              "type": "chart",
+              "x": 0, "y": 30, "width": 8, "height": 6,
               "properties": {
-                "query": "SOURCE '${MetricsLogGroup}' | filter `service.name` = \"cowork\" and `claude_code.session.count` > 0 | stats sum(`claude_code.session.count`) as Sessions by `os.type` | sort Sessions desc",
-                "region": "${MetricsRegion}",
                 "title": "Sessions by Operating System",
-                "queryLanguage": "cwli",
-                "view": "pie"
+                "view": "pie",
+                "region": "${MetricsRegion}",
+                "data": { "queries": [
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (\"@resource.os.type\")({\"claude_code.session.count\", \"@resource.service.name\"=\"cowork\"}))", "step": 60 }
+                ] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": true, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
-              "type": "log",
-              "x": 8, "y": 28, "width": 8, "height": 6,
+              "type": "chart",
+              "x": 8, "y": 30, "width": 8, "height": 6,
               "properties": {
-                "query": "SOURCE '${MetricsLogGroup}' | filter `service.name` = \"cowork\" and `claude_code.session.count` > 0 | stats sum(`claude_code.session.count`) as Sessions by `service.version` | sort Sessions desc | limit 10",
-                "region": "${MetricsRegion}",
                 "title": "CoWork Versions in Use",
-                "queryLanguage": "cwli",
-                "view": "table"
+                "view": "pie",
+                "region": "${MetricsRegion}",
+                "data": { "queries": [
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (\"@resource.service.version\")({\"claude_code.session.count\", \"@resource.service.name\"=\"cowork\"}))", "step": 60 }
+                ] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": true, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
-              "type": "log",
-              "x": 16, "y": 28, "width": 8, "height": 6,
+              "type": "chart",
+              "x": 16, "y": 30, "width": 8, "height": 6,
               "properties": {
-                "query": "SOURCE '${MetricsLogGroup}' | filter `service.name` = \"cowork\" and `claude_code.session.count` > 0 | stats sum(`claude_code.session.count`) as Sessions by `host.arch` | sort Sessions desc",
-                "region": "${MetricsRegion}",
                 "title": "Sessions by Architecture",
-                "queryLanguage": "cwli",
-                "view": "pie"
+                "view": "pie",
+                "region": "${MetricsRegion}",
+                "data": { "queries": [
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (\"@resource.host.arch\")({\"claude_code.session.count\", \"@resource.service.name\"=\"cowork\"}))", "step": 60 }
+                ] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": true, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             }
-
           ]
         }
 
@@ -226,7 +224,3 @@ Outputs:
   DashboardURL:
     Description: Direct URL to the CoWork CloudWatch dashboard
     Value: !Sub 'https://console.aws.amazon.com/cloudwatch/home?region=${AWS::Region}#dashboards:name=${DashboardName}'
-
-  LogsInsightsURL:
-    Description: URL to CloudWatch Logs Insights
-    Value: !Sub 'https://console.aws.amazon.com/cloudwatch/home?region=${AWS::Region}#logsV2:logs-insights'

--- a/deployment/infrastructure/lambda-functions/quota_check/index.py
+++ b/deployment/infrastructure/lambda-functions/quota_check/index.py
@@ -25,6 +25,7 @@ ENABLE_FINEGRAINED_QUOTAS = os.environ.get("ENABLE_FINEGRAINED_QUOTAS", "false")
 MONTHLY_TOKEN_LIMIT = int(os.environ.get("MONTHLY_TOKEN_LIMIT", "0"))
 DAILY_TOKEN_LIMIT = int(os.environ.get("DAILY_TOKEN_LIMIT", "0"))
 MONTHLY_ENFORCEMENT_MODE = os.environ.get("MONTHLY_ENFORCEMENT_MODE", "block")
+DAILY_ENFORCEMENT_MODE = os.environ.get("DAILY_ENFORCEMENT_MODE", "alert")
 WARNING_THRESHOLD_80 = int(os.environ.get("WARNING_THRESHOLD_80", "240000000"))
 WARNING_THRESHOLD_90 = int(os.environ.get("WARNING_THRESHOLD_90", "270000000"))
 
@@ -153,18 +154,20 @@ def lambda_handler(event, context):
 
         # Check daily token limit (if configured)
         if daily_limit and daily_limit > 0 and daily_tokens >= daily_limit:
-            return build_response(200, {
-                "allowed": False,
-                "reason": "daily_exceeded",
-                "enforcement_mode": enforcement_mode,
-                "usage": usage_summary,
-                "policy": {
-                    "type": policy.get("policy_type"),
-                    "identifier": policy.get("identifier")
-                },
-                "unblock_status": {"is_unblocked": False},
-                "message": f"Daily quota exceeded: {int(daily_tokens):,} / {int(daily_limit):,} tokens ({daily_tokens/daily_limit*100:.1f}%). Quota resets at UTC midnight."
-            })
+            daily_mode = policy.get("daily_enforcement_mode", "alert")
+            if daily_mode == "block":
+                return build_response(200, {
+                    "allowed": False,
+                    "reason": "daily_exceeded",
+                    "enforcement_mode": enforcement_mode,
+                    "usage": usage_summary,
+                    "policy": {
+                        "type": policy.get("policy_type"),
+                        "identifier": policy.get("identifier")
+                    },
+                    "unblock_status": {"is_unblocked": False},
+                    "message": f"Daily quota exceeded: {int(daily_tokens):,} / {int(daily_limit):,} tokens ({daily_tokens/daily_limit*100:.1f}%). Quota resets at UTC midnight."
+                })
 
         # All checks passed - access allowed
         return build_response(200, {
@@ -273,6 +276,7 @@ def resolve_quota_for_user(email: str, groups: list) -> dict | None:
             "warning_threshold_80": WARNING_THRESHOLD_80,
             "warning_threshold_90": WARNING_THRESHOLD_90,
             "enforcement_mode": MONTHLY_ENFORCEMENT_MODE,
+            "daily_enforcement_mode": DAILY_ENFORCEMENT_MODE,
             "enabled": True,
         }
 
@@ -321,6 +325,7 @@ def get_policy(policy_type: str, identifier: str) -> dict | None:
             "warning_threshold_80": int(item.get("warning_threshold_80", 0)),
             "warning_threshold_90": int(item.get("warning_threshold_90", 0)),
             "enforcement_mode": item.get("enforcement_mode", "alert"),
+            "daily_enforcement_mode": item.get("daily_enforcement_mode", "alert"),
             "enabled": item.get("enabled", True),
         }
     except Exception as e:

--- a/deployment/infrastructure/otel-collector.yaml
+++ b/deployment/infrastructure/otel-collector.yaml
@@ -52,7 +52,6 @@ Conditions:
   HasJwtAuth: !Not [!Equals [!Ref OidcIssuerUrl, '']]
   HasOidcClientId: !Not [!Equals [!Ref OidcClientId, '']]
   AnalyticsEnabled: !Equals [!Ref EnableAnalytics, 'true']
-  AnalyticsDisabled: !Not [!Equals [!Ref EnableAnalytics, 'true']]
 
 # Rules section removed - validation handled by deployment script
 
@@ -330,223 +329,218 @@ Resources:
                 Resource:
                   - !Sub 'arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/claude-code-otel-config'
 
-  # SSM Parameter for Configuration — OTLP-only (no analytics)
-  OTelConfigOtlpOnly:
+  # SSM Parameter for Configuration — single resource with conditional value
+  # to avoid delete+create race during stack updates between analytics modes.
+  OTelConfig:
     Type: AWS::SSM::Parameter
-    Condition: AnalyticsDisabled
     Properties:
       Name: claude-code-otel-config
       Type: String
       Tier: Advanced
-      Description: OpenTelemetry configuration - OTLP export only
-      Value: !Sub |
-        extensions:
-          health_check:
-            endpoint: 0.0.0.0:13133
-            path: /
-          sigv4auth:
-            service: "monitoring"
-            region: "${AWS::Region}"
+      Description: !If
+        - AnalyticsEnabled
+        - "OpenTelemetry configuration - dual export (OTLP + EMF)"
+        - "OpenTelemetry configuration - OTLP export only"
+      Value: !If
+        - AnalyticsEnabled
+        - !Sub |
+            extensions:
+              health_check:
+                endpoint: 0.0.0.0:13133
+                path: /
+              sigv4auth:
+                service: "monitoring"
+                region: "${AWS::Region}"
 
-        receivers:
-          otlp:
-            protocols:
-              grpc:
-                endpoint: 0.0.0.0:4317
-                include_metadata: true
-              http:
-                endpoint: 0.0.0.0:4318
-                include_metadata: true
+            receivers:
+              otlp:
+                protocols:
+                  grpc:
+                    endpoint: 0.0.0.0:4317
+                    include_metadata: true
+                  http:
+                    endpoint: 0.0.0.0:4318
+                    include_metadata: true
 
-        processors:
-          batch/metrics:
-            timeout: 60s
-          attributes:
-            actions:
-              - key: user.email
-                from_context: metadata.x-user-email
-                action: upsert
-              - key: user.id
-                from_context: metadata.x-user-id
-                action: upsert
-              - key: user.name
-                from_context: metadata.x-user-name
-                action: upsert
-              - key: department
-                from_context: metadata.x-department
-                action: upsert
-              - key: team.id
-                from_context: metadata.x-team-id
-                action: upsert
-              - key: cost_center
-                from_context: metadata.x-cost-center
-                action: upsert
-              - key: organization
-                from_context: metadata.x-organization
-                action: upsert
-              - key: location
-                from_context: metadata.x-location
-                action: upsert
-              - key: role
-                from_context: metadata.x-role
-                action: upsert
-              - key: manager
-                from_context: metadata.x-manager
-                action: upsert
-          resource:
-            attributes:
-              - key: aws.account_id
-                value: "${AWS::AccountId}"
-                action: insert
-              - key: deployment.environment
-                value: "production"
-                action: insert
+            processors:
+              batch/metrics:
+                timeout: 60s
+              attributes:
+                actions:
+                  - key: user.email
+                    from_context: metadata.x-user-email
+                    action: upsert
+                  - key: user.id
+                    from_context: metadata.x-user-id
+                    action: upsert
+                  - key: user.name
+                    from_context: metadata.x-user-name
+                    action: upsert
+                  - key: department
+                    from_context: metadata.x-department
+                    action: upsert
+                  - key: team.id
+                    from_context: metadata.x-team-id
+                    action: upsert
+                  - key: cost_center
+                    from_context: metadata.x-cost-center
+                    action: upsert
+                  - key: organization
+                    from_context: metadata.x-organization
+                    action: upsert
+                  - key: location
+                    from_context: metadata.x-location
+                    action: upsert
+                  - key: role
+                    from_context: metadata.x-role
+                    action: upsert
+                  - key: manager
+                    from_context: metadata.x-manager
+                    action: upsert
+              resource:
+                attributes:
+                  - key: aws.account_id
+                    value: "${AWS::AccountId}"
+                    action: insert
+                  - key: deployment.environment
+                    value: "production"
+                    action: insert
 
-        exporters:
-          otlphttp:
-            tls:
-              insecure: false
-            endpoint: "https://monitoring.${AWS::Region}.amazonaws.com"
-            auth:
-              authenticator: sigv4auth
+            exporters:
+              otlphttp:
+                tls:
+                  insecure: false
+                endpoint: "https://monitoring.${AWS::Region}.amazonaws.com"
+                auth:
+                  authenticator: sigv4auth
 
-        service:
-          extensions: [health_check, sigv4auth]
-          telemetry:
-            logs:
-              level: info
-              development: false
-              encoding: json
-              output_paths: [stdout]
-          pipelines:
-            metrics:
-              receivers: [otlp]
-              processors: [attributes, resource, batch/metrics]
-              exporters: [otlphttp]
+              awsemf:
+                namespace: ClaudeCode
+                log_group_name: /aws/claude-code/metrics
+                region: ${AWS::Region}
+                output_destination: cloudwatch
+                log_retention: 7
+                resource_to_telemetry_conversion:
+                  enabled: true
+                metric_declarations:
+                  - dimensions: [[OTelLib]]
+                    metric_name_selectors: [".*"]
+                  - dimensions: [[department, OTelLib]]
+                    metric_name_selectors: [".*"]
+                  - dimensions: [[team.id, OTelLib]]
+                    metric_name_selectors: [".*"]
+                  - dimensions: [[organization, OTelLib]]
+                    metric_name_selectors: [".*"]
+                  - dimensions: [[model, OTelLib]]
+                    metric_name_selectors: [".*"]
+                  - dimensions: [[cost_center, OTelLib]]
+                    metric_name_selectors: ["claude_code.cost.usage", "claude_code.token.usage"]
+                  - dimensions: [[type, OTelLib]]
+                    metric_name_selectors: ["claude_code.token.usage", "claude_code.lines_of_code.count"]
+                  - dimensions: [[tool_name, OTelLib]]
+                    metric_name_selectors: ["claude_code.code_edit_tool.*"]
+                  - dimensions: [[language, OTelLib]]
+                    metric_name_selectors: ["claude_code.code_edit_tool.*"]
+                  - dimensions: [[decision, OTelLib]]
+                    metric_name_selectors: ["claude_code.code_edit_tool.decision"]
 
-  # SSM Parameter for Configuration — dual-export (OTLP + EMF for analytics)
-  OTelConfigDualExport:
-    Type: AWS::SSM::Parameter
-    Condition: AnalyticsEnabled
-    Properties:
-      Name: claude-code-otel-config
-      Type: String
-      Tier: Advanced
-      Description: OpenTelemetry configuration - dual export (OTLP + EMF)
-      Value: !Sub |
-        extensions:
-          health_check:
-            endpoint: 0.0.0.0:13133
-            path: /
-          sigv4auth:
-            service: "monitoring"
-            region: "${AWS::Region}"
+            service:
+              extensions: [health_check, sigv4auth]
+              telemetry:
+                logs:
+                  level: info
+                  development: false
+                  encoding: json
+                  output_paths: [stdout]
+              pipelines:
+                metrics:
+                  receivers: [otlp]
+                  processors: [attributes, resource, batch/metrics]
+                  exporters: [otlphttp, awsemf]
+        - !Sub |
+            extensions:
+              health_check:
+                endpoint: 0.0.0.0:13133
+                path: /
+              sigv4auth:
+                service: "monitoring"
+                region: "${AWS::Region}"
 
-        receivers:
-          otlp:
-            protocols:
-              grpc:
-                endpoint: 0.0.0.0:4317
-                include_metadata: true
-              http:
-                endpoint: 0.0.0.0:4318
-                include_metadata: true
+            receivers:
+              otlp:
+                protocols:
+                  grpc:
+                    endpoint: 0.0.0.0:4317
+                    include_metadata: true
+                  http:
+                    endpoint: 0.0.0.0:4318
+                    include_metadata: true
 
-        processors:
-          batch/metrics:
-            timeout: 60s
-          attributes:
-            actions:
-              - key: user.email
-                from_context: metadata.x-user-email
-                action: upsert
-              - key: user.id
-                from_context: metadata.x-user-id
-                action: upsert
-              - key: user.name
-                from_context: metadata.x-user-name
-                action: upsert
-              - key: department
-                from_context: metadata.x-department
-                action: upsert
-              - key: team.id
-                from_context: metadata.x-team-id
-                action: upsert
-              - key: cost_center
-                from_context: metadata.x-cost-center
-                action: upsert
-              - key: organization
-                from_context: metadata.x-organization
-                action: upsert
-              - key: location
-                from_context: metadata.x-location
-                action: upsert
-              - key: role
-                from_context: metadata.x-role
-                action: upsert
-              - key: manager
-                from_context: metadata.x-manager
-                action: upsert
-          resource:
-            attributes:
-              - key: aws.account_id
-                value: "${AWS::AccountId}"
-                action: insert
-              - key: deployment.environment
-                value: "production"
-                action: insert
+            processors:
+              batch/metrics:
+                timeout: 60s
+              attributes:
+                actions:
+                  - key: user.email
+                    from_context: metadata.x-user-email
+                    action: upsert
+                  - key: user.id
+                    from_context: metadata.x-user-id
+                    action: upsert
+                  - key: user.name
+                    from_context: metadata.x-user-name
+                    action: upsert
+                  - key: department
+                    from_context: metadata.x-department
+                    action: upsert
+                  - key: team.id
+                    from_context: metadata.x-team-id
+                    action: upsert
+                  - key: cost_center
+                    from_context: metadata.x-cost-center
+                    action: upsert
+                  - key: organization
+                    from_context: metadata.x-organization
+                    action: upsert
+                  - key: location
+                    from_context: metadata.x-location
+                    action: upsert
+                  - key: role
+                    from_context: metadata.x-role
+                    action: upsert
+                  - key: manager
+                    from_context: metadata.x-manager
+                    action: upsert
+              resource:
+                attributes:
+                  - key: aws.account_id
+                    value: "${AWS::AccountId}"
+                    action: insert
+                  - key: deployment.environment
+                    value: "production"
+                    action: insert
 
-        exporters:
-          otlphttp:
-            tls:
-              insecure: false
-            endpoint: "https://monitoring.${AWS::Region}.amazonaws.com"
-            auth:
-              authenticator: sigv4auth
+            exporters:
+              otlphttp:
+                tls:
+                  insecure: false
+                endpoint: "https://monitoring.${AWS::Region}.amazonaws.com"
+                auth:
+                  authenticator: sigv4auth
 
-          awsemf:
-            namespace: ClaudeCode
-            log_group_name: /aws/claude-code/metrics
-            region: ${AWS::Region}
-            output_destination: cloudwatch
-            log_retention: 7
-            resource_to_telemetry_conversion:
-              enabled: true
-            metric_declarations:
-              - dimensions: [[OTelLib]]
-                metric_name_selectors: [".*"]
-              - dimensions: [[department, OTelLib]]
-                metric_name_selectors: [".*"]
-              - dimensions: [[team.id, OTelLib]]
-                metric_name_selectors: [".*"]
-              - dimensions: [[organization, OTelLib]]
-                metric_name_selectors: [".*"]
-              - dimensions: [[model, OTelLib]]
-                metric_name_selectors: [".*"]
-              - dimensions: [[cost_center, OTelLib]]
-                metric_name_selectors: ["claude_code.cost.usage", "claude_code.token.usage"]
-              - dimensions: [[type, OTelLib]]
-                metric_name_selectors: ["claude_code.token.usage", "claude_code.lines_of_code.count"]
-              - dimensions: [[tool_name, OTelLib]]
-                metric_name_selectors: ["claude_code.code_edit_tool.*"]
-              - dimensions: [[language, OTelLib]]
-                metric_name_selectors: ["claude_code.code_edit_tool.*"]
-              - dimensions: [[decision, OTelLib]]
-                metric_name_selectors: ["claude_code.code_edit_tool.decision"]
-
-        service:
-          extensions: [health_check, sigv4auth]
-          telemetry:
-            logs:
-              level: info
-              development: false
-              encoding: json
-              output_paths: [stdout]
-          pipelines:
-            metrics:
-              receivers: [otlp]
-              processors: [attributes, resource, batch/metrics]
-              exporters: [otlphttp, awsemf]
+            service:
+              extensions: [health_check, sigv4auth]
+              telemetry:
+                logs:
+                  level: info
+                  development: false
+                  encoding: json
+                  output_paths: [stdout]
+              pipelines:
+                metrics:
+                  receivers: [otlp]
+                  processors: [attributes, resource, batch/metrics]
+                  exporters: [otlphttp]
 
   # ECS Task Definition
   TaskDefinition:
@@ -567,10 +561,7 @@ Resources:
           Memory: 512
           Secrets:
             - Name: AOT_CONFIG_CONTENT
-              ValueFrom: !If
-                - AnalyticsEnabled
-                - !Ref OTelConfigDualExport
-                - !Ref OTelConfigOtlpOnly
+              ValueFrom: !Ref OTelConfig
           PortMappings:
             - ContainerPort: 4317
               Protocol: tcp
@@ -693,10 +684,7 @@ Outputs:
 
   ConfigParameterName:
     Description: SSM Parameter containing collector configuration
-    Value: !If
-      - AnalyticsEnabled
-      - !Ref OTelConfigDualExport
-      - !Ref OTelConfigOtlpOnly
+    Value: !Ref OTelConfig
 
   LogGroupName:
     Description: CloudWatch Log Group for metrics (only when analytics enabled)

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -119,11 +119,13 @@ class DeployCommand(Command):
                     console.print("[yellow]Monitoring is not enabled in your configuration.[/yellow]")
                     return 1
             elif stack_arg == "cowork-dashboard":
-                if profile.monitoring_enabled:
-                    stacks_to_deploy.append(("cowork-dashboard", "CoWork CloudWatch Dashboard"))
-                else:
+                if not profile.monitoring_enabled:
                     console.print("[yellow]Monitoring is not enabled in your configuration.[/yellow]")
                     return 1
+                if getattr(profile, "monitoring_mode", "central") == "sidecar":
+                    console.print("[yellow]CoWork dashboard requires central monitoring mode (Cowork cannot export telemetry in sidecar mode).[/yellow]")
+                    return 1
+                stacks_to_deploy.append(("cowork-dashboard", "CoWork CloudWatch Dashboard"))
             elif stack_arg == "analytics":
                 if profile.monitoring_enabled:
                     stacks_to_deploy.append(("analytics", "Analytics Pipeline (Kinesis Firehose + Athena)"))
@@ -236,7 +238,8 @@ class DeployCommand(Command):
 
             if should_delete:
                 console.print("\n[bold]Cleaning up orphaned stacks...[/bold]\n")
-                for stack_type, stack_name, _status in orphaned_stacks:
+                # Delete in reverse deployment order (dependents first)
+                for stack_type, stack_name, _status in reversed(orphaned_stacks):
                     try:
                         console.print(f"[yellow]Deleting {stack_type} stack: {stack_name}...[/yellow]")
                         cf_manager.delete_stack(stack_name)
@@ -719,7 +722,6 @@ class DeployCommand(Command):
                     "cowork-dashboard", f"{profile.identity_pool_name}-cowork-dashboard"
                 )
                 params = [
-                    f"MetricsLogGroup={profile.metrics_log_group}",
                     f"MetricsRegion={profile.aws_region}",
                 ]
                 return deploy_with_cf(
@@ -999,7 +1001,6 @@ class DeployCommand(Command):
             template = project_root / "deployment" / "infrastructure" / "cowork-dashboard.yaml"
             stack_name = profile.stack_names.get("cowork-dashboard", f"{profile.identity_pool_name}-cowork-dashboard")
             params = [
-                f"MetricsLogGroup={profile.metrics_log_group}",
                 f"MetricsRegion={region}",
             ]
             print_deploy_cmd(template, stack_name, params)
@@ -1175,6 +1176,7 @@ class DeployCommand(Command):
             "networking": "VPC Networking",
             "monitoring": "OpenTelemetry Collector",
             "dashboard": "CloudWatch Dashboard",
+            "cowork-dashboard": "CoWork CloudWatch Dashboard",
             "analytics": "Analytics Pipeline",
             "quota": "Quota Monitoring",
             "codebuild": "CodeBuild",

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -848,11 +848,13 @@ class InitCommand(Command):
                     "  [green]+[/green] Works offline — each dev machine runs its own collector\n"
                     "  [yellow]-[/yellow] No Athena SQL query pipeline (PromQL dashboards still included)\n"
                     "  [yellow]-[/yellow] Each machine manages its own collector process\n"
+                    "  [yellow]-[/yellow] Claude Cowork (desktop) telemetry not supported (cannot reach localhost collector)\n"
                 )
                 console.print(
                     "[cyan]Central:[/cyan]\n"
                     "  [green]+[/green] Optional Athena SQL pipeline (EMF → Firehose → S3 → Athena)\n"
                     "  [green]+[/green] Single collector for all users — centralized management\n"
+                    "  [green]+[/green] Supports Claude Cowork (desktop) telemetry\n"
                     "  [green]+[/green] Recommended if IT policies prevent users running a local OTel collector on localhost\n"
                     "  [yellow]-[/yellow] Requires VPC/ECS Fargate infrastructure\n"
                     "  [yellow]-[/yellow] Higher cost (ECS tasks, NAT gateways, load balancer)\n"

--- a/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
+++ b/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
@@ -71,21 +71,28 @@ def add_monitoring_config(mdm_config: dict, profile, console: Console) -> None:
     if not profile.monitoring_enabled:
         return
 
+    monitoring_mode = getattr(profile, "monitoring_mode", "central")
+
+    if monitoring_mode == "sidecar":
+        console.print("[dim]Sidecar mode — Cowork telemetry not supported, skipping OTLP config[/dim]")
+        return
+
     monitoring_stack = profile.stack_names.get(
         "monitoring", f"{profile.identity_pool_name}-otel-collector"
     )
-
     try:
         outputs = get_stack_outputs(monitoring_stack, profile.aws_region)
         endpoint = outputs.get("CollectorEndpoint")
-        if endpoint:
-            mdm_config["otlpEndpoint"] = endpoint
-            mdm_config["otlpProtocol"] = "http/protobuf"
-            console.print(f"[dim]OTLP endpoint: {endpoint}[/dim]")
-        else:
-            console.print("[dim]Monitoring stack not found — skipping OTLP config[/dim]")
     except Exception:
         console.print("[dim]Could not query monitoring stack — skipping OTLP config[/dim]")
+        return
+
+    if endpoint:
+        mdm_config["otlpEndpoint"] = endpoint
+        mdm_config["otlpProtocol"] = "http/protobuf"
+        console.print(f"[dim]OTLP endpoint: {endpoint}[/dim]")
+    else:
+        console.print("[dim]Monitoring endpoint not found — skipping OTLP config[/dim]")
 
 
 def _mdm_keys(config: dict) -> dict:

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -23,7 +23,7 @@ class Profile:
     schema_version: str = "2.0"  # Configuration schema version
     stack_names: dict[str, str] = field(default_factory=dict)
     monitoring_enabled: bool = True
-    monitoring_mode: str = "sidecar"  # "sidecar" (local collector) or "central" (ECS Fargate)
+    monitoring_mode: str = "central"  # "sidecar" (local collector) or "central" (ECS Fargate)
     monitoring_config: dict[str, Any] = field(default_factory=dict)
     analytics_enabled: bool = True  # Analytics pipeline for user metrics
     metrics_log_group: str = "/aws/claude-code/metrics"
@@ -181,6 +181,11 @@ class Profile:
             # If distribution was enabled but no type specified, default to presigned-s3
             if "distribution_type" not in data or data["distribution_type"] is None:
                 data["distribution_type"] = "presigned-s3"
+
+        # Ensure monitoring_mode defaults to "central" for existing profiles
+        # (new profiles created via init will explicitly set "sidecar")
+        if "monitoring_mode" not in data:
+            data["monitoring_mode"] = "central"
 
         # Set default cross-region profile if not present
         if "cross_region_profile" not in data:

--- a/source/claude_code_with_bedrock/models.py
+++ b/source/claude_code_with_bedrock/models.py
@@ -597,21 +597,21 @@ _CLAUDE_MODELS_RAW = {
                     "eu-central-1",  # Frankfurt
                     "eu-central-2",  # Zurich
                     "eu-north-1",  # Stockholm
+                    "eu-south-1",  # Milan
+                    "eu-south-2",  # Spain
                     "eu-west-1",  # Ireland
                     "eu-west-2",  # London
                     "eu-west-3",  # Paris
-                    "eu-south-2",  # Milan
-                    "eu-south-2",  # Spain
                 ],
                 "destination_regions": [
                     "eu-central-1",
                     "eu-central-2",
                     "eu-north-1",
+                    "eu-south-1",
+                    "eu-south-2",
                     "eu-west-1",
                     "eu-west-2",
                     "eu-west-3",
-                    "eu-south-2",
-                    "eu-south-2",
                 ],
             },
             "jp": {
@@ -643,7 +643,7 @@ _CLAUDE_MODELS_RAW = {
                     "eu-west-1",  # Ireland
                     "eu-west-2",  # London
                     "eu-west-3",  # Paris
-                    "eu-south-2",  # Milan
+                    "eu-south-1",  # Milan
                     "eu-south-2",  # Spain
                     # Asia Pacific
                     "ap-southeast-3",  # Jakarta
@@ -672,7 +672,7 @@ _CLAUDE_MODELS_RAW = {
                     "eu-west-1",
                     "eu-west-2",
                     "eu-west-3",
-                    "eu-south-2",
+                    "eu-south-1",
                     "eu-south-2",
                     # Asia Pacific
                     "ap-southeast-3",

--- a/source/tests/test_quota_check_lambda.py
+++ b/source/tests/test_quota_check_lambda.py
@@ -1,0 +1,517 @@
+# ABOUTME: Tests for the quota_check Lambda function's daily enforcement logic
+# ABOUTME: Covers both env-var (ENABLE_FINEGRAINED_QUOTAS=false) and DynamoDB-backed paths
+
+"""Tests for quota_check Lambda daily enforcement (block vs alert)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+LAMBDA_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "deployment"
+    / "infrastructure"
+    / "lambda-functions"
+    / "quota_check"
+    / "index.py"
+)
+
+
+def _load_quota_check(env: dict) -> object:
+    """Load the quota_check Lambda module fresh with the given environment.
+
+    The module reads env vars at import time, so we must reload it after
+    setting environment variables.
+    """
+    # Apply env vars before module import
+    for key, value in env.items():
+        os.environ[key] = value
+
+    # Force a fresh import each time so module-level env reads take effect
+    module_name = f"quota_check_index_{id(env)}"
+    spec = importlib.util.spec_from_file_location(module_name, LAMBDA_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _build_event(email: str = "user@example.com", groups: list[str] | None = None) -> dict:
+    claims: dict = {"email": email}
+    if groups is not None:
+        claims["groups"] = groups
+    return {"requestContext": {"authorizer": {"jwt": {"claims": claims}}}}
+
+
+def _parse(response: dict) -> dict:
+    return json.loads(response["body"])
+
+
+@pytest.fixture
+def base_env():
+    """Minimal env vars common to all tests."""
+    return {
+        "QUOTA_TABLE": "TestQuotaTable",
+        "POLICIES_TABLE": "TestPoliciesTable",
+        "MISSING_EMAIL_ENFORCEMENT": "block",
+        "ERROR_HANDLING_MODE": "fail_closed",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Env-var path: ENABLE_FINEGRAINED_QUOTAS=false
+# ---------------------------------------------------------------------------
+
+
+class TestDailyEnforcementEnvVarPath:
+    """ENABLE_FINEGRAINED_QUOTAS=false -> policy comes from env vars."""
+
+    def _make_module(self, base_env, daily_mode: str):
+        env = {
+            **base_env,
+            "ENABLE_FINEGRAINED_QUOTAS": "false",
+            "MONTHLY_TOKEN_LIMIT": "1000",
+            "DAILY_TOKEN_LIMIT": "100",
+            "MONTHLY_ENFORCEMENT_MODE": "block",
+            "DAILY_ENFORCEMENT_MODE": daily_mode,
+        }
+        return _load_quota_check(env)
+
+    def _patch_usage_and_unblock(self, mod, daily_tokens: int, monthly_tokens: int = 0):
+        mod.quota_table = MagicMock()
+        # First call = unblock status (no item), second call = monthly usage
+        mod.quota_table.get_item.side_effect = [
+            {},  # no unblock entry
+            {
+                "Item": {
+                    "total_tokens": monthly_tokens,
+                    "daily_tokens": daily_tokens,
+                    "daily_date": mod.datetime.now(mod.timezone.utc).strftime("%Y-%m-%d"),
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "cache_tokens": 0,
+                }
+            },
+        ]
+
+    def test_daily_block_mode_blocks_when_exceeded(self, base_env):
+        mod = self._make_module(base_env, daily_mode="block")
+        self._patch_usage_and_unblock(mod, daily_tokens=150)
+
+        body = _parse(mod.lambda_handler(_build_event(), None))
+        assert body["allowed"] is False
+        assert body["reason"] == "daily_exceeded"
+
+    def test_daily_alert_mode_allows_when_exceeded(self, base_env):
+        mod = self._make_module(base_env, daily_mode="alert")
+        self._patch_usage_and_unblock(mod, daily_tokens=150)
+
+        body = _parse(mod.lambda_handler(_build_event(), None))
+        assert body["allowed"] is True
+        assert body["reason"] == "within_quota"
+
+    def test_daily_block_mode_allows_under_limit(self, base_env):
+        mod = self._make_module(base_env, daily_mode="block")
+        self._patch_usage_and_unblock(mod, daily_tokens=50)
+
+        body = _parse(mod.lambda_handler(_build_event(), None))
+        assert body["allowed"] is True
+
+
+# ---------------------------------------------------------------------------
+# DynamoDB path: ENABLE_FINEGRAINED_QUOTAS=true
+# ---------------------------------------------------------------------------
+
+
+class TestDailyEnforcementFineGrainedPath:
+    """ENABLE_FINEGRAINED_QUOTAS=true -> policy comes from DynamoDB.
+
+    These tests cover the bug where get_policy() did not include
+    daily_enforcement_mode in its returned dict, causing daily block mode
+    to be silently downgraded to alert.
+    """
+
+    def _make_module(self, base_env):
+        env = {
+            **base_env,
+            "ENABLE_FINEGRAINED_QUOTAS": "true",
+        }
+        return _load_quota_check(env)
+
+    def _setup_mocks(
+        self,
+        mod,
+        policy_item: dict,
+        daily_tokens: int,
+        monthly_tokens: int = 0,
+    ):
+        # policies_table: user policy hit
+        mod.policies_table = MagicMock()
+        mod.policies_table.get_item.return_value = {"Item": policy_item}
+
+        # quota_table: no unblock, then monthly usage row
+        mod.quota_table = MagicMock()
+        mod.quota_table.get_item.side_effect = [
+            {},  # unblock lookup
+            {
+                "Item": {
+                    "total_tokens": monthly_tokens,
+                    "daily_tokens": daily_tokens,
+                    "daily_date": mod.datetime.now(mod.timezone.utc).strftime("%Y-%m-%d"),
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "cache_tokens": 0,
+                }
+            },
+        ]
+
+    def test_get_policy_returns_daily_enforcement_mode(self, base_env):
+        """get_policy() must include daily_enforcement_mode from DynamoDB."""
+        mod = self._make_module(base_env)
+        mod.policies_table = MagicMock()
+        mod.policies_table.get_item.return_value = {
+            "Item": {
+                "policy_type": "user",
+                "identifier": "user@example.com",
+                "monthly_token_limit": 1000,
+                "daily_token_limit": 100,
+                "warning_threshold_80": 800,
+                "warning_threshold_90": 900,
+                "enforcement_mode": "block",
+                "daily_enforcement_mode": "block",
+                "enabled": True,
+            }
+        }
+
+        policy = mod.get_policy("user", "user@example.com")
+        assert policy is not None
+        assert policy["daily_enforcement_mode"] == "block"
+
+    def test_get_policy_defaults_daily_enforcement_mode_to_alert(self, base_env):
+        """When DynamoDB item omits the field, default to 'alert'."""
+        mod = self._make_module(base_env)
+        mod.policies_table = MagicMock()
+        mod.policies_table.get_item.return_value = {
+            "Item": {
+                "policy_type": "user",
+                "identifier": "user@example.com",
+                "monthly_token_limit": 1000,
+                "daily_token_limit": 100,
+                "warning_threshold_80": 800,
+                "warning_threshold_90": 900,
+                "enforcement_mode": "block",
+                "enabled": True,
+                # daily_enforcement_mode intentionally omitted
+            }
+        }
+
+        policy = mod.get_policy("user", "user@example.com")
+        assert policy["daily_enforcement_mode"] == "alert"
+
+    def test_finegrained_daily_block_mode_blocks_when_exceeded(self, base_env):
+        """Regression: daily_enforcement_mode='block' from DynamoDB must block."""
+        mod = self._make_module(base_env)
+        self._setup_mocks(
+            mod,
+            policy_item={
+                "policy_type": "user",
+                "identifier": "user@example.com",
+                "monthly_token_limit": 1000,
+                "daily_token_limit": 100,
+                "warning_threshold_80": 800,
+                "warning_threshold_90": 900,
+                "enforcement_mode": "block",
+                "daily_enforcement_mode": "block",
+                "enabled": True,
+            },
+            daily_tokens=150,
+        )
+
+        body = _parse(mod.lambda_handler(_build_event(), None))
+        assert body["allowed"] is False
+        assert body["reason"] == "daily_exceeded"
+
+    def test_finegrained_daily_alert_mode_allows_when_exceeded(self, base_env):
+        mod = self._make_module(base_env)
+        self._setup_mocks(
+            mod,
+            policy_item={
+                "policy_type": "user",
+                "identifier": "user@example.com",
+                "monthly_token_limit": 1000,
+                "daily_token_limit": 100,
+                "warning_threshold_80": 800,
+                "warning_threshold_90": 900,
+                "enforcement_mode": "block",
+                "daily_enforcement_mode": "alert",
+                "enabled": True,
+            },
+            daily_tokens=150,
+        )
+
+        body = _parse(mod.lambda_handler(_build_event(), None))
+        assert body["allowed"] is True
+        assert body["reason"] == "within_quota"
+
+    def test_finegrained_missing_daily_mode_defaults_to_alert(self, base_env):
+        """If the DynamoDB item omits daily_enforcement_mode, treat as 'alert'."""
+        mod = self._make_module(base_env)
+        self._setup_mocks(
+            mod,
+            policy_item={
+                "policy_type": "user",
+                "identifier": "user@example.com",
+                "monthly_token_limit": 1000,
+                "daily_token_limit": 100,
+                "warning_threshold_80": 800,
+                "warning_threshold_90": 900,
+                "enforcement_mode": "block",
+                "enabled": True,
+                # daily_enforcement_mode missing
+            },
+            daily_tokens=150,
+        )
+
+        body = _parse(mod.lambda_handler(_build_event(), None))
+        assert body["allowed"] is True
+        assert body["reason"] == "within_quota"
+
+
+# ---------------------------------------------------------------------------
+# Contract tests: response schema validation
+# ---------------------------------------------------------------------------
+
+
+# Required keys in every quota_check response body
+RESPONSE_REQUIRED_KEYS = {"allowed"}
+
+# Keys expected when a quota policy exists and user is within quota
+NORMAL_RESPONSE_KEYS = {
+    "allowed", "reason", "enforcement_mode", "usage", "policy", "unblock_status", "message"
+}
+
+# Valid values for 'reason' field
+VALID_REASONS = {
+    "within_quota", "monthly_exceeded", "daily_exceeded",
+    "no_policy", "no_email", "unblocked", "missing_email_claim",
+}
+
+# Valid values for 'enforcement_mode' field
+VALID_ENFORCEMENT_MODES = {"alert", "block", None}
+
+
+class TestResponseSchemaContract:
+    """Contract tests ensuring quota_check Lambda responses conform to expected schema.
+
+    The credential-process binary parses these responses. If the schema changes,
+    credential-process breaks silently (users get blocked or allowed incorrectly).
+    These tests ensure both sides agree on the contract.
+    """
+
+    def _make_module(self, base_env, **overrides):
+        env = {
+            **base_env,
+            "ENABLE_FINEGRAINED_QUOTAS": "false",
+            "MONTHLY_TOKEN_LIMIT": "1000",
+            "DAILY_TOKEN_LIMIT": "100",
+            "MONTHLY_ENFORCEMENT_MODE": "block",
+            "DAILY_ENFORCEMENT_MODE": "block",
+            **overrides,
+        }
+        return _load_quota_check(env)
+
+    def _patch_usage(self, mod, daily_tokens: int = 0, monthly_tokens: int = 0):
+        mod.quota_table = MagicMock()
+        mod.quota_table.get_item.side_effect = [
+            {},  # unblock
+            {
+                "Item": {
+                    "total_tokens": monthly_tokens,
+                    "daily_tokens": daily_tokens,
+                    "daily_date": mod.datetime.now(mod.timezone.utc).strftime("%Y-%m-%d"),
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "cache_tokens": 0,
+                }
+            },
+        ]
+
+    def test_response_is_valid_json_with_status_code(self, base_env):
+        """Lambda returns dict with statusCode and JSON-parseable body."""
+        mod = self._make_module(base_env)
+        self._patch_usage(mod, daily_tokens=0)
+
+        response = mod.lambda_handler(_build_event(), None)
+        assert "statusCode" in response
+        assert "body" in response
+        assert isinstance(response["statusCode"], int)
+        body = json.loads(response["body"])
+        assert isinstance(body, dict)
+
+    def test_allowed_response_has_required_keys(self, base_env):
+        """When allowed=True, response includes all expected keys."""
+        mod = self._make_module(base_env)
+        self._patch_usage(mod, daily_tokens=0)
+
+        body = _parse(mod.lambda_handler(_build_event(), None))
+        assert body["allowed"] is True
+        for key in NORMAL_RESPONSE_KEYS:
+            assert key in body, f"Missing key '{key}' in allowed response"
+
+    def test_blocked_response_has_required_keys(self, base_env):
+        """When allowed=False, response includes all expected keys."""
+        mod = self._make_module(base_env)
+        self._patch_usage(mod, daily_tokens=150)  # exceeds 100 limit
+
+        body = _parse(mod.lambda_handler(_build_event(), None))
+        assert body["allowed"] is False
+        for key in NORMAL_RESPONSE_KEYS:
+            assert key in body, f"Missing key '{key}' in blocked response"
+
+    def test_reason_field_is_valid_enum(self, base_env):
+        """'reason' field uses a known value."""
+        mod = self._make_module(base_env)
+        self._patch_usage(mod, daily_tokens=0)
+
+        body = _parse(mod.lambda_handler(_build_event(), None))
+        assert body["reason"] in VALID_REASONS, f"Unknown reason: {body['reason']}"
+
+    def test_enforcement_mode_is_valid(self, base_env):
+        """'enforcement_mode' is alert, block, or None."""
+        mod = self._make_module(base_env)
+        self._patch_usage(mod, daily_tokens=0)
+
+        body = _parse(mod.lambda_handler(_build_event(), None))
+        assert body["enforcement_mode"] in VALID_ENFORCEMENT_MODES
+
+    def test_usage_summary_structure(self, base_env):
+        """'usage' field contains expected token count keys."""
+        mod = self._make_module(base_env)
+        self._patch_usage(mod, daily_tokens=50, monthly_tokens=200)
+
+        body = _parse(mod.lambda_handler(_build_event(), None))
+        usage = body["usage"]
+        assert usage is not None
+        assert "monthly_tokens" in usage
+        assert "monthly_limit" in usage
+        assert "monthly_percent" in usage
+        assert "daily_tokens" in usage
+        assert "daily_limit" in usage
+
+    def test_policy_field_structure(self, base_env):
+        """'policy' field contains type and identifier."""
+        mod = self._make_module(base_env)
+        self._patch_usage(mod, daily_tokens=0)
+
+        body = _parse(mod.lambda_handler(_build_event(), None))
+        policy = body["policy"]
+        assert policy is not None
+        assert "type" in policy
+        assert "identifier" in policy
+
+    def test_unblock_status_structure(self, base_env):
+        """'unblock_status' field contains is_unblocked boolean."""
+        mod = self._make_module(base_env)
+        self._patch_usage(mod, daily_tokens=0)
+
+        body = _parse(mod.lambda_handler(_build_event(), None))
+        assert "unblock_status" in body
+        assert "is_unblocked" in body["unblock_status"]
+        assert isinstance(body["unblock_status"]["is_unblocked"], bool)
+
+    def test_message_field_is_string(self, base_env):
+        """'message' field is always a human-readable string."""
+        mod = self._make_module(base_env)
+        self._patch_usage(mod, daily_tokens=0)
+
+        body = _parse(mod.lambda_handler(_build_event(), None))
+        assert isinstance(body["message"], str)
+        assert len(body["message"]) > 0
+
+    def test_monthly_exceeded_sets_reason_correctly(self, base_env):
+        """Monthly limit exceeded returns reason='monthly_exceeded'."""
+        mod = self._make_module(base_env)
+        self._patch_usage(mod, monthly_tokens=1500)  # exceeds 1000 limit
+
+        body = _parse(mod.lambda_handler(_build_event(), None))
+        assert body["allowed"] is False
+        assert body["reason"] == "monthly_exceeded"
+
+    def test_no_policy_response(self, base_env):
+        """When MONTHLY_TOKEN_LIMIT=0 (disabled), returns no_policy."""
+        mod = self._make_module(base_env, MONTHLY_TOKEN_LIMIT="0", DAILY_TOKEN_LIMIT="0")
+        self._patch_usage(mod)
+
+        body = _parse(mod.lambda_handler(_build_event(), None))
+        assert body["allowed"] is True
+        assert body["reason"] == "no_policy"
+
+
+class TestInputValidationContract:
+    """Contract tests for input handling — ensures malformed requests don't crash."""
+
+    def _make_module(self, base_env):
+        env = {
+            **base_env,
+            "ENABLE_FINEGRAINED_QUOTAS": "false",
+            "MONTHLY_TOKEN_LIMIT": "1000",
+            "DAILY_TOKEN_LIMIT": "100",
+            "MONTHLY_ENFORCEMENT_MODE": "block",
+            "DAILY_ENFORCEMENT_MODE": "block",
+        }
+        return _load_quota_check(env)
+
+    def test_missing_email_claim(self, base_env):
+        """Request with no email in JWT claims returns structured response."""
+        mod = self._make_module(base_env)
+        event = {"requestContext": {"authorizer": {"jwt": {"claims": {}}}}}
+
+        response = mod.lambda_handler(event, None)
+        assert response["statusCode"] == 200
+        body = _parse(response)
+        assert "allowed" in body
+        assert body.get("reason") == "missing_email_claim"
+
+    def test_missing_authorizer_context(self, base_env):
+        """Request with no authorizer context does not crash."""
+        mod = self._make_module(base_env)
+        event = {"requestContext": {}}
+
+        response = mod.lambda_handler(event, None)
+        assert response["statusCode"] == 200
+        body = _parse(response)
+        assert "allowed" in body
+
+    def test_empty_event(self, base_env):
+        """Completely empty event does not crash the Lambda."""
+        mod = self._make_module(base_env)
+
+        response = mod.lambda_handler({}, None)
+        assert response["statusCode"] == 200
+        body = _parse(response)
+        assert "allowed" in body
+
+    def test_missing_email_blocked_by_default(self, base_env):
+        """Missing email defaults to blocked (fail-closed security)."""
+        env = {**base_env, "MISSING_EMAIL_ENFORCEMENT": "block"}
+        mod = _load_quota_check({
+            **env,
+            "ENABLE_FINEGRAINED_QUOTAS": "false",
+            "MONTHLY_TOKEN_LIMIT": "1000",
+            "DAILY_TOKEN_LIMIT": "100",
+            "MONTHLY_ENFORCEMENT_MODE": "block",
+            "DAILY_ENFORCEMENT_MODE": "block",
+        })
+        event = {"requestContext": {"authorizer": {"jwt": {"claims": {}}}}}
+
+        body = _parse(mod.lambda_handler(event, None))
+        assert body["allowed"] is False


### PR DESCRIPTION
eu-south-2 (Spain) was listed twice in the EU and Global CRIS profiles for Sonnet 4.5, omitting eu-south-1 (Milan). This causes the generated IAM policy to miss eu-south-1, resulting in 403 when Bedrock cross-region inference routes to that region.