### PR TITLE
chore: add .claude/rules/ to steer coding agents toward reliability standards

### DIFF
--- a/.claude/rules/auth-type-compat.md
+++ b/.claude/rules/auth-type-compat.md
@@ -1,0 +1,23 @@
+# Auth Type Compatibility
+
+## Rule
+Use `profile.effective_auth_type` property. Never assume `auth_type` exists in saved configs.
+
+## Why
+Older profiles only have `sso_enabled` boolean. We need backward compatibility for the `sso_enabled` → `auth_type` migration.
+
+## Examples
+```python
+# ✅ Correct - handles both old and new configs
+auth_type = profile.effective_auth_type  # returns "oidc", "idc", or "none"
+
+# ❌ Wrong - crashes on old configs
+if profile.auth_type == "oidc":  # KeyError if auth_type doesn't exist
+```
+
+## Backward Compatibility Mapping
+- `sso_enabled=True` → "oidc"
+- `sso_enabled=False` → "none"
+
+## Related Issues
+#285, #287, #288, #304, #337, #430, #454, #456

--- a/.claude/rules/azure-tenant-extraction.md
+++ b/.claude/rules/azure-tenant-extraction.md
@@ -1,0 +1,19 @@
+# Azure Tenant Extraction
+
+## Rule
+Never pass raw `profile.*_domain` as CloudFormation parameter. Always use `_extract_azure_tenant_id()` helper.
+
+## Why
+Provider domains contain full URLs (e.g., `login.microsoftonline.com/tenant-id/v2.0`). CloudFormation parameters often expect just the tenant GUID or bare domain.
+
+## Examples
+```python
+# ❌ Wrong - passes full URL
+f"AzureTenantId={profile.distribution_idp_domain}"
+
+# ✅ Correct - extracts tenant GUID
+f"AzureTenantId={_extract_azure_tenant_id(profile.distribution_idp_domain)}"
+```
+
+## Related Issues
+#351, #52, #53

--- a/.claude/rules/binary-distribution.md
+++ b/.claude/rules/binary-distribution.md
@@ -1,0 +1,24 @@
+# Binary Distribution
+
+## Rule
+- macOS: Gatekeeper quarantines unsigned binaries
+- Windows: Defender/SmartScreen blocks unsigned
+- Cold start target: <100ms (Go binary)
+- Don't add heavy imports that regress startup
+
+## Why
+Unsigned binaries trigger security warnings and performance issues. Users expect fast startup times for credential processes.
+
+## Platform-Specific Issues
+- **macOS:** Unsigned binaries get quarantined by Gatekeeper. Document `xattr -cr` workaround.
+- **Windows:** Unsigned PyInstaller executables trigger Defender/SmartScreen. Document exclusion path.
+- **Performance:** Heavy Python imports regressed cold start from <100ms to 10s with PyInstaller.
+
+## Solutions
+- Use Go binary for credential process (fast startup)
+- Document security exclusion procedures
+- Avoid heavy imports in performance-critical paths
+- Target <100ms cold start time
+
+## Related Issues
+#27, #145, #223, #237, #395

--- a/.claude/rules/branch-strategy.md
+++ b/.claude/rules/branch-strategy.md
@@ -1,0 +1,23 @@
+# Branch Strategy
+
+## Rule
+- **Target branch: `beta`** (not `main`)
+- Always rebase onto latest `upstream/beta` before opening a PR
+- Feature branches: `feat/<name>` for large multi-PR features
+
+## Why
+`main` is release-only (`beta → main` promotion PRs). This keeps the release branch clean and allows for proper testing/validation in beta before public release.
+
+## Examples
+```bash
+# ✅ Correct workflow
+git checkout beta
+git pull upstream beta
+git checkout -b fix/issue-123
+# ... make changes ...
+git rebase upstream/beta  # before PR
+gh pr create --base beta
+
+# ❌ Wrong - targeting main
+gh pr create --base main
+```

