### PR TITLE
fix(test): match json.dumps({}) in otel helper contract test

### DIFF
--- a/source/tests/e2e/test_cross_platform.py
+++ b/source/tests/e2e/test_cross_platform.py
@@ -417,7 +417,7 @@ class TestOtelHelperContract:
         source_file = OTEL_DIR / "__main__.py"
         content = source_file.read_text(encoding="utf-8")
         # Must have a fallback that prints {} (empty headers) and exits 0
-        assert 'print("{}")' in content or "print('{}')" in content, (
+        assert 'print("{}")' in content or "print('{}')" in content or 'json.dumps({})' in content, (
             "otel_helper must emit empty JSON object on error path "
             "to satisfy Claude Code's otelHeadersHelper contract"
         )


### PR DESCRIPTION
Fixes CI failure from #411: the test checked for literal `print("{}")` but the actual code uses `print(json.dumps({}))`. One-line fix.