### PR TITLE
fix(package): refuse macOS builds from non-macOS hosts

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -669,10 +669,20 @@ Pick based on what your developers report:
 
 **Package Workflow:**
 
-1. **Local builds**: macOS/Linux executables are built locally using PyInstaller
+1. **Local builds**: macOS and Linux executables are built locally using PyInstaller. See the host-OS matrix below — PyInstaller cannot cross-compile across operating systems, so **macOS binaries must be built on macOS** and **Linux binaries must be built on Linux** (or on macOS via Docker).
 2. **Windows builds**: Trigger AWS CodeBuild for Windows executables (20+ minutes) - requires enabling CodeBuild during `init`
 3. **Check status**: Monitor build progress with `poetry run ccwb builds`
 4. **Create distribution**: Use `distribute` to upload and generate presigned URLs
+
+**Host-OS requirements for each target:**
+
+| Target binary | Build host must be | Tooling |
+|---|---|---|
+| `macos-arm64`, `macos-intel` | macOS | PyInstaller (native) |
+| `linux-x64`, `linux-arm64` | Linux, **or** macOS with Docker Desktop | PyInstaller (Docker container used when building from macOS) |
+| `windows` | any host with CodeBuild enabled | AWS CodeBuild (remote build) |
+
+> **Linux admins cannot build macOS binaries.** PyInstaller on Linux emits Linux ELF binaries regardless of the requested target architecture, and macOS cannot load ELF. If you run `ccwb package --target-platform=macos-arm64` on Linux, the build refuses with a clear error. To produce macOS binaries, use a macOS workstation or a CI macOS runner (e.g. GitHub Actions `macos-latest`) and collect the artifacts from there.
 
 > **Note**: Windows builds are optional and require CodeBuild to be enabled during the `init` process. If not enabled, the package command will skip Windows builds and continue with other platforms.
 
@@ -692,8 +702,9 @@ The `dist/` folder will contain:
 
 The package builder:
 
-- Automatically builds binaries for both macOS and Linux by default
-- Uses Docker to cross-compile Linux binaries when running on macOS — **Docker Desktop must be installed and running**; if not present, Linux builds are skipped with a warning and macOS/Windows builds continue unaffected
+- Builds binaries for the platforms your current host supports (see host-OS matrix above). On a macOS host that's macOS natively plus Linux via Docker; on a Linux host that's Linux only
+- Uses Docker to produce Linux binaries from a macOS host — **Docker Desktop must be installed and running**; if not present, Linux builds are skipped with a warning and other platforms continue unaffected
+- Refuses to attempt macOS targets from a non-macOS host (fails fast with a clear error rather than silently producing invalid binaries)
 - Includes the OTEL helper for extracting user attributes from JWT tokens
 - Creates a unified installer that auto-detects the user's platform
 

--- a/assets/docs/CLI_REFERENCE.md
+++ b/assets/docs/CLI_REFERENCE.md
@@ -279,6 +279,18 @@ With `--go`, all 5 platforms are always available regardless of the admin's OS. 
 
 **Legacy mode platform details (PyInstaller / Nuitka / Docker):**
 
+PyInstaller is a runtime bundler, not a cross-OS compiler. It emits binaries in the host OS's native format (Mach-O on macOS, ELF on Linux). That constrains which targets each build host can produce:
+
+| Target binary | Build host required | Tooling |
+|---|---|---|
+| `macos-arm64`, `macos-intel` | **macOS** | PyInstaller (native) |
+| `linux-x64`, `linux-arm64` | Linux, **or** macOS with Docker Desktop | PyInstaller (Docker container when building from macOS) |
+| `windows` | any host | AWS CodeBuild (remote) |
+
+> **Linux admins cannot build macOS binaries.** There is no supported path for producing Mach-O binaries on Linux — Apple's platform design makes this infeasible. If `ccwb package` detects a macOS target on a non-macOS host, the build refuses with a clear error rather than silently producing an ELF binary labeled as macOS (which would fail on end-user Macs with `exec format error`).
+>
+> To produce macOS binaries, use a macOS workstation, a CI macOS runner (GitHub Actions `macos-latest`, AWS CodeBuild macOS project, or a self-hosted Mac runner), or an EC2 Mac instance, and collect the artifacts from there.
+
 - **macOS**: Uses PyInstaller with architecture-specific builds
   - ARM64: Native build on Apple Silicon Macs only — cannot run on Intel Macs
   - Intel: Runs natively on Intel Macs and on Apple Silicon via Rosetta — covers all Mac users with one binary
@@ -288,7 +300,7 @@ With `--go`, all 5 platforms are always available regardless of the admin's OS. 
   - ARM64: Uses linux/arm64 Docker platform
   - Docker Desktop handles architecture emulation automatically
   - **Requires Docker Desktop to be installed and running** — see Graceful Fallback Behavior below
-  - Not required for macOS or Windows builds
+  - On a Linux host, PyInstaller runs natively — Docker is not required
 - **Windows**: Uses Nuitka via AWS CodeBuild (if enabled during init)
   - Automated builds take 12-15 minutes
   - Requires CodeBuild to be enabled during `init`
@@ -325,6 +337,7 @@ The package command is designed to handle missing optional components gracefully
   - Docker is not installed (`docker` binary not found in `$PATH`) — install Docker Desktop from https://docs.docker.com/get-docker/
   - Docker is installed but the daemon is not running — open Docker Desktop and wait for it to start, then retry
   - macOS and Windows builds are **unaffected** by Docker availability
