### PR TITLE
fix: extract Azure tenant GUID in distribution deploy path (#351)

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -26,6 +26,24 @@ from claude_code_with_bedrock.cli.utils.cf_exceptions import (
 from claude_code_with_bedrock.cli.utils.cloudformation import CloudFormationManager
 from claude_code_with_bedrock.config import Config
 
+# Azure tenant ID GUID pattern — matches UUIDs in various URL formats:
+#   login.microsoftonline.com/{tenant-id}/v2.0
+#   https://login.microsoftonline.com/{tenant-id}
+#   {tenant-id} (bare GUID)
+_AZURE_GUID_PATTERN = re.compile(
+    r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+)
+
+
+def _extract_azure_tenant_id(domain: str) -> str:
+    """Extract Azure AD tenant GUID from provider domain or URL.
+
+    Supports: full URLs, domain/tenant/v2.0, or bare GUIDs.
+    Returns the bare GUID, or the original input if no GUID found.
+    """
+    match = _AZURE_GUID_PATTERN.search(domain)
+    return match.group(0) if match else domain
+
 
 class DeployCommand(Command):
     name = "deploy"
@@ -436,23 +454,8 @@ class DeployCommand(Command):
                         ]
                     )
                 elif provider_type == "azure":
-                    # Azure uses tenant ID (GUID) instead of full domain
-                    # Support multiple input formats:
-                    # - login.microsoftonline.com/{tenant-id}/v2.0
-                    # - login.microsoftonline.com/{tenant-id}
-                    # - {tenant-id} (just the GUID)
-                    # - https://login.microsoftonline.com/{tenant-id}/v2.0
-
-                    # Extract GUID using regex pattern matching
-                    guid_pattern = r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
-                    match = re.search(guid_pattern, profile.provider_domain)
-
-                    if match:
-                        tenant_id = match.group(0)
-                    else:
-                        # If no GUID found, use the provider_domain as-is
-                        # (in case user provided just the GUID but in unexpected format)
-                        tenant_id = profile.provider_domain
+                    # Azure uses tenant ID (GUID) — extract from provider_domain URL
+                    tenant_id = _extract_azure_tenant_id(profile.provider_domain)
 
                     params.extend(
                         [
@@ -574,7 +577,7 @@ class DeployCommand(Command):
                         # Extract tenant ID from domain or use full domain
                         params.extend(
                             [
-                                f"AzureTenantId={profile.distribution_idp_domain}",
+                                f"AzureTenantId={_extract_azure_tenant_id(profile.distribution_idp_domain or '')}",
                                 f"AzureClientId={profile.distribution_idp_client_id}",
                                 f"AzureClientSecretArn={profile.distribution_idp_client_secret_arn}",
                             ]
@@ -972,9 +975,7 @@ class DeployCommand(Command):
                 elif provider_type == "auth0":
                     params.extend([f"Auth0Domain={profile.provider_domain}", f"Auth0ClientId={profile.client_id}"])
                 elif provider_type == "azure":
-                    guid_pattern = r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
-                    match = re.search(guid_pattern, profile.provider_domain)
-                    tenant_id = match.group(0) if match else profile.provider_domain
+                    tenant_id = _extract_azure_tenant_id(profile.provider_domain)
                     params.extend([f"AzureTenantId={tenant_id}", f"AzureClientId={profile.client_id}"])
                 elif provider_type == "cognito":
                     cognito_domain = (

--- a/source/tests/test_azure_tenant_id_extraction.py
+++ b/source/tests/test_azure_tenant_id_extraction.py
@@ -1,0 +1,80 @@
+"""Regression test for issue #351: Azure tenant ID extraction.
+
+The distribution deploy path must extract the tenant GUID from Azure
+provider domain URLs, not pass the full URL as AzureTenantId. The auth
+deploy path was fixed in #53, but the distribution path was missed.
+"""
+
+import re
+
+import pytest
+
+from claude_code_with_bedrock.cli.commands.deploy import _extract_azure_tenant_id
+
+
+class TestAzureTenantIdExtraction:
+    """Pin Azure tenant ID extraction to prevent URL duplication regression."""
+
+    VALID_GUID = "abc12345-1234-5678-9abc-def012345678"
+
+    @pytest.mark.parametrize(
+        "input_domain",
+        [
+            "login.microsoftonline.com/abc12345-1234-5678-9abc-def012345678/v2.0",
+            "https://login.microsoftonline.com/abc12345-1234-5678-9abc-def012345678/v2.0",
+            "login.microsoftonline.com/abc12345-1234-5678-9abc-def012345678",
+            "https://login.microsoftonline.com/abc12345-1234-5678-9abc-def012345678",
+            "abc12345-1234-5678-9abc-def012345678",
+        ],
+        ids=["domain/guid/v2.0", "https://domain/guid/v2.0", "domain/guid", "https://domain/guid", "bare-guid"],
+    )
+    def test_extracts_guid_from_various_formats(self, input_domain):
+        """Tenant GUID is correctly extracted from all supported URL formats."""
+        result = _extract_azure_tenant_id(input_domain)
+        assert result == self.VALID_GUID, (
+            f"Expected bare GUID '{self.VALID_GUID}' but got '{result}' "
+            f"from input '{input_domain}'"
+        )
+
+    def test_result_is_bare_guid_not_url(self):
+        """Result must never contain URL components like 'login' or 'microsoftonline'."""
+        domain = "login.microsoftonline.com/abc12345-1234-5678-9abc-def012345678/v2.0"
+        result = _extract_azure_tenant_id(domain)
+        assert "login" not in result
+        assert "microsoftonline" not in result
+        assert "/" not in result
+        assert "https" not in result
+
+    def test_passthrough_when_no_guid_found(self):
+        """If no GUID pattern found, return input as-is (graceful fallback)."""
+        result = _extract_azure_tenant_id("some-custom-domain.com")
+        assert result == "some-custom-domain.com"
+
+    def test_empty_string_passthrough(self):
+        """Empty input returns empty string without crashing."""
+        result = _extract_azure_tenant_id("")
+        assert result == ""
+
+    def test_distribution_path_uses_helper(self):
+        """deploy.py must use _extract_azure_tenant_id for distribution Azure params.
+
+        This prevents regression where distribution_idp_domain is passed raw
+        as AzureTenantId (issue #351).
+        """
+        from pathlib import Path
+
+        deploy_py = Path(__file__).resolve().parents[1] / "claude_code_with_bedrock" / "cli" / "commands" / "deploy.py"
+        content = deploy_py.read_text(encoding="utf-8")
+
+        # Ensure no raw domain is ever passed directly as AzureTenantId
+        # Bad patterns: f"AzureTenantId={profile.provider_domain}"
+        #               f"AzureTenantId={profile.distribution_idp_domain}"
+        lines = content.splitlines()
+        for i, line in enumerate(lines):
+            if "AzureTenantId=" in line and "profile." in line and "_domain" in line:
+                assert "_extract_azure_tenant_id" in line, (
+                    f"Line {i+1}: AzureTenantId parameter passes raw domain directly.\n"
+                    f"  Found: {line.strip()}\n"
+                    f"  Must use _extract_azure_tenant_id() to extract GUID.\n"
+                    f"  This prevents issue #351 (URL duplication in distribution path)."
+                )


### PR DESCRIPTION
## Why

Azure AD distribution deployments produce a malformed OAuth URL:
```
https://login.microsoftonline.com/login.microsoftonline.com/tenant-id/v2.0/oauth2/v2.0/authorize
```

The distribution deploy path passes `distribution_idp_domain` (full URL) as `AzureTenantId` (which should be a bare GUID). The auth deploy path was fixed in #53 but the distribution path was missed.

Fixes #351

## Changes

**`deploy.py`:**
- New `_extract_azure_tenant_id(domain)` helper — regex extracts the GUID from any input format
- Distribution path uses the helper (the actual fix)
- Auth deploy paths refactored to use same helper (DRY, was duplicated inline)

**`test_azure_tenant_id_extraction.py`** — 9 regression tests:
- 5 parametrized format tests (domain/guid/v2.0, https, bare GUID, etc.)
- URL component absence check
- Graceful fallback for non-GUID input
- Empty string safety
- **Lint rule**: any `AzureTenantId=` line containing a raw `profile.*_domain` fails → prevents this bug class permanently

## Risk

**Very low.** Only changes the Azure distribution path (which was broken anyway). Auth stack, OIDC, other providers, non-distribution deployments are unaffected.

## Result
```
449 passed, 4 skipped, 0 failures
```

Credit: @yagoTobi (issue report + customer patch)