### PR TITLE
fix: strip macOS quarantine attribute from otel-helper

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -2420,6 +2420,7 @@ if [ -f "$OTEL_BINARY" ]; then
     echo "Installing OTEL helper..."
     cp "$OTEL_BINARY" ~/claude-code-with-bedrock/otel-helper
     chmod +x ~/claude-code-with-bedrock/otel-helper
+    xattr -d com.apple.quarantine ~/claude-code-with-bedrock/otel-helper 2>/dev/null || true
     echo "✓ OTEL helper installed"
 fi
 


### PR DESCRIPTION
## Why

macOS Gatekeeper blocks the otel-helper binary with "Apple could not verify" for package installs downloaded from S3/landing page. This silently breaks telemetry collection — users' usage isn't tracked, dashboards show them as inactive, and quota enforcement may undercount.

The quarantine strip was already applied to `credential-process` (line 2365) but missed for `otel-helper`.

## Change

One line: `xattr -d com.apple.quarantine ~/claude-code-with-bedrock/otel-helper 2>/dev/null || true`

Same pattern already used for credential-process. The `2>/dev/null || true` ensures no-op on Linux/Windows or if the attribute doesn't exist.

## Risk

Zero regression risk — additive one-liner, only affects macOS, no-op on other platforms.

Credit: @jphuynh (original PR #243, rebased to latest beta)

Supersedes #243