### PR TITLE
fix: anchor install.sh to its own directory for any-CWD execution

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -2257,6 +2257,9 @@ RUN pyinstaller \
 
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "${{BASH_SOURCE[0]}}")" && pwd)"
+cd "$SCRIPT_DIR"
+
 echo "======================================"
 echo "Claude Code Authentication Installer"
 echo "======================================"


### PR DESCRIPTION
## Why

Running `bash /path/to/package/install.sh` from a different directory causes all relative paths to fail — the script can't find the binaries it needs to copy.

Companion to #474 (which fixed the same issue for `install.bat` on Windows).

## Change

```bash
SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
cd "$SCRIPT_DIR"
```

Standard shell pattern to resolve the script's own directory and anchor to it.

## Risk

**Near zero:**
- Idempotent — if already in the right directory, it's a no-op
- Standard pattern used by every serious shell installer
- No effect on Windows users
- `BASH_SOURCE[0]` is bash-specific but the script already uses bash features (`[[ ]]`, arrays)

Credit: @scouturier (original PR #333)
Supersedes #333