### PR TITLE
fix: include Bearer token in otel-helper output for ALB JWT validation

### DIFF
--- a/source/go/cmd/otel-helper/main.go
+++ b/source/go/cmd/otel-helper/main.go
@@ -73,6 +73,13 @@ func run(testMode bool) int {
 		headers, err := otel.ReadCachedHeaders(profile)
 		if err == nil && headers != nil {
 			debugPrint("Using cached OTEL headers (token still valid)")
+			// Resolve a Bearer token for ALB JWT validation.
+			// Try env var (free) then credential-process cache (fast ~20ms).
+			if t := os.Getenv("CLAUDE_CODE_MONITORING_TOKEN"); t != "" {
+				headers["authorization"] = "Bearer " + t
+			} else if t, err := getTokenViaCredentialProcess(profile); err == nil && t != "" {
+				headers["authorization"] = "Bearer " + t
+			}
 			outputJSON(headers)
 			return 0
 		}
@@ -119,9 +126,13 @@ func run(testMode bool) int {
 	headers := otel.FormatHeaders(userInfo)
 
 	if testMode {
+		// Include bearer in test output for visibility
+		headers["authorization"] = "Bearer " + token
 		printTestOutput(userInfo, headers)
 	} else {
-		// Cache headers for future calls
+		// Cache attribution headers only — never persist the Bearer token to disk.
+		// The token is sensitive and the cache file has weaker protection than
+		// the keyring/credential-process chain that issued it.
 		tokenExp := int64(claims.GetFloat("exp"))
 		if tokenExp > 0 {
 			if err := otel.WriteCachedHeaders(profile, headers, tokenExp); err != nil {
@@ -130,6 +141,11 @@ func run(testMode bool) int {
 		} else {
 			debugPrint("JWT has no exp claim, skipping cache write")
 		}
+
+		// Add Bearer token AFTER cache write — output only, never persisted.
+		// This enables ALB JWT validation (PR #129 / issue #126) while keeping
+		// the sensitive token out of the plaintext cache file.
+		headers["authorization"] = "Bearer " + token
 		outputJSON(headers)
 	}
 

--- a/source/go/cmd/otel-helper/main_test.go
+++ b/source/go/cmd/otel-helper/main_test.go
@@ -155,3 +155,189 @@ func TestRun_PopulatedExpiredEntry_ServedNotRewritten(t *testing.T) {
 			entry.Headers["x-user-email"], string(data))
 	}
 }
+
+// TestRun_WithToken_IncludesBearerHeader verifies that when a valid JWT token
+// is available, the output includes an "authorization" header with Bearer prefix
+// for ALB JWT validation (issue #126, PR #129).
+func TestRun_WithToken_IncludesBearerHeader(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+	t.Setenv("AWS_PROFILE", "ClaudeCode")
+
+	// Create a minimal valid JWT with email claim and future exp.
+	// Header: {"alg":"none","typ":"JWT"}
+	// Payload: {"email":"test@example.com","exp":9999999999,"sub":"user123"}
+	header := "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0"
+	payload := "eyJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJleHAiOjk5OTk5OTk5OTksInN1YiI6InVzZXIxMjMifQ"
+	sig := ""
+	token := header + "." + payload + "." + sig
+
+	t.Setenv("CLAUDE_CODE_MONITORING_TOKEN", token)
+
+	// Capture stdout
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	code := run(false)
+
+	w.Close()
+	os.Stdout = old
+
+	if code != 0 {
+		t.Fatalf("run() exit code = %d, want 0", code)
+	}
+
+	var buf [4096]byte
+	n, _ := r.Read(buf[:])
+	output := string(buf[:n])
+
+	var headers map[string]string
+	if err := json.Unmarshal([]byte(output), &headers); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, output)
+	}
+
+	auth, ok := headers["authorization"]
+	if !ok {
+		t.Fatal("output must include 'authorization' header for ALB JWT validation")
+	}
+	if auth != "Bearer "+token {
+		t.Errorf("authorization = %q, want 'Bearer %s'", auth, token)
+	}
+
+	// Also verify attribution headers are present
+	if headers["x-user-email"] != "test@example.com" {
+		t.Errorf("x-user-email = %q, want 'test@example.com'", headers["x-user-email"])
+	}
+}
+
+// TestRun_NoToken_NoBearerInOutput verifies that when no token is available,
+// the empty-headers output does NOT contain an "authorization" key. Sending
+// "Bearer " (empty) would be worse than sending nothing.
+func TestRun_NoToken_NoBearerInOutput(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+	t.Setenv("AWS_PROFILE", "ClaudeCode")
+	t.Setenv("CLAUDE_CODE_MONITORING_TOKEN", "")
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	run(false)
+
+	w.Close()
+	os.Stdout = old
+
+	var buf [4096]byte
+	n, _ := r.Read(buf[:])
+	output := string(buf[:n])
+
+	var headers map[string]string
+	if err := json.Unmarshal([]byte(output), &headers); err != nil {
+		t.Fatalf("output not valid JSON: %v", err)
+	}
+	if _, ok := headers["authorization"]; ok {
+		t.Error("empty-headers output must NOT contain 'authorization' key")
+	}
+}
+
+// TestRun_BearerTokenNotInCacheFile verifies that the sensitive Bearer token
+// is never persisted to the cache file on disk — only attribution headers
+// (x-user-email, etc.) should be cached.
+func TestRun_BearerTokenNotInCacheFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+	t.Setenv("AWS_PROFILE", "ClaudeCode")
+
+	// Valid JWT with future exp
+	header := "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0"
+	payload := "eyJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJleHAiOjk5OTk5OTk5OTksInN1YiI6InVzZXIxMjMifQ"
+	token := header + "." + payload + "."
+	t.Setenv("CLAUDE_CODE_MONITORING_TOKEN", token)
+
+	// Suppress stdout
+	old := os.Stdout
+	_, w, _ := os.Pipe()
+	os.Stdout = w
+	run(false)
+	w.Close()
+	os.Stdout = old
+
+	// Read the cache file
+	cachePath := filepath.Join(tmpDir, ".claude-code-session", "ClaudeCode-otel-headers.json")
+	data, err := os.ReadFile(cachePath)
+	if err != nil {
+		t.Fatalf("cache file should exist: %v", err)
+	}
+
+	// Verify no Bearer token in cache
+	var entry struct {
+		Headers map[string]string `json:"headers"`
+	}
+	if err := json.Unmarshal(data, &entry); err != nil {
+		t.Fatalf("cache not valid JSON: %v", err)
+	}
+	if _, ok := entry.Headers["authorization"]; ok {
+		t.Error("cache file must NOT contain 'authorization' — Bearer token should only be in stdout output")
+	}
+	// But attribution headers should be cached
+	if entry.Headers["x-user-email"] != "test@example.com" {
+		t.Errorf("cache should contain attribution: x-user-email = %q", entry.Headers["x-user-email"])
+	}
+}
+
+// TestRun_CacheHit_ResolvesTokenFromEnv verifies that when Layer 1 serves
+// cached headers, the output still includes a Bearer token (resolved from
+// the environment variable) for ALB JWT validation.
+func TestRun_CacheHit_ResolvesTokenFromEnv(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+	t.Setenv("AWS_PROFILE", "ClaudeCode")
+
+	// Seed cache with valid attribution headers (far-future exp)
+	cacheDir := filepath.Join(tmpDir, ".claude-code-session")
+	os.MkdirAll(cacheDir, 0700)
+	cachePath := filepath.Join(cacheDir, "ClaudeCode-otel-headers.json")
+	cache := `{"schema_version":2,"headers":{"x-user-email":"cached@user.com"},"token_exp":9999999999,"cached_at":1000}`
+	os.WriteFile(cachePath, []byte(cache), 0600)
+
+	// Set env token for Layer 1 to resolve
+	envToken := "eyJhbGciOiJub25lIn0.eyJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJleHAiOjk5OTk5OTk5OTl9."
+	t.Setenv("CLAUDE_CODE_MONITORING_TOKEN", envToken)
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	code := run(false)
+
+	w.Close()
+	os.Stdout = old
+
+	if code != 0 {
+		t.Fatalf("run() exit code = %d, want 0", code)
+	}
+
+	var buf [8192]byte
+	n, _ := r.Read(buf[:])
+	output := string(buf[:n])
+
+	var headers map[string]string
+	if err := json.Unmarshal([]byte(output), &headers); err != nil {
+		t.Fatalf("output not valid JSON: %v\noutput: %s", err, output)
+	}
+
+	// Should have cached attribution
+	if headers["x-user-email"] != "cached@user.com" {
+		t.Errorf("x-user-email = %q, want 'cached@user.com'", headers["x-user-email"])
+	}
+	// Should also have Bearer from env
+	if headers["authorization"] != "Bearer "+envToken {
+		t.Errorf("authorization = %q, want 'Bearer %s'", headers["authorization"], envToken)
+	}
+}

