### PR TITLE
chore: refresh secrets baseline to fix false-positive CI failures

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -301,9 +301,10 @@
       {
         "type": "Base64 High Entropy String",
         "filename": "source/tests/integration/test_package_structure.py",
-        "is_secret": false,
+        "hashed_secret": "a0422442dba3fda71eda7b743f0e726ad8af17a5",
+        "is_verified": false,
         "line_number": 385,
-        "hashed_secret": ""
+        "is_secret": false
       }
     ],
     "source/tests/test_cloudformation.py": [
@@ -344,25 +345,20 @@
     ],
     "source/tests/test_credential_passthrough.py": [
       {
-        "type": "AWS Access Key",
-        "filename": "source/tests/test_credential_passthrough.py",
-        "is_secret": false,
-        "line_number": 28,
-        "hashed_secret": ""
-      },
-      {
         "type": "Base64 High Entropy String",
         "filename": "source/tests/test_credential_passthrough.py",
-        "is_secret": false,
+        "hashed_secret": "d70eab08607a4d05faa2d0d6647206599e9abc65",
+        "is_verified": false,
         "line_number": 29,
-        "hashed_secret": ""
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "source/tests/test_credential_passthrough.py",
-        "is_secret": false,
+        "hashed_secret": "d70eab08607a4d05faa2d0d6647206599e9abc65",
+        "is_verified": false,
         "line_number": 29,
-        "hashed_secret": ""
+        "is_secret": false
       }
     ],
     "source/tests/test_oidc_discovery.py": [
@@ -394,5 +390,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-06T13:44:09Z"
+  "generated_at": "2026-06-07T05:15:04Z"
 }


### PR DESCRIPTION
## Problem

The `secrets-scanner` CI job fails on every PR with:

```
potential secrets in: ["source/tests/integration/test_package_structure.py","source/tests/test_credential_passthrough.py"]
```

These are **mock credentials in test files** (fake AWS access keys, base64 test fixtures). The baseline had stale entries with empty `hashed_secret` that no longer matched the current scan output, causing `detect-secrets` to re-detect them as unaudited (`is_secret: null`).

## Fix

1. Ran `detect-secrets scan --baseline .secrets.baseline` to refresh with current line numbers and hashes
2. Marked all test file findings as `is_secret: false` (audited false positives)
3. Removed stale entries with empty `hashed_secret` values

## Risk: None

- No code changes
- No workflow changes  
- Only updates the allowlist of known false positives
- CI `secrets-scanner` will now pass on all PRs