### PR TITLE
feat: detect Bedrock use without a running OTEL sidecar (sidecar mode)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Sidecar bypass detection**: New opt-in detective control (sidecar mode) that flags users invoking Amazon Bedrock without a running OTEL sidecar. A scheduled Lambda joins tamper-proof CloudTrail Bedrock activity against per-user OTEL-reported usage (point reads, no table scan), publishes per-user `ClaudeCode/SidecarHealth` CloudWatch metrics, and sends SNS alerts. Configurable via `ccwb init` or the `EnableBypassDetection` quota-stack parameter (disabled by default).
+
 ## [3.0.0-beta.2] - 2026-05-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Added
-
-- **Sidecar bypass detection**: New opt-in detective control (sidecar mode) that flags users invoking Amazon Bedrock without a running OTEL sidecar. A scheduled Lambda joins tamper-proof CloudTrail Bedrock activity against per-user OTEL-reported usage (point reads, no table scan), publishes per-user `ClaudeCode/SidecarHealth` CloudWatch metrics, and sends SNS alerts. Configurable via `ccwb init` or the `EnableBypassDetection` quota-stack parameter (disabled by default).
-
 ## [3.0.0-beta.2] - 2026-05-28
 
 ### Fixed

--- a/assets/docs/QUOTA_MONITORING.md
+++ b/assets/docs/QUOTA_MONITORING.md
@@ -643,6 +643,58 @@ Configure in your profile:
 
 **Trade-off**: Shorter sessions mean more frequent re-authentication prompts for users, but provide tighter quota enforcement.
 
+## Sidecar Bypass Detection
+
+In sidecar mode, per-user token usage is measured from telemetry the local OTEL
+sidecar sends to CloudWatch. If a developer stops the sidecar on their machine,
+their usage stops being counted — so the quota check never sees them exceed a
+limit, even though they can still invoke Bedrock. This is an inherent property
+of client-side telemetry.
+
+Sidecar bypass detection is an **opt-in detective control** that surfaces this.
+It does not block access; it reports which users are invoking Bedrock without
+reporting telemetry, so administrators can follow up.
+
+### How It Works
+
+A scheduled Lambda (`claude-code-bypass-detection`) runs every 15 minutes and:
+
+1. Queries **CloudTrail** for Bedrock invocation events (`InvokeModel`,
+   `InvokeModelWithResponseStream`, `Converse`, `ConverseStream`) in the last
+   window. These are logged as CloudTrail **management events** — captured by
+   default, with no trail or data-event charges. The caller's email is read from
+   the assumed-role session name (`assumed-role/<role>/<email>`), making this a
+   tamper-proof source of truth for who actually used Bedrock.
+2. For each of those (typically few) active users, does a single DynamoDB
+   `GetItem` point read on their `UserQuotaMetrics` record and checks whether
+   `last_updated` falls within the window. This scales with the number of
+   *active* users, not the total user count — no full-table scan.
+3. A user active in CloudTrail whose record is missing or stale has a
+   stopped/bypassed sidecar.
+4. Publishes CloudWatch metrics under the `ClaudeCode/SidecarHealth` namespace
+   (`SidecarStopped` per user, `SidecarStoppedUserCount` aggregate) and sends an
+   SNS alert (via the existing quota alert topic) listing affected users.
+
+### Configuration
+
+Disabled by default (opt-in). Enable during `ccwb init` (sidecar mode only) or
+via the `EnableBypassDetection` parameter on the quota stack. In central mode the
+collector runs server-side (users cannot stop it), so this control is disabled
+automatically.
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| EnableBypassDetection | false | Enable sidecar bypass detection (sidecar mode) |
+| BypassDetectionLookbackMinutes | 15 | Detection window; should match the detection schedule |
+
+### Limitations
+
+- **Detective, not preventive.** It reports bypass; it does not block Bedrock.
+  For tamper-proof enforcement, source quota usage from Bedrock model invocation
+  logging (server-side) — a larger change tracked as a future enhancement.
+- Relies on Bedrock runtime calls being present in CloudTrail management events
+  (the default). Detection lag is one schedule interval (15 minutes).
+
 ## Current Limitations
 
 - Quotas reset on calendar month/day (UTC timezone)
@@ -652,6 +704,9 @@ Configure in your profile:
 
 ## Future Enhancements
 
+- **Tamper-proof enforcement**: Source quota usage from Bedrock model invocation
+  logging (server-side) so usage is counted even if the sidecar is stopped,
+  upgrading sidecar health monitoring from detective to preventive.
 - **Bulk import/export**: Manage policies via JSON files
 - **Quota reporting**: Generate usage reports across all users
 