--- a/source/otel_helper/__main__.py
+++ b/source/otel_helper/__main__.py
@@ -653,7 +653,14 @@ def run_proxy(target_url: str, port: int = 4318):
             caller_identity = get_aws_caller_identity()
             user_info = create_anonymous_user_info(caller_identity)
 
-        return format_as_headers_dict(user_info)
+        headers = format_as_headers_dict(user_info)
+
+        # Include Bearer token for ALB JWT validation.
+        # The proxy forwards to the remote ALB which may have jwt-validation enabled.
+        if token:
+            headers["authorization"] = f"Bearer {token}"
+
+        return headers
 
     # Pre-fetch headers once at startup; refresh on each request so token
     # rotations are picked up without restarting the proxy.
@@ -886,7 +893,7 @@ def main():
             print("\n========================")
         else:
             # Normal mode: Output as JSON (flat object with string values)
-            # Cache headers for future calls (avoids credential-process on next invocation)
+            # Cache attribution headers only — never persist Bearer token to disk.
             if token:
                 token_exp = payload.get("exp")
                 if token_exp:
@@ -896,6 +903,13 @@ def main():
             else:
                 # Anonymous mode: cache with a synthetic TTL (5 minutes)
                 write_cached_headers(headers_dict, int(time.time()) + _STS_CACHE_TTL_SECONDS)
