### PR TITLE
fix: disable CodeBuild artifact encryption to resolve KMS AccessDenied (#355)

### DIFF
--- a/deployment/infrastructure/codebuild-windows.yaml
+++ b/deployment/infrastructure/codebuild-windows.yaml
@@ -131,6 +131,7 @@ Resources:
         Name: windows-binaries.zip
         Packaging: ZIP
         OverrideArtifactName: false
+        EncryptionDisabled: true
       Environment:
         Type: WINDOWS_SERVER_2022_CONTAINER
         ComputeType: BUILD_GENERAL1_LARGE
@@ -212,6 +213,7 @@ Resources:
         Name: linux-x64-binaries.zip
         Packaging: ZIP
         OverrideArtifactName: false
+        EncryptionDisabled: true
       Environment:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_LARGE
@@ -287,6 +289,7 @@ Resources:
         Name: linux-arm64-binaries.zip
         Packaging: ZIP
         OverrideArtifactName: false
+        EncryptionDisabled: true
       Environment:
         Type: ARM_CONTAINER
         ComputeType: BUILD_GENERAL1_LARGE


### PR DESCRIPTION
## Problem

CodeBuild artifact upload fails with `kms:Decrypt AccessDenied` (issue #355, reported by @yagoTobi). The CodeBuild service role doesn't have KMS permissions, so when CodeBuild tries to encrypt artifacts using the default AWS-managed KMS key, the upload fails — even though the build itself succeeds.

This affects enterprise accounts with SCPs mandating KMS encryption or accounts where the default S3 encryption overrides are in place.

## Fix

Set `EncryptionDisabled: true` on all three CodeBuild project Artifacts blocks (Windows, Linux x64, Linux arm64).

This tells CodeBuild not to apply its own encryption layer. Artifacts are still encrypted at rest via the S3 bucket's `SSEAlgorithm: AES256` configuration (already present on `BuildBucket`).

## Risk Assessment: Low

| Aspect | Detail |
|--------|--------|
| Change scope | 3 lines added (one per Artifacts block) |
| IAM changes | None |
| New parameters | None |
| Breaking change | No — existing deployments work the same; previously-failing deployments now succeed |
| Data at rest | Still AES256 encrypted (S3-managed) |
| Rollback | Remove the line; next CloudFormation update reverts to default |

## What we're NOT doing

- ❌ Adding KMS permissions to the service role (over-permissive)
- ❌ Creating/managing a KMS key (unnecessary complexity)
- ❌ Any IAM policy changes

## Testing

1. Deploy stack update → CodeBuild project updates artifact config
2. Trigger a build: `ccwb package --target-platform windows --force-codebuild`
3. Verify build completes and artifacts upload to S3
4. Confirm encryption: `aws s3api head-object` shows `ServerSideEncryption: AES256`

Closes #355