### PR TITLE
fix: smart destroy with retained resource awareness and pre-cleanup

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/destroy.py
+++ b/source/claude_code_with_bedrock/cli/commands/destroy.py
@@ -119,6 +119,7 @@ class DestroyCommand(Command):
         console.print("\n[bold]Destroying stacks...[/bold]\n")
 
         all_failed_resources = []  # Collect failed resources from all stacks
+        all_retained_resources = []  # Collect intentionally retained resources
         stacks_with_failures = []
 
         for stack in stacks_to_destroy:
@@ -153,14 +154,28 @@ class DestroyCommand(Command):
                 if failed:
                     all_failed_resources.extend(failed)
                     stacks_with_failures.append(stack_name)
-                console.print(
-                    f"[yellow]⚠ {stack.capitalize()} stack has resources requiring manual cleanup[/yellow]\n"
-                )
+                    console.print(f"[yellow]⚠ {stack.capitalize()} stack — failed resources:[/yellow]")
+                    for r in failed:
+                        console.print(f"    • {r['logical_id']} ({r['resource_type']}): {r['physical_id']}")
+                else:
+                    console.print(
+                        f"[yellow]⚠ {stack.capitalize()} stack has resources requiring manual cleanup[/yellow]"
+                    )
+                console.print()
             else:
-                console.print(f"[green]✓ {stack.capitalize()} stack destroyed[/green]\n")
+                # Check for silently retained resources (DeletionPolicy: Retain)
+                retained = self._get_retained_resources(stack_name, profile.aws_region)
+                if retained:
+                    all_retained_resources.extend(retained)
+                    console.print(f"[yellow]ℹ {stack.capitalize()} stack — retained resources (by policy):[/yellow]")
+                    for r in retained:
+                        console.print(f"    • {r['logical_id']} ({r['resource_type']}): {r['physical_id']}")
+                    console.print()
+                else:
+                    console.print(f"[green]✓ {stack.capitalize()} stack destroyed[/green]\n")
 
         # Show cleanup summary at the end
-        self._show_cleanup_summary(all_failed_resources, stacks_with_failures, profile, console)
+        self._show_cleanup_summary(all_failed_resources, all_retained_resources, stacks_with_failures, profile, console)
 
         return 0
 
@@ -180,10 +195,15 @@ class DestroyCommand(Command):
             console.print(f"[yellow]Stack {stack_name} not found or already deleted[/yellow]")
             return 0
 
-        # If already in DELETE_FAILED, report it (don't retry)
+        # If already in DELETE_FAILED, pre-clean and retry
         if status == "DELETE_FAILED":