--- a/.claude/rules/cfn-naming.md
+++ b/.claude/rules/cfn-naming.md
@@ -1,0 +1,30 @@
+# CloudFormation Naming
+
+## Rule
+- No hardcoded resource names
+- Use `!Sub '${AWS::StackName}-*'`
+- All templates must pass `cfn-lint`
+- Use `Condition` + `aws:RequestedRegion` for region scoping
+
+## Why
+Hardcoded names break multi-profile deployments when users try to deploy the same template multiple times. Dynamic naming based on stack name ensures uniqueness.
+
+## Examples
+```yaml
+# ❌ Wrong - breaks multi-profile deployments
+Resources:
+  TargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Name: otel-collector-tg
+
+# ✅ Correct - unique per stack
+Resources:
+  TargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Name: !Sub '${AWS::StackName}-tg'
+```
+
+## Related Issues
+#312, #398

--- a/.claude/rules/config-sync.md
+++ b/.claude/rules/config-sync.md
@@ -1,0 +1,33 @@
+# Config Sync
+
+## Rule
+Go `ProfileConfig` struct must match Python `Profile` dataclass. New fields need both sides + JSON tags.
+
+## Why
+`ccwb package` writes config.json from Python Profile → Go binary reads it into ProfileConfig struct. Missing fields from either side create silent failures.
+
+## Implementation
+When adding a field to Python `Profile` dataclass:
+1. Add corresponding field to `source/go/internal/config/config.go` `ProfileConfig` struct
+2. Add proper JSON tag in Go struct
+3. Test that field is properly serialized/deserialized
+
+## Storage Notes
+- **Google:** client_secret stored in config.json (non-confidential)
+- **Azure:** client_secret stored in OS keyring (confidential)
+
+## Examples
+```python
+# Python Profile dataclass
+@dataclass
+class Profile:
+    new_field: str = ""
+
+# Go ProfileConfig struct  
+type ProfileConfig struct {
+    NewField string `json:"new_field"`
+}
+```
+
+## Related Issues
+Missing fields cause silent failures in credential process.

--- a/.claude/rules/credential-helper-parity.md
+++ b/.claude/rules/credential-helper-parity.md
@@ -1,0 +1,27 @@
+# Credential Helper Parity (Go ↔ Python)
+
+The credential-process has Go and Python variants. Both must produce
+identical outputs for the same inputs.
+
+## Critical contract
+
+- `buildSessionName()` (Go) and session_name logic (Python) must use
+  the same claim priority: `email` → `sub` → `"claude-code"`
+- Same sanitization regex: `[^\w+=,.@-]` → `"-"`
+- Same length limits: email = 64 chars, sub = 32 chars
+- Same fallback format: `"claude-code-{sub_sanitized}"`
+
+## Why
+
+The STS RoleSessionName appears in CUR 2.0 `line_item_iam_principal`.
+If Go emits `alice@acme.com` but Python emits `claude-code-alice`, cost
+attribution splits the same user into two identities.
+
+## Testing
+
+Any change to either variant requires a parity test:
+- Feed identical JWT claims to both → assert identical session name
+- Edge cases: no email, no sub, pipe-delimited sub (`auth0|12345`), >64 char email
+- Verify sanitization produces identical output across variants
+
+*Issues: #204 (session name truncation), #58 (recursion)*

--- a/.claude/rules/credential-recursion.md
+++ b/.claude/rules/credential-recursion.md
@@ -1,0 +1,26 @@
+# Credential Recursion
+
+## Rule
+credential-process is called BY the AWS SDK. Never use boto3 inside it (infinite recursion).
+
+## Why
+The credential process binary is invoked BY the AWS SDK to get credentials. If the binary itself calls an AWS API that triggers credential resolution, you get infinite recursion.
+
+## Implementation
+- Use direct HTTPS calls (not boto3) for token exchange
+- Pre-resolve any AWS credentials needed inside the process
+- Never import or use AWS SDK within credential process
+
+## Examples
+```python
+# ✅ Correct - direct HTTPS call
+import requests
+response = requests.post(token_endpoint, data=token_data)
+
+# ❌ Wrong - will cause infinite recursion
+import boto3
+sts = boto3.client('sts')  # This will call credential-process again!
+```
+
+## Related Issues
+#58

