### PR TITLE
feat: add Google OIDC provider support

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -50,6 +50,7 @@ This guide covers the **AWS infrastructure** side of the deployment. It assumes 
 | **Okta** | [Okta Setup Guide](assets/docs/providers/okta-setup.md) |
 | **Microsoft Entra ID (Azure AD)** | [Microsoft Entra ID Setup Guide](assets/docs/providers/microsoft-entra-id-setup.md) |
 | **Auth0** | [Auth0 Setup Guide](assets/docs/providers/auth0-setup.md) |
+| **Google** | [Google Setup Guide](assets/docs/providers/google-oidc-setup.md) |
 | **AWS Cognito User Pool** | [Cognito User Pool Setup Guide](assets/docs/providers/cognito-user-pool-setup.md) |
 | **PingFederate, Keycloak, ForgeRock, or other generic OIDC** | [Generic OIDC Setup Guide](assets/docs/providers/generic-oidc-setup.md) |
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This guidance provides enterprise deployment patterns for Claude Code and Claude
 
 ### For Organizations
 
-- **Enterprise IdP Integration**: Leverage existing OIDC identity providers (Okta, Azure AD, Auth0, etc.)
+- **Enterprise IdP Integration**: Leverage existing OIDC identity providers (Okta, Azure AD, Auth0, Google, etc.)
 - **AWS SSO / IAM Identity Center**: Native AWS identity path for teams already using IAM Identity Center — no external IdP required
 - **Centralized Access Control**: Manage Claude Code access through your identity provider
 - **No API Key Management**: Eliminate the need to distribute or rotate long-lived credentials
@@ -44,7 +44,7 @@ This guidance provides enterprise deployment patterns for Claude Code and Claude
 
 ## Quick Start
 
-This guidance integrates Claude Code with your existing OIDC identity provider (Okta, Azure AD, Auth0, or Cognito User Pools) to provide federated access to Amazon Bedrock.
+This guidance integrates Claude Code with your existing OIDC identity provider (Okta, Azure AD, Auth0, Google, or Cognito User Pools) to provide federated access to Amazon Bedrock.
 
 ### What You Need
 
@@ -442,6 +442,8 @@ See [Analytics Guide](assets/docs/ANALYTICS.md) for SQL queries on historical da
 - [Okta](assets/docs/providers/okta-setup.md)
 - [Microsoft Entra ID (Azure AD)](assets/docs/providers/microsoft-entra-id-setup.md)
 - [Auth0](assets/docs/providers/auth0-setup.md)
+- [Google](assets/docs/providers/google-oidc-setup.md)
+- [AWS Cognito User Pool](assets/docs/providers/cognito-user-pool-setup.md)
 - [Generic OIDC (PingFederate, Keycloak, ForgeRock, etc.)](assets/docs/providers/generic-oidc-setup.md)
 
 ## License