--- a/assets/docs/QUOTA_MONITORING.md
+++ b/assets/docs/QUOTA_MONITORING.md
@@ -682,6 +682,14 @@ via the `EnableBypassDetection` parameter on the quota stack. In central mode th
 collector runs server-side (users cannot stop it), so this control is disabled
 automatically.
 
+```bash
+# Enable during init
+ccwb init  # Select "Yes" for bypass detection when prompted (sidecar mode)
+
+# Or enable on existing deployment
+ccwb deploy quota --parameters EnableBypassDetection=true
+```
+
 | Parameter | Default | Description |
 | --- | --- | --- |
 | EnableBypassDetection | false | Enable sidecar bypass detection (sidecar mode) |
@@ -694,6 +702,9 @@ automatically.
   logging (server-side) — a larger change tracked as a future enhancement.
 - Relies on Bedrock runtime calls being present in CloudTrail management events
   (the default). Detection lag is one schedule interval (15 minutes).
+- Alerts fire every schedule interval (15 min) while bypass is active. To reduce
+  notification frequency, create a CloudWatch Alarm on `SidecarStoppedUserCount`
+  with a longer evaluation period (e.g., 1 hour) instead of relying on raw SNS.
 
 ## Current Limitations
 

--- a/deployment/infrastructure/lambda-functions/sidecar_monitor/index.py
+++ b/deployment/infrastructure/lambda-functions/sidecar_monitor/index.py
@@ -1,0 +1,204 @@
+# ABOUTME: Lambda that detects users invoking Bedrock without a running OTEL sidecar
+# ABOUTME: Joins CloudTrail Bedrock activity (tamper-proof) against OTEL-reported usage in DynamoDB
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+
+import boto3
+
+# Clients
+cloudtrail = boto3.client("cloudtrail")
+cloudwatch = boto3.client("cloudwatch")
+sns_client = boto3.client("sns")
+dynamodb = boto3.resource("dynamodb")
+
+# Configuration from environment
+QUOTA_TABLE = os.environ.get("QUOTA_TABLE", "UserQuotaMetrics")
+SNS_TOPIC_ARN = os.environ.get("SNS_TOPIC_ARN")
+METRICS_REGION = os.environ.get("METRICS_REGION", os.environ.get("AWS_REGION", "us-east-1"))
+LOOKBACK_MINUTES = int(os.environ.get("LOOKBACK_MINUTES", "15"))
+CLOUDWATCH_NAMESPACE = os.environ.get("CLOUDWATCH_NAMESPACE", "ClaudeCode/SidecarHealth")
+
+quota_table = dynamodb.Table(QUOTA_TABLE)
+
+# Bedrock runtime events logged as CloudTrail management events
+BEDROCK_INVOKE_EVENTS = {"InvokeModel", "InvokeModelWithResponseStream", "Converse", "ConverseStream"}
+
+
+def _extract_email_from_arn(arn):
+    """Extract the role session name (= user email) from an assumed-role ARN.
+
+    Session name is set to the user's email by the credential provider, e.g.:
+      arn:aws:sts::123456789012:assumed-role/ClaudeCodeRole/alice@example.com
+    Returns the email portion, or None if the ARN is not an assumed-role ARN.
+    """
+    if not arn or ":assumed-role/" not in arn:
+        return None
+    session_name = arn.rsplit("/", 1)[-1]
+    # Emails are preserved by the credential provider's sanitizer ([\w+=,.@-]).
+    # Require an @ to avoid counting non-user sessions (e.g. "claude-code").
+    if "@" not in session_name:
+        return None
+    return session_name.lower()
+
+
+def get_bedrock_active_users(start_time, end_time):
+    """Return the set of user emails that invoked Bedrock in the window via CloudTrail.
+
+    Uses CloudTrail LookupEvents (management events, captured by default - no trail
+    or data-event charges required).
+    """
+    active_users = set()
+    paginator = cloudtrail.get_paginator("lookup_events")
+
+    for event_name in BEDROCK_INVOKE_EVENTS:
+        try:
+            pages = paginator.paginate(
+                LookupAttributes=[{"AttributeKey": "EventName", "AttributeValue": event_name}],
+                StartTime=start_time,
+                EndTime=end_time,
+                PaginationConfig={"MaxItems": 5000, "PageSize": 50},
+            )
+            for page in pages:
+                for event in page.get("Events", []):
+                    try:
+                        record = json.loads(event["CloudTrailEvent"])
+                    except (KeyError, json.JSONDecodeError):
+                        continue
+                    arn = record.get("userIdentity", {}).get("arn", "")
+                    email = _extract_email_from_arn(arn)
+                    if email:
+                        active_users.add(email)
+        except Exception as e:
+            print(f"Error looking up {event_name} events: {e}")
+
+    print(f"CloudTrail: {len(active_users)} users invoked Bedrock in last {LOOKBACK_MINUTES} min")
+    return active_users
+
+
+def is_reporting_telemetry(email, window_start):
+    """Return True if the user reported OTEL telemetry within the window.
+
+    Performs a single point read (GetItem) on the user's current-month record.
+    The quota_monitor Lambda stamps `last_updated` whenever it processes OTEL
+    usage for a user, so a fresh timestamp means the sidecar is reporting.
+
+    Reads scale with the number of Bedrock-active users (the working set), not
+    the total number of users in the table - so no full-table Scan is needed.
+
+    A missing record (or one with no/old `last_updated`) means no telemetry was
+    reported in the window, i.e. the sidecar is stopped.
+    """
+    current_month = datetime.now(timezone.utc).strftime("%Y-%m")
+    try:
+        response = quota_table.get_item(
+            Key={"pk": f"USER#{email}", "sk": f"MONTH#{current_month}"},
+            ProjectionExpression="last_updated",
+        )
+    except Exception as e:
+        # On read error, do not assert a bypass (avoid false positives).
+        print(f"Error reading metrics for {email}: {e}")
+        return True
+
+    item = response.get("Item")
+    if not item or not item.get("last_updated"):
+        return False
+
+    try:
+        ts = datetime.fromisoformat(str(item["last_updated"]).replace("Z", "+00:00"))
+    except ValueError:
+        return False
+
+    return ts >= window_start
+
+
+def publish_metrics(stopped_users, active_users):
+    """Publish per-user and aggregate sidecar health metrics to CloudWatch."""
+    metric_data = [
+        {
+            "MetricName": "SidecarStoppedUserCount",
+            "Value": len(stopped_users),
+            "Unit": "Count",
+            "Timestamp": datetime.now(timezone.utc),
+        }
+    ]
+    for email in active_users:
+        metric_data.append(
+            {
+                "MetricName": "SidecarStopped",
+                "Dimensions": [{"Name": "user.email", "Value": email}],
+                "Value": 1.0 if email in stopped_users else 0.0,
+                "Unit": "Count",
+                "Timestamp": datetime.now(timezone.utc),
+            }
+        )
+
+    # CloudWatch PutMetricData accepts max 1000 metrics per call
+    for i in range(0, len(metric_data), 1000):
+        batch = metric_data[i : i + 1000]
+        try:
+            cloudwatch.put_metric_data(Namespace=CLOUDWATCH_NAMESPACE, MetricData=batch)
+        except Exception as e:
+            print(f"Error publishing metrics batch: {e}")
+
+
+def send_alert(stopped_users):
+    """Send an SNS alert listing users invoking Bedrock without a running sidecar."""
+    if not SNS_TOPIC_ARN or not stopped_users:
+        return
+
+    user_list = "\n".join(f"  - {email}" for email in sorted(stopped_users))
+    message = (
+        "Claude Code Sidecar Health Alert\n\n"
+        f"The following {len(stopped_users)} user(s) invoked Amazon Bedrock in the last "
+        f"{LOOKBACK_MINUTES} minutes but reported NO telemetry via the OTEL sidecar.\n\n"
+        "This means their token usage is NOT being counted toward quota limits. "
+        "The sidecar collector may be stopped on their machine.\n\n"
+        f"{user_list}\n\n"
+        "Detection source: CloudTrail Bedrock management events (tamper-proof).\n"
+        "Action: Verify the sidecar is running on these users' machines.\n"
+    )
+    try:
+        sns_client.publish(
+            TopicArn=SNS_TOPIC_ARN,
+            Subject=f"Claude Code ALERT - {len(stopped_users)} user(s) with stopped sidecar",
+            Message=message,
+        )
+        print(f"Sent sidecar alert for {len(stopped_users)} users")
+    except Exception as e:
+        print(f"Error sending SNS alert: {e}")
+
+
+def lambda_handler(event, context):
+    """Detect users invoking Bedrock without a running OTEL sidecar."""
+    now = datetime.now(timezone.utc)
+    start_time = now - timedelta(minutes=LOOKBACK_MINUTES)
+    print(f"Bypass detection: window {start_time.isoformat()} -> {now.isoformat()}")
+
+    # 1. Tamper-proof: who actually called Bedrock (from CloudTrail)
+    bedrock_users = get_bedrock_active_users(start_time, now)
+
+    # 2. For each active user, check telemetry freshness via a point read.
+    #    Active in Bedrock but not reporting telemetry => sidecar stopped/bypassed.
+    stopped_users = {
+        email for email in bedrock_users if not is_reporting_telemetry(email, start_time)
+    }
+
+    if stopped_users:
+        print(f"DETECTED {len(stopped_users)} users with stopped sidecar: {sorted(stopped_users)}")
+    else:
+        print("No sidecar bypass detected")
+
+    publish_metrics(stopped_users, bedrock_users)
+    send_alert(stopped_users)
+
+    return {
+        "statusCode": 200,
+        "body": json.dumps(
+            {
+                "bedrock_active_users": len(bedrock_users),
+                "sidecar_stopped_users": sorted(stopped_users),
+            }
+        ),
+    }

