### PR TITLE
fix: handle SSO disabled mode in review configuration

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1926,9 +1926,12 @@ sso_registration_scopes = sso:account:access"""
                 else "Session Files (temporary)"
             ),
         )
-        table.add_row("Infrastructure Region", f"{config['aws']['region']} (Cognito, IAM, Monitoring)")
-        table.add_row("Identity Pool", config["aws"]["identity_pool_name"])
-        table.add_row("Monitoring", "✓ Enabled" if config["monitoring"]["enabled"] else "✗ Disabled")
+        if sso_enabled:
+            table.add_row("Infrastructure Region", f"{config['aws']['region']} (Cognito, IAM, Monitoring)")
+            table.add_row("Identity Pool", config.get("aws", {}).get("identity_pool_name", "—"))
+        else:
+            table.add_row("Infrastructure Region", f"{config['aws']['region']} (IAM, Monitoring)")
+        table.add_row("Monitoring", "✓ Enabled" if config.get("monitoring", {}).get("enabled") else "✗ Disabled")
         if config.get("monitoring", {}).get("enabled"):
             mode = config.get("monitoring", {}).get("mode", "sidecar")
             mode_label = "Central (ECS Fargate)" if mode == "central" else "Sidecar (local collector)"
@@ -2005,10 +2008,11 @@ sso_registration_scopes = sso:account:access"""
 
         # Show what will be created
         console.print("\n[bold yellow]Resources to be created:[/bold yellow]")
-        if config.get("federation_type") == "direct":
-            console.print("• IAM OIDC Provider for authentication")
-        else:
-            console.print("• Cognito Identity Pool for authentication")
+        if sso_enabled:
+            if config.get("federation_type") == "direct":
+                console.print("• IAM OIDC Provider for authentication")
+            else:
+                console.print("• Cognito Identity Pool for authentication")
         console.print("• IAM roles and policies for Bedrock access")
         if config.get("monitoring", {}).get("enabled"):
             mode = config.get("monitoring", {}).get("mode", "sidecar")

--- a/source/tests/test_review_config_sso_disabled.py
+++ b/source/tests/test_review_config_sso_disabled.py
@@ -1,0 +1,74 @@
+"""Regression test for PR #367: _review_configuration must not crash when SSO is disabled."""
+
+import ast
+from pathlib import Path
+
+
+INIT_FILE = Path(__file__).resolve().parents[1] / "claude_code_with_bedrock" / "cli" / "commands" / "init.py"
+
+
+class TestReviewConfigSSO:
+    """Ensure _review_configuration handles sso_enabled=False without KeyError."""
+
+    def _get_review_source(self):
+        """Extract the _review_configuration method source."""
+        content = INIT_FILE.read_text(encoding="utf-8")
+        tree = ast.parse(content)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "_review_configuration":
+                start = node.lineno - 1
+                end = node.end_lineno
+                lines = content.split("\n")[start:end]
+                return "\n".join(lines)
+        return ""
+
+    def test_identity_pool_uses_safe_access(self):
+        """identity_pool_name must use .get() not direct dict access."""
+        source = self._get_review_source()
+        # Must NOT have config["aws"]["identity_pool_name"] (bare key access)
+        assert 'config["aws"]["identity_pool_name"]' not in source, (
+            "_review_configuration accesses config['aws']['identity_pool_name'] directly. "
+            "This causes KeyError when SSO is disabled and no identity pool exists. "
+            "Use config.get('aws', {}).get('identity_pool_name', '—') instead."
+        )
+
+    def test_monitoring_uses_safe_access(self):
+        """monitoring.enabled must use .get() not direct dict access."""
+        source = self._get_review_source()
+        # Must NOT have config["monitoring"]["enabled"] (bare key access)
+        assert 'config["monitoring"]["enabled"]' not in source, (
+            "_review_configuration accesses config['monitoring']['enabled'] directly. "
+            "This causes KeyError when monitoring section is absent. "
+            "Use config.get('monitoring', {}).get('enabled') instead."
+        )
+
+    def test_resources_section_guards_sso(self):
+        """'Resources to be created' section must not show Cognito/OIDC when SSO disabled."""
+        source = self._get_review_source()
+        # The federation_type / Cognito block must be inside an sso_enabled check
+        assert "if sso_enabled" in source, (
+            "_review_configuration 'Resources to be created' section must guard "
+            "Cognito/OIDC resource listing behind sso_enabled check. "
+            "Without this, non-SSO users see misleading resource list."
+        )
+
+    def test_identity_pool_row_guarded(self):
+        """Identity Pool table row must only show when SSO is enabled."""
+        source = self._get_review_source()
+        # identity_pool_name should appear inside an if sso_enabled block
+        lines = source.split("\n")
+        in_sso_block = False
+        pool_in_block = False
+        for line in lines:
+            if "if sso_enabled" in line:
+                in_sso_block = True
+            if in_sso_block and "identity_pool_name" in line:
+                pool_in_block = True
+                break
+            if in_sso_block and line.strip() and not line.strip().startswith(("#", "table", "if", "else")):
+                if line.strip().startswith("else") or (not line.startswith(" " * 8) and line.strip()):
+                    pass  # Keep going through the block
+        assert pool_in_block, (
+            "identity_pool_name display must be inside an 'if sso_enabled' guard. "
+            "Non-SSO deployments don't have an identity pool."
+        )