--- a/.claude/rules/custom-domain-vpc.md
+++ b/.claude/rules/custom-domain-vpc.md
@@ -1,0 +1,39 @@
+# Custom Domain VPC
+
+## Rule
+- OTEL HTTPS listener needs custom domain + ACM cert OR conditional
+- Distribution landing page: handle None domain gracefully
+- Don't require Route53 in same account
+- "Use existing VPC" must read nested config correctly
+
+## Why
+Custom domains are optional but when present require proper certificate management. VPC configuration has nested structure that must be parsed correctly.
+
+## Implementation
+- Make OTEL HTTPS listener conditional on custom domain presence
+- Handle `None` domain values gracefully in landing pages
+- Support Route53 hosted zones in different AWS accounts
+- Parse nested VPC configuration structure correctly
+
+## Examples
+```yaml
+# ✅ Correct - conditional HTTPS listener
+Conditions:
+  HasCustomDomain: !Not [!Equals [!Ref CustomDomainName, ""]]
+
+Resources:
+  HTTPSListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Condition: HasCustomDomain
+```
+
+```python
+# ✅ Correct - handle None domain
+if profile.custom_domain:
+    landing_page_url = f"https://{profile.custom_domain}"
+else:
+    landing_page_url = "https://default-domain.example.com"
+```
+
+## Related Issues
+#55, #102, #120, #216, #286, #394

--- a/.claude/rules/iam-actions.md
+++ b/.claude/rules/iam-actions.md
@@ -1,0 +1,21 @@
+# IAM Actions
+
+## Rule
+Use `bedrock:` namespace only for Bedrock IAM actions.
+
+## Why
+The `bedrock-runtime:` prefix doesn't exist in IAM. It's been a persistent source of broken templates and deploy failures.
+
+## Examples
+```yaml
+# ❌ Wrong - causes deploy failures
+- bedrock-runtime:InvokeModel
+- bedrock-runtime:InvokeModelWithResponseStream
+
+# ✅ Correct
+- bedrock:InvokeModel
+- bedrock:InvokeModelWithResponseStream
+```
+
+## Related Issues
+#375, #63

--- a/.claude/rules/issuer-url-format.md
+++ b/.claude/rules/issuer-url-format.md
@@ -1,0 +1,33 @@
+# Issuer URL Format
+
+## Rule
+Issuer URL format is provider-specific. Follow exact format requirements for each provider.
+
+## Why
+Mismatch causes JWT validation failures at ALB or API Gateway level. Each provider has strict requirements about trailing slashes and URL structure.
+
+## Provider Formats
+| Provider | Issuer URL format | Trailing slash? |
+|----------|------------------|----------------|
+| Auth0 | `https://company.auth0.com/` | ✅ Required |
+| Azure | `https://login.microsoftonline.com/{tenant}/v2.0` | ❌ Must NOT have |
+| Okta | `https://company.okta.com/oauth2/default` | ❌ No |
+| Cognito | `https://cognito-idp.{region}.amazonaws.com/{pool-id}` | ❌ No |
+
+## Examples
+```python
+# ✅ Correct - Auth0 requires trailing slash
+issuer = "https://company.auth0.com/"
+
+# ❌ Wrong - Auth0 without trailing slash
+issuer = "https://company.auth0.com"
+
+# ✅ Correct - Azure must NOT have trailing slash
+issuer = "https://login.microsoftonline.com/tenant-id/v2.0"
+
+# ❌ Wrong - Azure with trailing slash
+issuer = "https://login.microsoftonline.com/tenant-id/v2.0/"
+```
+
+## Related Issues
+#97, #115