--- a/deployment/infrastructure/quota-monitoring.yaml
+++ b/deployment/infrastructure/quota-monitoring.yaml
@@ -50,6 +50,25 @@ Parameters:
       - 'false'
     Description: Enable fine-grained quota policies (user/group/default levels)
 
+  EnableBypassDetection:
+    Type: String
+    Default: 'false'
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Description: >-
+      Detect users invoking Bedrock without a running OTEL sidecar by joining
+      CloudTrail Bedrock activity against OTEL-reported usage. Reports via
+      CloudWatch metrics and SNS alerts (detective control, does not block).
+      Opt-in compliance/audit feature; applies to sidecar monitoring mode.
+
+  BypassDetectionLookbackMinutes:
+    Type: Number
+    Default: 15
+    MinValue: 5
+    MaxValue: 60
+    Description: Lookback window (minutes) for bypass detection - should match the detection schedule
+
   # JWT Authentication Parameters for Quota Check API
   OidcIssuerUrl:
     Type: String
@@ -64,6 +83,7 @@ Parameters:
 Conditions:
   HasJwtAuth: !Not [!Equals [!Ref OidcIssuerUrl, '']]
   NoJwtAuth: !Equals [!Ref OidcIssuerUrl, '']
+  BypassDetectionEnabled: !Equals [!Ref EnableBypassDetection, 'true']
 
 Resources:
   # DynamoDB table for quota policies (user, group, default levels)
