### PR TITLE
feat: add IAM SigV4 quota check for Identity Center users (Go binary)

### DIFF
--- a/source/go/internal/quota/quota.go
+++ b/source/go/internal/quota/quota.go
@@ -1,11 +1,15 @@
 package quota
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"time"
+
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 )
 
 // Result represents the quota check API response.
@@ -19,6 +23,10 @@ type Result struct {
 
 // Check calls the quota API endpoint with the given JWT token.
 func Check(endpoint, idToken string, timeout int, failMode string) *Result {
+	if idToken == "" {
+		// No JWT token — try IAM auth (IDC path)
+		return CheckWithIAM(endpoint, timeout, failMode)
+	}
 	client := &http.Client{Timeout: time.Duration(timeout) * time.Second}
 
 	req, err := http.NewRequest("GET", endpoint+"/check", nil)
@@ -54,4 +62,58 @@ func failResult(failMode, reason, message string) *Result {
 		return &Result{Allowed: false, Reason: reason, Message: message}
 	}
 	return &Result{Allowed: true, Reason: reason}
+}
+
+// CheckWithIAM calls the quota API using AWS SigV4 authentication.
+// Used by IAM Identity Center (IDC) users who don't have a JWT token.
+// The API Gateway validates the IAM credentials and the Lambda extracts
+// the user email from the IAM caller ARN session name.
+func CheckWithIAM(endpoint string, timeout int, failMode string) *Result {
+	ctx := context.Background()
+
+	cfg, err := awsconfig.LoadDefaultConfig(ctx)
+	if err != nil {
+		return failResult(failMode, "iam_config_error", fmt.Sprintf("Could not load AWS config: %v", err))
+	}
+
+	creds, err := cfg.Credentials.Retrieve(ctx)
+	if err != nil {
+		return failResult(failMode, "iam_creds_error", fmt.Sprintf("Could not retrieve AWS credentials: %v", err))
+	}
+
+	url := endpoint + "/check"
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return failResult(failMode, "error", fmt.Sprintf("creating request: %v", err))
+	}
+
+	// Sign the request with SigV4 for execute-api service
+	signer := v4.NewSigner()
+	hash := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" // SHA256 of empty body
+	err = signer.SignHTTP(ctx, creds, req, hash, "execute-api", cfg.Region, time.Now())
+	if err != nil {
+		return failResult(failMode, "sigv4_error", fmt.Sprintf("Could not sign request: %v", err))
+	}
+
+	client := &http.Client{Timeout: time.Duration(timeout) * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return failResult(failMode, "connection_error", fmt.Sprintf("Could not connect to quota service: %v", err))
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+
+	switch resp.StatusCode {
+	case 200:
+		var result Result
+		if err := json.Unmarshal(body, &result); err != nil {
+			return failResult(failMode, "parse_error", "Could not parse quota response")
+		}
+		return &result
+	case 403:
+		return failResult(failMode, "iam_forbidden", "Quota check IAM authentication failed - check execute-api:Invoke permission")
+	default:
+		return failResult(failMode, "api_error", fmt.Sprintf("Quota check failed with status %d", resp.StatusCode))
+	}
 }

--- a/source/go/internal/quota/quota_test.go
+++ b/source/go/internal/quota/quota_test.go
@@ -1,0 +1,76 @@
+package quota
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCheck_EmptyToken_FallsToIAMPath(t *testing.T) {
+	// When idToken is empty, Check should attempt IAM auth (CheckWithIAM).
+	// Without valid AWS credentials in the test env, it will fail gracefully
+	// with the fail-open mode returning allowed=true.
+	result := Check("http://localhost:1", "", 1, "open")
+	if result == nil {
+		t.Fatal("Check with empty token should return a result, not nil")
+	}
+	// In fail-open mode, errors should still allow
+	if !result.Allowed {
+		t.Errorf("fail-open mode should allow even on error, got allowed=%v reason=%s", result.Allowed, result.Reason)
+	}
+}
+
+func TestCheck_WithToken_UsesJWTPath(t *testing.T) {
+	// Mock a quota endpoint that expects Bearer token
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer test-token-123" {
+			w.WriteHeader(401)
+			return
+		}
+		json.NewEncoder(w).Encode(Result{Allowed: true, Reason: "within_limits"})
+	}))
+	defer server.Close()
+
+	result := Check(server.URL, "test-token-123", 5, "closed")
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if !result.Allowed {
+		t.Errorf("expected allowed=true with valid token, got reason=%s", result.Reason)
+	}
+}
+
+func TestCheck_WithToken_InvalidToken_Returns401(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(401)
+	}))
+	defer server.Close()
+
+	result := Check(server.URL, "bad-token", 5, "closed")
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.Allowed {
+		t.Error("401 with fail-closed should not be allowed")
+	}
+	if result.Reason != "jwt_invalid" {
+		t.Errorf("reason = %q, want jwt_invalid", result.Reason)
+	}
+}
+
+func TestCheck_FailOpen_AllowsOnError(t *testing.T) {
+	// Unreachable endpoint
+	result := Check("http://localhost:1", "token", 1, "open")
+	if !result.Allowed {
+		t.Error("fail-open mode should allow on connection error")
+	}
+}
+
+func TestCheck_FailClosed_BlocksOnError(t *testing.T) {
+	result := Check("http://localhost:1", "token", 1, "closed")
+	if result.Allowed {
+		t.Error("fail-closed mode should block on connection error")
+	}
+}


### PR DESCRIPTION
## Problem

PR #402 adds IDC quota enforcement for the Lambda and Python credential-provider, but the **Go binary** (primary credential-process on beta) skips quota checks entirely when no JWT token is available. IDC users have no quota enforcement.

## Solution

When `idToken` is empty, `quota.Check()` now routes to a new `CheckWithIAM()` function that signs the request with SigV4 instead of attaching a Bearer token. The API Gateway validates IAM credentials and the Lambda extracts the user email from the ARN session name.

### Flow:

```
IDC user → credential-process → no id_token available
  → quota.Check("", ...) → detects empty token
  → CheckWithIAM() → SigV4-signs GET /check
  → API Gateway validates IAM auth
  → Lambda: arn:aws:sts::ACCOUNT:assumed-role/.../user@company.com → email
  → Quota enforced ✅
```

## Changes (2 files, +138 lines)

| File | What |
|---|---|
| `go/internal/quota/quota.go` | Add `CheckWithIAM()` with SigV4 signing; route empty token to IAM path |
| `go/internal/quota/quota_test.go` | 5 unit tests |

## Backward compatible

- Non-empty `idToken` → JWT path (unchanged)
- Empty `idToken` → IAM path (new, previously skipped)
- Connection/auth failures respect `failMode` (open/closed)

## Testing

- 5 unit tests: empty token IAM fallback, JWT path with mock server, 401 handling, fail-open, fail-closed
- All existing Go tests pass

Companion to #402 (Lambda + CF template + Python provider)