### PR TITLE
fix: guard config['okta'] access when SSO authentication is disabled (#430)

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1748,24 +1748,31 @@ class InitCommand(Command):
         table.add_column("Setting", style="white", no_wrap=True)
         table.add_column("Value", style="green")
 
-        table.add_row("OIDC Provider", config["okta"]["domain"])
-        table.add_row(
-            "OIDC Client ID",
-            (
-                config["okta"]["client_id"][:20] + "..."
-                if len(config["okta"]["client_id"]) > 20
-                else config["okta"]["client_id"]
-            ),
-        )
+        sso_enabled = config.get("sso_enabled", True)
+        if sso_enabled:
+            okta_config = config.get("okta", {})
+            okta_domain = okta_config.get("domain", "")
+            okta_client_id = okta_config.get("client_id", "")
+            table.add_row("OIDC Provider", okta_domain or "—")
+            table.add_row(
+                "OIDC Client ID",
+                (
+                    okta_client_id[:20] + "..."
+                    if len(okta_client_id) > 20
+                    else (okta_client_id or "—")
+                ),
+            )
 
-        table.add_row(
-            "Credential Storage",
-            (
-                "Keyring (OS secure storage)"
-                if config.get("credential_storage") == "keyring"
-                else "Session Files (temporary)"
-            ),
-        )
+            table.add_row(
+                "Credential Storage",
+                (
+                    "Keyring (OS secure storage)"
+                    if config.get("credential_storage") == "keyring"
+                    else "Session Files (temporary)"
+                ),
+            )
+        else:
+            table.add_row("SSO Authentication", "Disabled (IAM credentials used)")
         table.add_row("Infrastructure Region", f"{config['aws']['region']} (Cognito, IAM, Monitoring)")
         table.add_row("Identity Pool", config["aws"]["identity_pool_name"])
         table.add_row("Monitoring", "✓ Enabled" if config["monitoring"]["enabled"] else "✗ Disabled")
@@ -2183,9 +2190,12 @@ class InitCommand(Command):
             params = []
 
         # Update with our values
+        sso_enabled = config.get("sso_enabled", True)
+        okta_domain = config.get("okta", {}).get("domain", "none") if sso_enabled else "none"
+        okta_client_id = config.get("okta", {}).get("client_id", "none") if sso_enabled else "none"
         param_map = {
-            "OktaDomain": config["okta"]["domain"],
-            "OktaClientId": config["okta"]["client_id"],
+            "OktaDomain": okta_domain,
+            "OktaClientId": okta_client_id,
             "IdentityPoolName": config["aws"]["identity_pool_name"],
             "AllowedBedrockRegions": ",".join(config["aws"]["allowed_bedrock_regions"]),
             "EnableMonitoring": "true" if config["monitoring"]["enabled"] else "false",
@@ -2468,7 +2478,10 @@ class InitCommand(Command):
         """Show summary of existing deployment."""
         console = Console()
 
-        console.print(f"• OIDC Provider: [cyan]{config['okta']['domain']}[/cyan]")
+        if config.get("sso_enabled", True) and "okta" in config and "domain" in config["okta"]:
+            console.print(f"• OIDC Provider: [cyan]{config['okta']['domain']}[/cyan]")
+        else:
+            console.print("• SSO Authentication: [cyan]Disabled (IAM credentials used)[/cyan]")
 
         # Show Cognito-specific fields if using Cognito User Pool
         if "cognito_user_pool_id" in config:

--- a/source/tests/cli/commands/test_init.py
+++ b/source/tests/cli/commands/test_init.py
@@ -425,6 +425,90 @@ class TestNamedFunctionsIntegration:
         assert callable(init_module.validate_cognito_user_pool_id)
 
 
+class TestSsoDisabledRendering:
+    """Regression tests for issue #430.
+
+    Ensure the wizard does not crash with KeyError: 'okta' when SSO is
+    disabled. The okta key is only populated by the OIDC flow, so methods
+    that render or persist it must guard against its absence.
+    """
+
+    @pytest.fixture
+    def cmd(self):
+        from claude_code_with_bedrock.cli.commands.init import InitCommand
+        return InitCommand()
+
+    @pytest.fixture
+    def base_aws(self):
+        return {
+            "region": "us-east-1",
+            "identity_pool_name": "demo-pool",
+            "allowed_bedrock_regions": ["us-east-1"],
+            "stacks": {},
+        }
+
+    def test_review_configuration_without_okta_key_does_not_raise(self, cmd, base_aws):
+        config = {
+            "sso_enabled": False,
+            "credential_storage": "session",
+            "aws": base_aws,
+            "monitoring": {"enabled": False},
+        }
+        # Must not raise KeyError: 'okta'
+        assert cmd._review_configuration(config) is True
+
+    def test_review_configuration_sso_enabled_still_renders_okta(self, cmd, base_aws):
+        config = {
+            "sso_enabled": True,
+            "okta": {"domain": "company.okta.com", "client_id": "abcdef1234567890abcdef"},
+            "credential_storage": "keyring",
+            "aws": base_aws,
+            "monitoring": {"enabled": False},
+        }
+        assert cmd._review_configuration(config) is True
+
+    def test_show_existing_deployment_without_okta_key_does_not_raise(self, cmd, base_aws):
+        config = {
+            "sso_enabled": False,
+            "aws": base_aws,
+            "monitoring": {"enabled": False},
+        }
+        # Must not raise KeyError: 'okta'
+        cmd._show_existing_deployment(config)
+
+    def test_update_parameters_file_without_okta_key_writes_none(self, cmd, base_aws, tmp_path):
+        import json
+
+        params_file = tmp_path / "params.json"
+        config = {
+            "sso_enabled": False,
+            "aws": base_aws,
+            "monitoring": {"enabled": False},
+        }
+        cmd._update_parameters_file(params_file, config)
+
+        with open(params_file) as f:
+            params = json.load(f)
+        param_map = {p["ParameterKey"]: p["ParameterValue"] for p in params}
+        assert param_map["OktaDomain"] == "none"
+        assert param_map["OktaClientId"] == "none"
+
+    def test_review_configuration_with_empty_okta_dict_does_not_raise(self, cmd, base_aws):
+        """Edge case: SSO enabled but the user cancelled before entering a domain.
+
+        Config can end up with `okta: {}`. The defensive .get() chain must
+        handle this without raising KeyError on missing 'domain' / 'client_id'.
+        """
+        config = {
+            "sso_enabled": True,
+            "okta": {},  # OIDC flow started but cancelled before fields were set
+            "credential_storage": "session",
+            "aws": base_aws,
+            "monitoring": {"enabled": False},
+        }
+        assert cmd._review_configuration(config) is True
+
+
 if __name__ == "__main__":
     # Run the tests
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Description

Guards three direct accesses to `config["okta"]` in `init.py` so the wizard no longer crashes with `KeyError: 'okta'` when the user disables SSO authentication. Aligns the affected methods with the defensive pattern already used in `_save_configuration`.

## Why is this change needed

`poetry run ccwb init` crashes at **Step 4: Review Configuration** with `Error: 'okta'` when the user answers **No** to "Enable SSO authentication?". This breaks the documented "Deploy Without SSO Authentication" flow (README §"Optional: Deploy Without SSO Authentication", v2.1+).

The `okta` key is only populated inside the SSO-enabled branch (`init.py` line 709). Three other methods accessed it directly without guarding, so they raised `KeyError` whenever SSO was disabled.

Fixes #430

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Infrastructure/deployment change
- [ ] Dependency update
- [ ] CI/CD changes

## Changes Made

- `_review_configuration`: gate the OIDC rows on `config.get("sso_enabled", True)`. When SSO is disabled, render `"SSO Authentication: Disabled (IAM credentials used)"` instead.
- `_update_parameters_file`: write `OktaDomain` / `OktaClientId` as `"none"` when SSO is disabled, mirroring the pattern in `_save_configuration`.
- `_show_existing_deployment`: guard the OIDC provider line on `"okta" in config`, matching the existing guard for `client_id` on the next line.
- Adds five regression tests in `tests/cli/commands/test_init.py::TestSsoDisabledRendering` covering all three methods, the SSO-enabled rendering path, and the empty-`okta`-dict edge case.

## Additional Notes

No new logic — this only applies the same defensive pattern (`config.get("okta", {}).get(..., "none") if sso_enabled else "none"`) that `_save_configuration` already uses. No user-facing behaviour changes when SSO is enabled.

Two cosmetic follow-ups suggested by the reviewer (`context.py` and `package.py` rendering `"none"` for SSO-disabled profiles) are tracked in separate issues and intentionally out of scope here.

---

## Testing Checklist

### What was tested

- [x] Unit/integration tests pass (`ccwb test`)
- [x] CLI commands tested (`ccwb init/deploy/build/package/test`)
- [ ] CloudFormation templates deployed successfully
- [ ] Binary installation tested (`install.sh` / `install.bat`)
- [ ] End-to-end authentication flow tested

## Testing Evidence

**Test Environment:** macOS (darwin, arm64), Python 3.12.13, Poetry 2.4.1, AWS CLI v2

**1. Reproducing the bug on `main` (`ccc46ea`)**

```text
$ python -c "from claude_code_with_bedrock.cli.commands.init import InitCommand; \
    InitCommand()._review_configuration({'sso_enabled': False, ...})"

Step 4: Review Configuration
──────────────────────────────
KeyError: 'okta'
```

**2. After applying this fix — `_review_configuration` with SSO disabled**

```text
Step 4: Review Configuration
──────────────────────────────
                            Configuration Summary
╭───────────────────────┬───────────────────────────────────────────────────╮
│ Setting               │ Value                                             │
├───────────────────────┼───────────────────────────────────────────────────┤
│ SSO Authentication    │ Disabled (IAM credentials used)                   │
│ Infrastructure Region │ us-east-1 (Cognito, IAM, Monitoring)              │
│ Identity Pool         │ demo-pool                                         │
│ Monitoring            │ ✗ Disabled                                        │
│ Bedrock Regions       │ US Cross-Region (us-east-1, us-east-2, us-west-2) │
╰───────────────────────┴───────────────────────────────────────────────────╯
```

**3. Regression — `_review_configuration` with SSO enabled (unchanged behaviour)**

```text
                            Configuration Summary
╭───────────────────────┬───────────────────────────────────────────────────╮
│ Setting               │ Value                                             │
├───────────────────────┼───────────────────────────────────────────────────┤
│ OIDC Provider         │ company.okta.com                                  │
│ OIDC Client ID        │ abcdef1234567890abcd...                           │
│ Credential Storage    │ Keyring (OS secure storage)                       │
│ Infrastructure Region │ us-east-1 (Cognito, IAM, Monitoring)              │
│ Identity Pool         │ demo-pool                                         │
│ Monitoring            │ ✗ Disabled                                        │
│ Bedrock Regions       │ US Cross-Region (us-east-1, us-east-2, us-west-2) │
╰───────────────────────┴───────────────────────────────────────────────────╯
```

**4. New regression tests — all five pass**

```text
$ poetry run pytest tests/cli/commands/test_init.py::TestSsoDisabledRendering -v

tests/cli/commands/test_init.py::TestSsoDisabledRendering::test_review_configuration_without_okta_key_does_not_raise PASSED
tests/cli/commands/test_init.py::TestSsoDisabledRendering::test_review_configuration_sso_enabled_still_renders_okta PASSED
tests/cli/commands/test_init.py::TestSsoDisabledRendering::test_show_existing_deployment_without_okta_key_does_not_raise PASSED
tests/cli/commands/test_init.py::TestSsoDisabledRendering::test_update_parameters_file_without_okta_key_writes_none PASSED
tests/cli/commands/test_init.py::TestSsoDisabledRendering::test_review_configuration_with_empty_okta_dict_does_not_raise PASSED

============================== 5 passed in 3.75s ===============================
```

**5. Full init-command test suite (no regressions)**

```text
$ poetry run pytest tests/cli/commands/test_init.py tests/cli/commands/test_init_e2e.py \
    tests/cli/commands/test_init_models.py tests/cli/commands/test_init_quota.py

35 passed, 4 warnings in 0.58s
```

**6. CLI smoke test — `ccwb init` with SSO disabled completes through Step 4**

End-to-end run on this branch confirmed the wizard no longer crashes when the user answers **No** to "Enable SSO authentication?" and proceeds through Step 4 (Review Configuration) to profile save.

@wirjo independently rebased this branch onto latest `beta` and reported all 410 tests passing in [his review comment](https://github.com/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock/pull/431#issuecomment-4631361807).