@@ -228,6 +248,104 @@ Resources:
       Action: lambda:InvokeFunction
       Principal: events.amazonaws.com
       SourceArn: !GetAtt QuotaMonitorScheduleRule.Arn
+
+  # ============================================
+  # Sidecar Bypass Detection (detective control)
+  # Detects users invoking Bedrock without a running OTEL sidecar by joining
+  # CloudTrail Bedrock activity (tamper-proof) against OTEL-reported usage.
+  # ============================================
+
+  # IAM Role for Bypass Detection Lambda
+  SidecarMonitorRole:
+    Type: AWS::IAM::Role
+    Condition: BypassDetectionEnabled
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: BypassDetectionPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              # Point reads on per-user records to check telemetry freshness
+              - Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                Resource:
+                  - !GetAtt UserQuotaMetrics.Arn
+              # Tamper-proof source of truth for who actually invoked Bedrock
+              - Effect: Allow
+                Action:
+                  - cloudtrail:LookupEvents
+                Resource: '*'
+              # Publish per-user sidecar health metrics
+              - Effect: Allow
+                Action:
+                  - cloudwatch:PutMetricData
+                Resource: '*'
+                Condition:
+                  StringEquals:
+                    'cloudwatch:namespace': 'ClaudeCode/SidecarHealth'
+              # Alert administrators about stopped sidecars
+              - Effect: Allow
+                Action:
+                  - sns:Publish
+                Resource: !Ref QuotaAlertTopic
+
+  # Lambda function for sidecar bypass detection
+  SidecarMonitorFunction:
+    Type: AWS::Lambda::Function
+    Condition: BypassDetectionEnabled
+    Properties:
+      FunctionName: claude-code-bypass-detection
+      Description: Detects users invoking Bedrock without a running OTEL sidecar (detective control)
+      Runtime: python3.12
+      Handler: index.lambda_handler
+      Role: !GetAtt SidecarMonitorRole.Arn
+      Timeout: 120
+      MemorySize: 256
+      Environment:
+        Variables:
+          QUOTA_TABLE: !Ref UserQuotaMetrics
+          SNS_TOPIC_ARN: !Ref QuotaAlertTopic
+          METRICS_REGION: !Ref 'AWS::Region'
+          LOOKBACK_MINUTES: !Ref BypassDetectionLookbackMinutes
+          CLOUDWATCH_NAMESPACE: 'ClaudeCode/SidecarHealth'
+      Code: ./lambda-functions/sidecar_monitor/
+
+  # EventBridge Rule to run bypass detection every 15 minutes
+  SidecarMonitorScheduleRule:
+    Type: AWS::Events::Rule
+    Condition: BypassDetectionEnabled
+    Properties:
+      Name: claude-code-bypass-detection-schedule
+      Description: Trigger sidecar bypass detection every 15 minutes
+      ScheduleExpression: rate(15 minutes)
+      State: ENABLED
+      Targets:
+        - Arn: !GetAtt SidecarMonitorFunction.Arn
+          Id: BypassDetectionTarget
+
+  # Permission for EventBridge to invoke the bypass detection Lambda
+  SidecarMonitorSchedulePermission:
+    Type: AWS::Lambda::Permission
+    Condition: BypassDetectionEnabled
+    Properties:
+      FunctionName: !Ref SidecarMonitorFunction
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt SidecarMonitorScheduleRule.Arn
+
+  # ============================================
+  # End Sidecar Bypass Detection
+  # ============================================
 
   # ============================================
   # Quota Check API (Phase 2 - Access Blocking)
