### PR TITLE
fix: restore default quota policy seeding on deploy

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -860,9 +860,15 @@ class DeployCommand(Command):
                     )
 
                     # Deploy the packaged template
-                    return deploy_with_cf(
+                    result = deploy_with_cf(
                         packaged_template_path, stack_name, params, task_description="Deploying quota monitoring..."
                     )
+
+                    # Seed default quota policy on successful deploy
+                    if result == 0:
+                        self._create_default_quota_policy(profile, stack_name, console)
+
+                    return result
 
                 finally:
                     # Clean up temp file
@@ -1054,8 +1060,6 @@ class DeployCommand(Command):
             daily_limit = getattr(profile, "daily_token_limit", None)
             params = [
                 f"MonthlyTokenLimit={monthly_limit}",
-                f"MetricsTableArn=<MetricsTableArn from {dashboard_stack}>",
-                f"MetricsAggregatorRoleName=<MetricsAggregatorRoleName from {dashboard_stack}>",
                 f"WarningThreshold80={getattr(profile, 'warning_threshold_80', int(monthly_limit * 0.8))}",
                 f"WarningThreshold90={getattr(profile, 'warning_threshold_90', int(monthly_limit * 0.9))}",
                 f"DailyTokenLimit={daily_limit or 0}",
@@ -1184,52 +1188,6 @@ class DeployCommand(Command):
                     if quota_outputs.get("QuotaTableName"):
                         profile.user_quota_metrics_table = quota_outputs["QuotaTableName"]
                     config.save_profile(profile)
-
-    def _update_metrics_aggregator_env(self, profile, quota_stack_name: str, console: Console) -> None:
-        """Update metrics aggregator Lambda environment variable to include quota table."""
-        try:
-            import boto3
-
-            # Get the quota table name from the quota stack outputs
-            quota_outputs = get_stack_outputs(quota_stack_name, profile.aws_region)
-            if not quota_outputs or not quota_outputs.get("QuotaTableName"):
-                console.print("[yellow]Warning: Could not get quota table name from stack outputs[/yellow]")
-                return
-
-            quota_table_name = quota_outputs["QuotaTableName"]
-
-            # Get the metrics aggregator function name
-            metrics_aggregator_name = "ClaudeCode-MetricsAggregator"
-
-            console.print(f"[dim]Updating {metrics_aggregator_name} environment variables...[/dim]")
-
-            # Update the Lambda function environment variables
-            lambda_client = boto3.client("lambda", region_name=profile.aws_region)
-
-            try:
-                lambda_client.update_function_configuration(
-                    FunctionName=metrics_aggregator_name,
-                    Environment={
-                        "Variables": {
-                            "METRICS_LOG_GROUP": profile.metrics_log_group,
-                            "METRICS_REGION": profile.aws_region,
-                            "METRICS_TABLE": "ClaudeCodeMetrics",
-                            "QUOTA_TABLE": quota_table_name,
-                        }
-                    },
-                )
-                console.print("[green]✓ Updated metrics aggregator to enable quota tracking[/green]")
-            except Exception as e:
-                console.print(
-                    f"[yellow]Warning: Failed to update metrics aggregator environment variables: {str(e)}[/yellow]"
-                )
-                console.print(
-                    f"[dim]You may need to manually add QUOTA_TABLE={quota_table_name} "
-                    f"to the metrics aggregator Lambda[/dim]"
-                )
-
-        except Exception as e:
-            console.print(f"[yellow]Warning: Error updating metrics aggregator: {str(e)}[/yellow]")
 
     def _create_default_quota_policy(self, profile, quota_stack_name: str, console: Console) -> None:
         """Auto-create default quota policy in DynamoDB after quota stack deployment."""

--- a/source/tests/e2e/test_cross_platform.py
+++ b/source/tests/e2e/test_cross_platform.py
@@ -454,3 +454,44 @@ class TestInstallerScriptSafety:
         if "install.bat" in content or "install_bat" in content:
             # Just verify the template section exists
             assert "config" in content.lower()
+
+
+# ---------------------------------------------------------------------------
+# Post-Deploy Hook Guards (prevent accidental removal of critical calls)
+# ---------------------------------------------------------------------------
+
+
+class TestDeployPostHooks:
+    """Regression guards for deploy.py post-deploy hooks."""
+
+    def test_quota_deploy_calls_create_default_policy(self):
+        """Quota deploy must seed default policy on success (regression from #439)."""
+        deploy_file = CLI_DIR / "cli" / "commands" / "deploy.py"
+        content = deploy_file.read_text(encoding="utf-8")
+        # Find quota deploy section
+        quota_idx = content.find('stack_type == "quota"')
+        assert quota_idx != -1, "deploy.py must have a quota deploy branch"
+        quota_section = content[quota_idx:]
+        assert "_create_default_quota_policy" in quota_section, (
+            "quota deploy path must call _create_default_quota_policy after successful deploy. "
+            "Without this, fine-grained quota mode has no default cap on fresh deployments. "
+            "See issue #440."
+        )
+
+    def test_create_default_quota_policy_method_exists(self):
+        """The _create_default_quota_policy method must exist in deploy.py."""
+        deploy_file = CLI_DIR / "cli" / "commands" / "deploy.py"
+        content = deploy_file.read_text(encoding="utf-8")
+        assert "def _create_default_quota_policy" in content, (
+            "_create_default_quota_policy method removed from deploy.py — "
+            "this breaks fresh fine-grained quota deployments"
+        )
+
+    def test_no_stale_metrics_table_arn_reference(self):
+        """deploy.py must not reference MetricsTableArn (removed in OTLP refactor)."""
+        deploy_file = CLI_DIR / "cli" / "commands" / "deploy.py"
+        content = deploy_file.read_text(encoding="utf-8")
+        assert "MetricsTableArn" not in content, (
+            "deploy.py still references MetricsTableArn which was removed from "
+            "quota-monitoring.yaml in the OTLP architecture refactor"
+        )


### PR DESCRIPTION
Fixes #440

PR #439 accidentally removed the `_create_default_quota_policy` call from the quota deploy path. Fine-grained quota mode requires a default policy row in DynamoDB; without it, new deploys enforce no cap.

**Changes (1 file, +7/-49):**
1. Restore `_create_default_quota_policy()` call after successful quota deploy
2. Remove dead `_update_metrics_aggregator_env` method (the MetricsAggregator Lambda was removed in the OTLP refactor)
3. Remove stale `MetricsTableArn`/`MetricsAggregatorRoleName` from `--show-commands` output (quota-monitoring.yaml no longer declares these parameters)