+- **macOS builds (from non-macOS host)**: Refused with a clear error explaining that PyInstaller cannot cross-compile and listing alternative paths (macOS workstation, CI runner, EC2 Mac). Other targets in the same `ccwb package` invocation continue to build normally.
 - **At least one platform must build successfully** for the package command to succeed
 
 This ensures that packaging always works, even if some optional platforms are not available.

--- a/assets/docs/DEPLOYMENT.md
+++ b/assets/docs/DEPLOYMENT.md
@@ -84,6 +84,16 @@ This command reads federation configuration from the admin profile (saved during
 
 **Legacy build mode (PyInstaller / Nuitka / Docker):**
 
+PyInstaller emits binaries in the host OS's native format, so the build host must match the target OS. Only Windows (via CodeBuild) escapes this constraint.
+
+| Target binary | Build host required | Tooling |
+|---|---|---|
+| `macos-arm64`, `macos-intel` | **macOS** | PyInstaller (native) |
+| `linux-x64`, `linux-arm64` | Linux, **or** macOS with Docker Desktop | PyInstaller (Docker container when building from macOS) |
+| `windows` | any host | AWS CodeBuild (remote) |
+
+**Linux admins cannot produce macOS binaries** — see [CLI Reference: Platform Support](CLI_REFERENCE.md#platform-support-hybrid-build-system) for details. The package command refuses this combination with a clear error; to produce macOS binaries use a macOS workstation, a CI macOS runner, or an EC2 Mac instance.
+
 - **Windows**: Uses Nuitka via AWS CodeBuild
   - Optimized for performance and minimal antivirus false positives
 - **macOS**: Uses PyInstaller with architecture-specific builds
@@ -93,7 +103,7 @@ This command reads federation configuration from the admin profile (saved during
 - **Linux x64/ARM64**: Uses PyInstaller in Docker containers (cross-compiled from macOS)
   - Automatically builds both architectures when Docker is available
   - Docker Desktop handles architecture emulation via Rosetta
-  - **Requires Docker Desktop installed and running** — if absent, Linux builds are skipped with a warning and all other platforms continue normally
+  - **When building from macOS, requires Docker Desktop installed and running** — if absent, Linux builds are skipped with a warning and all other platforms continue normally
   - macOS and Windows builds have no dependency on Docker
 
 **Which macOS binary should you ship?**

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -102,6 +102,40 @@ def _ensure_cross_arch_venv(arch: str, universal2_python: Path, runtime_packages
     return venv_dir
 
 
+def _assert_host_os_can_build_macos() -> None:
+    """Refuse to produce macOS binaries from a non-macOS host.
+
+    PyInstaller is not a cross-OS compiler: run on Linux, it emits Linux ELF
+    binaries regardless of --target-arch. Without this guard, a Linux-host
+    build would write ELF content into a macOS-named output file, and the
+    resulting package would fail on end-user Macs with "exec format error"
+    (the macOS kernel cannot load ELF binaries and Rosetta only translates
+    Mach-O, not ELF).
+
+    macOS binaries must be built on macOS — this is a property of Apple's
+    platform, not a limitation of this tool.
+    """
+    host = platform.system().lower()
+    if host == "darwin":
+        return
+    raise RuntimeError(
+        f"Cannot build macOS binaries on {platform.system()}.\n"
+        f"\n"
+        f"PyInstaller cannot cross-compile across operating systems. On "
+        f"{platform.system()}, it produces {platform.system()}-native binaries "
+        f"regardless of --target-arch.\n"
+        f"\n"
+        f"Options for producing macOS binaries:\n"
+        f"  1. Run `ccwb package` on a macOS workstation\n"
+        f"  2. Use a CI macOS runner (GitHub Actions `macos-latest`, AWS\n"
+        f"     CodeBuild macOS project, or a self-hosted Mac runner) and\n"
+        f"     collect the artifacts from there\n"
+        f"  3. Drop macOS targets from this build — run with\n"
+        f"     --target-platform=linux-x64,linux-arm64,windows\n"
+        f"     to build only the platforms your current host supports"
+    )
+
+
 class PackageCommand(Command):
     """
     Build distribution packages for your organization
@@ -908,6 +942,7 @@ class PackageCommand(Command):
 
     def _build_macos_pyinstaller(self, output_dir: Path, arch: str) -> Path:
         """Build macOS executable using PyInstaller with target architecture."""
+        _assert_host_os_can_build_macos()
         console = Console()
         verbose = self.option("build-verbose")
 
@@ -1667,6 +1702,9 @@ RUN pyinstaller \
     def _build_otel_helper_pyinstaller(self, output_dir: Path, platform_name: str, arch: str | None) -> Path:
         """Build OTEL helper using PyInstaller."""
         import platform as platform_module
+
+        if platform_name == "macos":
+            _assert_host_os_can_build_macos()
 
         console = Console()
         verbose = self.option("build-verbose")


### PR DESCRIPTION
Adds a guard that refuses macOS target builds when running on a non-macOS host, preventing silent production of invalid ELF binaries labeled as macOS.

## Why

PyInstaller emits binaries in the host OS's native format. On Linux it produces ELF, on macOS it produces Mach-O. Running `ccwb package --target-platform=macos-arm64` on Linux would silently output an ELF binary that fails on Macs with `exec format error`.

## What

- `_assert_host_os_can_build_macos()` guard function with clear error message and alternative paths
- Called in `_build_macos_pyinstaller()` and `_build_otel_helper_pyinstaller()`
- Updated docs (QUICK_START, CLI_REFERENCE, DEPLOYMENT) with host-OS matrix table

## Verified

`--target-platform=all` on Linux only selects `linux` targets (never adds macos to the build list). The guard only fires on **explicit** macOS target selection from a non-macOS host.

Credit: @scouturier (original #322)