--- a/.claude/rules/keyring-chunking.md
+++ b/.claude/rules/keyring-chunking.md
@@ -1,0 +1,28 @@
+# Keyring Chunking
+
+## Rule
+Windows Credential Manager has a 1280-byte limit per entry. Tokens >1280 bytes must be chunked.
+
+## Why
+Large tokens (common with some OIDC providers) exceed Windows Credential Manager's per-entry limit, causing storage failures and authentication issues.
+
+## Implementation
+- Test with realistic token sizes (not just small test tokens)
+- Implement chunking logic for tokens >1280 bytes
+- `Path.home()` uses USERPROFILE on Windows (not HOME)
+
+## Examples
+```python
+# ✅ Correct - check token size and chunk if needed
+if len(token) > 1280:
+    # Implement chunking logic
+    store_chunked_token(key, token)
+else:
+    keyring.set_password(service, key, token)
+
+# ❌ Wrong - will fail with large tokens
+keyring.set_password(service, key, large_token)  # Fails if >1280 bytes
+```
+
+## Related Issues
+#348, #381, #427, #453

--- a/.claude/rules/oauth-callback-safety.md
+++ b/.claude/rules/oauth-callback-safety.md
@@ -1,0 +1,33 @@
+# OAuth Callback Safety
+
+## Rule
+- Don't shut down server after first request (could be favicon)
+- Use port locking, not TOCTOU checks
+- WSL + VPN may block localhost forwarding
+
+## Why
+OAuth callback servers can receive multiple requests (favicon, actual callback). Early shutdown causes auth failures. WSL with VPN breaks localhost forwarding, preventing callback completion.
+
+## Implementation
+- Wait for actual OAuth callback, not just any HTTP request
+- Use proper port locking mechanisms
+- Document WSL/VPN workarounds for users
+
+## Examples
+```python
+# ✅ Correct - wait for actual callback
+def handle_callback():
+    while True:
+        request = server.get_request()
+        if 'code=' in request.query_string:  # Actual OAuth callback
+            return process_callback(request)
+        # Ignore favicon and other requests
+
+# ❌ Wrong - shuts down on first request
+def handle_callback():
+    request = server.get_request()  # Could be favicon
+    server.shutdown()  # Too early!
+```
+
+## Related Issues
+#269, #270, #393, #428

