### PR TITLE
fix(windows): guard SO_REUSEADDR to non-Windows + scrub orphaned keyring chunks

### DIFF
--- a/source/credential_provider/__main__.py
+++ b/source/credential_provider/__main__.py
@@ -550,25 +550,27 @@ class MultiProviderAuth:
         # Clear monitoring token from keyring
         try:
             if platform.system() == "Windows":
-                # Chunked format: expire the meta and overwrite every chunk so the
+                # Chunked format: overwrite every chunk and reset the meta so the
                 # real token is not left recoverable. Also clear any legacy entry.
-                meta_json = keyring.get_password("claude-code-with-bedrock", f"{self.profile}-monitoring-meta")
                 cleared_monitoring = False
+                # Reset meta to count:0 BEFORE scrubbing chunks so an interrupted clear
+                # leaves the read gated to None rather than reassembling stale chunks.
+                meta_json = keyring.get_password("claude-code-with-bedrock", f"{self.profile}-monitoring-meta")
                 if meta_json:
-                    try:
-                        count = json.loads(meta_json).get("count", 0)
-                    except Exception:
-                        count = 0
-                    for idx in range(1, count + 1):
-                        entry = f"{self.profile}-monitoring-{idx}"
-                        if keyring.get_password("claude-code-with-bedrock", entry):
-                            keyring.set_password("claude-code-with-bedrock", entry, "EXPIRED")
                     keyring.set_password(
                         "claude-code-with-bedrock",
                         f"{self.profile}-monitoring-meta",
                         json.dumps({"count": 0, "expires": 0, "email": "", "profile": self.profile}),
                     )
                     cleared_monitoring = True
