### PR TITLE
fix: dashboard widgets fall back to user.id when user.email absent

### DIFF
--- a/deployment/infrastructure/claude-code-dashboard.yaml
+++ b/deployment/infrastructure/claude-code-dashboard.yaml
@@ -43,7 +43,7 @@ Resources:
                 "title": "Active Users",
                 "view": "number",
                 "region": "${MetricsRegion}",
-                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "count(group by (\"user.email\")({\"claude_code.session.count\", \"@resource.service.name\"=\"claude-code\"}))", "step": 60, "label": "Users" }] },
+                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "count(group by (\"user.email\", \"user.id\")({\"claude_code.session.count\", \"@resource.service.name\"=\"claude-code\"}))", "step": 60, "label": "Users" }] },
                 "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
@@ -124,7 +124,7 @@ Resources:
                 "view": "line",
                 "region": "${MetricsRegion}",
                 "data": { "queries": [
-                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (\"user.email\")({\"claude_code.token.usage\", \"@resource.service.name\"=\"claude-code\"}))", "step": 60 }
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (\"user.email\", \"user.id\")({\"claude_code.token.usage\", \"@resource.service.name\"=\"claude-code\"}))", "step": 60 }
                 ] },
                 "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
@@ -137,7 +137,7 @@ Resources:
                 "view": "line",
                 "region": "${MetricsRegion}",
                 "data": { "queries": [
-                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (\"user.email\")({\"claude_code.cost.usage\", \"@resource.service.name\"=\"claude-code\"}))", "step": 60 }
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(500, sum by (\"user.email\", \"user.id\")({\"claude_code.cost.usage\", \"@resource.service.name\"=\"claude-code\"}))", "step": 60 }
                 ] },
                 "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
@@ -150,7 +150,7 @@ Resources:
                 "view": "line",
                 "region": "${MetricsRegion}",
                 "data": { "queries": [
-                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "count(group by (\"user.email\")({\"claude_code.session.count\", \"@resource.service.name\"=\"claude-code\"}))", "step": 60, "label": "Active Users" }
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "count(group by (\"user.email\", \"user.id\")({\"claude_code.session.count\", \"@resource.service.name\"=\"claude-code\"}))", "step": 60, "label": "Active Users" }
                 ] },
                 "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }

--- a/source/tests/test_dashboard_user_fallback.py
+++ b/source/tests/test_dashboard_user_fallback.py
@@ -1,0 +1,71 @@
+"""Regression test for issue #365: dashboard widgets must not hard-filter on user.email only."""
+
+import json
+from pathlib import Path
+
+import yaml
+
+
+INFRA_DIR = Path(__file__).resolve().parents[2] / "deployment" / "infrastructure"
+
+
+# Custom YAML loader for CloudFormation intrinsic functions
+class CfnLoader(yaml.SafeLoader):
+    pass
+
+
+def _cfn_tag_constructor(loader, tag_suffix, node):
+    if isinstance(node, yaml.ScalarNode):
+        return loader.construct_scalar(node)
+    elif isinstance(node, yaml.SequenceNode):
+        return loader.construct_sequence(node)
+    elif isinstance(node, yaml.MappingNode):
+        return loader.construct_mapping(node)
+
+
+CfnLoader.add_multi_constructor("!", _cfn_tag_constructor)
+
+
+class TestDashboardUserFallback:
+    """Dashboard widgets must group by both user.email and user.id for resilience."""
+
+    def _get_dashboard_body(self):
+        """Extract the dashboard JSON body from the CloudFormation template."""
+        template_path = INFRA_DIR / "claude-code-dashboard.yaml"
+        with open(template_path, encoding="utf-8") as f:
+            template = yaml.load(f, Loader=CfnLoader)
+
+        # Find the dashboard resource
+        for name, resource in template.get("Resources", {}).items():
+            if resource.get("Type") == "AWS::CloudWatch::Dashboard":
+                body = resource.get("Properties", {}).get("DashboardBody", "")
+                if isinstance(body, str):
+                    return body
+        return ""
+
+    def test_active_users_widget_includes_user_id(self):
+        """Active Users widget must group by user.id (not just user.email)."""
+        body = self._get_dashboard_body()
+        # Check that any group by clause includes user.id
+        assert "user.id" in body, (
+            "Dashboard must include user.id in group-by clauses. "
+            "Without this, users whose OTEL stream lacks user.email "
+            "(e.g., no otel-helper installed) are invisible in dashboards. "
+            "See issue #365."
+        )
+
+    def test_no_exclusive_user_email_grouping(self):
+        """No widget should group ONLY by user.email without user.id fallback."""
+        body = self._get_dashboard_body()
+        # Find all group by / sum by clauses
+        import re
+        # Match: group by ("user.email") or sum by ("user.email") WITHOUT user.id
+        exclusive_patterns = re.findall(
+            r'(?:group|sum) by \(\\"user\.email\\"\)(?!\s*,\s*\\"user\.id\\")',
+            body
+        )
+        assert len(exclusive_patterns) == 0, (
+            f"Found {len(exclusive_patterns)} widget(s) that group exclusively by "
+            f"user.email without user.id fallback. This causes widgets to show 0 "
+            f"when otel-helper is not installed. See issue #365."
+        )


### PR DESCRIPTION
## Why

All per-user dashboard widgets (Active Users, Top Users, Token Usage by User, Cost by User) show **0** when the OTEL stream lacks `user.email` — which happens for:
- IDC (Identity Center) users where email is resolved server-side
- Deployments with `sso_enabled=false`
- Users without otel-helper installed (direct OTEL endpoint usage)

The widgets hard-filtered with `group by ("user.email")` / `sum by ("user.email")`, silently dropping all metrics without that attribute.

## Change

Replace exclusive `user.email` grouping with `user.email, user.id`:

```promql
# Before
count(group by ("user.email")({...}))

# After  
count(group by ("user.email", "user.id")({...}))
```

This ensures metrics are counted regardless of which user identifier is present. Users with otel-helper still show by email; IDC/anonymous users show by their hashed machine ID.

## Testing

Regression test verifies:
1. `user.id` appears in dashboard body
2. No widget groups exclusively by `user.email` without `user.id` fallback

## Risk

**Near zero** — only changes dashboard query grouping labels. No infrastructure, no auth, no credential paths affected.

Relates to #365