### PR TITLE
fix: add cowork-dashboard to destroy command

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/destroy.py
+++ b/source/claude_code_with_bedrock/cli/commands/destroy.py
@@ -14,6 +14,20 @@ from claude_code_with_bedrock.cli.utils.cloudformation import CloudFormationMana
 from claude_code_with_bedrock.config import Config
 
 
+# All destroyable stacks in reverse dependency order (destroy-all uses this sequence).
+# Keep in sync with deploy.py's stack types when adding new stacks.
+DESTROYABLE_STACKS = [
+    "analytics",
+    "quota",
+    "cowork-dashboard",
+    "dashboard",
+    "monitoring",
+    "networking",
+    "s3bucket",
+    "auth",
+]
+
+
 class DestroyCommand(Command):
     name = "destroy"
     description = "Remove deployed AWS infrastructure"
@@ -21,7 +35,7 @@ class DestroyCommand(Command):
     arguments = [
         argument(
             "stack",
-            description="Specific stack to destroy (auth/networking/monitoring/dashboard/analytics)",
+            description=f"Specific stack to destroy ({'/'.join(DESTROYABLE_STACKS)})",
             optional=True,
         )
     ]
@@ -64,15 +78,15 @@ class DestroyCommand(Command):
 
         stacks_to_destroy = []
         if stack_arg:
-            if stack_arg in ["auth", "networking", "monitoring", "dashboard", "analytics", "s3bucket", "quota"]:
+            if stack_arg in DESTROYABLE_STACKS:
                 stacks_to_destroy.append(stack_arg)
             else:
                 console.print(f"[red]Unknown stack: {stack_arg}[/red]")
-                console.print("Valid stacks: auth, networking, monitoring, dashboard, analytics, s3bucket, quota")
+                console.print(f"Valid stacks: {', '.join(DESTROYABLE_STACKS)}")
                 return 1
         else:
-            # Destroy all stacks in reverse order
-            stacks_to_destroy = ["analytics", "quota", "dashboard", "monitoring", "networking", "s3bucket", "auth"]
+            # Destroy all stacks in reverse dependency order
+            stacks_to_destroy = list(DESTROYABLE_STACKS)
 
         # Show what will be destroyed
         console.print(

--- a/source/tests/e2e/test_cross_platform.py
+++ b/source/tests/e2e/test_cross_platform.py
@@ -495,3 +495,30 @@ class TestDeployPostHooks:
             "deploy.py still references MetricsTableArn which was removed from "
             "quota-monitoring.yaml in the OTLP architecture refactor"
         )
+
+
+# ---------------------------------------------------------------------------
+# Destroy Command Completeness
+# ---------------------------------------------------------------------------
+
+
+class TestDestroyCommand:
+    """Regression guards for destroy command stack coverage."""
+
+    def test_cowork_dashboard_in_destroyable_stacks(self):
+        """cowork-dashboard must be destroyable (deployed via ccwb deploy cowork-dashboard)."""
+        destroy_file = CLI_DIR / "cli" / "commands" / "destroy.py"
+        content = destroy_file.read_text(encoding="utf-8")
+        assert "cowork-dashboard" in content, (
+            "destroy.py must include cowork-dashboard in DESTROYABLE_STACKS — "
+            "it can be deployed but must also be cleanable. See issue #347."
+        )
+
+    def test_destroyable_stacks_constant_exists(self):
+        """Destroy command must use a DESTROYABLE_STACKS constant (single source of truth)."""
+        destroy_file = CLI_DIR / "cli" / "commands" / "destroy.py"
+        content = destroy_file.read_text(encoding="utf-8")
+        assert "DESTROYABLE_STACKS" in content, (
+            "destroy.py must define DESTROYABLE_STACKS constant to avoid "
+            "forgetting stacks in one list but not the other"
+        )


### PR DESCRIPTION
Fixes #347

`cowork-dashboard` was deployable via `ccwb deploy cowork-dashboard` but missing from the destroy command.

**Changes:**
- Introduce `DESTROYABLE_STACKS` constant (single source of truth for valid destroy targets)
- Use constant for both stack validation and destroy-all sequence
- Add 2 regression guard tests

**Before:** `ccwb destroy cowork-dashboard` → "Unknown stack" error
**After:** Works correctly, also included in `ccwb destroy` (all stacks)