-            console.print(f"[yellow]Stack {stack_name} is in DELETE_FAILED state[/yellow]")
-            return 1  # Signal that manual cleanup is needed
+            console.print(f"[yellow]Stack {stack_name} is in DELETE_FAILED state, retrying after cleanup...[/yellow]")
+
+        # Pre-clean resources that block deletion (non-empty S3 buckets, Athena workgroups)
+        cf_manager.pre_cleanup_stack(
+            stack_name,
+            on_event=lambda msg: console.print(f"  [dim]{msg}[/dim]"),
+        )
 
         # Use progress indicator
         with Progress(
@@ -220,16 +240,32 @@ class DestroyCommand(Command):
         cf_manager = CloudFormationManager(region=region)
         return cf_manager.get_failed_resources(stack_name)
 
+    def _get_retained_resources(self, stack_name: str, region: str) -> list[dict]:
+        """Get resources silently retained (DeletionPolicy: Retain) during deletion."""
+        cf_manager = CloudFormationManager(region=region)
+        return cf_manager.get_retained_resources(stack_name)
+
     def _show_cleanup_summary(
         self,
         failed_resources: list[dict],
+        retained_resources: list[dict],
         stacks: list[str],
         profile,
         console: Console,
     ) -> None:
-        """Show cleanup instructions for failed resources."""
-        if not failed_resources and not stacks:
+        """Show cleanup instructions for failed and retained resources."""
+        if not failed_resources and not retained_resources and not stacks:
             console.print("\n[green]✓ All stacks destroyed successfully![/green]")
+            return
+
+        if retained_resources:
+            console.print("\n[bold]Retained resources (DeletionPolicy: Retain):[/bold]")
+            console.print("[dim]These were kept intentionally. Delete manually if no longer needed:[/dim]\n")
+            for r in retained_resources:
+                console.print(f"  • {r['logical_id']} ({r['resource_type']}): {r['physical_id']}")
+            console.print()
+
+        if not failed_resources:
             return
 
         console.print("\n[yellow]⚠ Manual cleanup required for the following resources:[/yellow]\n")

--- a/source/claude_code_with_bedrock/cli/utils/cloudformation.py
+++ b/source/claude_code_with_bedrock/cli/utils/cloudformation.py
@@ -291,6 +291,112 @@ class CloudFormationManager:
         except Exception:
             return []
 
+    def get_retained_resources(self, stack_name: str) -> list[dict[str, str]]:
+        """Get resources retained (DeletionPolicy: Retain) during stack deletion.
+
+        These resources are silently skipped by CloudFormation and won't appear
+        in get_failed_resources(). They still exist in the account.
+
+        Co-authored-by: peepeepopapapeepeepo (from PR #330)
+        """
+        try:
+            response = self.cf_client.describe_stack_resources(StackName=stack_name)
+            retained = []
+            for resource in response.get("StackResources", []):
+                if resource["ResourceStatus"] == "DELETE_SKIPPED":
+                    retained.append(
+                        {
+                            "logical_id": resource["LogicalResourceId"],
+                            "physical_id": resource.get("PhysicalResourceId", "N/A"),
+                            "resource_type": resource["ResourceType"],
+                            "status_reason": "DeletionPolicy: Retain",
+                        }
+                    )
+            return retained
+        except ClientError:
+            return []
+        except Exception:
+            return []
+
+    def pre_cleanup_stack(self, stack_name: str, on_event: Callable | None = None) -> None:
+        """Pre-clean resources that block CloudFormation deletion.
+
+        S3 buckets must be empty before CF can delete them.
+        Athena workgroups must have named queries removed first.
+        Skips resources with DeletionPolicy: Retain (kept intentionally).
+
+        Co-authored-by: peepeepopapapeepeepo (from PR #330)
+        """
+        import logging
+
+        try:
+            # Read template to identify Retain resources
+            retained_logical_ids: set[str] = set()
+            try:
+                template_resp = self.cf_client.get_template(StackName=stack_name)
+                import yaml
+
+                template_body = template_resp.get("TemplateBody", {})
+                if isinstance(template_body, str):
+                    template_body = yaml.safe_load(template_body)
+                resources = template_body.get("Resources", {})
+                for logical_id, resource_def in resources.items():
+                    if isinstance(resource_def, dict) and resource_def.get("DeletionPolicy") == "Retain":
+                        retained_logical_ids.add(logical_id)
+            except Exception as e:
+                logging.debug(f"Could not parse template for {stack_name}: {e}")
+
+            response = self.cf_client.describe_stack_resources(StackName=stack_name)
+            for resource in response.get("StackResources", []):
+                physical_id = resource.get("PhysicalResourceId")
+                logical_id = resource.get("LogicalResourceId", "")
+                if not physical_id:
+                    continue
+                if logical_id in retained_logical_ids:
+                    continue
+                rtype = resource["ResourceType"]
+                if rtype == "AWS::S3::Bucket":
+                    if on_event:
+                        on_event(f"Emptying bucket {physical_id}...")
+                    self._empty_bucket(physical_id)
+                elif rtype == "AWS::Athena::WorkGroup":
+                    if on_event:
+                        on_event(f"Cleaning workgroup {physical_id}...")
+                    self._clean_athena_workgroup(physical_id)
+        except ClientError as e:
+            logging.debug(f"Could not pre-clean stack {stack_name}: {e}")
+
+    def _empty_bucket(self, bucket_name: str) -> None:
+        """Delete all objects and versions from an S3 bucket (1000 per batch)."""
+        import logging
+
+        try:
+            paginator = self.s3_client.get_paginator("list_object_versions")
+            for page in paginator.paginate(Bucket=bucket_name):
+                objects = []
+                for v in page.get("Versions", []):
+                    objects.append({"Key": v["Key"], "VersionId": v["VersionId"]})
+                for dm in page.get("DeleteMarkers", []):
+                    objects.append({"Key": dm["Key"], "VersionId": dm["VersionId"]})
+                for i in range(0, len(objects), 1000):
+                    batch = objects[i : i + 1000]
+                    self.s3_client.delete_objects(
+                        Bucket=bucket_name,
+                        Delete={"Objects": batch, "Quiet": True},
+                    )
+        except ClientError as e:
+            logging.debug(f"Could not empty bucket {bucket_name}: {e}")
+
+    def _clean_athena_workgroup(self, workgroup_name: str) -> None:
+        """Force-delete an Athena workgroup and all its contents."""
+        import logging
+
+        try:
+            athena = self.session.client("athena")
+            athena.delete_work_group(WorkGroup=workgroup_name, RecursiveDeleteOption=True)
+        except ClientError as e:
+            logging.debug(f"Could not clean Athena workgroup {workgroup_name}: {e}")
+
     def package_template(
         self, template_path: str | Path, s3_bucket: str, s3_prefix: str = None, on_event: Callable = None
     ) -> str:


### PR DESCRIPTION
## Why

`ccwb destroy` fails silently on non-empty S3 buckets and doesn't report resources kept by `DeletionPolicy: Retain`. Users see generic 'manual cleanup required' without knowing what was retained vs what actually failed. Issue #360.

## What

Cherry-picked destroy improvements from PR #330 (credit: @peepeepopapapeepeepo):

1. **`pre_cleanup_stack()`** — reads CF template to identify Retain resources, then empties S3 buckets and cleans Athena workgroups before deletion. Never touches Retain resources.

2. **`get_retained_resources()`** — reports `DELETE_SKIPPED` resources so users know what was intentionally kept.

3. **DELETE_FAILED retry** — instead of giving up, runs pre-cleanup and retries deletion.

4. **Batch delete** — `_empty_bucket` uses 1000-object batches (S3 API hard limit).

5. **Improved output** — per-resource failure details + retained resource list with cleanup instructions.

## Testing

- Syntax validated (Python AST parse)
- No changes to existing test assertions
- Additive methods on `CloudFormationManager` — zero risk to deploy/other commands

## Credit

Co-authored-by: @peepeepopapapeepeepo (from PR #330)

Fixes #360