--- a/.claude/rules/otel-attribution-chain.md
+++ b/.claude/rules/otel-attribution-chain.md
@@ -1,0 +1,47 @@
+# OTEL Attribution Chain
+
+User identity flows through multiple layers. A break in any layer
+causes anonymous telemetry — invisible to the user but breaks cost
+attribution and quota enforcement.
+
+## The chain
+
+```
+OIDC token (email, sub, groups)
+  → otel-helper: ExtractUserInfo → FormatHeaders
+    → cache file (per-profile JSON)
+      → OTEL collector reads headers → CloudWatch dimensions
+```
+
+## Rules
+
+- Never emit empty headers when a cached valid token exists (check cache FIRST)
+- Empty headers TTL must be short (≤300s) to limit the attribution gap
+- `x-user-email` must ALWAYS be present (fallback: `"unknown@example.com"`)
+- `FormatHeaders` must exclude empty strings (don't send `x-team-id=""`)
+- Sidecar mode: reads local cache file directly
+- Proxy mode: ALB forwards headers from JWT validation
+- IDC mode: no JWT → no OTEL attribution (document clearly, don't crash)
+
+## Header contract (stable — never rename these)
+
+| Header | Source claim | Fallback |
+|--------|-------------|----------|
+| `x-user-email` | `email` | `"unknown@example.com"` |
+| `x-user-id` | `sub` | (omit) |
+| `x-user-name` | `preferred_username` → email prefix | (omit) |
+| `x-department` | `department` | (omit) |
+| `x-team-id` | `team` / `groups` | (omit) |
+| `x-cost-center` | `cost_center` | (omit) |
+| `x-project` | custom tag key from config | (omit) |
+
+## Testing
+
+- Token with all claims → verify all headers present
+- Token with only `sub` → verify email fallback + `x-user-id` present
+- Expired token → verify cache served until TTL
+- Empty cache + no token → verify empty headers emitted (not crash)
+- Sidecar: verify local cache file read correctly
+- Proxy: verify ALB-forwarded headers match expected format
+
+*Issues: #361, #365, #441, #446*

--- a/.claude/rules/pr-standards.md
+++ b/.claude/rules/pr-standards.md
@@ -1,0 +1,24 @@
+# PR Standards
+
+## Rule
+- **One concern per PR.** If touching >3 files for different reasons, split it.
+- **Maximum ~300 lines** for reviewability. Decompose larger changes.
+- **Start description with "Why"** — the user impact, not just what changed.
+- **Every fix MUST include a regression test** that would have caught the bug.
+- **Credit external contributors** in commit messages and PR body.
+
+## Why
+Small, focused PRs are easier to review, less likely to introduce bugs, and faster to merge. Starting with "Why" helps reviewers understand the context and importance of the change.
+
+## Examples
+```markdown
+# ✅ Good PR description
+## Why
+Users get 403 Forbidden when using Azure domains because we pass raw URLs instead of tenant GUIDs.
+
+## What
+Extract tenant GUID from domain URL before passing to CloudFormation.
+
+# ❌ Bad PR description
+Fixed Azure domain issue
+```

--- a/.claude/rules/quota-requires-oidc.md
+++ b/.claude/rules/quota-requires-oidc.md
@@ -1,0 +1,26 @@
+# Quota Requires OIDC
+
+## Rule
+Quota enforcement needs JWT from OIDC provider. Skip for `auth_type in ("idc", "none")`.
+
+## Why
+Quota monitoring depends on JWT tokens for user identification. IDC and "none" auth types don't provide JWTs, so quota stacks will fail to deploy.
+
+## Implementation
+- **Init wizard:** don't offer quota when SSO disabled
+- **Deploy:** skip quota stack with warning, don't let CloudFormation fail
+
+## Examples
+```python
+# ✅ Correct - guard quota features
+if profile.effective_auth_type == "oidc":
+    # Deploy quota stack
+else:
+    logger.warning("Skipping quota - requires OIDC authentication")
+
+# ❌ Wrong - will cause CloudFormation failures
+# Always deploy quota regardless of auth type
+```
+
+## Related Issues
+#287, #337, #454, #458

--- a/.claude/rules/region-availability.md
+++ b/.claude/rules/region-availability.md
@@ -1,0 +1,33 @@
+# Region Availability
+
+## Rule
+- ELB account IDs differ by region
+- CodeBuild Windows not in all regions
+- Bedrock models vary by region
+- Never hardcode us-east-1 without fallback
+
+## Why
+AWS services and features have different availability across regions. Hardcoding region-specific values breaks deployments in other regions.
+
+## Implementation
+- Use region-specific ELB access log account IDs
+- Check CodeBuild Windows container availability before deployment
+- Use `AllowedBedrockRegions` parameter for model availability
+- Always provide configurable region fallbacks
+
+## Examples
+```yaml
+# ✅ Correct - region-specific ELB account ID
+Mappings:
+  ELBAccountIds:
+    us-east-1: { AccountId: "127311923021" }
+    us-west-2: { AccountId: "797873946194" }
+    eu-west-1: { AccountId: "156460612806" }
+
+# ❌ Wrong - hardcoded us-east-1 account ID
+S3BucketPolicy:
+  Principal: { AWS: "arn:aws:iam::127311923021:root" }
+```
+
+## Related Issues
+#125, #187, #212, #213, #262, #354, #382

--- a/.claude/rules/review-tiers.md
+++ b/.claude/rules/review-tiers.md
@@ -1,0 +1,47 @@
+# Review Tiers
+
+Changes to critical components require proportionally higher testing
+and review standards. This prevents regressions in paths that affect
+all users.
+
+## Tier 1 — Critical (all users affected if broken)
+
+**Files:**
+- `source/claude_code_with_bedrock/config.py`
+- `source/claude_code_with_bedrock/cli/commands/deploy.py`
+- `source/go/cmd/credential-process/main.go`
+- `source/go/internal/config/config.go`
+- `source/go/cmd/otel-helper/main.go`
+- `source/go/internal/otel/extract.go`, `headers.go`
+- `source/go/internal/federation/sts.go`
+- `deployment/infrastructure/bedrock-auth-*.yaml`
+
+**Requirements:**
+- Regression test for every changed code path
+- Backward-compat test (old configs still load and work)
+- Cross-platform CI must pass (no admin merge override)
+- Parity check if touching Go ↔ Python equivalents
+- Test with all auth types: oidc, idc, none
+
+## Tier 2 — High (subset of users affected)
+
+**Files:**
+- `source/claude_code_with_bedrock/cli/commands/init.py`
+- `source/claude_code_with_bedrock/cli/commands/package.py`
+- `source/credential_provider/__main__.py`
+- `deployment/infrastructure/otel-collector.yaml`
+- `deployment/infrastructure/quota-monitoring.yaml`
+- `source/go/internal/oidc/`, `source/go/internal/federation/`
+
+**Requirements:**
+- Regression test required
+- cfn-lint for template changes
+- Test on Windows if touching credential/packaging paths
+
+## Tier 3 — Standard (limited blast radius)
+
+**Files:** docs, dashboards, analytics, tests, CI workflows
+
+**Requirements:**
+- Tests must pass
+- No regression test required (unless fixing a bug)

--- a/.claude/rules/stack-ordering.md
+++ b/.claude/rules/stack-ordering.md
@@ -1,0 +1,29 @@
+# Stack Ordering
+
+## Rule
+Networking must deploy before distribution/monitoring. Never assume stack outputs exist — check and fail with clear error.
+
+## Why
+CloudFormation stack dependencies must be explicitly managed. Stacks that reference outputs from other stacks will fail if those dependencies aren't deployed first.
+
+## Implementation
+- Deploy networking stacks before any stacks that reference their outputs
+- Check for required stack outputs before attempting to reference them
+- Fail gracefully with clear error messages pointing to missing dependencies
+
+## Examples
+```python
+# ✅ Correct - check dependencies
+try:
+    vpc_id = get_stack_output('networking-stack', 'VpcId')
+    if not vpc_id:
+        raise ValueError("VPC stack must be deployed first")
+except StackNotFoundError:
+    raise ValueError("Deploy networking stack before distribution stack")
+
+# ❌ Wrong - assumes output exists
+vpc_id = get_stack_output('networking-stack', 'VpcId')  # May not exist
+```
+
+## Related Issues
+#116, #214, #383, #417

--- a/.claude/rules/windows-platform-guards.md
+++ b/.claude/rules/windows-platform-guards.md
@@ -1,0 +1,33 @@
+# Windows Platform Guards
+
+## Rule
+Add platform-specific guards for Windows compatibility:
+- `SO_REUSEADDR` needs `sys.platform != "win32"` guard
+- Use `shutil.move()` not `os.rename()`
+- Always `open(path, encoding="utf-8")`
+- CRLF line endings in generated scripts
+
+## Why
+Windows handles sockets, file operations, and encodings differently. These differences cause runtime failures if not handled properly.
+
+## Examples
+```python
+# ✅ Correct socket handling
+if sys.platform != "win32":
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+
+# ✅ Correct file operations
+import shutil
+shutil.move(src, dst)  # NOT os.rename() — fails cross-device on Windows
+
+# ✅ Correct file encoding
+open(path, encoding="utf-8")  # ALWAYS specify encoding
+
+# ❌ Wrong - crashes on Windows
+sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)  # Always
+os.rename(src, dst)  # Fails cross-device
+open(path)  # Uses system default encoding
+```
+
+## Related Issues
+#267, #348, #350, #353, #356, #357, #381, #427, #428, #429

--- a/.gitignore
+++ b/.gitignore
@@ -36,8 +36,8 @@ Thumbs.db
 .env
 .env.local
 
-# Claude Code settings
-.claude/
+# Claude Code settings (rules are tracked)
+# .claude/ directory should be committed
 
 #Claude Code plugin settings
 .claude-plugin
@@ -54,7 +54,6 @@ output.json
 # Local POC test scripts at repo root only -- not source/tests/test_*.py
 /test_*.py
 
-CLAUDE.md
 
 guidance-docs/
 parameters.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,32 @@
+# CLAUDE.md
+
+Project rules for AI coding agents. Detailed rules in `.claude/rules/`.
+
+## Repository
+AWS guidance for Claude Code with Amazon Bedrock. Python CLI (`ccwb`) + Go credential-process binary + CloudFormation templates.
+
+## Branch Strategy
+- Target branch: `beta` (not `main`)
+- Rebase onto latest `upstream/beta` before opening PRs
+- `main` is release-only
+
+## Architecture
+```
+ccwb init (wizard) → config.yaml → ccwb deploy → CloudFormation templates
+                                  → ccwb package → config.json + binary → credential-process (Go)
+```
+
+### Key files
+- `source/claude_code_with_bedrock/config.py` — Profile dataclass
+- `source/claude_code_with_bedrock/cli/commands/init.py` — Setup wizard
+- `source/claude_code_with_bedrock/cli/commands/deploy.py` — Stack deployment
+- `source/claude_code_with_bedrock/cli/commands/package.py` — Binary packaging
+- `source/go/cmd/credential-process/main.go` — Go credential provider
+- `source/go/internal/config/config.go` — Go config struct
+- `deployment/infrastructure/` — CloudFormation templates
+
+## Testing
+- `cd source && poetry run pytest tests/ -q` before pushing
+- Must pass Linux, macOS, AND Windows (CI matrix)
+- Windows tests are blocking
+- Every fix needs a regression test


### PR DESCRIPTION
## Why

AI coding agents (Claude Code, Codex, Cursor) increasingly contribute to this repo. Without guardrails, they repeat the same mistakes that caused past regressions — invalid IAM namespaces, raw URL passing, missing Windows guards, broken user attribution chains.

This PR establishes **reliability standards for AI-assisted development** by encoding lessons from 35+ resolved issues into structured rules.

## Changes

### `CLAUDE.md` — lightweight entry point
- Repository overview and architecture diagram
- Key file locations for quick orientation
- Testing commands (Python, Go, contract tests)
- Index of all rules in `.claude/rules/`

### `.claude/rules/` — 11 thematic rules (consolidated from 20)

| Rule file | Coverage |
|---|---|
| `identity-and-auth.md` | Auth types, issuer URLs, Azure tenant extraction, quota-requires-OIDC |
| `credential-process.md` | Go/Python parity, recursion avoidance, keyring chunking, cache security |
| `cloudformation.md` | Dynamic naming, stack ordering, region awareness, conditions, IAM actions |
| `cross-platform.md` | Windows guards, OAuth callbacks, binary distribution |
| `otel-sidecar-vs-proxy.md` | Two OTEL modes, header contracts, graceful degradation |
| `claude-code-cowork.md` | Single-user (Code) vs multi-user (Cowork) architecture |
| `wizard-init-destroy.md` | Init validation, re-init preservation, destroy ordering |
| `error-handling.md` | When to crash vs degrade vs retry, by context |
| `review-tiers.md` | Change criticality (Tier 1/2/3) and review requirements |
| `branch-strategy.md` | Beta/main/feature branch workflow |
| `pr-standards.md` | PR format, CI requirements, Windows-blocking policy |

### Design Principles

- **Thematic, not tactical** — rules grouped by domain (auth, infra, platform) not individual issues
- **Examples over prose** — every rule has ✅/❌ code examples
- **Issue linkage** — each rule references the issues it would have prevented
- **Testable** — rules are specific enough to be enforced by static analysis

## Testing

No functional code changes — rules only. Zero regression risk.
