### PR TITLE
fix: replace Nuitka with Go for Windows CodeBuild binaries

### DIFF
--- a/deployment/infrastructure/codebuild-windows.yaml
+++ b/deployment/infrastructure/codebuild-windows.yaml
@@ -178,6 +178,9 @@ Resources:
             post_build:
               commands:
                 - echo Build completed
+                - echo Validating all required binaries exist...
+                - if (-not (Test-Path credential-process-windows.exe)) { Write-Error "FATAL: credential-process-windows.exe was not built. Nuitka compilation failed."; exit 1 }
+                - if (-not (Test-Path otel-helper-windows.exe)) { Write-Error "FATAL: otel-helper-windows.exe was not built. Nuitka compilation failed. Consider using 'ccwb package --go' for reliable Go-based builds."; exit 1 }
                 - Get-ChildItem *.exe | ForEach-Object { Write-Host "$($_.Name) - $([math]::Round($_.Length/1MB, 1)) MB" }
 
           artifacts:


### PR DESCRIPTION
## Why

Windows users running `ccwb package_cb` get a distribution package missing `otel-helper-windows.exe` (issue #426, reported by @surya-my). The Nuitka compilation for the OTEL helper can silently fail, but the CodeBuild build still reports SUCCESS and produces an incomplete artifact zip.

## Context: Two Valid Build Paths

| Path | Command | How it works | Cross-compile? |
|------|---------|-------------|----------------|
| **Go** | `ccwb package --go` | Local Go cross-compilation for all platforms | ✅ Yes — builds Windows/Linux/macOS from any OS |
| **Python (Nuitka)** | `ccwb package_cb` | Remote CodeBuild with Nuitka (Python→native) | ❌ No — needs Windows CodeBuild for Windows binaries |

Both are valid deployment options. Users choose based on their preference:
- `--go`: Faster (~30s), smaller binaries (~10MB), no AV false positives, works locally
- `package_cb`: Produces Python-native binaries, uses existing CodeBuild infra

**This PR does NOT change the build mechanism.** It only adds validation so that Nuitka failures are caught immediately rather than producing incomplete packages.

## What Changed

**1 file, +3 lines** in `deployment/infrastructure/codebuild-windows.yaml`:

Added `post_build` validation steps:
```powershell
# Fail the build if either binary is missing
if (-not (Test-Path credential-process-windows.exe)) { Write-Error "FATAL: ..."; exit 1 }
if (-not (Test-Path otel-helper-windows.exe)) { Write-Error "FATAL: ... Consider using 'ccwb package --go'"; exit 1 }
```

## What This Does NOT Change

- ❌ Does not switch from Nuitka to Go
- ❌ Does not change the build process
- ❌ Does not affect `ccwb package --go` (that path already works fine)
- ❌ Does not affect Linux or macOS builds

## User Experience After This Fix

**Before:** CodeBuild reports SUCCESS → user downloads zip → zip is missing otel-helper → Windows users have no OTEL metrics → discovered much later

**After:** CodeBuild reports FAILED → error message says "otel-helper-windows.exe was not built. Nuitka compilation failed. Consider using 'ccwb package --go' for reliable Go-based builds." → user knows immediately and has a clear workaround

## Why Not Just Switch to Go for CodeBuild?

Go cross-compilation works locally (`--go` flag) without needing CodeBuild at all. The CodeBuild Python/Nuitka path exists for users who prefer Python-native binaries. Both paths should remain valid — we just need the Nuitka path to fail loudly when it breaks.

## Testing

- YAML validates correctly (CloudFormation intrinsics parsed)
- No functional changes — only adds post_build checks
- Zero regression risk (validation only runs after build, doesn't affect build itself)

Fixes #426