### PR DESCRIPTION
## Why

`ccwb init` crashes at the review step (Step 5) with a `KeyError` when users select **"No" for SSO**. The `_review_configuration` method directly accesses `config['aws']['identity_pool_name']` and `config['monitoring']['enabled']` — both of which don't exist in non-SSO configurations.

This affects users deploying with IAM Identity Center (IDC) or "no auth" mode — they can't complete the init wizard.

## User Impact

| User type | Before this fix | After |
|-----------|----------------|-------|
| SSO disabled (IDC/none) | ❌ Crash at review step — can't complete init | ✅ Review shows "IAM-based (SSO disabled)" cleanly |
| SSO enabled (OIDC) | ✅ Works | ✅ No change |
| Re-init existing profile | ❌ Crash if monitoring section absent | ✅ Safe `.get()` access |

**Error users saw:**
```
KeyError: 'identity_pool_name'
```
at the review configuration step, after completing all wizard questions.

## Changes

| File | What |
|------|------|
| `init.py` | Guard `identity_pool_name` row behind `if sso_enabled` |
| `init.py` | Use `.get()` for `monitoring.enabled` (safe access) |
| `init.py` | Show "IAM, Monitoring" instead of "Cognito, IAM, Monitoring" for non-SSO |
| `init.py` | Guard auth resource listing (Cognito/OIDC) behind `sso_enabled` |
| `test_review_config_sso_disabled.py` | 4 static analysis regression tests |

## Regression Prevention

The 4 tests use **AST-based static analysis** — they parse `_review_configuration` and verify:

1. `config["aws"]["identity_pool_name"]` never appears (must use `.get()`)
2. `config["monitoring"]["enabled"]` never appears (must use `.get()`)
3. `if sso_enabled` guard exists before Cognito/OIDC resource listing
4. `identity_pool_name` display is inside an `sso_enabled` block

These tests catch regressions at the **code pattern level** — if someone adds a new direct dict access in `_review_configuration`, CI fails immediately without needing to exercise the runtime path.

## Suggested Further Improvements

1. **Apply the same pattern repo-wide:** Other commands (deploy, status) likely have similar bare `config["key"]` access that crashes in non-SSO mode. A broader sweep would help.

2. **Config schema validation:** A `validate_config()` function that checks required fields exist before entering command logic would catch these earlier than at the point of access.

3. **Integration test with non-SSO config:** The static analysis tests catch the pattern, but an actual integration test that runs `_review_configuration` with a minimal non-SSO config dict would catch any NEW fields added without guards.

## Risk

**Low** — only changes display logic in the review step. No auth, credential, or deployment paths affected. The review step is read-only (it just renders a table for the user to confirm).

Credit: @dineshSajwan (original PR #367)
Fixes the crash reported in #367
