### PR TITLE
fix: add client_secret support for Google OAuth token exchange

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -737,6 +737,24 @@ sso_registration_scopes = sso:account:access"""
             client_certificate_path = None
             client_certificate_key_path = None
 
+            # Google Desktop OAuth requires a client_secret for token exchange.
+            # Google documents this as non-confidential for installed/native apps,
+            # so we store it in config.json (not the OS keyring).
+            if provider_type == "google":
+                console.print("\n[bold]Client Secret[/bold]")
+                console.print(
+                    "Google OAuth requires a client secret for desktop applications.\n"
+                    "Find it in Google Cloud Console → Credentials → your OAuth client.\n"
+                    "[dim]Note: Google considers desktop app secrets non-confidential.[/dim]"
+                )
+                client_secret = questionary.password(
+                    "Client secret (from Google Cloud Console):",
+                    validate=lambda x: bool(x) or "Client secret is required for Google OAuth",
+                ).ask()
+                if not client_secret:
+                    return None
+                config["client_secret"] = client_secret
+
             if provider_type == "azure":
                 console.print("\n[bold]Azure AD Authentication Mode[/bold]")
                 console.print(

--- a/source/go/cmd/credential-process/main.go
+++ b/source/go/cmd/credential-process/main.go
@@ -522,6 +522,12 @@ func (a *credentialApp) authenticate() (*oidc.AuthResult, error) {
 // installs stay portable across machines. Returns nil for public-client flows.
 func (a *credentialApp) resolveConfidentialAuth() (*oidc.ConfidentialAuth, error) {
 	if a.providerType != "azure" {
+		// Non-Azure providers: use client_secret from config.json if present.
+		// Google Desktop OAuth requires this for token exchange (Google documents
+		// it as non-confidential for installed apps). Other providers use PKCE-only.
+		if a.cfg.ClientSecret != "" {
+			return &oidc.ConfidentialAuth{ClientSecret: a.cfg.ClientSecret}, nil
+		}
 		return nil, nil
 	}
 	mode := a.cfg.AzureAuthMode

--- a/source/go/internal/config/config.go
+++ b/source/go/internal/config/config.go
@@ -78,6 +78,11 @@ type ProfileConfig struct {
 	// from "explicitly false" (passthrough mode).
 	SsoEnabled *bool `json:"sso_enabled,omitempty"`
 
+	// Non-confidential client secret read from config.json (e.g. Google Desktop
+	// OAuth requires a client_secret for token exchange, but Google documents it
+	// as non-confidential for installed/native apps). Empty means PKCE-only.
+	ClientSecret string `json:"client_secret,omitempty"`
+
 	// Legacy field names
 	OktaDomain   string `json:"okta_domain"`
 	OktaClientID string `json:"okta_client_id"`

--- a/source/tests/test_google_client_secret.py
+++ b/source/tests/test_google_client_secret.py
@@ -1,0 +1,111 @@
+"""Regression tests for Google OAuth client_secret support.
+
+Google Desktop OAuth requires a client_secret for token exchange (unlike Okta/Auth0
+which use PKCE-only for native apps). Google documents this secret as non-confidential
+for installed applications, so it's stored in config.json rather than the OS keyring.
+"""
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+
+class TestGoogleClientSecretConfig:
+    """Verify client_secret is read from config.json for Google provider."""
+
+    def test_config_go_struct_has_client_secret_field(self):
+        """The Go ProfileConfig struct must declare client_secret."""
+        config_go = (
+            Path(__file__).resolve().parents[2]
+            / "source"
+            / "go"
+            / "internal"
+            / "config"
+            / "config.go"
+        )
+        if not config_go.exists():
+            pytest.skip("Go source not found")
+        content = config_go.read_text(encoding="utf-8")
+        assert 'json:"client_secret' in content, (
+            "ProfileConfig must have a ClientSecret field with "
+            'json:"client_secret" tag for Google OAuth support'
+        )
+
+    def test_credential_process_reads_client_secret_for_non_azure(self):
+        """resolveConfidentialAuth must check cfg.ClientSecret for non-Azure providers."""
+        main_go = (
+            Path(__file__).resolve().parents[2]
+            / "source"
+            / "go"
+            / "cmd"
+            / "credential-process"
+            / "main.go"
+        )
+        if not main_go.exists():
+            pytest.skip("Go source not found")
+        content = main_go.read_text(encoding="utf-8")
+        # The function should read ClientSecret when provider is not Azure
+        assert "a.cfg.ClientSecret" in content, (
+            "resolveConfidentialAuth must read ClientSecret from config "
+            "for non-Azure providers (Google needs it for token exchange)"
+        )
+
+    def test_init_wizard_prompts_google_secret(self):
+        """The init wizard must prompt for client_secret when provider is Google."""
+        init_py = (
+            Path(__file__).resolve().parents[2]
+            / "source"
+            / "claude_code_with_bedrock"
+            / "cli"
+            / "commands"
+            / "init.py"
+        )
+        content = init_py.read_text(encoding="utf-8")
+        # Verify Google-specific secret prompt exists
+        assert 'provider_type == "google"' in content
+        assert 'config["client_secret"]' in content, (
+            "Init wizard must write client_secret to config for Google provider"
+        )
+
+    def test_package_includes_google_client_secret(self):
+        """package.py must include client_secret in config.json for Google."""
+        package_py = (
+            Path(__file__).resolve().parents[2]
+            / "source"
+            / "claude_code_with_bedrock"
+            / "cli"
+            / "commands"
+            / "package.py"
+        )
+        content = package_py.read_text(encoding="utf-8")
+        assert "client_secret" in content
+        assert "google" in content.lower()
+
+    def test_google_secret_not_in_keyring_path(self):
+        """Google's client_secret must NOT use keyring (it's non-confidential)."""
+        init_py = (
+            Path(__file__).resolve().parents[2]
+            / "source"
+            / "claude_code_with_bedrock"
+            / "cli"
+            / "commands"
+            / "init.py"
+        )
+        content = init_py.read_text(encoding="utf-8")
+        # Find the Google block and verify it writes to config, not keyring
+        lines = content.splitlines()
+        in_google_block = False
+        for i, line in enumerate(lines):
+            if 'provider_type == "google"' in line and "client_secret" not in line:
+                in_google_block = True
+                block_start = i
+            elif in_google_block:
+                if 'provider_type == "azure"' in line:
+                    break  # reached end of google block
+                assert "set_password" not in line, (
+                    f"Line {i+1}: Google client_secret should be stored in config.json, "
+                    f"not OS keyring (Google documents it as non-confidential)"
+                )


### PR DESCRIPTION
## Why

Google Desktop OAuth requires a `client_secret` for the authorization code exchange — PKCE alone is insufficient for Google's installed-app flow. The init wizard currently has no prompt for it, forcing users to manually edit config files.

Reported by a customer deploying with Google OIDC on beta.

## Design

Google [explicitly documents](https://developers.google.com/identity/protocols/oauth2/native-app#creatingcred) that Desktop app secrets are non-confidential (they're embedded in distributed binaries). The storage hierarchy:

| Provider | Secret type | Storage |
|----------|------------|---------|
| Azure | Confidential (enterprise) | OS keyring (unchanged) |
| Google | Non-confidential (installed app) | config.json |
| Okta/Auth0/Cognito/generic | N/A (PKCE-only) | No secret needed |

## Changes

**`source/go/internal/config/config.go`** — Add `ClientSecret` field to `ProfileConfig`

**`source/go/cmd/credential-process/main.go`** — `resolveConfidentialAuth()` now reads `cfg.ClientSecret` for non-Azure providers before returning nil (PKCE-only fallback)

**`source/claude_code_with_bedrock/cli/commands/init.py`** — Prompt for client_secret when `provider_type == "google"`, writes to config (not keyring)

**`source/tests/test_google_client_secret.py`** — 5 regression tests

## Result

```
438 passed, 4 skipped, 0 failures
```

Note: Go build requires 1.24 (CI will validate). Changes are additive — no existing provider flows are affected.

cc @pipeflo for review (original Google OIDC support in #432)