+                # Scan actual chunk entries from index 1 rather than trusting
+                # meta.count: this also scrubs orphans from a larger prior token and
+                # a meta-less set left by a crash mid-save.
+                idx = 1
+                while keyring.get_password("claude-code-with-bedrock", f"{self.profile}-monitoring-{idx}") is not None:
+                    keyring.set_password("claude-code-with-bedrock", f"{self.profile}-monitoring-{idx}", "EXPIRED")
+                    cleared_monitoring = True
+                    idx += 1
                 # Legacy single-entry monitoring token (pre-chunk installs)
                 if keyring.get_password("claude-code-with-bedrock", f"{self.profile}-monitoring"):
                     keyring.set_password(
@@ -728,6 +730,17 @@ class MultiProviderAuth:
                 except Exception:
                     pass
             raise
+
+        # Purge orphaned higher-index chunks left by a previous, larger token so no
+        # plaintext tail survives a shrink. Chunks are written contiguously 1..N, so
+        # scanning until the first gap is safe.
+        try:
+            idx = len(chunks) + 1
+            while keyring.get_password("claude-code-with-bedrock", f"{self.profile}-monitoring-{idx}") is not None:
+                keyring.delete_password("claude-code-with-bedrock", f"{self.profile}-monitoring-{idx}")
+                idx += 1
+        except Exception:
+            pass
 
         # Remove a legacy single-entry monitoring token so stale data can't shadow
         # the chunked entries on read.
@@ -1562,7 +1575,11 @@ class MultiProviderAuth:
             # Keep the socket BOUND (don't close it) so the port is held
             # continuously through authenticate_oidc — see run() for the rationale.
             lock_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            lock_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            # SO_REUSEADDR lets a TIME_WAIT socket be rebound on POSIX (the macOS/Linux
+            # fix from review). On Windows it instead lets a SECOND ACTIVE listener bind
+            # the same port, which would defeat the inter-process port lock — guard it off.
+            if platform.system() != "Windows":
+                lock_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             try:
                 lock_socket.bind(("127.0.0.1", self.redirect_port))
                 self._debug_print("Port available, proceeding with monitoring authentication")
@@ -2179,7 +2196,11 @@ class MultiProviderAuth:
             # continuously through authenticate_oidc — closing it here would open
             # a TOCTOU window for a concurrent credential-process to also auth.
             lock_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            lock_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            # SO_REUSEADDR lets a TIME_WAIT socket be rebound on POSIX (the macOS/Linux
+            # fix from review). On Windows it instead lets a SECOND ACTIVE listener bind
+            # the same port, which would defeat the inter-process port lock — guard it off.
+            if platform.system() != "Windows":
+                lock_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             try:
                 lock_socket.bind(("127.0.0.1", self.redirect_port))
                 self._debug_print("Port available, proceeding with authentication")

--- a/source/tests/test_monitoring_keyring_chunks.py
+++ b/source/tests/test_monitoring_keyring_chunks.py
@@ -1,0 +1,121 @@
+# ABOUTME: Tests for the Windows chunked monitoring-token keyring storage (#427 fix)
+# ABOUTME: Regression coverage for scouturier's PR #429 finding #3 (recoverable orphan chunks)
+"""Tests for Windows monitoring-token chunk hygiene on save and clear.
+
+PR #429 added a chunked Windows keyring format for the monitoring id_token
+({profile}-monitoring-1..N + {profile}-monitoring-meta) to fix #427. scouturier's
+review (finding #3) showed the cleanup paths trust meta.count, so:
+
+  - SAVE of a shorter token leaves higher-index chunks from a prior larger token
+    behind (a recoverable plaintext tail), and
+  - CLEAR only expires 1..meta.count and is gated on meta presence, so a meta-less
+    chunk set (e.g. a crash between the chunk writes and the meta write) is never
+    scrubbed.
+
+These tests pin both behaviors.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+SERVICE = "claude-code-with-bedrock"
+PROFILE = "TestProfile"
+
+
+class FakeKeyring:
+    """In-memory keyring backend keyed by (service, name)."""
+
+    def __init__(self):
+        self.store = {}
+
+    def get_password(self, service, name):
+        return self.store.get((service, name))
+
+    def set_password(self, service, name, value):
+        self.store[(service, name)] = value
+
+    def delete_password(self, service, name):
+        # Real backends raise if absent; callers here only delete when present.
+        self.store.pop((service, name), None)
+
+
+def _entry(name):
+    return (SERVICE, f"{PROFILE}-{name}")
+
+
+@pytest.fixture
+def auth():
+    """A keyring-mode MultiProviderAuth instance with config/storage mocked out."""
+    config = {
+        "provider_domain": "test.okta.com",
+        "client_id": "test-client-id",
+        "identity_pool_id": "us-east-1:test-pool",
+        "aws_region": "us-east-1",
+        "credential_storage": "keyring",
+        "provider_type": "okta",
+        "federation_type": "cognito",
+        "max_session_duration": 28800,
+    }
+    with (
+        patch("credential_provider.__main__.MultiProviderAuth._load_config", return_value=config),
+        patch("credential_provider.__main__.MultiProviderAuth._init_credential_storage"),
+    ):
+        from credential_provider.__main__ import MultiProviderAuth
+
+        instance = MultiProviderAuth(profile=PROFILE)
+        instance.credential_storage = "keyring"
+        return instance
+
+
+@pytest.fixture
+def fake_keyring():
+    fk = FakeKeyring()
+    with patch("credential_provider.__main__.keyring", fk):
+        yield fk
+
+
+def test_save_purges_orphaned_chunks_when_token_shrinks(auth, fake_keyring):
+    """A shorter token must not leave a prior, larger token's tail chunk behind."""
+    big = {"token": "A" * 2500, "expires": 111, "email": "a@example.com", "profile": PROFILE}
+    auth._save_monitoring_keyring_windows(big)
+    # 2500 chars / 1000 -> 3 chunks
+    assert fake_keyring.get_password(*_entry("monitoring-3")) is not None
+    assert fake_keyring.get_password(*_entry("monitoring-meta")) is not None
+
+    small = {"token": "B" * 1500, "expires": 222, "email": "a@example.com", "profile": PROFILE}
+    auth._save_monitoring_keyring_windows(small)
+    # 1500 chars / 1000 -> 2 chunks; the old chunk 3 must be gone, not left holding "AAA...".
+    assert fake_keyring.get_password(*_entry("monitoring-3")) is None
+
+    # And the reassembled token is exactly the new one (no stale tail).
+    assert auth._read_monitoring_keyring_windows()["token"] == "B" * 1500
+
+
+def test_clear_expires_orphaned_chunk_beyond_meta_count(auth, fake_keyring):
+    """clear_cached_credentials must scrub chunks beyond the (stale) meta.count."""
+    fake_keyring.set_password(*_entry("monitoring-1"), "AAA")
+    fake_keyring.set_password(*_entry("monitoring-2"), "BBB")
+    fake_keyring.set_password(*_entry("monitoring-3"), "CCC")  # orphan from a larger prior token
+    fake_keyring.set_password(
+        *_entry("monitoring-meta"),
+        '{"count": 2, "expires": 999, "email": "a@example.com", "profile": "TestProfile"}',
+    )
+
+    with patch("credential_provider.__main__.platform.system", return_value="Windows"):
+        auth.clear_cached_credentials()
+
+    assert fake_keyring.get_password(*_entry("monitoring-3")) == "EXPIRED"
+
+
+def test_clear_scrubs_chunks_when_meta_is_absent(auth, fake_keyring):
+    """A meta-less chunk set (crash between chunk and meta writes) must still be cleared."""
+    fake_keyring.set_password(*_entry("monitoring-1"), "AAA")
+    fake_keyring.set_password(*_entry("monitoring-2"), "BBB")
+    # No -monitoring-meta entry on purpose.
+
+    with patch("credential_provider.__main__.platform.system", return_value="Windows"):
+        auth.clear_cached_credentials()
+
+    assert fake_keyring.get_password(*_entry("monitoring-1")) == "EXPIRED"
+    assert fake_keyring.get_password(*_entry("monitoring-2")) == "EXPIRED"

--- a/source/tests/test_oauth_soreuseaddr_guard.py
+++ b/source/tests/test_oauth_soreuseaddr_guard.py
@@ -1,0 +1,88 @@
+# ABOUTME: Tests that SO_REUSEADDR on the OAuth port-lock socket is guarded to non-Windows
+# ABOUTME: On Windows SO_REUSEADDR lets a 2nd active listener bind the same port (defeats #428 lock)
+"""SO_REUSEADDR must be set on POSIX but NOT on Windows.
+
+PR #429 (merged) added SO_REUSEADDR to the port-lock socket to fix a macOS/Linux
+TIME_WAIT regression, but applied it unconditionally. On Windows SO_REUSEADDR before
+bind() lets a SECOND active listener bind the SAME port, which defeats the
+inter-process port lock (#428) and can reintroduce the cold-start double-browser bug.
+
+These tests pin the platform-conditional behavior at both bind sites:
+run() and authenticate_for_monitoring().
+"""
+
+import errno
+import socket
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import credential_provider.__main__ as cp
+
+
+@pytest.fixture
+def auth():
+    config = {
+        "provider_domain": "test.okta.com",
+        "client_id": "test-client-id",
+        "identity_pool_id": "us-east-1:test-pool",
+        "aws_region": "us-east-1",
+        "credential_storage": "session",
+        "provider_type": "okta",
+        "federation_type": "cognito",
+        "max_session_duration": 28800,
+    }
+    with (
+        patch.object(cp.MultiProviderAuth, "_load_config", return_value=config),
+        patch.object(cp.MultiProviderAuth, "_init_credential_storage"),
+    ):
+        return cp.MultiProviderAuth(profile="TestProfile")
+
+
+def _reuseaddr_was_set(mock_sock):
+    """True if setsockopt(SOL_SOCKET, SO_REUSEADDR, 1) was called on the socket."""
+    for call in mock_sock.setsockopt.call_args_list:
+        if call.args[:3] == (socket.SOL_SOCKET, socket.SO_REUSEADDR, 1):
+            return True
+    return False
+
+
+def _make_lock_socket():
+    """A mock lock socket whose bind() raises EADDRINUSE to short-circuit the flow
+    right after the (guarded) setsockopt call."""
+    mock_sock = MagicMock()
+    mock_sock.bind.side_effect = OSError(errno.EADDRINUSE, "in use")
+    return mock_sock
+
+
+# --- run() bind site ---
+
+
+@pytest.mark.parametrize("system,expected", [("Windows", False), ("Linux", True), ("Darwin", True)])
+def test_run_reuseaddr_guarded_by_platform(auth, system, expected):
+    mock_sock = _make_lock_socket()
+    with (
+        patch.object(cp.platform, "system", return_value=system),
+        patch.object(cp.socket, "socket", return_value=mock_sock),
+        patch.object(auth, "get_cached_credentials", return_value=None),
+        patch.object(auth, "_wait_for_auth_completion", return_value=None),
+        patch("builtins.print"),
+    ):
+        auth.run()
+    assert _reuseaddr_was_set(mock_sock) is expected
+
+
+# --- authenticate_for_monitoring() bind site ---
+
+
+@pytest.mark.parametrize("system,expected", [("Windows", False), ("Linux", True), ("Darwin", True)])
+def test_monitoring_reuseaddr_guarded_by_platform(auth, system, expected):
+    mock_sock = _make_lock_socket()
+    with (
+        patch.object(cp.platform, "system", return_value=system),
+        patch.object(cp.socket, "socket", return_value=mock_sock),
+        patch.object(auth, "_wait_for_auth_completion", return_value=None),
+        patch.object(auth, "get_monitoring_token", return_value=None),
+    ):
+        auth.authenticate_for_monitoring()
+    assert _reuseaddr_was_set(mock_sock) is expected


### PR DESCRIPTION
## Description

Follow-up to the [#429](https://github.com/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock/pull/429) review by @scouturier. #429 merged @wirjo's fix for the `SO_REUSEADDR` finding, but applied the option **unconditionally**; and the keyring orphan-chunk finding was not addressed. This PR fixes both, each with a reproduce-first regression test.

`Related: #427 #428` (both closed by #429 — this hardens the fixes that landed there).

## Why this change is needed

**1. Unconditional `SO_REUSEADDR` re-opens the #428 port-lock race on Windows.**

#429 added `lock_socket.setsockopt(SO_REUSEADDR, 1)` before `bind()` at both port-lock sites to fix a macOS/Linux `TIME_WAIT` regression. That fix is correct on POSIX, but the flag has **different semantics on Windows**: `SO_REUSEADDR` there lets a *second active listener* bind a port that is already actively bound. Since #428's inter-process lock relies on the second `credential-process` failing to bind the port, the unconditional flag lets both processes pass the lock check — reintroducing the cold-start double-browser / `ERR_CONNECTION_REFUSED` bug #428 fixed.

Verified empirically on both platforms:

| | Windows 11 | macOS 26.5 |
|---|---|---|
| Two active listeners bind same port, `SO_REUSEADDR` on | **second bind SUCCEEDS** (lock defeated) | second bind FAILS, `EADDRINUSE` (lock holds) |

So the flag must be guarded to non-Windows. I also confirmed against the real code path (a two-thread bind race driving `authenticate_for_monitoring`) that with the guard in place, a second process's lock-check bind gets `EADDRINUSE` on Windows — i.e. the #428 lock holds again.

**2. Windows monitoring-token chunk cleanup trusts `meta.count`, leaving recoverable plaintext.**

The chunked Windows keyring store added for #427 (`{profile}-monitoring-1..N` + `-meta`) cleaned up by trusting `meta.count`. Two gaps:

- **Shrink orphan:** saving a token that splits into fewer chunks than a prior, larger token (Azure id_token size varies with optional/group claims) overwrote only `1..len(new)` and left the higher-index chunk(s) holding the previous token's plaintext tail.
- **Meta-less clear:** `clear_cached_credentials` looped `range(1, count+1)` *and* was gated on `if meta_json:`. Because save writes the chunks first and the meta last (and rollback only runs on a caught exception), a crash between those writes leaves chunks with no meta — and the old clear was then a no-op, leaving the full live id_token readable while reporting success.

The read guard reads exactly `meta.count` chunks, so an orphan is never reassembled into a usable token — this is an at-rest residual-plaintext exposure within the user's DPAPI-protected Credential Manager, contradicting the code's own "not left recoverable" comment.

## Changes Made

- **`credential_provider/__main__.py`**
  - `authenticate_for_monitoring` / `run`: guard the `SO_REUSEADDR` setsockopt behind `platform.system() != "Windows"` (keeps the POSIX `TIME_WAIT` fix, removes the Windows lock-defeat).
  - `_save_monitoring_keyring_windows`: after the writes, purge orphaned `-monitoring-{len+1..}` chunks (scan to the first gap; chunks are written contiguously so this is safe).
  - `clear_cached_credentials` (Windows branch): reset the meta to `count:0` **first** (so an interrupted clear gates the read to `None` rather than reassembling stale chunks), then scrub `-monitoring-{1..}` from index 1 to the first gap, **regardless of whether the meta entry exists** (covers both the orphan-beyond-count and meta-less cases).
- **Tests (reproduce-first, red → green)**
  - `tests/test_oauth_soreuseaddr_guard.py`: asserts `SO_REUSEADDR` is set on Linux/Darwin and **not** on Windows, at both bind sites.
  - `tests/test_monitoring_keyring_chunks.py`: shrink-orphan on save, orphan beyond `meta.count` on clear, and meta-less chunk set on clear.

The orphaned-OAuth-socket finding (#2 in @scouturier's review) already shipped in #429 (`server.socket.close()`), so it is not touched here.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- New tests: 9 passed (6 SO_REUSEADDR platform-guard + 3 keyring chunk).
- Chunk hygiene additionally verified against the **real Windows Credential Manager** (shrink / beyond-count / meta-less: all scrubbed).
- Port-lock-holds-on-Windows verified against the real code path (two-thread bind race → `EADDRINUSE`).
- `ruff` / `black` / `mypy`: 0 net-new findings vs `beta`. Full suite: 0 net-new failures (pre-existing `beta` failures unchanged).

**AWS Region:** ap-southeast-2 · **Python:** 3.12 · **OS:** Windows 11 (+ macOS 26.5 for the cross-platform `SO_REUSEADDR` check)
