### PR TITLE
fix: guard config['okta'] access when SSO authentication is disabled (#430)

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1748,24 +1748,31 @@ class InitCommand(Command):
         table.add_column("Setting", style="white", no_wrap=True)
         table.add_column("Value", style="green")
 
-        table.add_row("OIDC Provider", config["okta"]["domain"])
-        table.add_row(
-            "OIDC Client ID",
-            (
-                config["okta"]["client_id"][:20] + "..."
-                if len(config["okta"]["client_id"]) > 20
-                else config["okta"]["client_id"]
-            ),
-        )
+        sso_enabled = config.get("sso_enabled", True)
+        if sso_enabled:
+            okta_config = config.get("okta", {})
+            okta_domain = okta_config.get("domain", "")
+            okta_client_id = okta_config.get("client_id", "")
+            table.add_row("OIDC Provider", okta_domain or "—")
+            table.add_row(
+                "OIDC Client ID",
+                (
+                    okta_client_id[:20] + "..."
+                    if len(okta_client_id) > 20
+                    else (okta_client_id or "—")
+                ),
+            )
 
-        table.add_row(
-            "Credential Storage",
-            (
-                "Keyring (OS secure storage)"
-                if config.get("credential_storage") == "keyring"
-                else "Session Files (temporary)"
-            ),
-        )
+            table.add_row(
+                "Credential Storage",
+                (
+                    "Keyring (OS secure storage)"
+                    if config.get("credential_storage") == "keyring"
+                    else "Session Files (temporary)"
+                ),
+            )
+        else:
+            table.add_row("SSO Authentication", "Disabled (IAM credentials used)")
         table.add_row("Infrastructure Region", f"{config['aws']['region']} (Cognito, IAM, Monitoring)")
         table.add_row("Identity Pool", config["aws"]["identity_pool_name"])
         table.add_row("Monitoring", "✓ Enabled" if config["monitoring"]["enabled"] else "✗ Disabled")
@@ -2183,9 +2190,12 @@ class InitCommand(Command):
             params = []
 
         # Update with our values
+        sso_enabled = config.get("sso_enabled", True)
+        okta_domain = config.get("okta", {}).get("domain", "none") if sso_enabled else "none"
+        okta_client_id = config.get("okta", {}).get("client_id", "none") if sso_enabled else "none"
         param_map = {
-            "OktaDomain": config["okta"]["domain"],
-            "OktaClientId": config["okta"]["client_id"],
+            "OktaDomain": okta_domain,
+            "OktaClientId": okta_client_id,
             "IdentityPoolName": config["aws"]["identity_pool_name"],
             "AllowedBedrockRegions": ",".join(config["aws"]["allowed_bedrock_regions"]),
             "EnableMonitoring": "true" if config["monitoring"]["enabled"] else "false",
@@ -2468,7 +2478,10 @@ class InitCommand(Command):
         """Show summary of existing deployment."""
         console = Console()
 
-        console.print(f"• OIDC Provider: [cyan]{config['okta']['domain']}[/cyan]")
+        if config.get("sso_enabled", True) and "okta" in config and "domain" in config["okta"]:
+            console.print(f"• OIDC Provider: [cyan]{config['okta']['domain']}[/cyan]")
+        else:
+            console.print("• SSO Authentication: [cyan]Disabled (IAM credentials used)[/cyan]")
 
         # Show Cognito-specific fields if using Cognito User Pool
         if "cognito_user_pool_id" in config:

--- a/source/tests/cli/commands/test_init.py
+++ b/source/tests/cli/commands/test_init.py
@@ -425,6 +425,196 @@ class TestNamedFunctionsIntegration:
         assert callable(init_module.validate_cognito_user_pool_id)
 
 
+class TestSsoDisabledRendering:
+    """Regression tests for issue #430.
+
+    Ensure the wizard does not crash with KeyError: 'okta' when SSO is
+    disabled. The okta key is only populated by the OIDC flow, so methods
+    that render or persist it must guard against its absence.
+    """
+
+    @pytest.fixture
+    def cmd(self):
+        from claude_code_with_bedrock.cli.commands.init import InitCommand
+        return InitCommand()
+
+    @pytest.fixture
+    def base_aws(self):
+        return {
+            "region": "us-east-1",
+            "identity_pool_name": "demo-pool",
+            "allowed_bedrock_regions": ["us-east-1"],
+            "stacks": {},
+        }
+
+    def test_review_configuration_without_okta_key_does_not_raise(self, cmd, base_aws):
+        config = {
+            "sso_enabled": False,
+            "credential_storage": "session",
+            "aws": base_aws,
+            "monitoring": {"enabled": False},
+        }
+        # Must not raise KeyError: 'okta'
+        assert cmd._review_configuration(config) is True
+
+    def test_review_configuration_sso_enabled_still_renders_okta(self, cmd, base_aws):
+        config = {
+            "sso_enabled": True,
+            "okta": {"domain": "company.okta.com", "client_id": "abcdef1234567890abcdef"},
+            "credential_storage": "keyring",
+            "aws": base_aws,
+            "monitoring": {"enabled": False},
+        }
+        assert cmd._review_configuration(config) is True
+
+    def test_show_existing_deployment_without_okta_key_does_not_raise(self, cmd, base_aws):
+        config = {
+            "sso_enabled": False,
+            "aws": base_aws,
+            "monitoring": {"enabled": False},
+        }
+        # Must not raise KeyError: 'okta'
+        cmd._show_existing_deployment(config)
+
+    def test_update_parameters_file_without_okta_key_writes_none(self, cmd, base_aws, tmp_path):
+        import json
+
+        params_file = tmp_path / "params.json"
+        config = {
+            "sso_enabled": False,
+            "aws": base_aws,
+            "monitoring": {"enabled": False},
+        }
+        cmd._update_parameters_file(params_file, config)
+
+        with open(params_file) as f:
+            params = json.load(f)
+        param_map = {p["ParameterKey"]: p["ParameterValue"] for p in params}
+        assert param_map["OktaDomain"] == "none"
+        assert param_map["OktaClientId"] == "none"
+
+    def test_review_configuration_with_empty_okta_dict_does_not_raise(self, cmd, base_aws):
+        """Edge case: SSO enabled but the user cancelled before entering a domain.
+
+        Config can end up with `okta: {}`. The defensive .get() chain must
+        handle this without raising KeyError on missing 'domain' / 'client_id'.
+        """
+        config = {
+            "sso_enabled": True,
+            "okta": {},  # OIDC flow started but cancelled before fields were set
+            "credential_storage": "session",
+            "aws": base_aws,
+            "monitoring": {"enabled": False},
+        }
+        assert cmd._review_configuration(config) is True
+
+    def test_save_configuration_sso_disabled_creates_profile(self, cmd, base_aws, tmp_path):
+        """_save_configuration must create a valid Profile when SSO is disabled.
+
+        The Profile dataclass has required fields (provider_domain, client_id)
+        that must be populated with sensible defaults when no OIDC flow ran.
+        """
+        import json
+        from unittest.mock import patch
+        from claude_code_with_bedrock.config import Config
+
+        config_data = {
+            "sso_enabled": False,
+            "aws": {
+                **base_aws,
+                "cross_region_profile": "us",
+                "selected_model": None,
+            },
+            "monitoring": {"enabled": False},
+            "credential_storage": "session",
+        }
+
+        config_dir = tmp_path / ".ccwb"
+        config_dir.mkdir()
+        profiles_dir = config_dir / "profiles"
+        profiles_dir.mkdir()
+        config_file = config_dir / "config.json"
+        config_file.write_text(json.dumps({"schema_version": "2.0", "active_profile": None}))
+
+        with patch.object(Config, "CONFIG_DIR", config_dir), \
+             patch.object(Config, "CONFIG_FILE", config_file), \
+             patch.object(Config, "PROFILES_DIR", profiles_dir):
+            # Must not raise KeyError or TypeError
+            cmd._save_configuration(config_data, "test-no-sso")
+
+            # Verify the saved profile has sensible defaults
+            profile_file = profiles_dir / "test-no-sso.json"
+            assert profile_file.exists()
+            saved = json.loads(profile_file.read_text())
+            assert saved["provider_domain"] == "none"
+            assert saved["client_id"] == "none"
+            assert saved["sso_enabled"] is False
+
+    def test_save_configuration_round_trip_preserves_sso_enabled(self, cmd, base_aws, tmp_path):
+        """A profile saved with sso_enabled=False must reload with sso_enabled=False.
+
+        Regression guard: if the field isn't persisted, re-running ccwb init
+        on an existing deployment could flip sso_enabled back to True (the default),
+        which would re-enable the auth stack and break the deployment.
+        """
+        import json
+        from unittest.mock import patch
+        from claude_code_with_bedrock.config import Config
+
+        config_data = {
+            "sso_enabled": False,
+            "aws": {
+                **base_aws,
+                "cross_region_profile": "us",
+                "selected_model": None,
+            },
+            "monitoring": {"enabled": False},
+            "credential_storage": "session",
+        }
+
+        config_dir = tmp_path / ".ccwb"
+        config_dir.mkdir()
+        profiles_dir = config_dir / "profiles"
+        profiles_dir.mkdir()
+        config_file = config_dir / "config.json"
+        config_file.write_text(json.dumps({"schema_version": "2.0", "active_profile": "test-roundtrip"}))
+
+        with patch.object(Config, "CONFIG_DIR", config_dir), \
+             patch.object(Config, "CONFIG_FILE", config_file), \
+             patch.object(Config, "PROFILES_DIR", profiles_dir):
+            cmd._save_configuration(config_data, "test-roundtrip")
+
+            # Reload from disk
+            reloaded = Config.load()
+            profile = reloaded.get_profile("test-roundtrip")
+            assert profile is not None
+            assert profile.sso_enabled is False
+            assert profile.provider_domain == "none"
+
+    def test_update_parameters_file_sso_enabled_uses_real_values(self, cmd, base_aws, tmp_path):
+        """When SSO is enabled, OktaDomain/OktaClientId must use real values (not 'none').
+
+        Prevents a regression where the sso_enabled guard is inverted or
+        the .get() chain defaults mask a real configuration.
+        """
+        import json
+
+        params_file = tmp_path / "params.json"
+        config = {
+            "sso_enabled": True,
+            "okta": {"domain": "company.okta.com", "client_id": "abc123xyz"},
+            "aws": base_aws,
+            "monitoring": {"enabled": False},
+        }
+        cmd._update_parameters_file(params_file, config)
+
+        with open(params_file) as f:
+            params = json.load(f)
+        param_map = {p["ParameterKey"]: p["ParameterValue"] for p in params}
+        assert param_map["OktaDomain"] == "company.okta.com"
+        assert param_map["OktaClientId"] == "abc123xyz"
+
+
 if __name__ == "__main__":
     # Run the tests
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Why

`ccwb init` crashes with `KeyError: 'okta'` at Step 4 (Review Configuration) when the user selects "No" for SSO authentication. This breaks the documented "Deploy Without SSO" flow for IAM Identity Center users.

Root cause: three methods in init.py access `config["okta"]["domain"]` and `config["okta"]["client_id"]` directly, but the `okta` key is only populated during the OIDC provider setup flow (which is skipped when SSO is disabled).

Fixes #430

## Changes

- Guard `_review_configuration`, `_update_parameters_file`, and `_show_existing_deployment` to use `.get()` with fallback when `sso_enabled=False` or `okta` key is absent
- When SSO disabled: render "SSO Authentication: Disabled" instead of blank/crash
- When SSO disabled: write `OktaDomain=none` / `OktaClientId=none` to params file (matches deploy.py expectations)
- `_save_configuration` already handled by existing defensive pattern

## Tests (8 regression tests)

1. `test_review_configuration_without_okta_key_does_not_raise` — no crash when okta key missing
2. `test_review_configuration_sso_enabled_still_renders_okta` — SSO-on path still works
3. `test_show_existing_deployment_without_okta_key_does_not_raise` — summary view safe
4. `test_update_parameters_file_without_okta_key_writes_none` — params get "none" defaults
5. `test_review_configuration_with_empty_okta_dict_does_not_raise` — cancelled mid-flow edge case
6. `test_save_configuration_sso_disabled_creates_profile` — Profile created with correct defaults
7. `test_save_configuration_round_trip_preserves_sso_enabled` — flag survives save/reload
8. `test_update_parameters_file_sso_enabled_uses_real_values` — SSO-on uses real values (not "none")

## Result

```
414 passed, 4 skipped, 0 failures
```

Credit: original fix by @AwsPascal (PR #431), additional regression tests added.