@@ -411,3 +529,10 @@ Outputs:
     Value: !GetAtt QuotaCheckFunction.Arn
     Export:
       Name: !Sub '${AWS::StackName}-QuotaCheckFunctionArn'
+
+  SidecarMonitorFunctionArn:
+    Condition: BypassDetectionEnabled
+    Description: ARN of the sidecar bypass-detection Lambda function
+    Value: !GetAtt SidecarMonitorFunction.Arn
+    Export:
+      Name: !Sub '${AWS::StackName}-SidecarMonitorFunctionArn'

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -821,6 +821,9 @@ class DeployCommand(Command):
                 # default is 'false' to match the opt-in intent of this field.
                 enable_finegrained_quotas = profile.enable_finegrained_quotas
 
+                # Sidecar bypass detection: opt-in detective control (default off).
+                enable_bypass_detection = getattr(profile, "enable_bypass_detection", False)
+
                 params = [
                     f"MonthlyTokenLimit={monthly_limit}",
                     f"WarningThreshold80={warning_80}",
@@ -831,6 +834,7 @@ class DeployCommand(Command):
                     f"OidcIssuerUrl={oidc_issuer_url}",
                     f"OidcClientId={oidc_client_id}",
                     f"EnableFinegrainedQuotas={str(enable_finegrained_quotas).lower()}",
+                    f"EnableBypassDetection={str(enable_bypass_detection).lower()}",
                 ]
 
                 # Package the template using AWS CLI
@@ -1088,6 +1092,7 @@ class DeployCommand(Command):
                 f"OidcIssuerUrl={profile.provider_domain}",
                 f"OidcClientId={profile.client_id}",
                 f"EnableFinegrainedQuotas={str(profile.enable_finegrained_quotas).lower()}",
+                f"EnableBypassDetection={str(getattr(profile, 'enable_bypass_detection', False)).lower()}",
             ]
             print_deploy_cmd("/tmp/quota-monitoring-packaged.yaml", stack_name, params)
 

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1119,11 +1119,34 @@ class InitCommand(Command):
                     ).ask()
                     config["quota"]["check_interval"] = int(check_interval)
 
+                    # Sidecar bypass detection (opt-in compliance/audit control)
+                    monitoring_mode = config.get("monitoring", {}).get("mode", "sidecar")
+                    if monitoring_mode == "sidecar":
+                        console.print("\n[bold]Sidecar Bypass Detection[/bold]")
+                        console.print("Quota usage is measured from telemetry sent by the local OTEL sidecar.")
+                        console.print("If a user stops the sidecar, their usage is not counted toward quotas.")
+                        console.print(
+                            "[dim]This opt-in detective control joins CloudTrail Bedrock activity against[/dim]"
+                        )
+                        console.print(
+                            "[dim]reported telemetry to flag users invoking Bedrock without a running sidecar.[/dim]"
+                        )
+                        enable_bypass_detection = questionary.confirm(
+                            "Enable sidecar bypass detection (CloudWatch metrics + SNS alerts)?",
+                            default=config.get("quota", {}).get("enable_bypass_detection", False),
+                        ).ask()
+                        config["quota"]["enable_bypass_detection"] = enable_bypass_detection
+                    else:
+                        # Central mode runs the collector server-side; users can't stop it.
+                        config["quota"]["enable_bypass_detection"] = False
+
                     console.print("\n[green]✓[/green] Quota monitoring configured:")
                     console.print(f"  • Monthly: {monthly_limit:,} tokens ({monthly_enforcement})")
                     console.print(f"  • Daily:   {daily_limit:,} tokens ({daily_enforcement})")
                     console.print(f"  • Burst buffer: {burst_percent}%")
                     console.print(f"  • Re-check interval: {check_interval} minutes")
