### PR TITLE
fix(auth): make Okta auth server configurable for developer vs paid plans

### DIFF
--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -38,6 +38,7 @@ class Profile:
     updated_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
     provider_type: str | None = None  # Auto-detected: "okta", "auth0", "azure", "cognito", "google", "generic"
     cognito_user_pool_id: str | None = None  # Only for Cognito User Pool providers
+    okta_auth_server: str = ""  # Okta authorization server ID ("default" for dev/free plans, empty for Org server on paid plans)
 
     # Generic OIDC provider configuration (provider_type == "generic")
     # Required when the IdP isn't Okta/Auth0/Azure/Cognito (e.g. PingFederate, Keycloak, ForgeRock).

--- a/source/credential_provider/__main__.py
+++ b/source/credential_provider/__main__.py
@@ -41,8 +41,8 @@ __version__ = "1.0.0"
 PROVIDER_CONFIGS = {
     "okta": {
         "name": "Okta",
-        "authorize_endpoint": "/oauth2/v1/authorize",
-        "token_endpoint": "/oauth2/v1/token",
+        "authorize_endpoint": "/oauth2/{auth_server}/v1/authorize",
+        "token_endpoint": "/oauth2/{auth_server}/v1/token",
         "scopes": "openid profile email",
         "response_type": "code",
         "response_mode": "query",
@@ -112,7 +112,20 @@ class MultiProviderAuth:
                 f"Unknown provider type '{self.provider_type}'. "
                 f"Valid providers: {', '.join(PROVIDER_CONFIGS.keys())}"
             )
-        self.provider_config = PROVIDER_CONFIGS[self.provider_type]
+        self.provider_config = dict(PROVIDER_CONFIGS[self.provider_type])
+
+        # For Okta, resolve the authorization server in endpoint paths.
+        # "default" = Okta custom auth server (free/developer plans).
+        # Empty string with trailing slash removed = Org auth server (paid plans).
+        if self.provider_type == "okta":
+            auth_server = self.config.get("okta_auth_server", "")
+            if auth_server:
+                self.provider_config["authorize_endpoint"] = self.provider_config["authorize_endpoint"].format(auth_server=auth_server)
+                self.provider_config["token_endpoint"] = self.provider_config["token_endpoint"].format(auth_server=auth_server)
+            else:
+                # Org auth server (paid plans) — no auth server ID in path
+                self.provider_config["authorize_endpoint"] = "/oauth2/v1/authorize"
+                self.provider_config["token_endpoint"] = "/oauth2/v1/token"
 
         # OAuth callback port — also used for inter-process locking.
         # Precedence: REDIRECT_PORT env var > config.json redirect_port > default 8400


### PR DESCRIPTION
Adds `okta_auth_server` config field to support both Okta plan types:

| Plan | Config value | Endpoint pattern |
|---|---|---|
| Paid/Enterprise | `""` (empty, default) | `/oauth2/v1/authorize` (Org auth server) |
| Free/Developer | `"default"` | `/oauth2/default/v1/authorize` (Custom auth server) |
| Custom CAS | `"abc123"` | `/oauth2/abc123/v1/authorize` |

## Problem
Customers on Okta free/developer plans get auth failures because the Org Authorization Server endpoints (`/oauth2/v1/`) aren't available on free plans — they need to use a Custom Authorization Server (`/oauth2/default/v1/`).

## Changes (2 files, +17/-3 lines)
- `config.py`: add `okta_auth_server` field
- `credential_provider/__main__.py`: resolve auth server in endpoint paths at runtime

## Backwards compatible
Empty string (default) preserves current behavior (Org auth server). No config change needed for existing installs.

Cherry-picked from #384, credit to @ClintEastman02.