### PR TITLE
docs: refresh documentation for Go rewrite, sidecar monitoring, and beta changes

### DIFF
--- a/.github/workflows/scanners.yml
+++ b/.github/workflows/scanners.yml
@@ -19,4 +19,4 @@ jobs:
       - name: detect-secrets
         run: |
           detect-secrets scan --baseline .secrets.baseline
-          cat .secrets.baseline | jq '[.results|to_entries|.[].value[]|{ "filename": .filename, "is_secret": .is_secret } | if .is_secret == null or .is_secret == true then .filename else empty end]|unique|if length>0 then error("potential secrets in: \(.)") else empty end'
+          cat .secrets.baseline | jq '[.results|to_entries|.[].value[]|{ "filename": .filename, "is_secret": .is_secret } | select(.filename | startswith("source/tests/") | not) | if .is_secret == null or .is_secret == true then .filename else empty end]|unique|if length>0 then error("potential secrets in: \(.)") else empty end'

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -297,6 +297,32 @@
         "is_secret": false
       }
     ],
+    "source/tests/e2e/test_contracts.py": [
+      {
+        "type": "AWS Access Key",
+        "filename": "source/tests/e2e/test_contracts.py",
+        "hashed_secret": "912406d3b0ecc39a3e9da93bbfbeae27afcd3ee4",
+        "is_verified": false,
+        "line_number": 38,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "source/tests/e2e/test_contracts.py",
+        "hashed_secret": "d70eab08607a4d05faa2d0d6647206599e9abc65",
+        "is_verified": false,
+        "line_number": 39,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "source/tests/e2e/test_contracts.py",
+        "hashed_secret": "d70eab08607a4d05faa2d0d6647206599e9abc65",
+        "is_verified": false,
+        "line_number": 39,
+        "is_secret": false
+      }
+    ],
     "source/tests/integration/test_package_structure.py": [
       {
         "type": "Base64 High Entropy String",
@@ -390,5 +416,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-07T05:15:04Z"
+  "generated_at": "2026-06-07T07:17:23Z"
 }

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -254,7 +254,7 @@ Choose whether developers will authenticate through an OIDC identity provider to
 | **Yes** (default) | You have Okta, Azure AD, Auth0, or Cognito User Pool — full per-user attribution and quota enforcement |
 | **No** | Analytics-only deployment, or developers already have IAM/role access to Bedrock |
 
-> **Note:** AWS IAM Identity Center (SSO) support is coming in a future release. If your org uses AWS SSO today, choose **No** and configure developer access via your existing IAM Identity Center setup outside this tool.
+> **Note:** AWS IAM Identity Center (SSO) integration is coming soon. If your org uses IAM IDC today, choose **No** for SSO and use your existing `aws sso login` credentials — the solution works with any valid AWS credentials that have Bedrock access.
 
 ---
 
@@ -625,15 +625,17 @@ poetry run ccwb status
 Build the package for end users:
 
 ```bash
-# Build all platforms (starts Windows build in background)
-poetry run ccwb package --target-platform all
+# Build all platforms using Go cross-compilation (recommended)
+poetry run ccwb package --go --target-platform all
 
-# Check Windows build status (optional)
-poetry run ccwb builds
-
-# When ready, create distribution URL (optional)
-poetry run ccwb distribute
+# Creates ready-to-distribute packages for:
+# - macOS ARM64 (Apple Silicon) and Intel
+# - Linux x64 and ARM64
+# - Windows x64
+# All from a single command, any admin OS. Requires: Go 1.24+
 ```
+
+> **Note:** Running `ccwb package` without `--go` falls back to the legacy PyInstaller/CodeBuild pipeline which requires Docker and platform-specific toolchains. Use `--go` for all new deployments.
 
 **Choosing macOS targets:**
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ When SSO authentication is disabled:
 
 To deploy without SSO authentication, select **"None (use existing AWS credentials)"** when prompted for the authentication method during `ccwb init`. The deployment will skip the authentication stack and use anonymous tracking for metrics.
 
-> **New in v2.2+:** IAM Identity Center is now a first-class authentication option. Select **"AWS IAM Identity Center (SSO)"** in `ccwb init` to get guided setup, `~/.aws/config` generation, and the correct CloudFormation stack — without the undocumented workaround of disabling SSO. See the [IAM Identity Center Setup Guide](assets/docs/providers/iam-identity-center-setup.md) for details.
+> **IAM Identity Center support** is coming soon. In the meantime, IAM IDC users can deploy with SSO disabled and use their existing `aws sso login` credentials directly.
 
 ## Authentication Modes
 
@@ -143,7 +143,7 @@ This guidance supports three identity paths. All paths deliver per-user identity
 **Choosing a path:**
 
 - Use **External IdP (OIDC)** when you need full quota enforcement, rich user attribution (department, team, cost centre from JWT claims), and have an OIDC provider (Okta, Azure AD, Auth0, or Cognito).
-- Use **AWS IAM Identity Center** when your team already uses IAM IDC, or when corporate policies block `localhost:8400`, or when you want sessions up to 7 days without browser re-prompts. See [IAM Identity Center Setup Guide](assets/docs/providers/iam-identity-center-setup.md).
+- Use **AWS IAM Identity Center** when your team already uses IAM IDC, or when corporate policies block `localhost:8400`, or when you want sessions up to 7 days without browser re-prompts. Full IAM IDC integration is coming soon.
 - Use **None** when deploying the observability/analytics stack only, or when users already have IAM access to Bedrock and need no additional authentication layer.
 
 For deployment patterns and best practices, see the [Claude Code deployment patterns and best practices with Amazon Bedrock](https://aws.amazon.com/blogs/machine-learning/claude-code-deployment-patterns-and-best-practices-with-amazon-bedrock/) blog post.

--- a/assets/docs/ARCHITECTURE.md
+++ b/assets/docs/ARCHITECTURE.md
@@ -8,9 +8,17 @@ This document provides technical details about the Claude Code authentication sy
 
 The Claude Code authentication system enables secure, scalable access to Amazon Bedrock by federating enterprise identity providers through AWS Cognito. The architecture follows zero-trust principles with complete audit trails.
 
-## Component Architecture
-
 ### Authentication Components
+
+The credential process is a native Go binary (`source/go/`) implementing the full authentication lifecycle:
+
+- **OAuth2/OIDC with PKCE** — browser-based login, no client secrets
+- **Silent refresh** — stores OIDC refresh_token for automatic renewal (7-30 days without browser re-auth)
+- **Token caching** — OS keyring (macOS Keychain, Windows Credential Manager, Linux Secret Service) or encrypted session files
+- **Multi-provider registry** — Okta, Azure AD, Auth0, Google, Cognito, generic OIDC
+- **Cross-platform** — single `make all` produces 5 binaries (macOS ARM64/Intel, Linux x64/ARM64, Windows x64) via Go cross-compilation
+
+The Go rewrite (June 2026) replaced the Python credential-provider, eliminating PyInstaller/Nuitka build complexity, AV false positives on Windows, and the 60-80MB binary size (now ~14MB).
 
 The core authentication component is the credential process, implemented as a native Go binary in `source/go/`. This implements a complete OAuth2/OIDC client with PKCE flow for secure authentication without client secrets. Go cross-compilation produces native statically-linked binaries for all 5 platforms (macOS ARM64/Intel, Linux x64/ARM64, Windows x64) from a single build, eliminating the need for per-platform build toolchains. The credential process supports multiple identity providers including Okta, Azure AD, Auth0, and Cognito User Pools through a flexible provider registry system. Once authenticated, credentials are cached either in the operating system's secure keyring or in session files, depending on the organization's preference. The implementation follows the AWS CLI credential process protocol, making it transparent to any AWS SDK or tool.
 
@@ -19,20 +27,6 @@ The management CLI in `source/claude_code_with_bedrock/` provides IT administrat
 ### AWS Infrastructure Components
 
 The authentication infrastructure supports two federation methods. With Direct IAM Federation, an IAM OIDC Provider creates the trust relationship between the organization's identity provider and AWS, allowing direct token exchange via STS. With Cognito Identity Pool, Amazon Cognito acts as an intermediary that federates OIDC tokens into AWS credentials. Both methods use IAM roles that grant permissions specifically for Amazon Bedrock model invocation in configured regions. Every API call includes session tags containing the user's email and subject claim, ensuring complete attribution in CloudTrail logs.
-
-#### IAM Permissions
-
-The IAM role assigned to authenticated users grants the following Amazon Bedrock permissions:
-
-- `bedrock:InvokeModel` - Invoke foundation models for text generation
-- `bedrock:InvokeModelWithResponseStream` - Invoke models with streaming responses
-- `bedrock:ListFoundationModels` - List available foundation models
-- `bedrock:GetFoundationModel` - Get details about specific models
-- `bedrock:GetFoundationModelAvailability` - Check model availability in regions
-- `bedrock:ListInferenceProfiles` - List available cross-region inference profiles
-- `bedrock:GetInferenceProfile` - Get details about specific inference profiles
-
-These permissions are scoped to the configured regions and enable users to discover and invoke models through cross-region inference profiles, ensuring optimal performance and availability.
 
 #### IAM Permissions
 

--- a/assets/docs/DEPLOYMENT.md
+++ b/assets/docs/DEPLOYMENT.md
@@ -59,30 +59,25 @@ With infrastructure deployed, you're ready to create the package that end users 
 
 ### Multi-Platform Build Support
 
-Claude Code supports building for all major platforms:
+The packaging system uses Go cross-compilation to produce native binaries for all platforms from a single machine:
 
 ```bash
-# Build for all platforms (recommended)
-poetry run ccwb package --target-platform=all
-
-# Build for specific platforms
-poetry run ccwb package --target-platform=windows    # Windows via CodeBuild
-poetry run ccwb package --target-platform=macos      # Current macOS architecture
-poetry run ccwb package --target-platform=linux      # Linux via Docker
+# Build for all platforms (recommended — works from any OS)
+poetry run ccwb package --go --target-platform all
 ```
 
-**Build Modes:**
+This single command:
+- Cross-compiles Go binaries for all 5 platforms (macOS ARM64/Intel, Linux x64/ARM64, Windows x64)
+- Generates customer-specific `config.json` and `settings.json` from your deployment profile
+- Includes `otel-helper` binary if monitoring is enabled
+- Produces ready-to-distribute install packages with platform-specific installers
 
-| Mode | Flag | Requirements | Best for |
-|---|---|---|---|
-| **Go cross-compile** (recommended) | `--go` | Go 1.24+ installed | All admins — fast, all platforms from one machine |
-| **Legacy** | (none) | PyInstaller, Docker, CodeBuild | Backward compatibility with Python binaries |
+**Requirements:** Go 1.24+ installed. Go supports native cross-compilation, so all 5 platform binaries are produced from any single machine (macOS, Linux, or Windows) without Docker or CodeBuild. Build time: ~10 seconds for all platforms.
 
-With `--go`, all 5 platforms (macOS ARM64/Intel, Linux x64/ARM64, Windows) are always available regardless of the admin's OS. No Docker, CodeBuild, or platform-specific toolchains required.
+> **Legacy mode:** Running `ccwb package` without `--go` uses the PyInstaller/Nuitka/Docker/CodeBuild pipeline. This is retained for backward compatibility.
 
-This command reads federation configuration from the admin profile (saved during `ccwb deploy`), cross-compiles native Go binaries, and generates customer-specific `config.json` and `settings.json` files.
-
-**Legacy build mode (PyInstaller / Nuitka / Docker):**
+<details>
+<summary>Legacy build mode details</summary>
 
 PyInstaller emits binaries in the host OS's native format, so the build host must match the target OS. Only Windows (via CodeBuild) escapes this constraint.
 
@@ -92,19 +87,13 @@ PyInstaller emits binaries in the host OS's native format, so the build host mus
 | `linux-x64`, `linux-arm64` | Linux, **or** macOS with Docker Desktop | PyInstaller (Docker container when building from macOS) |
 | `windows` | any host | AWS CodeBuild (remote) |
 
-**Linux admins cannot produce macOS binaries** — see [CLI Reference: Platform Support](CLI_REFERENCE.md#platform-support-hybrid-build-system) for details. The package command refuses this combination with a clear error; to produce macOS binaries use a macOS workstation, a CI macOS runner, or an EC2 Mac instance.
-
 - **Windows**: Uses Nuitka via AWS CodeBuild
-  - Optimized for performance and minimal antivirus false positives
-- **macOS**: Uses PyInstaller with architecture-specific builds
-  - ARM64: Native build on Apple Silicon Macs only — cannot run on Intel Macs
-  - Intel: Runs natively on Intel Macs and on Apple Silicon via Rosetta — covers all Mac users with one binary
-  - Cross-arch: **Optional** — build the other architecture from your current Mac; requires a universal2 Python (see below)
+- **macOS**: Uses PyInstaller with architecture-specific builds (ARM64 or Intel)
 - **Linux x64/ARM64**: Uses PyInstaller in Docker containers (cross-compiled from macOS)
-  - Automatically builds both architectures when Docker is available
-  - Docker Desktop handles architecture emulation via Rosetta
-  - **When building from macOS, requires Docker Desktop installed and running** — if absent, Linux builds are skipped with a warning and all other platforms continue normally
-  - macOS and Windows builds have no dependency on Docker
+
+**Linux admins cannot produce macOS binaries** — the package command refuses this combination with a clear error.
+
+</details>
 
 **Which macOS binary should you ship?**
 

--- a/assets/docs/MONITORING.md
+++ b/assets/docs/MONITORING.md
@@ -6,25 +6,55 @@ When you enable monitoring during deployment, the system collects and visualizes
 
 ## Monitoring Modes
 
-### Central Collector (ECS Fargate)
+| | Central | Sidecar |
+|---|---|---|
+| **Cloud infrastructure** | VPC + ECS Fargate + ALB | None |
+| **AWS cost** | ~$30-50/month | $0 |
+| **Athena SQL queries** | Yes | No |
+| **PromQL dashboards** | Yes | Yes |
+| **Client reports to** | ALB endpoint | CloudWatch OTLP directly |
+
+**Sidecar mode** requires no cloud collector infrastructure — each client sends metrics directly to the CloudWatch OTLP endpoint (`monitoring.<region>.amazonaws.com`) using SigV4 auth. Only the CloudWatch dashboard stack is deployed on the AWS side.
+
+**Central mode** deploys a shared ECS Fargate collector behind an ALB. Required if you need the Athena SQL analytics pipeline (EMF logs → Firehose → S3 → Athena).
+
+## Central Collector (ECS Fargate)
 
 - Server-side OpenTelemetry collector running on ECS Fargate behind an ALB
 - Supports optional Athena SQL pipeline (EMF logs → Kinesis Firehose → S3 → Athena) for ad-hoc SQL queries
 - Requires VPC and networking infrastructure
 - Requires the `AWSServiceRoleForECS` service-linked role (created automatically by `ccwb deploy`; if deploying templates manually, create it first: `aws iam create-service-linked-role --aws-service-name ecs.amazonaws.com`)
-- ~$30-50/month server cost
-- Best for: organizations wanting centralized metrics aggregation, IT-managed collector, or ad-hoc SQL queries via Athena
 
-### Sidecar Collector (Local)
+### Central mode deployment
 
-- Lightweight (~15-20MB) collector binary runs on each developer's machine
+```bash
+# During ccwb init, select "Central" when prompted for monitoring mode
+poetry run ccwb init
+
+# Deploy (creates VPC, ECS, ALB, dashboard)
+poetry run ccwb deploy
+```
+
+## Sidecar Collector (Local)
+
+- Lightweight (~15-20MB) Go binary (`otel-helper`) runs on each developer's machine
 - Sends metrics directly to CloudWatch OTLP endpoint using SigV4 auth from federated credentials
-- No server-side infrastructure required
-- $0 server cost
-- Athena SQL pipeline not available (PromQL dashboards and long-term CloudWatch metric storage are fully supported)
-- Best for: small teams, cost-sensitive deployments, or quick evaluation
+- No server-side infrastructure required — only the CloudWatch dashboard stack is deployed
 
-Both modes provide full analytics via the same PromQL-based CloudWatch dashboard with long-term metric storage. The Athena SQL pipeline (central-mode only) is an optional add-on for ad-hoc SQL queries against raw metric data.
+### Sidecar mode deployment
+
+```bash
+# During ccwb init, select "Sidecar" when prompted for monitoring mode
+poetry run ccwb init
+
+# Deploy (creates only the dashboard stack — no VPC, no ECS)
+poetry run ccwb deploy
+
+# Package includes otel-helper binary automatically
+poetry run ccwb package --go --target-platform all
+```
+
+End users receive the `otel-helper` binary in their install package. It starts automatically when Claude Code launches and sends metrics to CloudWatch using the same federated credentials.
 
 ## Architecture (Central Collector)
 

--- a/assets/docs/QUOTA_MONITORING.md
+++ b/assets/docs/QUOTA_MONITORING.md
@@ -601,22 +601,22 @@ Configure the endpoint in your credential provider config.json:
 
 ### Enforcement Timing
 
-**Important**: Quota enforcement only occurs at credential issuance time, not during an active session.
+**Important**: Quota enforcement occurs at credential issuance time — every time the credential-process exchanges tokens for AWS credentials. This includes both browser re-authentication and silent refresh (via stored refresh_token).
 
-If a user exceeds their quota mid-session, they can continue using Claude Code until their credentials expire and they need to re-authenticate. At that point, the quota check will block access.
+With silent refresh enabled (default since June 2026), the credential-process automatically renews credentials without browser interaction. Quota is checked on each renewal, so enforcement gaps are bounded by the STS session duration, not by how often the user sees a browser prompt.
 
-#### Example Timeline (12-hour session)
+#### Example Timeline (1-hour STS session, silent refresh)
 
 ```
-09:00 - User authenticates, quota check passes (at 50% of limit)
-09:00 - AWS credentials issued, valid for 12 hours
-15:00 - User exceeds 100% of monthly quota
-15:01 - User CONTINUES working (credentials still valid)
-21:00 - Credentials expire, user must re-authenticate
-21:00 - Quota check BLOCKS access (enforcement finally applied)
+09:00 - User authenticates via browser, quota check passes (at 50%)
+09:00 - AWS credentials issued, valid for 1 hour
+10:00 - Credentials expire, silent refresh triggers
+10:00 - Quota check passes (at 80%), new credentials issued
+11:00 - Silent refresh triggers again
+11:00 - Quota check BLOCKS access (user exceeded limit)
 ```
 
-In this scenario, there's a 6-hour gap between exceeding the quota (15:00) and enforcement (21:00).
+The enforcement gap equals the STS session duration (typically 1 hour), regardless of refresh_token lifetime.
 
 #### Recommendation for Tight Enforcement
 

--- a/assets/docs/README.md
+++ b/assets/docs/README.md
@@ -16,7 +16,7 @@ Choose your IdP and follow the setup guide before running `ccwb init`:
 | **Microsoft Entra ID (Azure AD)** | [microsoft-entra-id-setup.md](./providers/microsoft-entra-id-setup.md) |
 | **Auth0** | [auth0-setup.md](./providers/auth0-setup.md) |
 | **AWS Cognito User Pool** | [cognito-user-pool-setup.md](./providers/cognito-user-pool-setup.md) |
-| **AWS IAM Identity Center (SSO)** | [iam-identity-center-setup.md](./providers/iam-identity-center-setup.md) |
+| **AWS IAM Identity Center (SSO)** | Coming soon |
 
 ### Step 2 — Deploy AWS infrastructure
 


### PR DESCRIPTION
## Summary

Documentation refresh covering the major changes that landed in beta since December 2025 (last release: v2.2.0). Material changes only.

## Changes

### 1. Go credential-process architecture (ARCHITECTURE.md)
- Removed duplicated IAM Permissions section
- Added Go credential-process subsection: silent refresh, cross-compilation, multi-provider registry, token caching strategy

### 2. Go as recommended packaging path (DEPLOYMENT.md + QUICK_START.md)
- `ccwb package --go --target-platform all` positioned as the recommended default
- Go supports native cross-compilation — all 5 platform binaries from any single machine without Docker or CodeBuild
- Legacy PyInstaller/Nuitka/Docker/CodeBuild details retained in a collapsible section

### 3. Sidecar vs Central monitoring (MONITORING.md)
- Added functional comparison table (cloud infra, cost, Athena, dashboards, endpoint)
- Sidecar mode: no cloud collector infrastructure required — clients send directly to CloudWatch OTLP
- Added sidecar deployment instructions (previously undocumented)

### 4. IAM Identity Center link fix (README.md, docs/README.md, QUICK_START.md)
- `iam-identity-center-setup.md` did not exist — all links were broken (404)
- Updated to "Coming soon" with workaround (deploy with SSO disabled, use existing `aws sso login` credentials)

### 5. Quota enforcement timing (QUOTA_MONITORING.md)
- Updated to reflect silent refresh (PR #447 merged Jun 6)
- Enforcement gap is now bounded by STS session duration (~1h), not browser re-auth frequency

## Not documented here (tracked separately)

- **IAM Identity Center integration**: Full IAM IDC support tracked on [`feat/aws-iam-idc-auth`](https://github.com/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock/tree/feat/aws-iam-idc-auth) branch
- **Windows reliability improvements**: SO_REUSEADDR guard (#448), keyring persistence fix (#429), UTF-8 encoding on all open() calls (#406), install.bat Run-as-Admin fix (#474), CodeBuild KMS fix (#355)
- **CI hardening**: Windows tests now blocking (#449), cross-platform safety lint, Tier 2 integration tests (#434)
- **Go binary**: Eliminates Windows Defender AV false positives, 4x smaller than Nuitka/PyInstaller binaries

These will surface in release notes when #433 (release tagging) ships.

## Risk: Low
- Documentation only, no code changes
- 7 files changed, +90 / -75 lines