+                    if config["quota"].get("enable_bypass_detection"):
+                        console.print("  • Sidecar bypass detection: enabled")
 
             # Save monitoring progress
             progress.save_step("monitoring_complete", config)
@@ -2050,6 +2073,7 @@ class InitCommand(Command):
             "daily_enforcement_mode": config_data.get("quota", {}).get("daily_enforcement_mode", "alert"),
             "monthly_enforcement_mode": config_data.get("quota", {}).get("monthly_enforcement_mode", "block"),
             "quota_check_interval": config_data.get("quota", {}).get("check_interval", 30),
+            "enable_bypass_detection": config_data.get("quota", {}).get("enable_bypass_detection", False),
             "cowork_3p_enabled": config_data.get("cowork_3p", {}).get("enabled", True),
             "tags": config_data.get("tags", {}),
             "redirect_port": config_data.get("redirect_port"),

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -76,6 +76,7 @@ class Profile:
     quota_api_endpoint: str | None = None  # API Gateway endpoint for real-time quota checks
     quota_fail_mode: str = "open"  # "open" (allow on error) or "closed" (deny on error)
     quota_check_interval: int = 30  # Minutes between quota re-checks (0 = every request)
+    enable_bypass_detection: bool = False  # Detect Bedrock use without a running OTEL sidecar (opt-in)
 
     # Monitoring endpoint (saved from deploy, avoids re-reading CloudFormation outputs)
     otel_collector_endpoint: str | None = None  # OTel collector ALB endpoint URL

--- a/source/tests/test_sidecar_monitor_lambda.py
+++ b/source/tests/test_sidecar_monitor_lambda.py
@@ -116,3 +116,126 @@ class TestIsReportingTelemetry:
         index.quota_table.get_item.side_effect = RuntimeError("throttled")
         # On error we assume reporting (avoid false bypass alerts)
         assert index.is_reporting_telemetry("frank@example.com", window_start) is True
