### PR TITLE
fix: anchor install.bat to its own directory for Run as Administrator

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -2532,6 +2532,7 @@ echo
 
         installer_content = f"""@echo off
 SETLOCAL ENABLEDELAYEDEXPANSION
+cd /d "%~dp0"
 REM Claude Code Authentication Installer for Windows
 REM Organization: {profile.provider_domain}
 REM Generated: {datetime.now().strftime("%Y-%m-%d %H:%M:%S")}


### PR DESCRIPTION
## Why

Windows changes CWD to `C:\Windows\System32` when batch files are launched via right-click "Run as Administrator". All relative `copy` commands then fail because the binaries aren't in System32.

This affects all Windows enterprise/government users who follow the standard right-click → Run as Administrator pattern.

## Change

One line added after `SETLOCAL ENABLEDELAYEDEXPANSION`:

```batch
cd /d "%~dp0"
```

This anchors the script to its own directory regardless of how it was launched.

## Risk

**Near zero regression:**
- `cd /d "%~dp0"` is idempotent — if already in the right directory, it's a no-op
- Standard Windows pattern used by virtually every batch installer
- No effect on Linux/macOS installers
- No effect on users who already run from the correct directory

Closes #392