+
+            # Add Bearer token AFTER cache write — output only, never persisted.
+            # Enables ALB JWT validation (PR #129 / issue #126) while keeping
+            # the sensitive token out of the plaintext cache file.
+            if token:
+                headers_dict["authorization"] = f"Bearer {token}"
+
             print(json.dumps(headers_dict))
 
         if DEBUG_MODE or TEST_MODE:

--- a/source/tests/e2e/test_cross_platform.py
+++ b/source/tests/e2e/test_cross_platform.py
@@ -654,3 +654,94 @@ class TestProfilePreservation:
             "init.py wizard_fields must include model_alias so it's preserved "
             "when re-running ccwb init (added in PR #278)"
         )
+# Server/Client Auth Contract Alignment
+# ---------------------------------------------------------------------------
+
+GO_OTEL_HELPER = SOURCE_ROOT / "go" / "cmd" / "otel-helper" / "main.go"
+PY_OTEL_HELPER = SOURCE_ROOT / "otel_helper" / "__main__.py"
+
+
+class TestAuthContractAlignment:
+    """Static analysis guards for server/client authentication contracts.
+
+    Prevents the class of bug where server-side auth is added (e.g. ALB JWT
+    validation) without the corresponding client-side implementation (e.g.
+    otel-helper outputting a Bearer token). These mismatches cause silent
+    failures that are hard to diagnose in production.
+
+    Bugs this prevents:
+    - PR #129: ALB JWT validation added but otel-helper never sent Bearer token
+    """
+
+    def test_alb_jwt_auth_has_go_helper_bearer_output(self):
+        """If otel-collector.yaml has jwt-validation, Go otel-helper must output authorization header."""
+        template = DEPLOYMENT_DIR / "otel-collector.yaml"
+        content = template.read_text(encoding="utf-8")
+
+        if "jwt-validation" not in content:
+            pytest.skip("No JWT validation configured in otel-collector.yaml")
+
+        helper_code = GO_OTEL_HELPER.read_text(encoding="utf-8")
+        assert '"authorization"' in helper_code, (
+            "otel-collector.yaml has jwt-validation action but Go otel-helper "
+            "does not output an 'authorization' header. "
+            "Server/client auth contract mismatch — ALB will reject all OTLP requests. "
+            "See issue #126, PR #129."
+        )
+
+    def test_alb_jwt_auth_has_python_helper_bearer_output(self):
+        """If otel-collector.yaml has jwt-validation, Python otel-helper must output authorization header."""
+        template = DEPLOYMENT_DIR / "otel-collector.yaml"
+        content = template.read_text(encoding="utf-8")
+
+        if "jwt-validation" not in content:
+            pytest.skip("No JWT validation configured in otel-collector.yaml")
+
+        helper_code = PY_OTEL_HELPER.read_text(encoding="utf-8")
+        assert '"authorization"' in helper_code or "'authorization'" in helper_code, (
+            "otel-collector.yaml has jwt-validation action but Python otel-helper "
+            "does not output an 'authorization' header. "
+            "Server/client auth contract mismatch — ALB will reject all OTLP requests. "
+            "See issue #126, PR #129."
+        )
+
+    def test_bearer_token_not_in_cache_write(self):
+        """otel-helper must NOT persist Bearer tokens to the cache file.
+
+        The cache stores attribution headers (x-user-*) which are low-sensitivity.
+        Bearer tokens are high-sensitivity credentials that should only exist in
+        process memory and stdout output, never in plaintext files on disk.
+        """
+        helper_code = GO_OTEL_HELPER.read_text(encoding="utf-8")
+        lines = helper_code.splitlines()
+
+        # In the main auth flow (not Layer 1 cache hit), WriteCachedHeaders
+        # must appear BEFORE the authorization header is added to output.
+        # Look for the pattern: WriteCachedHeaders(profile, headers, ...)
+        # followed later by headers["authorization"] = "Bearer " + token
+        # and then outputJSON(headers)
+        main_cache_write_line = None
+        main_auth_line = None
+        in_main_flow = False
+
+        for i, line in enumerate(lines):
+            # The main flow starts after "Cache attribution headers only"
+            if "Cache attribution headers only" in line:
+                in_main_flow = True
+            if in_main_flow:
+                if "WriteCachedHeaders" in line and main_cache_write_line is None:
+                    main_cache_write_line = i
+                if '"authorization"' in line and "Bearer" in line and main_auth_line is None:
+                    main_auth_line = i
+
+        assert main_cache_write_line is not None, (
+            "Expected 'WriteCachedHeaders' in main auth flow of otel-helper"
+        )
+        assert main_auth_line is not None, (
+            "Expected authorization header assignment in main auth flow of otel-helper"
+        )
+        assert main_cache_write_line < main_auth_line, (
+            f"Bearer token (line {main_auth_line}) must be added AFTER "
+            f"WriteCachedHeaders (line {main_cache_write_line}) — "
+            f"sensitive tokens must never be persisted to the cache file on disk."
+        )