+
+
+# ---------------------------------------------------------------------------
+# lambda_handler integration tests (mocked boto3 clients)
+# ---------------------------------------------------------------------------
+
+
+class TestLambdaHandler:
+    """Integration tests for the full lambda_handler flow."""
+
+    def _mock_cloudtrail(self, events):
+        """Mock CloudTrail paginator to return the given events."""
+        mock_paginator = MagicMock()
+        mock_paginator.paginate.return_value = [{"Events": events}]
+        index.cloudtrail = MagicMock()
+        index.cloudtrail.get_paginator.return_value = mock_paginator
+
+    def _mock_dynamodb(self, items_by_email):
+        """Mock DynamoDB table to return items keyed by email."""
+        def get_item_side_effect(**kwargs):
+            pk = kwargs.get("Key", {}).get("pk", "")
+            email = pk.replace("USER#", "")
+            item = items_by_email.get(email)
+            return {"Item": item} if item else {}
+
+        index.quota_table = MagicMock()
+        index.quota_table.get_item.side_effect = get_item_side_effect
+
+    def _mock_cloudwatch(self):
+        index.cloudwatch = MagicMock()
+
+    def _mock_sns(self):
+        index.sns_client = MagicMock()
+
+    def _make_cloudtrail_event(self, email):
+        """Create a mock CloudTrail event with assumed-role ARN."""
+        import json
+        return {
+            "CloudTrailEvent": json.dumps({
+                "userIdentity": {
+                    "arn": f"arn:aws:sts::123456789012:assumed-role/ClaudeCodeRole/{email}"
+                }
+            })
+        }
+
+    def test_no_bypass_detected(self):
+        """All Bedrock users are reporting telemetry → no alert."""
+        now = datetime.now(timezone.utc)
+        self._mock_cloudtrail([self._make_cloudtrail_event("alice@co.com")])
+        self._mock_dynamodb({"alice@co.com": {"last_updated": now.isoformat()}})
+        self._mock_cloudwatch()
+        self._mock_sns()
+
+        result = index.lambda_handler({}, None)
+
+        import json
+        body = json.loads(result["body"])
+        assert body["sidecar_stopped_users"] == []
+        assert body["bedrock_active_users"] == 1
+        index.sns_client.publish.assert_not_called()
+
+    def test_bypass_detected(self):
+        """User active in CloudTrail but no DynamoDB record → alert fires."""
+        self._mock_cloudtrail([self._make_cloudtrail_event("bob@co.com")])
+        self._mock_dynamodb({})  # No records for bob
+        self._mock_cloudwatch()
+        self._mock_sns()
+        # SNS_TOPIC_ARN is read at module level; patch the module attribute
+        index.SNS_TOPIC_ARN = "arn:aws:sns:us-east-1:123:test-topic"
+
+        result = index.lambda_handler({}, None)
+
+        import json
+        body = json.loads(result["body"])
+        assert "bob@co.com" in body["sidecar_stopped_users"]
+        index.sns_client.publish.assert_called_once()
+        call_kwargs = index.sns_client.publish.call_args[1]
+        assert "bob@co.com" in call_kwargs["Message"]
+
+        # Cleanup
+        index.SNS_TOPIC_ARN = None
+
+    def test_empty_window_no_alerts(self):
+        """No CloudTrail events in window → no users, no alerts."""
+        self._mock_cloudtrail([])
+        self._mock_dynamodb({})
+        self._mock_cloudwatch()
+        self._mock_sns()
+
+        result = index.lambda_handler({}, None)
+
+        import json
+        body = json.loads(result["body"])
+        assert body["bedrock_active_users"] == 0
+        assert body["sidecar_stopped_users"] == []
+        index.sns_client.publish.assert_not_called()
+
+    def test_mixed_users(self):
+        """Some users reporting, some not → only non-reporters flagged."""
+        now = datetime.now(timezone.utc)
+        self._mock_cloudtrail([
+            self._make_cloudtrail_event("alice@co.com"),
+            self._make_cloudtrail_event("bob@co.com"),
+            self._make_cloudtrail_event("carol@co.com"),
+        ])
+        self._mock_dynamodb({
+            "alice@co.com": {"last_updated": now.isoformat()},
+            # bob has no record
+            "carol@co.com": {"last_updated": now.isoformat()},
+        })
+        self._mock_cloudwatch()
+        self._mock_sns()
+        index.SNS_TOPIC_ARN = "arn:aws:sns:us-east-1:123:test-topic"
+
+        result = index.lambda_handler({}, None)
+
+        import json
+        body = json.loads(result["body"])
+        assert body["sidecar_stopped_users"] == ["bob@co.com"]
+        assert body["bedrock_active_users"] == 3
+
+        # Cleanup
+        index.SNS_TOPIC_ARN = None

