### PR TITLE
fix(test): set USERPROFILE so otel cache tests pass on Windows

### DIFF
--- a/source/tests/test_otel_jwt_expiry.py
+++ b/source/tests/test_otel_jwt_expiry.py
@@ -25,7 +25,10 @@ def mock_cache_dir(tmp_path):
 @pytest.fixture
 def mock_cache_file(mock_cache_dir, monkeypatch):
     """Mock the cache file path to use temporary directory."""
+    # Path.home() reads HOME on POSIX but USERPROFILE on Windows, so set both
+    # to keep the otel-helper's cache dir pointed at the temp dir on every OS.
     monkeypatch.setenv("HOME", str(mock_cache_dir.parent))
+    monkeypatch.setenv("USERPROFILE", str(mock_cache_dir.parent))
     monkeypatch.setenv("AWS_PROFILE", "test-profile")
     cache_path = mock_cache_dir / "test-profile-otel-headers.json"
     return cache_path


### PR DESCRIPTION
## Summary

Fixes 3 Windows-only test failures in `tests/test_otel_jwt_expiry.py` that block the (now-required) Windows CI job on `beta`.

## Root cause

The `mock_cache_file` fixture redirects the otel-helper's cache directory to a temp path by setting `HOME`:

```python
monkeypatch.setenv("HOME", str(mock_cache_dir.parent))
```

But the helper computes its cache dir with `Path.home()` (`otel_helper/__main__.py:244,781`), and **`Path.home()` reads `HOME` on POSIX but `USERPROFILE` on Windows**. On the Windows runner the helper therefore looked at the real home directory instead of the temp dir, so:

- `test_read_cached_headers_with_valid_token` — `read_cached_headers()` returned `None`
- `test_write_cached_headers_includes_token_exp` — the cache file wasn't where the test looked
- `test_main_refreshes_expired_cache` — credential-process was never invoked

The otel-helper code is correct (`Path.home()` is the right cross-platform call); only the test fixture mocked the wrong env var.

## Fix

Set `USERPROFILE` alongside `HOME` in the fixture so the redirect works on every OS. One line, test-only — no change to otel-helper behavior.

## Notes

- The bug has existed since the test was introduced (2026-05-10, commit `ec26017`); it only surfaced now that PR #449 made the Windows test job blocking.
- This is failing on `beta` itself, so it currently blocks every PR branched from beta.
- Verified locally on macOS: 9/9 pass. Windows is verified by this PR's CI run.