### PR DESCRIPTION
## Problem

PR #129 added ALB JWT validation for the OTEL collector HTTPS endpoint, but the **client-side was never implemented** — neither the Go nor Python otel-helper included the `Authorization: Bearer <token>` header in their output. Since Claude Code sends all otel-helper output headers on OTLP requests, the ALB rejects every telemetry submission with `target_status_code: -` and `classification_reason: JWTHeaderNotPresent` when JWT validation is enabled.

**Impact:** Any deployment with HTTPS + `OidcIssuerUrl` configured on the monitoring stack has completely broken telemetry collection.

## Root Cause

The otel-helper already fetches the monitoring token (id_token) and uses it to extract user claims (`x-user-email`, etc.), but it never passed the token itself as an `authorization` header. The ALB's `jwt-validation` action looks for `Authorization: Bearer <token>` — which was never sent.

## Fix

Include the Bearer token in otel-helper output, covering all OTLP client paths:

| Path | How it reaches the ALB | Fix |
|---|---|---|
| **Claude Code CLI** | otel-helper output → OTEL SDK attaches headers → POST to ALB | Go + Python helper: add `authorization: Bearer <token>` to stdout output |
| **CoWork proxy mode** | CoWork → localhost:4318 proxy → forwards to remote ALB | Proxy's `get_user_headers()` now includes Bearer when forwarding |
| **Sidecar (local collector)** | Claude Code → localhost:4318 → CloudWatch directly | No ALB in path — not affected, no change needed |

## Security: Token never persisted to disk

The Bearer token is added to output AFTER the cache write — never stored in the plaintext cache file (`~/.claude-code-session/{profile}-otel-headers.json`). The cache only contains low-sensitivity attribution headers (`x-user-email`, etc.).

For the Layer 1 cache hit path (where cached attribution headers are served), the token is resolved fresh from `CLAUDE_CODE_MONITORING_TOKEN` env var (free) or credential-process `--get-monitoring-token` (fast, ~20ms).

## Token lifecycle

| Step | What happens |
|---|---|
| Cache hit (Layer 1) | Serve cached attribution + resolve fresh Bearer from env/credential-process |
| Cache miss | Full token fetch → extract claims → cache attribution → add Bearer to output |
| Claude Code debounce | Re-invokes otel-helper every ~29 min |
| Token lifetime | Typically 1-24h (IdP-configurable) |
| Proxy mode | Refreshes headers every 5 min (`_HEADER_REFRESH_SECONDS`) |

## Graceful degradation

- **No token available** → empty headers output → no authorization header → ALB rejects (same as today, no regression)
- **JWT disabled on ALB** (`OidcIssuerUrl` empty) → authorization header is a harmless extra HTTP header the collector ignores

## Changes (4 files, +313/-3)

| File | What |
|---|---|
| `go/cmd/otel-helper/main.go` | Add Bearer to output (after cache write); Layer 1 resolves token from env |
| `go/cmd/otel-helper/main_test.go` | 4 tests: bearer present, not in cache, not when no token, cache hit path |
| `otel_helper/__main__.py` | Bearer in normal output + proxy `get_user_headers()` |
| `tests/e2e/test_cross_platform.py` | 3 static analysis guards (auth contract alignment) |

## Static analysis guards (prevents recurrence)

| Test | What it catches |
|---|---|
| `test_alb_jwt_auth_has_go_helper_bearer_output` | Someone removes Bearer from Go helper while ALB has JWT |
| `test_alb_jwt_auth_has_python_helper_bearer_output` | Same for Python helper |
| `test_bearer_token_not_in_cache_write` | Bearer accidentally moved before cache write (credential leak) |

## Testing

- 8/8 Go otel-helper tests pass (4 new + 4 existing)
- 3/3 static analysis guards pass
- Go build compiles clean

Relates to #126, completes PR #129