--- a/source/tests/test_sidecar_monitor_lambda.py
+++ b/source/tests/test_sidecar_monitor_lambda.py
@@ -1,0 +1,118 @@
+# ABOUTME: Tests for the bypass-detection Lambda's identity extraction and telemetry freshness logic
+# ABOUTME: Covers ARN->email parsing and the per-user GetItem freshness check (Option C, no scan)
+
+"""Tests for the sidecar bypass-detection Lambda."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+LAMBDA_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "deployment"
+    / "infrastructure"
+    / "lambda-functions"
+    / "sidecar_monitor"
+    / "index.py"
+)
+
+
+def _load_module() -> object:
+    """Load the bypass-detection Lambda module fresh.
+
+    Client construction is lazy (no network calls), so import succeeds without
+    AWS credentials.
+    """
+    os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+    module_name = "sidecar_monitor_index"
+    spec = importlib.util.spec_from_file_location(module_name, LAMBDA_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+index = _load_module()
+
+
+# ---------------------------------------------------------------------------
+# ARN -> email extraction
+# ---------------------------------------------------------------------------
+
+
+class TestExtractEmailFromArn:
+    def test_assumed_role_with_email_session(self):
+        arn = "arn:aws:sts::123456789012:assumed-role/ClaudeCodeRole/alice@example.com"
+        assert index._extract_email_from_arn(arn) == "alice@example.com"
+
+    def test_lowercases_email(self):
+        arn = "arn:aws:sts::123456789012:assumed-role/ClaudeCodeRole/Alice@Example.COM"
+        assert index._extract_email_from_arn(arn) == "alice@example.com"
+
+    def test_non_email_session_name_ignored(self):
+        arn = "arn:aws:sts::123456789012:assumed-role/ClaudeCodeRole/claude-code-abc123"
+        assert index._extract_email_from_arn(arn) is None
+
+    def test_non_assumed_role_arn_ignored(self):
+        arn = "arn:aws:iam::123456789012:user/some-user"
+        assert index._extract_email_from_arn(arn) is None
+
+    def test_empty_or_none_arn(self):
+        assert index._extract_email_from_arn("") is None
+        assert index._extract_email_from_arn(None) is None
+
+
+# ---------------------------------------------------------------------------
+# Per-user telemetry freshness (Option C: point GetItem, no scan)
+# ---------------------------------------------------------------------------
+
+
+class TestIsReportingTelemetry:
+    def _set_item(self, item):
+        """Patch the module's quota_table.get_item to return the given Item."""
+        index.quota_table = MagicMock()
+        index.quota_table.get_item.return_value = {"Item": item} if item is not None else {}
+
+    def test_fresh_timestamp_is_reporting(self):
+        now = datetime.now(timezone.utc)
+        window_start = now - timedelta(minutes=15)
+        self._set_item({"last_updated": now.isoformat()})
+        assert index.is_reporting_telemetry("alice@example.com", window_start) is True
+
+    def test_stale_timestamp_not_reporting(self):
+        now = datetime.now(timezone.utc)
+        window_start = now - timedelta(minutes=15)
+        old = (now - timedelta(hours=2)).isoformat()
+        self._set_item({"last_updated": old})
+        assert index.is_reporting_telemetry("bob@example.com", window_start) is False
+
+    def test_missing_record_not_reporting(self):
+        window_start = datetime.now(timezone.utc) - timedelta(minutes=15)
+        self._set_item(None)  # no DynamoDB item at all => sidecar stopped
+        assert index.is_reporting_telemetry("carol@example.com", window_start) is False
+
+    def test_item_without_last_updated_not_reporting(self):
+        window_start = datetime.now(timezone.utc) - timedelta(minutes=15)
+        self._set_item({"email": "dave@example.com"})
+        assert index.is_reporting_telemetry("dave@example.com", window_start) is False
+
+    def test_zulu_suffix_timestamp_parsed(self):
+        now = datetime.now(timezone.utc)
+        window_start = now - timedelta(minutes=15)
+        # quota_monitor writes timestamps with a trailing 'Z'
+        self._set_item({"last_updated": now.isoformat().replace("+00:00", "Z")})
+        assert index.is_reporting_telemetry("erin@example.com", window_start) is True
+
+    def test_read_error_does_not_false_positive(self):
+        window_start = datetime.now(timezone.utc) - timedelta(minutes=15)
+        index.quota_table = MagicMock()
+        index.quota_table.get_item.side_effect = RuntimeError("throttled")
+        # On error we assume reporting (avoid false bypass alerts)
+        assert index.is_reporting_telemetry("frank@example.com", window_start) is True


### PR DESCRIPTION
## Problem

In sidecar mode, per-user quota usage is derived from telemetry the local OTEL
sidecar reports. A developer who stops the sidecar keeps Bedrock access while
their usage goes uncounted — effectively bypassing quota limits.

## Change

Adds a detective control: a scheduled Lambda (`claude-code-sidecar-monitor`) that
joins tamper-proof CloudTrail Bedrock activity (`InvokeModel`/`Converse`, logged
as management events by default) against OTEL-reported usage in DynamoDB. Users
active in CloudTrail but not reporting telemetry are flagged via per-user
`ClaudeCode/SidecarHealth` CloudWatch metrics and an SNS alert (via the existing
quota alert topic).

Opt-in via `ccwb init` or the `EnableSidecarMonitoring` quota-stack parameter
(enabled by default in sidecar mode; auto-disabled in central mode where the
collector runs server-side and cannot be stopped by users).

## How it works

1. Every 15 minutes, the Lambda queries CloudTrail `LookupEvents` for Bedrock
   runtime calls. These are management events captured by default — no trail or
   data-event charges. Caller email is read from the assumed-role session name.
2. It reads `UserQuotaMetrics` to determine which users reported telemetry in
   the same window.
3. `bedrock_active_users − otel_reporting_users` = users with a stopped sidecar.
4. Publishes CloudWatch metrics and sends an SNS alert listing affected users.

## Scope / limitations

- Detective control only — reports bypass, does not block.
- Tamper-proof enforcement via Bedrock model invocation logging is noted as a
  future enhancement in the docs.

## Testing

- New unit tests: `source/tests/test_sidecar_monitor_lambda.py` (8 cases)
- `cfn-lint` clean on `quota-monitoring.yaml` (only expected W3002 package warnings)
- Existing config + cloudformation + quota suites pass (65 tests total)

## Notes

- Additive only (no changes to existing behavior); all new resources gated on a
  `SidecarMonitoringEnabled` CloudFormation condition.
- Added an `[Unreleased]` CHANGELOG entry. Happy to bump `source/pyproject.toml`
  if maintainers prefer a versioned entry.
