### PR TITLE
chore: extract shared utility helpers from PR #330

### DIFF
--- a/source/claude_code_with_bedrock/cli/utils/helpers.py
+++ b/source/claude_code_with_bedrock/cli/utils/helpers.py
@@ -1,0 +1,58 @@
+# ABOUTME: Shared AWS utility helpers for CLI commands
+# ABOUTME: Extracted from multiple commands to reduce duplication
+
+"""Additional AWS utility helpers."""
+
+import configparser
+import logging
+from pathlib import Path
+
+
+def clear_cached_credentials(profile_name: str) -> bool:
+    """Clear cached AWS credentials created by this tool for a profile.
+
+    Only removes the credentials section if it was created by ccwb
+    (contains credential_process referencing claude-code-with-bedrock or ccwb).
+
+    Returns True if credentials were cleared, False otherwise.
+
+    Co-authored-by: peepeepopapapeepeepo (from PR #330)
+    """
+    try:
+        cred_path = Path.home() / ".aws" / "credentials"
+        if not cred_path.exists():
+            return False
+
+        config = configparser.ConfigParser()
+        config.read(cred_path, encoding="utf-8")
+
+        if profile_name not in config:
+            return False
+
+        # Only remove if it's a section created by this tool
+        section_items = dict(config.items(profile_name))
+        is_ours = any(
+            "credential-process" in v or "claude-code-with-bedrock" in v or "ccwb" in v
+            for v in section_items.values()
+        )
+        if not is_ours:
+            return False
+
+        config.remove_section(profile_name)
+        with open(cred_path, "w", encoding="utf-8") as f:
+            config.write(f)
+        return True
+    except Exception as e:
+        logging.debug(f"Could not clear cached credentials for {profile_name}: {e}")
+        return False
+
+
+def get_codebuild_region(profile) -> str:
+    """Get the region where CodeBuild resources are deployed.
+
+    Currently returns profile.aws_region. Extracted as a helper so
+    future cross-region CodeBuild support has a single point of change.
+
+    Co-authored-by: peepeepopapapeepeepo (from PR #330)
+    """
+    return getattr(profile, "codebuild_region", None) or profile.aws_region

--- a/source/tests/cli/utils/test_helpers.py
+++ b/source/tests/cli/utils/test_helpers.py
@@ -1,0 +1,87 @@
+# ABOUTME: Tests for shared CLI utility helpers
+# ABOUTME: Verifies clear_cached_credentials and get_codebuild_region
+
+"""Tests for cli/utils/helpers.py."""
+
+import configparser
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from claude_code_with_bedrock.cli.utils.helpers import (
+    clear_cached_credentials,
+    get_codebuild_region,
+)
+
+
+class TestClearCachedCredentials:
+    """Tests for clear_cached_credentials utility."""
+
+    def test_clears_ccwb_credential_section(self, tmp_path):
+        """Removes credential section created by ccwb."""
+        cred_file = tmp_path / ".aws" / "credentials"
+        cred_file.parent.mkdir(parents=True)
+        cred_file.write_text(
+            "[my-profile]\n"
+            "credential_process = /usr/local/bin/claude-code-with-bedrock credential-process --profile my-profile\n"
+        )
+        with patch("claude_code_with_bedrock.cli.utils.helpers.Path.home", return_value=tmp_path):
+            result = clear_cached_credentials("my-profile")
+        assert result is True
+        # Verify section is gone
+        config = configparser.ConfigParser()
+        config.read(cred_file)
+        assert "my-profile" not in config
+
+    def test_does_not_clear_unrelated_credentials(self, tmp_path):
+        """Does not touch credential sections not created by ccwb."""
+        cred_file = tmp_path / ".aws" / "credentials"
+        cred_file.parent.mkdir(parents=True)
+        cred_file.write_text(
+            "[my-profile]\n"
+            "aws_access_key_id = AKIAIOSFODNN7EXAMPLE\n"  # pragma: allowlist secret
+            "aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n"  # pragma: allowlist secret
+        )
+        with patch("claude_code_with_bedrock.cli.utils.helpers.Path.home", return_value=tmp_path):
+            result = clear_cached_credentials("my-profile")
+        assert result is False
+
+    def test_returns_false_when_no_credentials_file(self, tmp_path):
+        """Returns False when ~/.aws/credentials doesn't exist."""
+        with patch("claude_code_with_bedrock.cli.utils.helpers.Path.home", return_value=tmp_path):
+            result = clear_cached_credentials("any-profile")
+        assert result is False
+
+    def test_returns_false_when_profile_not_in_credentials(self, tmp_path):
+        """Returns False when profile section doesn't exist."""
+        cred_file = tmp_path / ".aws" / "credentials"
+        cred_file.parent.mkdir(parents=True)
+        cred_file.write_text("[other-profile]\naws_access_key_id = test\n")
+        with patch("claude_code_with_bedrock.cli.utils.helpers.Path.home", return_value=tmp_path):
+            result = clear_cached_credentials("my-profile")
+        assert result is False
+
+
+class TestGetCodebuildRegion:
+    """Tests for get_codebuild_region utility."""
+
+    def test_returns_aws_region_by_default(self):
+        """Returns profile.aws_region when no codebuild_region set."""
+        profile = MagicMock()
+        profile.aws_region = "us-west-2"
+        profile.codebuild_region = None
+        assert get_codebuild_region(profile) == "us-west-2"
+
+    def test_returns_codebuild_region_when_set(self):
+        """Returns codebuild_region override when explicitly set."""
+        profile = MagicMock()
+        profile.aws_region = "us-west-2"
+        profile.codebuild_region = "us-east-1"
+        assert get_codebuild_region(profile) == "us-east-1"
+
+    def test_falls_back_when_codebuild_region_missing(self):
+        """Falls back to aws_region when attr doesn't exist."""
+        profile = MagicMock(spec=[])
+        profile.aws_region = "eu-west-1"
+        assert get_codebuild_region(profile) == "eu-west-1"


### PR DESCRIPTION
## Why

Several utilities from PR #330 (@peepeepopapapeepeepo) are useful independently of the larger changes. Extracting them as shared helpers reduces future duplication.

## What

New file: `source/claude_code_with_bedrock/cli/utils/helpers.py`

### `clear_cached_credentials(profile_name)`
Safely removes AWS credential sections created by ccwb from `~/.aws/credentials`. Only touches sections it owns (checks for `credential-process`/`claude-code-with-bedrock`/`ccwb` in values). Useful for destroy and re-init workflows.

### `get_codebuild_region(profile)`
Returns the region for CodeBuild resources. Currently returns `profile.aws_region` but extracted as a single point of change for future cross-region CodeBuild support.

## Risk

**Very low — purely additive.**
- No existing code is modified
- New helpers are not wired into any commands yet (zero call sites)
- Only adds new files + tests
- 7 regression tests cover both helpers including edge cases
- Cross-platform safe (uses `pathlib`, `configparser`)

## Files

- `source/claude_code_with_bedrock/cli/utils/helpers.py` — 2 shared helpers
- `source/tests/cli/utils/__init__.py` — test package init
- `source/tests/cli/utils/test_helpers.py` — 7 tests

Co-authored-by: peepeepopapapeepeepo (from PR #330)