--- a/assets/docs/providers/google-oidc-setup.md
+++ b/assets/docs/providers/google-oidc-setup.md
@@ -1,0 +1,106 @@
+# Google OIDC Setup Guide
+
+This guide covers setting up Google as the identity provider for Claude Code with Amazon Bedrock. Use this when your organization uses **Google Workspace** and you want users to authenticate with their existing Google accounts.
+
+## Table of Contents
+
+1. [Prerequisites](#1-prerequisites)
+2. [Create OAuth Application in Google Cloud Console](#2-create-oauth-application-in-google-cloud-console)
+3. [Collect Required Information](#3-collect-required-information)
+4. [Run ccwb init](#4-run-ccwb-init)
+5. [Important Notes](#5-important-notes)
+6. [Troubleshooting](#6-troubleshooting)
+
+---
+
+## 1. Prerequisites
+
+- A **Google Cloud project** with the OAuth consent screen configured
+- Your Google Workspace domain (e.g., `example.com`) — or personal Google accounts if testing
+- AWS account with permissions to create IAM OIDC providers and roles
+
+---
+
+## 2. Create OAuth Application in Google Cloud Console
+
+1. Go to [Google Cloud Console → APIs & Services → Credentials](https://console.cloud.google.com/apis/credentials)
+2. Click **Create Credentials → OAuth client ID**
+3. Select application type: **Desktop app** (or "Web application" if you prefer)
+4. Configure:
+
+| Setting | Value |
+|---------|-------|
+| Application type | Desktop app |
+| Name | Claude Code with Bedrock |
+| Authorized redirect URIs | `http://localhost:8400/callback` |
+
+5. Click **Create** and note the **Client ID** and **Client Secret**
+
+> **Note:** Unlike other providers in this solution, Google OAuth requires a `client_secret` for the authorization code exchange even with PKCE. The secret is included in the packaged `config.json` distributed to end users. This is standard for Google's "installed application" OAuth flow — the secret is not considered confidential in this context (see [Google's documentation](https://developers.google.com/identity/protocols/oauth2/native-app)).
+
+---
+
+## 3. Collect Required Information
+
+| Value | Where to find it | Example |
+|-------|-------------------|---------|
+| Provider domain | Always `accounts.google.com` | `accounts.google.com` |
+| Client ID | Google Cloud Console → Credentials | `123456789-abc.apps.googleusercontent.com` |
+| Client Secret | Google Cloud Console → Credentials | `GOCSPX-...` |
+
+---
+
+## 4. Run ccwb init
+
+```bash
+poetry run ccwb init
+```
+
+The wizard will:
+1. Ask for your provider domain — enter `accounts.google.com`
+2. Auto-detect the provider type as **Google**
+3. Ask for your **Client ID**
+4. Ask for your **Client Secret** (stored in the profile and included in packaged config)
+5. Continue with region, model, and monitoring configuration
+
+---
+
+## 5. Important Notes
+
+### Token Endpoint
+
+Google uses a different domain for token exchange (`oauth2.googleapis.com`) than for authorization (`accounts.google.com`). The credential helper handles this automatically.
+
+### IAM OIDC Provider
+
+The CloudFormation template (`bedrock-auth-google.yaml`) creates an IAM OIDC provider with:
+- Issuer URL: `https://accounts.google.com`
+- Audience: Your Google Client ID
+- Thumbprint: Automatically computed from Google's JWKS endpoint
+
+### Session Duration
+
+With Direct IAM federation (recommended), sessions last up to **12 hours**. The credential helper caches credentials and refreshes them silently using the cached ID token when possible.
+
+### Restricting Access to Your Domain
+
+The IAM role trust policy restricts access by **audience** (your Client ID). Since only users in your Google Cloud project can obtain tokens with your Client ID, access is inherently scoped to authorized users. For additional restrictions, configure the OAuth consent screen to "Internal" (Google Workspace only).
+
+---
+
+## 6. Troubleshooting
+
+### "Token is not from a supported provider"
+
+- Verify the IAM OIDC provider's issuer URL is exactly `https://accounts.google.com` (no trailing slash)
+- Confirm the Client ID in your IAM OIDC provider matches the one in `config.json`
+
+### "invalid_client" during token exchange
+
+- Ensure the Client Secret is correctly included in `config.json`
+- Verify the OAuth application in Google Cloud Console has the redirect URI `http://localhost:8400/callback`
+
+### Browser doesn't open / callback timeout
+
+- Check that port 8400 is not in use by another process
+- If behind a corporate proxy, ensure `localhost` traffic is not intercepted

--- a/deployment/infrastructure/bedrock-auth-google.yaml
+++ b/deployment/infrastructure/bedrock-auth-google.yaml
@@ -1,0 +1,404 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'Claude Code with Bedrock - Google Authentication Stack'
+
+Parameters:
+  FederationType:
+    Type: String
+    Default: direct
+    AllowedValues:
+      - direct
+      - cognito
+    Description: Authentication mode - Direct IAM or Cognito Identity Pool
+
+  GoogleDomain:
+    Type: String
+    Description: Google OIDC provider domain (accounts.google.com)
+    AllowedPattern: '^[a-zA-Z0-9][a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
+    ConstraintDescription: Must be a valid domain name
+
+  GoogleClientId:
+    Type: String
+    Description: Google OAuth 2.0 client ID
+    AllowedPattern: '^[a-zA-Z0-9._-]+$'
+    MaxLength: 256
+    ConstraintDescription: Must be a valid Google client ID
+
+  IdentityPoolName:
+    Type: String
+    Default: claude-code-google
+    Description: Name for the Cognito Identity Pool (used in cognito mode)
+    AllowedPattern: '^[\w\s+=,.@-]+$'
+    MaxLength: 128
+
+  FederatedRoleName:
+    Type: String
+    Default: BedrockGoogleFederatedRole
+    Description: Name for the IAM role used for federation
+    AllowedPattern: '^[a-zA-Z][a-zA-Z0-9-_]*$'
+    MaxLength: 64
+
+  AllowedBedrockRegions:
+    Type: CommaDelimitedList
+    Default: 'us-east-1,us-west-2'
+    Description: Comma-delimited list of AWS regions where Bedrock access is allowed
+
+  EnableMonitoring:
+    Type: String
+    Default: 'true'
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Description: Enable CloudWatch monitoring for Bedrock usage
+
+Conditions:
+  UseDirectIAM: !Equals [!Ref FederationType, direct]
+  UseCognitoIdentity: !Equals [!Ref FederationType, cognito]
+  MonitoringEnabled: !Equals [!Ref EnableMonitoring, 'true']
+  # Partition-aware conditions for Cognito Identity service principals
+  IsGovCloudWest: !Equals [!Ref 'AWS::Region', 'us-gov-west-1']
+  IsGovCloudEast: !Equals [!Ref 'AWS::Region', 'us-gov-east-1']
+  IsGovCloud: !Or [!Condition IsGovCloudWest, !Condition IsGovCloudEast]
+
+Resources:
+  # ===============================================
+  # OIDC Provider for Google
+  # ===============================================
+
+  GoogleOIDCProvider:
+    Type: AWS::IAM::OIDCProvider
+    Properties:
+      Url: !Sub 'https://${GoogleDomain}'
+      ClientIdList:
+        - !Ref GoogleClientId
+      # AWS automatically fetches and validates thumbprints for well-known
+      # OIDC providers like Google. A placeholder is required by CloudFormation.
+      ThumbprintList:
+        - aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      Tags:
+        - Key: Purpose
+          Value: Claude Code Google Authentication
+        - Key: Provider
+          Value: Google
+
+  # ===============================================
+  # Bedrock Access Policy (Shared)
+  # ===============================================
+
+  BedrockAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: Policy for accessing Bedrock services
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: AllowBedrockInvokeRegional
+            Effect: Allow
+            Action:
+              - 'bedrock:InvokeModel'
+              - 'bedrock:InvokeModelWithResponseStream'
+              - 'bedrock-runtime:InvokeModel'
+              - 'bedrock-runtime:InvokeModelWithResponseStream'
+              - 'bedrock-runtime:ConverseStream'
+              - 'bedrock-runtime:Converse'
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:bedrock:*::foundation-model/*'
+              - !Sub 'arn:${AWS::Partition}:bedrock:*:*:inference-profile/*'
+            Condition:
+              StringEquals:
+                'aws:RequestedRegion': !Ref AllowedBedrockRegions
+          - Sid: AllowBedrockInvokeGlobal
+            Effect: Allow
+            Action:
+              - 'bedrock:InvokeModel'
+              - 'bedrock:InvokeModelWithResponseStream'
+              - 'bedrock-runtime:InvokeModel'
+              - 'bedrock-runtime:InvokeModelWithResponseStream'
+              - 'bedrock-runtime:ConverseStream'
+              - 'bedrock-runtime:Converse'
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:bedrock:::foundation-model/*'
+          - Sid: AllowBedrockListRegional
+            Effect: Allow
+            Action:
+              - 'bedrock:ListFoundationModels'
+              - 'bedrock:GetFoundationModel'
+              - 'bedrock:GetFoundationModelAvailability'
+              - 'bedrock:ListInferenceProfiles'
+              - 'bedrock:GetInferenceProfile'
+            Resource: '*'
+            Condition:
+              StringEquals:
+                'aws:RequestedRegion': !Ref AllowedBedrockRegions
+          - Sid: AllowBedrockListGlobal
+            Effect: Allow
+            Action:
+              - 'bedrock:ListFoundationModels'
+              - 'bedrock:GetFoundationModel'
+              - 'bedrock:GetFoundationModelAvailability'
+              - 'bedrock:ListInferenceProfiles'
+              - 'bedrock:GetInferenceProfile'
+            Resource: '*'
+          - !If
+            - MonitoringEnabled
+            - Sid: AllowCloudWatchMetrics
+              Effect: Allow
+              Action:
+                - 'cloudwatch:PutMetricData'
+              Resource: '*'
+              Condition:
+                StringEquals:
+                  'cloudwatch:namespace':
+                    - 'ClaudeCode/Bedrock/Usage'
+                    - 'AWS/Bedrock'
+            - !Ref 'AWS::NoValue'
+
+  # ===============================================
+  # Direct IAM Resources (when FederationType=direct)
+  # ===============================================
+
+  DirectIAMRole:
+    Type: AWS::IAM::Role
+    Condition: UseDirectIAM
+    Properties:
+      RoleName: !Ref FederatedRoleName
+      Description: Direct IAM role for Google users accessing Bedrock
+      MaxSessionDuration: 43200  # 12 hours
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Federated: !GetAtt GoogleOIDCProvider.Arn
+            Action:
+              - 'sts:AssumeRoleWithWebIdentity'
+              - 'sts:TagSession'
+            Condition:
+              StringEquals:
+                'accounts.google.com:aud': !Ref GoogleClientId
+      ManagedPolicyArns:
+        - !Ref BedrockAccessPolicy
+      Tags:
+        - Key: Purpose
+          Value: Claude Code Direct IAM Authentication
+        - Key: Provider
+          Value: Google
+        - Key: FederationType
+          Value: direct
+
+  # ===============================================
+  # Cognito Identity Pool Resources (when FederationType=cognito)
+  # ===============================================
+
+  CognitoIdentityPool:
+    Type: AWS::Cognito::IdentityPool
+    Condition: UseCognitoIdentity
+    Properties:
+      IdentityPoolName: !Ref IdentityPoolName
+      AllowUnauthenticatedIdentities: false
+      AllowClassicFlow: false
+      OpenIdConnectProviderARNs:
+        - !GetAtt GoogleOIDCProvider.Arn
+
+  CognitoAuthenticatedRole:
+    Type: AWS::IAM::Role
+    Condition: UseCognitoIdentity
+    Properties:
+      Description: Role for authenticated Cognito Identity Pool users
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Federated: !If
+                - IsGovCloudWest
+                - cognito-identity-us-gov.amazonaws.com
+                - !If
+                  - IsGovCloudEast
+                  - cognito-identity.us-gov-east-1.amazonaws.com
+                  - cognito-identity.amazonaws.com
+            Action:
+              - 'sts:AssumeRoleWithWebIdentity'
+            Condition:
+              StringEquals:
+                !If
+                  - IsGovCloudWest
+                  - 'cognito-identity-us-gov.amazonaws.com:aud': !Ref CognitoIdentityPool
+                  - !If
+                    - IsGovCloudEast
+                    - 'cognito-identity.us-gov-east-1.amazonaws.com:aud': !Ref CognitoIdentityPool
+                    - 'cognito-identity.amazonaws.com:aud': !Ref CognitoIdentityPool
+              'ForAnyValue:StringLike':
+                !If
+                  - IsGovCloudWest
+                  - 'cognito-identity-us-gov.amazonaws.com:amr': authenticated
+                  - !If
+                    - IsGovCloudEast
+                    - 'cognito-identity.us-gov-east-1.amazonaws.com:amr': authenticated
+                    - 'cognito-identity.amazonaws.com:amr': authenticated
+      ManagedPolicyArns:
+        - !Ref BedrockAccessPolicy
+      Tags:
+        - Key: Purpose
+          Value: Claude Code Cognito Authentication
+        - Key: Provider
+          Value: Google
+
+  CognitoUnauthenticatedRole:
+    Type: AWS::IAM::Role
+    Condition: UseCognitoIdentity
+    Properties:
+      Description: Role for unauthenticated Cognito Identity Pool users (restricted)
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Federated: !If
+                - IsGovCloudWest
+                - cognito-identity-us-gov.amazonaws.com
+                - !If
+                  - IsGovCloudEast
+                  - cognito-identity.us-gov-east-1.amazonaws.com
+                  - cognito-identity.amazonaws.com
+            Action:
+              - 'sts:AssumeRoleWithWebIdentity'
+            Condition:
+              StringEquals:
+                !If
+                  - IsGovCloudWest
+                  - 'cognito-identity-us-gov.amazonaws.com:aud': !Ref CognitoIdentityPool
+                  - !If
+                    - IsGovCloudEast
+                    - 'cognito-identity.us-gov-east-1.amazonaws.com:aud': !Ref CognitoIdentityPool
+                    - 'cognito-identity.amazonaws.com:aud': !Ref CognitoIdentityPool
+              'ForAnyValue:StringLike':
+                !If
+                  - IsGovCloudWest
+                  - 'cognito-identity-us-gov.amazonaws.com:amr': unauthenticated
+                  - !If
+                    - IsGovCloudEast
+                    - 'cognito-identity.us-gov-east-1.amazonaws.com:amr': unauthenticated
+                    - 'cognito-identity.amazonaws.com:amr': unauthenticated
+      Policies:
+        - PolicyName: DenyAll
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Deny
+                Action: '*'
+                Resource: '*'
+      Tags:
+        - Key: Purpose
+          Value: Claude Code Cognito Unauthenticated Role
+        - Key: Provider
+          Value: Google
+
+  CognitoIdentityPoolRoleAttachment:
+    Type: AWS::Cognito::IdentityPoolRoleAttachment
+    Condition: UseCognitoIdentity
+    Properties:
+      IdentityPoolId: !Ref CognitoIdentityPool
+      Roles:
+        authenticated: !GetAtt CognitoAuthenticatedRole.Arn
+        unauthenticated: !GetAtt CognitoUnauthenticatedRole.Arn
+
+  # Principal Tag Mapping for Session Tags
+  IdentityPoolPrincipalTag:
+    Type: AWS::Cognito::IdentityPoolPrincipalTag
+    Condition: UseCognitoIdentity
+    DeletionPolicy: Delete
+    Properties:
+      IdentityPoolId: !Ref CognitoIdentityPool
+      IdentityProviderName: !Ref GoogleDomain
+      UseDefaults: false
+      PrincipalTags:
+        UserEmail: email
+        UserId: sub
+        UserName: name
+
+  # ===============================================
+  # Optional Monitoring Resources
+  # ===============================================
+
+  BedrockAccessLogGroup:
+    Type: AWS::Logs::LogGroup
+    Condition: MonitoringEnabled
+    Properties:
+      LogGroupName: !Sub '/aws/bedrock/claude-code-${AWS::StackName}'
+      RetentionInDays: 30
+
+Outputs:
+  FederationType:
+    Description: Current federation type configuration
+    Value: !Ref FederationType
+    Export:
+      Name: !Sub '${AWS::StackName}-FederationType'
+
+  OIDCProviderArn:
+    Description: ARN of the Google OIDC Provider
+    Value: !GetAtt GoogleOIDCProvider.Arn
+    Export:
+      Name: !Sub '${AWS::StackName}-OIDCProviderArn'
+
+  FederatedRoleArn:
+    Description: ARN of the federated role for Google users
+    Value: !If
+      - UseDirectIAM
+      - !GetAtt DirectIAMRole.Arn
+      - !GetAtt CognitoAuthenticatedRole.Arn
+    Export:
+      Name: !Sub '${AWS::StackName}-FederatedRoleArn'
+
+  DirectSTSRoleArn:
+    Description: Direct STS federated role ARN (when using direct IAM)
+    Condition: UseDirectIAM
+    Value: !GetAtt DirectIAMRole.Arn
+    Export:
+      Name: !Sub '${AWS::StackName}-DirectSTSRoleArn'
+
+  BedrockRoleArn:
+    Description: IAM Role ARN for Bedrock access (for backward compatibility)
+    Value: !If
+      - UseDirectIAM
+      - !GetAtt DirectIAMRole.Arn
+      - !GetAtt CognitoAuthenticatedRole.Arn
+    Export:
+      Name: !Sub '${AWS::StackName}-BedrockRoleArn'
+
+  IdentityPoolId:
+    Description: Cognito Identity Pool ID (if using Cognito mode)
+    Condition: UseCognitoIdentity
+    Value: !Ref CognitoIdentityPool
+    Export:
+      Name: !Sub '${AWS::StackName}-IdentityPoolId'
+
+  BedrockPolicyArn:
+    Description: ARN of the Bedrock access policy
+    Value: !Ref BedrockAccessPolicy
+    Export:
+      Name: !Sub '${AWS::StackName}-BedrockPolicyArn'
+
+  ConfigurationJson:
+    Description: Configuration JSON for CLI tool
+    Value: !If
+      - UseDirectIAM
+      - !Sub |
+        {
+          "federation_type": "direct",
+          "provider_type": "google",
+          "provider_domain": "${GoogleDomain}",
+          "client_id": "${GoogleClientId}",
+          "federated_role_arn": "${DirectIAMRole.Arn}",
+          "aws_region": "${AWS::Region}",
+          "max_session_duration": 43200
+        }
+      - !Sub |
+        {
+          "federation_type": "cognito",
+          "provider_type": "google",
+          "provider_domain": "${GoogleDomain}",
+          "client_id": "${GoogleClientId}",
+          "identity_pool_id": "${CognitoIdentityPool}",
+          "federated_role_arn": "${CognitoAuthenticatedRole.Arn}",
+          "aws_region": "${AWS::Region}"
+        }

--- a/deployment/infrastructure/bedrock-auth-google.yaml
+++ b/deployment/infrastructure/bedrock-auth-google.yaml
@@ -39,7 +39,7 @@ Parameters:
 
   AllowedBedrockRegions:
     Type: CommaDelimitedList
-    Default: 'us-east-1,us-west-2'
+    Default: 'af-south-1,ap-east-2,ap-northeast-1,ap-northeast-2,ap-northeast-3,ap-south-1,ap-south-2,ap-south-5,ap-southeast-1,ap-southeast-2,ap-southeast-3,ap-southeast-4,ca-central-1,ca-west-1,eu-central-1,eu-central-2,eu-north-1,eu-south-1,eu-south-2,eu-south-3,eu-west-1,eu-west-2,eu-west-3,il-central-1,me-central-1,me-south-1,sa-east-1,us-east-1,us-east-2,us-west-1,us-west-2'
     Description: Comma-delimited list of AWS regions where Bedrock access is allowed
 
   EnableMonitoring:

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -380,6 +380,8 @@ class DeployCommand(Command):
                     "auth0": "bedrock-auth-auth0.yaml",
                     "azure": "bedrock-auth-azure.yaml",
                     "cognito": "bedrock-auth-cognito-pool.yaml",
+                    "google": "bedrock-auth-google.yaml",
+                    "generic": "bedrock-auth-generic.yaml",
                 }
 
                 template_file = template_map.get(provider_type, "bedrock-auth-okta.yaml")
@@ -996,6 +998,8 @@ class DeployCommand(Command):
                     "auth0": "bedrock-auth-auth0.yaml",
                     "azure": "bedrock-auth-azure.yaml",
                     "cognito": "bedrock-auth-cognito-pool.yaml",
+                    "google": "bedrock-auth-google.yaml",
+                    "generic": "bedrock-auth-generic.yaml",
                 }
                 template_file = template_map.get(provider_type, "bedrock-auth-okta.yaml")
                 template = project_root / "deployment" / "infrastructure" / template_file

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -453,6 +453,27 @@ class DeployCommand(Command):
                             f"CognitoUserPoolDomain={cognito_domain}",
                         ]
                     )
+                elif provider_type == "google":
+                    params.extend(
+                        [
+                            f"GoogleDomain={profile.provider_domain}",
+                            f"GoogleClientId={profile.client_id}",
+                        ]
+                    )
+                elif provider_type == "generic":
+                    if not (profile.oidc_issuer_url and profile.oidc_thumbprint):
+                        console.print(
+                            "[red]Generic OIDC provider requires oidc_issuer_url and oidc_thumbprint."
+                            " Re-run `ccwb init` to configure them.[/red]"
+                        )
+                        return 1
+                    params.extend(
+                        [
+                            f"OidcIssuerUrl={profile.oidc_issuer_url}",
+                            f"OidcClientId={profile.client_id}",
+                            f"OidcThumbprintList={profile.oidc_thumbprint}",
+                        ]
+                    )
 
                 # Use profile regions, or fall back to all known Bedrock regions
                 bedrock_regions = profile.allowed_bedrock_regions

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -393,6 +393,8 @@ class InitCommand(Command):
                     elif hostname_lower.startswith("cognito-idp.") and ".amazonaws.com" in hostname_lower:
                         # Handle cognito-idp.{region}.amazonaws.com format (commercial and GovCloud)
                         provider_type = "cognito"
+                    elif hostname_lower == "accounts.google.com":
+                        provider_type = "google"
                     elif questionary.confirm("Is this a custom domain for AWS Cognito User Pool?", default=False).ask():
                         provider_type = "cognito"
             except Exception:
@@ -411,6 +413,7 @@ class InitCommand(Command):
                         questionary.Choice("Microsoft Entra ID / Azure AD", value="azure"),
                         questionary.Choice("Auth0", value="auth0"),
                         questionary.Choice("AWS Cognito User Pool", value="cognito"),
+                        questionary.Choice("Google", value="google"),
                         questionary.Choice("Generic OIDC (PingFederate, Keycloak, ForgeRock, etc.)", value="generic"),
                     ],
                     instruction="(Used to select the correct CloudFormation template)",
@@ -1180,6 +1183,7 @@ class InitCommand(Command):
                 questionary.Choice("Azure AD / Entra ID", value="azure"),
                 questionary.Choice("Auth0", value="auth0"),
                 questionary.Choice("AWS Cognito User Pool", value="cognito"),
+                questionary.Choice("Google", value="google"),
             ]
 
             idp_provider = questionary.select(

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -2064,6 +2064,11 @@ RUN pyinstaller \
         if hasattr(profile, "selected_model") and profile.selected_model:
             config[profile_name]["selected_model"] = profile.selected_model
 
+        # Google OAuth requires client_secret for server-side token exchange (PKCE alone
+        # is insufficient for the installed-app flow used by the credential-process binary).
+        if getattr(profile, "provider_type", None) == "google" and getattr(profile, "client_secret", None):
+            config[profile_name]["client_secret"] = profile.client_secret
+
         # Add confidential client fields for Azure AD if present.
         # client_secret is never written to config.json — it lives in the OS keyring.
         # End users set it with: credential-process --set-client-secret --profile <profile>

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -36,7 +36,7 @@ class Profile:
     selected_source_region: str | None = None  # User-selected source region for AWS config and Claude Code settings
     created_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
     updated_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
-    provider_type: str | None = None  # Auto-detected: "okta", "auth0", "azure", "cognito", "generic"
+    provider_type: str | None = None  # Auto-detected: "okta", "auth0", "azure", "cognito", "google", "generic"
     cognito_user_pool_id: str | None = None  # Only for Cognito User Pool providers
 
     # Generic OIDC provider configuration (provider_type == "generic")
@@ -179,6 +179,8 @@ class Profile:
                             data["provider_type"] = "cognito"
                         elif hostname_lower.startswith("cognito-idp.") and ".amazonaws.com" in hostname_lower:
                             data["provider_type"] = "cognito"
+                        elif hostname_lower == "accounts.google.com":
+                            data["provider_type"] = "google"
                 except Exception:
                     pass  # Leave provider_type unset if parsing fails
 

--- a/source/claude_code_with_bedrock/utils/url_validation.py
+++ b/source/claude_code_with_bedrock/utils/url_validation.py
@@ -17,7 +17,7 @@ def detect_provider_type_secure(domain: str) -> str:
         domain: The provider domain URL or hostname
 
     Returns:
-        Provider type: "okta", "auth0", "azure", "cognito", or "oidc"
+        Provider type: "okta", "auth0", "azure", "cognito", "google", or "oidc"
     """
     if not domain:
         return "oidc"
@@ -50,6 +50,8 @@ def detect_provider_type_secure(domain: str) -> str:
             return "cognito"
         elif hostname_lower.startswith("cognito-idp.") and ".amazonaws.com" in hostname_lower:
             return "cognito"
+        elif hostname_lower == "accounts.google.com":
+            return "google"
         else:
             return "oidc"
     except Exception:

--- a/source/claude_code_with_bedrock/validators.py
+++ b/source/claude_code_with_bedrock/validators.py
@@ -124,7 +124,7 @@ class ProfileValidator:
 
         # Validate provider type if specified
         provider_type = profile_data.get("provider_type")
-        if provider_type and provider_type not in ["okta", "auth0", "azure", "cognito", "generic"]:
+        if provider_type and provider_type not in ["okta", "auth0", "azure", "cognito", "google", "generic"]:
             warnings.append(f"Unknown provider_type: {provider_type}")
 
         # Conditional validation: Cognito requires user_pool_id

--- a/source/credential_provider/__main__.py
+++ b/source/credential_provider/__main__.py
@@ -71,6 +71,14 @@ PROVIDER_CONFIGS = {
         "response_type": "code",
         "response_mode": "query",
     },
+    "google": {
+        "name": "Google",
+        "authorize_endpoint": "/o/oauth2/v2/auth",
+        "token_endpoint": "https://oauth2.googleapis.com/token",
+        "scopes": "openid profile email",
+        "response_type": "code",
+        "response_mode": "query",
+    },
     # Generic OIDC: paths come from the profile (oidc_authorization_endpoint /
     # oidc_token_endpoint), so we leave these as empty placeholders.
     "generic": {
@@ -331,11 +339,13 @@ class MultiProviderAuth:
             elif hostname_lower.startswith("cognito-idp.") and ".amazonaws.com" in hostname_lower:
                 # Cognito User Pool IdP format: cognito-idp.{region}.amazonaws.com
                 return "cognito"
+            elif hostname_lower == "accounts.google.com":
+                return "google"
             else:
                 # Fail with clear error for unknown providers
                 raise ValueError(
                     f"Unable to auto-detect provider type for domain '{domain}'. "
-                    f"Known providers: Okta, Auth0, Microsoft/Azure, AWS Cognito User Pool. "
+                    f"Known providers: Okta, Auth0, Microsoft/Azure, AWS Cognito User Pool, Google. "
                     f"Please check your provider domain configuration."
                 )
         except ValueError:
@@ -1017,10 +1027,13 @@ class MultiProviderAuth:
 
         # Build token endpoint URL (configured value wins for generic OIDC)
         configured_token = self.config.get("oidc_token_endpoint")
+        token_endpoint = self.provider_config["token_endpoint"]
         if configured_token:
             token_url = configured_token
+        elif token_endpoint.startswith("https://"):
+            token_url = token_endpoint
         else:
-            token_url = f"{base_url}{self.provider_config['token_endpoint']}"
+            token_url = f"{base_url}{token_endpoint}"
 
         # Confidential client: inject client_secret or certificate assertion
         if self.config.get("client_certificate_path") and self.config.get("client_certificate_key_path"):

--- a/source/tests/test_google_provider.py
+++ b/source/tests/test_google_provider.py
@@ -1,0 +1,100 @@
+# ABOUTME: Tests for Google OIDC provider support
+# ABOUTME: Validates provider detection, token endpoint handling, and deploy parameter wiring
+
+"""Tests for Google OIDC provider integration (#414)."""
+
+from pathlib import Path
+
+import pytest
+
+from claude_code_with_bedrock.utils.url_validation import detect_provider_type_secure as detect_provider_type
+
+
+class TestGoogleProviderDetection:
+    """Verify Google is correctly detected from domain input."""
+
+    def test_detect_google_standard_domain(self):
+        """accounts.google.com is detected as google."""
+        assert detect_provider_type("accounts.google.com") == "google"
+
+    def test_detect_google_with_https(self):
+        """Full URL with https is detected as google."""
+        assert detect_provider_type("https://accounts.google.com") == "google"
+
+    def test_detect_google_not_confused_with_generic(self):
+        """Google domain should not fall through to generic OIDC."""
+        result = detect_provider_type("accounts.google.com")
+        assert result != "oidc"
+        assert result == "google"
+
+    def test_detect_google_subdomain_attack(self):
+        """Malicious subdomain should not match as google."""
+        # accounts.google.com.evil.com should NOT be detected as google
+        result = detect_provider_type("accounts.google.com.evil.com")
+        assert result != "google"
+
+    def test_detect_google_prefix_attack(self):
+        """Domain with google as prefix should not match."""
+        result = detect_provider_type("accounts.google.com.attacker.com")
+        assert result != "google"
+
+    def test_other_providers_unchanged(self):
+        """Adding Google doesn't break other provider detection."""
+        assert detect_provider_type("mycompany.okta.com") == "okta"
+        assert detect_provider_type("mycompany.auth0.com") == "auth0"
+        assert detect_provider_type("login.microsoftonline.com/tenant-id/v2.0") == "azure"
+
+
+class TestGoogleTokenEndpoint:
+    """Verify absolute token endpoint is handled correctly."""
+
+    def test_google_token_endpoint_is_absolute(self):
+        """Google's token_endpoint starts with https:// (absolute URL)."""
+        cp_path = Path(__file__).resolve().parents[1] / "credential_provider" / "__main__.py"
+        source = cp_path.read_text(encoding="utf-8")
+        assert '"token_endpoint": "https://oauth2.googleapis.com/token"' in source
+
+    def test_absolute_url_detection_logic(self):
+        """Absolute URLs (https://) should be used directly, not prefixed with base_url."""
+        token_endpoint = "https://oauth2.googleapis.com/token"
+        base_url = "https://accounts.google.com"
+
+        # This replicates the logic in credential_provider/__main__.py line 1029-1031
+        if token_endpoint.startswith("https://"):
+            token_url = token_endpoint
+        else:
+            token_url = f"{base_url}{token_endpoint}"
+
+        assert token_url == "https://oauth2.googleapis.com/token"
+        assert "accounts.google.com" not in token_url
+
+
+class TestGoogleDeployParams:
+    """Verify deploy.py passes correct CloudFormation parameters for Google."""
+
+    def test_deploy_has_google_in_template_map(self):
+        """deploy.py maps 'google' to the correct template file."""
+        source_path = (
+            Path(__file__).resolve().parents[1]
+            / "claude_code_with_bedrock"
+            / "cli"
+            / "commands"
+            / "deploy.py"
+        )
+        source = source_path.read_text(encoding="utf-8")
+        assert '"google": "bedrock-auth-google.yaml"' in source
+
+    def test_deploy_passes_google_params(self):
+        """deploy.py has elif block for google that passes GoogleDomain and GoogleClientId."""
+        source_path = (
+            Path(__file__).resolve().parents[1]
+            / "claude_code_with_bedrock"
+            / "cli"
+            / "commands"
+            / "deploy.py"
+        )
+        source = source_path.read_text(encoding="utf-8")
+        # Verify the parameter wiring exists
+        assert "GoogleDomain={profile.provider_domain}" in source
+        assert "GoogleClientId={profile.client_id}" in source
+


### PR DESCRIPTION
Adds Google as a supported OIDC identity provider for Claude Code with Bedrock.

Rebased cleanly onto current beta (resolves conflicts from original #414).

## Changes
- Google OIDC provider auto-detection (`accounts.google.com`)
- CloudFormation template `bedrock-auth-google.yaml`
- Deploy params for Google provider
- Provider detection tests
- Setup docs (`assets/docs/providers/google-oidc-setup.md`)
- All Bedrock regions added to Google auth template

Credit: original work by @pipeflo (#414)