### PR TITLE
fix: cross-platform ccwb test + destroy distribution/codebuild stacks

### DIFF
--- a/assets/docs/CLI_REFERENCE.md
+++ b/assets/docs/CLI_REFERENCE.md
@@ -1172,7 +1172,7 @@ poetry run ccwb destroy [stack] [options]
 
 **Arguments:**
 
-- `stack` - Specific stack to destroy: auth, networking, monitoring, dashboard, or analytics (optional)
+- `stack` - Specific stack to destroy: codebuild, analytics, quota, cowork-dashboard, dashboard, monitoring, distribution, networking, s3bucket, or auth (optional)
 
 **Options:**
 
@@ -1181,7 +1181,7 @@ poetry run ccwb destroy [stack] [options]
 
 **What it does:**
 
-- Deletes CloudFormation stacks in reverse order (analytics → dashboard → monitoring → networking → auth)
+- Deletes CloudFormation stacks in reverse dependency order (codebuild → analytics → quota → cowork-dashboard → dashboard → monitoring → distribution → networking → s3bucket → auth), skipping any not enabled for the profile
 - Shows resources to be deleted before proceeding
 - Warns about manual cleanup requirements (e.g., CloudWatch LogGroups)
 

--- a/source/claude_code_with_bedrock/cli/commands/destroy.py
+++ b/source/claude_code_with_bedrock/cli/commands/destroy.py
@@ -17,11 +17,13 @@ from claude_code_with_bedrock.config import Config
 # All destroyable stacks in reverse dependency order (destroy-all uses this sequence).
 # Keep in sync with deploy.py's stack types when adding new stacks.
 DESTROYABLE_STACKS = [
+    "codebuild",
     "analytics",
     "quota",
     "cowork-dashboard",
     "dashboard",
     "monitoring",
+    "distribution",
     "networking",
     "s3bucket",
     "auth",
@@ -135,6 +137,10 @@ class DestroyCommand(Command):
             if monitoring_mode == "sidecar" and stack in ("networking", "monitoring", "analytics", "s3bucket"):
                 continue
             if stack == "quota" and not getattr(profile, "quota_monitoring_enabled", False):
+                continue
+            if stack == "distribution" and not getattr(profile, "enable_distribution", False):
+                continue
+            if stack == "codebuild" and not getattr(profile, "enable_codebuild", False):
                 continue
 
             stack_name = profile.stack_names.get(stack, f"{profile.identity_pool_name}-{stack}")

--- a/source/claude_code_with_bedrock/cli/commands/test.py
+++ b/source/claude_code_with_bedrock/cli/commands/test.py
@@ -232,7 +232,12 @@ class TestCommand(Command):
 
             # Set up temporary AWS profile for testing
             test_profile = f"ccwb-test-{uuid.uuid4().hex[:8]}"
-            credential_command = f"/bin/sh -c 'CCWB_PROFILE={test_profile_name} {credential_binary}'"
+            # Pass the profile via --profile flag (cross-platform, no shell wrapper).
+            # The binary also reads CCWB_PROFILE, but a POSIX shell wrapper does not
+            # exist on Windows, so the --profile flag is used instead.
+            # Quote the binary path so a space in it survives botocore's shell split
+            # (shlex on POSIX); the profile name is validated to [A-Za-z0-9-] so needs none.
+            credential_command = f'"{credential_binary}" --profile {test_profile_name}'
             subprocess.run(
                 ["aws", "configure", "set", f"profile.{test_profile}.credential_process", credential_command],
                 capture_output=True,
@@ -271,9 +276,12 @@ class TestCommand(Command):
         console.print(f"[dim]Using temporary profile: {test_profile}[/dim]")
 
         # Configure the test profile
-        # Set environment variable to tell credential binary which profile to use from config.json
-        # Use shell to set environment variable
-        credential_command = f"/bin/sh -c 'CCWB_PROFILE={test_profile_name} {credential_binary}'"
+        # Pass the profile via --profile flag (cross-platform, no shell wrapper).
+        # The binary also reads CCWB_PROFILE, but a POSIX shell wrapper does not
+        # exist on Windows, so the --profile flag is used instead.
+        # Quote the binary path so a space in it survives botocore's shell split
+        # (shlex on POSIX); the profile name is validated to [A-Za-z0-9-] so needs none.
+        credential_command = f'"{credential_binary}" --profile {test_profile_name}'
         aws_config_result = subprocess.run(
             ["aws", "configure", "set", f"profile.{test_profile}.credential_process", credential_command],
             capture_output=True,

--- a/source/tests/cli/commands/test_destroy_skip_logic.py
+++ b/source/tests/cli/commands/test_destroy_skip_logic.py
@@ -1,0 +1,119 @@
+# ABOUTME: Behavioral tests for destroy command skip-guard logic
+# ABOUTME: Drives DestroyCommand and asserts which stacks are actually deleted
+
+"""Behavioral tests for `ccwb destroy` stack selection and skip guards.
+
+Where test_destroy_stacks.py checks the static DESTROYABLE_STACKS data, these
+tests run the command end-to-end (mocking the profile and the actual CFN delete)
+and assert which stacks `_delete_stack` is called for under each profile shape.
+A removed or broken skip guard fails one of these.
+"""
+
+from unittest.mock import Mock, patch
+
+from cleo.testers.command_tester import CommandTester
+
+from claude_code_with_bedrock.cli.commands.destroy import DestroyCommand
+
+
+def _profile(**overrides):
+    """A mock profile with sensible defaults; override per test."""
+    p = Mock()
+    p.identity_pool_name = "test-pool"
+    p.stack_names = {}
+    p.monitoring_enabled = True
+    p.monitoring_mode = "central"
+    p.quota_monitoring_enabled = False
+    p.enable_distribution = False
+    p.enable_codebuild = False
+    p.aws_region = "us-east-1"
+    for k, v in overrides.items():
+        setattr(p, k, v)
+    return p
+
+
+def _run_destroy(profile, stack_arg=None):
+    """Run `destroy --force` with a mocked profile; return the set of stacks
+    `_delete_stack` was actually invoked for."""
+    deleted = []
+
+    with (
+        patch("claude_code_with_bedrock.cli.commands.destroy.Config") as MockConfig,
+        patch.object(DestroyCommand, "_delete_stack", return_value=0) as mock_delete,
+        patch.object(DestroyCommand, "_get_failed_resources", return_value=[]),
+        patch.object(DestroyCommand, "_show_cleanup_summary"),
+    ):
+        MockConfig.load.return_value.get_profile.return_value = profile
+        MockConfig.load.return_value.active_profile = "test"
+
+        # _delete_stack(self, stack_name, region, console) -> record the stack_name
+        mock_delete.side_effect = lambda stack_name, region, console: deleted.append(stack_name) or 0
+
+        command = DestroyCommand()
+        tester = CommandTester(command)
+        args = "--force"
+        if stack_arg:
+            args = f"{stack_arg} --force"
+        exit_code = tester.execute(args)
+
+    # Map stack_names (test-pool-<stack>) back to stack keys for readability.
+    return exit_code, {name.replace("test-pool-", "") for name in deleted}
+
+
+class TestSkipGuards:
+    def test_distribution_deleted_only_when_enabled(self):
+        _, with_it = _run_destroy(_profile(enable_distribution=True))
+        assert "distribution" in with_it
+
+        _, without_it = _run_destroy(_profile(enable_distribution=False))
+        assert "distribution" not in without_it
+
+    def test_codebuild_deleted_only_when_enabled(self):
+        _, with_it = _run_destroy(_profile(enable_codebuild=True))
+        assert "codebuild" in with_it
+
+        _, without_it = _run_destroy(_profile(enable_codebuild=False))
+        assert "codebuild" not in without_it
+
+    def test_monitoring_stacks_skipped_when_monitoring_disabled(self):
+        _, deleted = _run_destroy(_profile(monitoring_enabled=False))
+        for stack in ("monitoring", "dashboard", "networking", "analytics", "s3bucket"):
+            assert stack not in deleted, f"{stack} should be skipped when monitoring disabled"
+        # auth always destroyed
+        assert "auth" in deleted
+
+    def test_sidecar_mode_skips_ecs_stacks(self):
+        _, deleted = _run_destroy(_profile(monitoring_enabled=True, monitoring_mode="sidecar"))
+        for stack in ("networking", "monitoring", "analytics", "s3bucket"):
+            assert stack not in deleted, f"{stack} should be skipped in sidecar mode"
+
+    def test_quota_deleted_only_when_enabled(self):
+        _, with_it = _run_destroy(_profile(quota_monitoring_enabled=True))
+        assert "quota" in with_it
+        _, without_it = _run_destroy(_profile(quota_monitoring_enabled=False))
+        assert "quota" not in without_it
+
+    def test_full_profile_deletes_new_stacks(self):
+        # A profile with everything on must tear down distribution AND codebuild
+        # (the two stacks this PR adds) -- the orphaned-stack regression.
+        _, deleted = _run_destroy(
+            _profile(enable_distribution=True, enable_codebuild=True, quota_monitoring_enabled=True)
+        )
+        assert {"distribution", "codebuild"} <= deleted
+
+
+class TestSingleStackArg:
+    def test_distribution_arg_accepted(self):
+        exit_code, deleted = _run_destroy(_profile(enable_distribution=True), stack_arg="distribution")
+        assert exit_code == 0
+        assert deleted == {"distribution"}
+
+    def test_codebuild_arg_accepted(self):
+        exit_code, deleted = _run_destroy(_profile(enable_codebuild=True), stack_arg="codebuild")
+        assert exit_code == 0
+        assert deleted == {"codebuild"}
+
+    def test_unknown_stack_arg_rejected(self):
+        exit_code, deleted = _run_destroy(_profile(), stack_arg="nonexistent")
+        assert exit_code == 1
+        assert deleted == set()

--- a/source/tests/cli/commands/test_destroy_stacks.py
+++ b/source/tests/cli/commands/test_destroy_stacks.py
@@ -1,0 +1,68 @@
+# ABOUTME: Tests for destroy command stack coverage and skip logic
+# ABOUTME: Ensures destroy tears down every stack that deploy can create
+
+"""Tests that `ccwb destroy` covers all deployable stacks.
+
+Regression coverage for the gap where `distribution`, `codebuild`, and
+`cowork-dashboard` stacks were deployed but never destroyed, leaving
+orphaned S3/IAM, CodeBuild projects, and dashboards behind.
+"""
+
+import re
+from pathlib import Path
+
+from claude_code_with_bedrock.cli.commands.destroy import DESTROYABLE_STACKS
+
+DEPLOY_SOURCE = (
+    Path(__file__).resolve().parents[3]
+    / "claude_code_with_bedrock"
+    / "cli"
+    / "commands"
+    / "deploy.py"
+)
+
+
+def _deployable_stack_types() -> set[str]:
+    """Extract every stack type deploy.py can append to its deploy list."""
+    source = DEPLOY_SOURCE.read_text(encoding="utf-8")
+    return set(re.findall(r'stacks_to_deploy\.append\(\(\s*"([a-z0-9-]+)"', source))
+
+
+class TestDestroyStackCoverage:
+    """Every stack deploy can create must also be destroyable."""
+
+    def test_destroy_covers_every_deployable_stack(self):
+        deployable = _deployable_stack_types()
+        missing = deployable - set(DESTROYABLE_STACKS)
+        assert not missing, f"destroy is missing deployable stacks: {sorted(missing)}"
+
+    def test_no_phantom_destroyable_stacks(self):
+        # Destroy should not reference stacks deploy never creates.
+        deployable = _deployable_stack_types()
+        phantom = set(DESTROYABLE_STACKS) - deployable
+        assert not phantom, f"destroy lists non-deployable stacks: {sorted(phantom)}"
+
+    def test_previously_missing_stacks_present(self):
+        for stack in ("distribution", "codebuild", "cowork-dashboard"):
+            assert stack in DESTROYABLE_STACKS, f"{stack} must be destroyable"
+
+    def test_no_duplicate_stacks(self):
+        assert len(DESTROYABLE_STACKS) == len(set(DESTROYABLE_STACKS))
+
+
+class TestDestroyReverseDependencyOrder:
+    """Destroy runs in reverse dependency order relative to deploy."""
+
+    def test_distribution_destroyed_before_networking(self):
+        # distribution reads networking outputs, so it must be torn down first.
+        assert DESTROYABLE_STACKS.index("distribution") < DESTROYABLE_STACKS.index("networking")
+
+    def test_auth_destroyed_last(self):
+        # auth is the root dependency; everything else goes first.
+        assert DESTROYABLE_STACKS[-1] == "auth"
+
+    def test_dependents_before_monitoring(self):
+        # dashboard / cowork-dashboard / analytics / quota depend on monitoring.
+        monitoring_idx = DESTROYABLE_STACKS.index("monitoring")
+        for dependent in ("dashboard", "cowork-dashboard", "analytics", "quota"):
+            assert DESTROYABLE_STACKS.index(dependent) < monitoring_idx

--- a/source/tests/cli/commands/test_test_cross_platform.py
+++ b/source/tests/cli/commands/test_test_cross_platform.py
@@ -1,0 +1,88 @@
+# ABOUTME: Tests that `ccwb test` builds a cross-platform credential_process command
+# ABOUTME: Regression guard against the /bin/sh wrapper that broke on Windows
+
+"""Cross-platform regression tests for the `ccwb test` credential command.
+
+The credential_process previously used a `/bin/sh -c '...'` wrapper to set the
+CCWB_PROFILE env var. `/bin/sh` does not exist on Windows, so the temporary test
+profile could never execute. The fix passes the profile via the binary's
+`--profile` flag instead -- the same convention the install scripts use -- and
+quotes the binary path so a space in it survives botocore's shell split.
+"""
+
+from pathlib import Path
+
+import pytest
+
+# botocore is the parser that actually executes credential_process; test against
+# the real splitter (shlex on POSIX, a Windows-rules splitter on win32) rather
+# than re-implementing it.
+from botocore.compat import compat_shell_split
+
+TEST_SOURCE = (
+    Path(__file__).resolve().parents[3]
+    / "claude_code_with_bedrock"
+    / "cli"
+    / "commands"
+    / "test.py"
+)
+
+
+def _build_command(credential_binary: str, test_profile_name: str) -> str:
+    """The exact credential_process string `ccwb test` writes (both call sites).
+
+    Kept in sync with test.py; the source-text test below guards against drift.
+    """
+    return f'"{credential_binary}" --profile {test_profile_name}'
+
+
+class TestNoShellWrapper:
+    """The Windows-incompatible /bin/sh wrapper must not return."""
+
+    def test_no_bin_sh_in_source(self):
+        source = TEST_SOURCE.read_text(encoding="utf-8")
+        # Allow the substring in comments/docstrings; forbid the executable wrapper.
+        assert "/bin/sh -c" not in source, "test.py must not use a /bin/sh wrapper (breaks on Windows)"
+        assert "/bin/bash -c" not in source, "test.py must not use a /bin/bash wrapper (breaks on Windows)"
+
+    def test_both_call_sites_use_helper_format(self):
+        # Both credential_command assignments use the quoted --profile form.
+        source = TEST_SOURCE.read_text(encoding="utf-8")
+        assert source.count('credential_command = f\'"{credential_binary}" --profile {test_profile_name}\'') == 2
+
+
+class TestCredentialCommandParsing:
+    """The command must parse, via botocore's real splitter, back to argv."""
+
+    @pytest.mark.parametrize(
+        "binary",
+        [
+            "/home/user/claude-code-with-bedrock/credential-process",
+            "/opt/credential-process",
+            r"C:\Users\dev\claude-code-with-bedrock\credential-process.exe",
+            # The regression that motivated quoting: a space in the path.
+            r"C:\Users\First Last\claude code with bedrock\credential-process.exe",
+            "/Users/jane doe/claude-code-with-bedrock/credential-process",
+        ],
+    )
+    @pytest.mark.parametrize("platform", ["linux2", "darwin", "win32"])
+    def test_path_survives_shell_split(self, binary, platform):
+        # Skip Windows-style backslash paths on POSIX splitters and vice versa;
+        # each path form is only ever produced on its own platform.
+        is_windows_path = "\\" in binary
+        if is_windows_path and platform != "win32":
+            pytest.skip("Windows path only occurs on win32")
+        if not is_windows_path and platform == "win32":
+            pytest.skip("POSIX path only occurs on POSIX")
+
+        cmd = _build_command(binary, "ClaudeCode")
+        argv = compat_shell_split(cmd, platform=platform)
+        # The binary path must come back as ONE argument, not split on its spaces.
+        assert argv[0] == binary, f"path was mis-split on {platform}: {argv}"
+        assert argv[-2:] == ["--profile", "ClaudeCode"]
+
+    def test_no_shell_metacharacters(self):
+        # No /bin/sh, no env-var wrapper -- just a quoted path plus flag.
+        cmd = _build_command("/opt/credential-process", "prod")
+        assert "sh -c" not in cmd
+        assert "CCWB_PROFILE" not in cmd


### PR DESCRIPTION
## Why

Two reliability fixes for Windows users and resource cleanup:

1. **`ccwb test` fails on Windows** — wraps credential_process in `/bin/sh -c '...'` which doesn't exist on Windows
2. **`ccwb destroy --all` orphans stacks** — distribution and codebuild stacks never added to DESTROYABLE_STACKS

## Changes

- `test.py`: Replace `/bin/sh` wrapper with `--profile` flag (cross-platform)
- `destroy.py`: Add distribution + codebuild in reverse-dependency order with skip-logic
- `CLI_REFERENCE.md`: Updated docs
- 3 regression test files

## Testing

- Includes regression tests for both fixes
- Verified cross-platform: `--profile` flag works identically on Windows/macOS/Linux

Credit: @scouturier (original PR #452, rebased to latest beta)

Closes #452