### PR TITLE
ci: add automatic release tagging for beta and main branches

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -1,0 +1,148 @@
+---
+name: Beta Pre-release Tag
+description: |
+  Auto-triggered on every push to the beta branch.
+  Creates an incrementing pre-release tag (v{base}-beta.{N}) and publishes
+  a GitHub pre-release with auto-generated notes from commits since the last beta tag.
+on:
+  push:
+    branches:
+      - beta
+permissions: {}
+jobs:
+  tag-beta:
+    name: Create Beta Pre-release Tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Determine base version and next beta number
+        id: version
+        run: |
+          set -euo pipefail
+
+          # Read base version from pyproject.toml
+          BASE_VERSION=$(python3 -c "
+          import re
+          content = open('source/pyproject.toml').read()
+          m = re.search(r'^version\s*=\s*\"([^\"]+)\"', content, re.MULTILINE)
+          if not m:
+              raise SystemExit('ERROR: version not found in source/pyproject.toml')
+          # Strip any existing pre-release suffix for the base
+          v = m.group(1).split('-')[0]
+          print(v)
+          ")
+
+          echo "Base version: $BASE_VERSION"
+
+          # Find the highest existing beta tag for this base version
+          LAST_BETA=$(git tag --list "v${BASE_VERSION}-beta.*" --sort=-version:refname | head -1)
+
+          if [[ -z "$LAST_BETA" ]]; then
+            NEXT_NUM=1
+            echo "No existing beta tags for v${BASE_VERSION} — starting at beta.1"
+          else
+            # Extract the beta number: v3.0.0-beta.5 → 5
+            CURRENT_NUM=$(echo "$LAST_BETA" | sed "s/v${BASE_VERSION}-beta\.//")
+            NEXT_NUM=$((CURRENT_NUM + 1))
+            echo "Last beta tag: $LAST_BETA — next is beta.${NEXT_NUM}"
+          fi
+
+          TAG="v${BASE_VERSION}-beta.${NEXT_NUM}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "base_version=$BASE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "beta_num=$NEXT_NUM" >> "$GITHUB_OUTPUT"
+          echo "last_tag=${LAST_BETA:-}" >> "$GITHUB_OUTPUT"
+          echo "Next tag: $TAG"
+
+      - name: Skip if tag already exists (idempotency)
+        id: check
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists — skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate release notes from commits
+        if: steps.check.outputs.skip != 'true'
+        id: notes
+        run: |
+          set -euo pipefail
+
+          LAST_TAG="${{ steps.version.outputs.last_tag }}"
+          TAG="${{ steps.version.outputs.tag }}"
+
+          if [[ -z "$LAST_TAG" ]]; then
+            # No previous beta tag — use last stable release or last 30 commits
+            LAST_STABLE=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-version:refname \
+              | grep -v 'beta\|rc\|alpha' | head -1 || true)
+            if [[ -n "$LAST_STABLE" ]] && git rev-parse "$LAST_STABLE" >/dev/null 2>&1; then
+              RANGE="${LAST_STABLE}..HEAD"
+              echo "Collecting commits since last stable release: $LAST_STABLE"
+            else
+              RANGE="HEAD~30..HEAD"
+              echo "No reference tag found — using last 30 commits"
+            fi
+          else
+            RANGE="${LAST_TAG}..HEAD"
+            echo "Collecting commits since $LAST_TAG"
+          fi
+
+          COMMITS=$(git log --no-merges --format="- %s" $RANGE 2>/dev/null || git log --no-merges --format="- %s" -n 30)
+          COUNT=$(echo "$COMMITS" | wc -l)
+
+          {
+            echo "## What's changed since ${LAST_TAG:-last stable release}"
+            echo ""
+            echo "$COMMITS"
+            echo ""
+            echo "---"
+            echo "_${COUNT} commit(s) • Pre-release from \`beta\` branch_"
+          } > /tmp/release_notes.txt
+
+          echo "--- notes preview (first 20 lines) ---"
+          head -20 /tmp/release_notes.txt
+
+      - name: Create annotated tag
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          set -euo pipefail
+
+          TAG="${{ steps.version.outputs.tag }}"
+
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name  "github-actions[bot]"
+
+          git tag -a "$TAG" -m "Pre-release $TAG from beta branch"
+          git push origin "$TAG"
+
+          echo "::notice::Created and pushed tag $TAG"
+
+      - name: Publish GitHub Pre-release
+        if: steps.check.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          TAG="${{ steps.version.outputs.tag }}"
+
+          gh release create "$TAG" \
+            --repo "${{ github.repository }}" \
+            --title "Pre-release $TAG" \
+            --notes-file /tmp/release_notes.txt \
+            --prerelease \
+            --verify-tag
+
+          echo "### 🏷️ Beta Pre-release Published" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**$TAG** — [View release](https://github.com/${{ github.repository }}/releases/tag/$TAG)" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Problem

Release management stopped in December 2025 (last release: `v2.2.0` on Dec 5, 2025). Since then, 450+ commits have landed across beta and main with no version tags, no changelogs, and no release notes. This creates several issues:

1. **No traceability** — When users report bugs, we cannot determine which version they deployed. "I cloned main last week" is not a version. The last 6 months of development are unversioned.
2. **No upgrade path** — Admins have no way to diff what changed between their last deploy and current HEAD. They must read hundreds of commits manually.
3. **No stability signal** — Beta features land in `beta` but there is no clear "this batch is production-ready" gate for promoting to `main`.
4. **Manual binary distribution** — Go binaries (credential-process, otel-helper) must be compiled via CodeBuild per-deployment. There is no central source of pre-built, version-pinned binaries.
5. **No changelog** — Contributors and users have no release notes. 6 months of features, bug fixes, and breaking changes are invisible unless you watch every commit.

The project had a healthy release cadence from Sep–Dec 2025 (`v1.1.0` through `v2.2.0`). This PR re-establishes that cadence with automation so it cannot lapse again.

## Proposed Release Workflow

```
beta branch                          main branch
    │                                     │
    ├── merge PR ──► v3.0.0-beta.1        │
    ├── merge PR ──► v3.0.0-beta.2        │
    ├── merge PR ──► v3.0.0-beta.3        │
    │                                     │
    └── promote (merge beta → main) ──────► v3.0.0 (stable release)
                                          │
    ├── merge hotfix ► v3.0.1-beta.1      │
    └── promote ──────────────────────────► v3.0.1 (patch release)
```

### Beta releases (automatic, on every merge to `beta`)

1. Read base version from `source/pyproject.toml` (e.g. `3.0.0`)
2. Find highest existing `v3.0.0-beta.N` tag
3. Create `v3.0.0-beta.{N+1}` annotated tag
4. Publish GitHub **pre-release** with commit notes since last beta tag
5. Pre-release flag = won't show as "latest" on releases page

### Stable releases (automatic, on version bump merged to `main`)

1. Read version from `source/pyproject.toml` (e.g. `3.0.0`)
2. Skip if `v3.0.0` tag already exists (idempotent)
3. Create `v3.0.0` tag and publish GitHub **stable release** (marked as `latest`)
4. Generate changelog from commits since previous stable tag (`v2.2.0`)
5. Version in `pyproject.toml` controls when a release is cut — multiple commits at the same version don't create duplicate tags

### Version bump convention

| Change type | Example | When |
|---|---|---|
| Patch (`3.0.0` → `3.0.1`) | Bug fixes, security patches | Hotfix merged to main |
| Minor (`3.0.1` → `3.1.0`) | New features, non-breaking changes | Feature batch promoted from beta |
| Major (`3.1.0` → `4.0.0`) | Breaking changes, architecture shifts | Major redesign |

## Future: Binary compilation via GitHub Releases

GitHub Releases provide the natural attachment point for pre-compiled binaries. This PR establishes the tagging foundation; a follow-up PR will add binary compilation.

### Current state

The Go credential-process and OTEL helper binaries are compiled via CodeBuild (`ccwb package --force-codebuild`). This requires:
- A deployed CodeBuild stack (3 projects: Windows, Linux x64, Linux arm64)
- AWS credentials with CodeBuild permissions
- ~5 min per build
- Manual trigger by the admin before distributing packages

### Future state (follow-up PR)

The release workflow triggers a build matrix that compiles Go binaries for all platforms using GitHub Actions runners directly:

```yaml
build-binaries:
  strategy:
    matrix:
      include:
        - os: windows-latest
          goos: windows
          goarch: amd64
          artifact: credential-process-windows.exe
        - os: ubuntu-latest
          goos: linux
          goarch: amd64
          artifact: credential-process-linux-amd64
        - os: ubuntu-latest
          goos: linux
          goarch: arm64
          artifact: credential-process-linux-arm64
        - os: macos-latest
          goos: darwin
          goarch: arm64
          artifact: credential-process-darwin-arm64
  steps:
    - uses: actions/setup-go@v5
    - run: GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -o ${{ matrix.artifact }} ./source/go/
    - run: gh release upload $TAG ${{ matrix.artifact }}
```

### Benefits

| Aspect | Current (CodeBuild) | With Release Assets |
|--------|---------------------|---------------------|
| **Build trigger** | Manual (`ccwb package`) | Automatic on tag creation |
| **AWS dependency** | Requires CodeBuild stack + credentials | None — GitHub runners only |
| **Distribution** | S3 bucket per deployment | Public GitHub Release URL |
| **Reproducibility** | Tied to admin's AWS environment | Pinned to tagged commit SHA |
| **Verification** | Trust the admin's build | SHA256 checksums in release notes |
| **Cross-platform** | 3 separate CodeBuild projects | Single workflow with matrix strategy |
| **Air-gapped installs** | Download from private S3 | Download release .zip from GitHub |
| **Version pinning** | Whatever HEAD was at build time | Exact tag → exact binary |

Admins can either:
1. **Use pre-built binaries** from the GitHub Release (zero AWS infra needed), or
2. **Continue using CodeBuild** for custom/private builds (existing workflow unchanged)

## What this PR adds

- `.github/workflows/release-beta.yml` — automatic beta pre-release tagging
- `.github/workflows/release-main.yml` — automatic stable release tagging (to be added in this PR)

## Safety

- **Idempotent** — skips if tag already exists for current commit/version
- **Pre-release flag** — beta tags won't appear as "latest"
- **No manual trigger** — fully automatic, no human steps to forget
- **Version bump controls release** — main only tags when `pyproject.toml` version changes
- **No impact on existing workflows** — CodeBuild, CI, deploy all unchanged