### PR TITLE
feat: cost-based quota enforcement mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ PARTITION_*.md
 FEEDBACK.md
 .claudeignore
 .mcp.json
+__pycache__/

--- a/assets/docs/QUOTA_MONITORING.md
+++ b/assets/docs/QUOTA_MONITORING.md
@@ -95,6 +95,26 @@ Each limit type can be configured with different enforcement:
 - **Daily**: `alert` - Warn about unusual patterns, don't interrupt work
 - **Monthly**: `block` - Hard stop at budget limit
 
+### Quota Modes
+
+Two enforcement modes control how usage is measured:
+
+| Mode | Limits set as | What's compared | Best for |
+|------|---------------|-----------------|----------|
+| **token** (default) | Token counts (e.g., 10M/month) | Raw total tokens consumed | Simple deployments, predictable single-model usage |
+| **cost** | USD amounts (e.g., $500/month) | Estimated spend using Bedrock rates | Multi-model deployments, teams confused by cache-inflated token counts |
+
+**Cost mode** applies per-token-type pricing (input, output, cache read, cache write) so cache-heavy usage doesn't trigger false alerts. A user consuming 15M cache read tokens costs ~$4.65, not the $45 that raw token counting implies.
+
+Configure via the `QuotaMode` CloudFormation parameter:
+```yaml
+QuotaMode: cost
+MonthlyCostLimitUsd: 500
+DailyCostLimitUsd: 50
+```
+
+> **Note:** Cost estimates use published Bedrock on-demand rates shipped with each release. Actual costs may differ due to committed throughput discounts or pricing changes. Use AWS Cost Explorer for billing truth.
+
 ### Example Configuration
 
 ```

--- a/deployment/infrastructure/claude-code-dashboard.yaml
+++ b/deployment/infrastructure/claude-code-dashboard.yaml
@@ -156,7 +156,6 @@ Resources:
               }
             },
             {
-            {
               "type": "text",
               "x": 0, "y": 26, "width": 24, "height": 2,
               "properties": { "markdown": "## Estimated Cost\n\nEstimates based on Bedrock on-demand rates. Use AWS Cost Explorer for billing truth.", "background": "transparent" }

--- a/deployment/infrastructure/claude-code-dashboard.yaml
+++ b/deployment/infrastructure/claude-code-dashboard.yaml
@@ -156,13 +156,83 @@ Resources:
               }
             },
             {
+            {
+              "type": "text",
+              "x": 0, "y": 26, "width": 24, "height": 2,
+              "properties": { "markdown": "## Estimated Cost\n\nEstimates based on Bedrock on-demand rates. Use AWS Cost Explorer for billing truth.", "background": "transparent" }
+            },
+            {
+              "type": "chart",
+              "x": 0, "y": 28, "width": 8, "height": 4,
+              "properties": {
+                "title": "Total Estimated Cost",
+                "view": "sparkline",
+                "region": "${MetricsRegion}",
+                "data": { "queries": [
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.cost.estimated.total\", \"@resource.service.name\"=\"claude-code\"})", "step": 3600, "label": "$" }
+                ] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
+              }
+            },
+            {
+              "type": "chart",
+              "x": 8, "y": 28, "width": 8, "height": 4,
+              "properties": {
+                "title": "Avg Cost per User",
+                "view": "sparkline",
+                "region": "${MetricsRegion}",
+                "data": { "queries": [
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "avg(sum by (\"user.email\")({\"claude_code.cost.estimated.total\", \"@resource.service.name\"=\"claude-code\"}))", "step": 3600, "label": "$/user" }
+                ] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
+              }
+            },
+            {
+              "type": "chart",
+              "x": 16, "y": 28, "width": 8, "height": 4,
+              "properties": {
+                "title": "Top Spender",
+                "view": "sparkline",
+                "region": "${MetricsRegion}",
+                "data": { "queries": [
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "max(sum by (\"user.email\")({\"claude_code.cost.estimated.total\", \"@resource.service.name\"=\"claude-code\"}))", "step": 3600, "label": "$" }
+                ] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
+              }
+            },
+            {
+              "type": "chart",
+              "x": 0, "y": 32, "width": 12, "height": 6,
+              "properties": {
+                "title": "Cost Over Time",
+                "view": "line",
+                "region": "${MetricsRegion}",
+                "data": { "queries": [
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"claude_code.cost.estimated.total\", \"@resource.service.name\"=\"claude-code\"})", "step": 3600, "label": "Total $" }
+                ] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": true, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
+              }
+            },
+            {
+              "type": "chart",
+              "x": 12, "y": 32, "width": 12, "height": 6,
+              "properties": {
+                "title": "Cost by User (Top 10)",
+                "view": "line",
+                "region": "${MetricsRegion}",
+                "data": { "queries": [
+                  { "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(10, sum by (\"user.email\")({\"claude_code.cost.estimated\", \"@resource.service.name\"=\"claude-code\"}))", "step": 3600 }
+                ] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": true, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
+              }
+            },
               "type": "text",
               "x": 0, "y": 26, "width": 24, "height": 2,
               "properties": { "markdown": "## Developer Productivity", "background": "transparent" }
             },
             {
               "type": "chart",
-              "x": 0, "y": 28, "width": 6, "height": 6,
+              "x": 0, "y": 40, "width": 6, "height": 6,
               "properties": {
                 "title": "Lines of Code",
                 "view": "line",
@@ -176,7 +246,7 @@ Resources:
             },
             {
               "type": "chart",
-              "x": 6, "y": 28, "width": 6, "height": 6,
+              "x": 6, "y": 40, "width": 6, "height": 6,
               "properties": {
                 "title": "Commits",
                 "view": "line",
@@ -189,7 +259,7 @@ Resources:
             },
             {
               "type": "chart",
-              "x": 12, "y": 28, "width": 6, "height": 6,
+              "x": 12, "y": 40, "width": 6, "height": 6,
               "properties": {
                 "title": "Active Hours",
                 "view": "line",
@@ -202,7 +272,7 @@ Resources:
             },
             {
               "type": "chart",
-              "x": 18, "y": 28, "width": 6, "height": 6,
+              "x": 18, "y": 40, "width": 6, "height": 6,
               "properties": {
                 "title": "Pull Requests",
                 "view": "line",
@@ -215,7 +285,7 @@ Resources:
             },
             {
               "type": "chart",
-              "x": 0, "y": 34, "width": 8, "height": 6,
+              "x": 0, "y": 46, "width": 8, "height": 6,
               "properties": {
                 "title": "Code Generation by Language",
                 "view": "pie",
@@ -228,7 +298,7 @@ Resources:
             },
             {
               "type": "chart",
-              "x": 8, "y": 34, "width": 8, "height": 6,
+              "x": 8, "y": 46, "width": 8, "height": 6,
               "properties": {
                 "title": "Code Edit Decisions",
                 "view": "line",
@@ -241,7 +311,7 @@ Resources:
             },
             {
               "type": "chart",
-              "x": 16, "y": 34, "width": 8, "height": 6,
+              "x": 16, "y": 46, "width": 8, "height": 6,
               "properties": {
                 "title": "Code Edits by Tool",
                 "view": "line",
@@ -254,12 +324,12 @@ Resources:
             },
             {
               "type": "text",
-              "x": 0, "y": 40, "width": 24, "height": 2,
+              "x": 0, "y": 52, "width": 24, "height": 2,
               "properties": { "markdown": "## Organizational Breakdown", "background": "transparent" }
             },
             {
               "type": "chart",
-              "x": 0, "y": 42, "width": 12, "height": 6,
+              "x": 0, "y": 54, "width": 12, "height": 6,
               "properties": {
                 "title": "Token Usage by Department",
                 "view": "line",
@@ -272,7 +342,7 @@ Resources:
             },
             {
               "type": "chart",
-              "x": 12, "y": 42, "width": 12, "height": 6,
+              "x": 12, "y": 54, "width": 12, "height": 6,
               "properties": {
                 "title": "Token Usage by Team",
                 "view": "line",
@@ -285,12 +355,12 @@ Resources:
             },
             {
               "type": "text",
-              "x": 0, "y": 48, "width": 24, "height": 2,
+              "x": 0, "y": 60, "width": 24, "height": 2,
               "properties": { "markdown": "## Bedrock API Health", "background": "transparent" }
             },
             {
               "type": "metric",
-              "x": 0, "y": 50, "width": 8, "height": 6,
+              "x": 0, "y": 62, "width": 8, "height": 6,
               "properties": {
                 "metrics": [
                   [ { "expression": "SELECT SUM(InvocationThrottles) FROM \"AWS/Bedrock\" GROUP BY ModelId", "id": "throttles", "region": "${MetricsRegion}" } ]
@@ -303,7 +373,7 @@ Resources:
             },
             {
               "type": "metric",
-              "x": 8, "y": 50, "width": 8, "height": 6,
+              "x": 8, "y": 62, "width": 8, "height": 6,
               "properties": {
                 "metrics": [
                   [ { "expression": "SELECT SUM(InvocationClientErrors) FROM \"AWS/Bedrock\" GROUP BY ModelId", "id": "client_errors", "region": "${MetricsRegion}" } ]
@@ -316,7 +386,7 @@ Resources:
             },
             {
               "type": "metric",
-              "x": 16, "y": 50, "width": 8, "height": 6,
+              "x": 16, "y": 62, "width": 8, "height": 6,
               "properties": {
                 "metrics": [
                   [ { "expression": "SELECT SUM(InvocationServerErrors) FROM \"AWS/Bedrock\" GROUP BY ModelId", "id": "server_errors", "region": "${MetricsRegion}" } ]

--- a/deployment/infrastructure/lambda-functions/quota_check/index.py
+++ b/deployment/infrastructure/lambda-functions/quota_check/index.py
@@ -1,13 +1,18 @@
 # ABOUTME: Lambda function for real-time quota checking before credential issuance
 # ABOUTME: Returns allowed/blocked status based on user quota policy and current usage
+# ABOUTME: Supports two modes: 'token' (raw token counting) and 'cost' (dollar-based)
 # ABOUTME: Requires JWT authentication - extracts user identity from API Gateway JWT Authorizer claims
 
 import json
+import sys
 import boto3
 import os
 from datetime import datetime, timezone
 from decimal import Decimal
 from boto3.dynamodb.conditions import Key, Attr
+
+# Add shared utilities to path (deployed alongside this Lambda)
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 # Initialize clients
 dynamodb = boto3.resource("dynamodb")
@@ -20,10 +25,16 @@ POLICIES_TABLE = os.environ.get("POLICIES_TABLE", "QuotaPolicies")
 MISSING_EMAIL_ENFORCEMENT = os.environ.get("MISSING_EMAIL_ENFORCEMENT", "block")
 ERROR_HANDLING_MODE = os.environ.get("ERROR_HANDLING_MODE", "fail_closed")
 
+# Quota mode: 'token' (default, existing) or 'cost' (dollar-based)
+QUOTA_MODE = os.environ.get("QUOTA_MODE", "token")
+
 # Default limits from environment (used when fine-grained quotas are disabled)
 ENABLE_FINEGRAINED_QUOTAS = os.environ.get("ENABLE_FINEGRAINED_QUOTAS", "false").lower() == "true"
 MONTHLY_TOKEN_LIMIT = int(os.environ.get("MONTHLY_TOKEN_LIMIT", "0"))
 DAILY_TOKEN_LIMIT = int(os.environ.get("DAILY_TOKEN_LIMIT", "0"))
+# Cost-mode limits (USD, as cents in env var to avoid float parsing issues)
+MONTHLY_COST_LIMIT = float(os.environ.get("MONTHLY_COST_LIMIT_USD", "0"))
+DAILY_COST_LIMIT = float(os.environ.get("DAILY_COST_LIMIT_USD", "0"))
 MONTHLY_ENFORCEMENT_MODE = os.environ.get("MONTHLY_ENFORCEMENT_MODE", "block")
 DAILY_ENFORCEMENT_MODE = os.environ.get("DAILY_ENFORCEMENT_MODE", "alert")
 WARNING_THRESHOLD_80 = int(os.environ.get("WARNING_THRESHOLD_80", "240000000"))
@@ -130,35 +141,24 @@ def lambda_handler(event, context):
                 "message": "Access granted - enforcement mode is alert-only"
             })
 
-        # 5. Check limits (monthly, daily)
-        monthly_tokens = usage.get("total_tokens", 0)
-        daily_tokens = usage.get("daily_tokens", 0)
+        # 5. Check limits (monthly, daily) — token mode or cost mode
+        if QUOTA_MODE == "cost":
+            # Cost-based enforcement: convert tokens to USD, compare against $ limits
+            cost_data = _calculate_usage_cost(usage)
+            monthly_cost = cost_data["monthly_cost"]
+            daily_cost = cost_data["daily_cost"]
 
-        monthly_limit = policy.get("monthly_token_limit", 0)
-        daily_limit = policy.get("daily_token_limit")
+            monthly_cost_limit = policy.get("monthly_cost_limit", MONTHLY_COST_LIMIT)
+            daily_cost_limit = policy.get("daily_cost_limit", DAILY_COST_LIMIT)
 
-        # Check monthly token limit
-        if monthly_limit > 0 and monthly_tokens >= monthly_limit:
-            return build_response(200, {
-                "allowed": False,
-                "reason": "monthly_exceeded",
-                "enforcement_mode": enforcement_mode,
-                "usage": usage_summary,
-                "policy": {
-                    "type": policy.get("policy_type"),
-                    "identifier": policy.get("identifier")
-                },
-                "unblock_status": {"is_unblocked": False},
-                "message": f"Monthly quota exceeded: {int(monthly_tokens):,} / {int(monthly_limit):,} tokens ({monthly_tokens/monthly_limit*100:.1f}%). Contact your administrator for assistance."
-            })
+            # Enrich usage summary with cost data
+            usage_summary["monthly_cost_usd"] = round(monthly_cost, 4)
+            usage_summary["daily_cost_usd"] = round(daily_cost, 4)
 
-        # Check daily token limit (if configured)
-        if daily_limit and daily_limit > 0 and daily_tokens >= daily_limit:
-            daily_mode = policy.get("daily_enforcement_mode", "alert")
-            if daily_mode == "block":
+            if monthly_cost_limit > 0 and monthly_cost >= monthly_cost_limit:
                 return build_response(200, {
                     "allowed": False,
-                    "reason": "daily_exceeded",
+                    "reason": "monthly_cost_exceeded",
                     "enforcement_mode": enforcement_mode,
                     "usage": usage_summary,
                     "policy": {
@@ -166,8 +166,63 @@ def lambda_handler(event, context):
                         "identifier": policy.get("identifier")
                     },
                     "unblock_status": {"is_unblocked": False},
-                    "message": f"Daily quota exceeded: {int(daily_tokens):,} / {int(daily_limit):,} tokens ({daily_tokens/daily_limit*100:.1f}%). Quota resets at UTC midnight."
+                    "message": f"Monthly spend limit exceeded: ${monthly_cost:.2f} / ${monthly_cost_limit:.2f} ({monthly_cost/monthly_cost_limit*100:.1f}%). Contact your administrator."
                 })
+
+            if daily_cost_limit > 0 and daily_cost >= daily_cost_limit:
+                daily_mode = policy.get("daily_enforcement_mode", "alert")
+                if daily_mode == "block":
+                    return build_response(200, {
+                        "allowed": False,
+                        "reason": "daily_cost_exceeded",
+                        "enforcement_mode": enforcement_mode,
+                        "usage": usage_summary,
+                        "policy": {
+                            "type": policy.get("policy_type"),
+                            "identifier": policy.get("identifier")
+                        },
+                        "unblock_status": {"is_unblocked": False},
+                        "message": f"Daily spend limit exceeded: ${daily_cost:.2f} / ${daily_cost_limit:.2f} ({daily_cost/daily_cost_limit*100:.1f}%). Resets at UTC midnight."
+                    })
+        else:
+            # Token-based enforcement (existing behavior, unchanged)
+            monthly_tokens = usage.get("total_tokens", 0)
+            daily_tokens = usage.get("daily_tokens", 0)
+
+            monthly_limit = policy.get("monthly_token_limit", 0)
+            daily_limit = policy.get("daily_token_limit")
+
+            # Check monthly token limit
+            if monthly_limit > 0 and monthly_tokens >= monthly_limit:
+                return build_response(200, {
+                    "allowed": False,
+                    "reason": "monthly_exceeded",
+                    "enforcement_mode": enforcement_mode,
+                    "usage": usage_summary,
+                    "policy": {
+                        "type": policy.get("policy_type"),
+                        "identifier": policy.get("identifier")
+                    },
+                    "unblock_status": {"is_unblocked": False},
+                    "message": f"Monthly quota exceeded: {int(monthly_tokens):,} / {int(monthly_limit):,} tokens ({monthly_tokens/monthly_limit*100:.1f}%). Contact your administrator for assistance."
+                })
+
+            # Check daily token limit (if configured)
+            if daily_limit and daily_limit > 0 and daily_tokens >= daily_limit:
+                daily_mode = policy.get("daily_enforcement_mode", "alert")
+                if daily_mode == "block":
+                    return build_response(200, {
+                        "allowed": False,
+                        "reason": "daily_exceeded",
+                        "enforcement_mode": enforcement_mode,
+                        "usage": usage_summary,
+                        "policy": {
+                            "type": policy.get("policy_type"),
+                            "identifier": policy.get("identifier")
+                        },
+                        "unblock_status": {"is_unblocked": False},
+                        "message": f"Daily quota exceeded: {int(daily_tokens):,} / {int(daily_limit):,} tokens ({daily_tokens/daily_limit*100:.1f}%). Quota resets at UTC midnight."
+                    })
 
         # All checks passed - access allowed
         return build_response(200, {
@@ -199,6 +254,54 @@ def lambda_handler(event, context):
             "unblock_status": None,
             "message": f"Quota check failed ({ERROR_HANDLING_MODE}): {str(e)}"
         })
+
+
+def _calculate_usage_cost(usage: dict, model_family: str = "sonnet") -> dict:
+    """Calculate cost from usage data for cost-mode enforcement.
+
+    Uses the shared pricing utility to convert token counts to USD.
+    DynamoDB stores: input_tokens, output_tokens, cache_tokens (cache_read).
+    Cache write is derived: total - input - output - cache_read.
+
+    Returns: {"monthly_cost": float, "daily_cost": float}
+    """
+    try:
+        from shared.pricing import calculate_cost, get_pricing_rates
+        rates = get_pricing_rates()
+    except ImportError:
+        # Shared pricing not deployed — fall back to simple estimate
+        # Use sonnet input rate as approximation
+        total_monthly = usage.get("total_tokens", 0)
+        total_daily = usage.get("daily_tokens", 0)
+        return {
+            "monthly_cost": (total_monthly / 1_000_000) * 3.0,
+            "daily_cost": (total_daily / 1_000_000) * 3.0,
+        }
+
+    input_tokens = usage.get("input_tokens", 0)
+    output_tokens = usage.get("output_tokens", 0)
+    cache_read_tokens = usage.get("cache_tokens", 0)
+    total_tokens = usage.get("total_tokens", 0)
+    # Derive cache_write: total minus known types
+    cache_write_tokens = max(0, total_tokens - input_tokens - output_tokens - cache_read_tokens)
+
+    tokens_by_type = {
+        "input": input_tokens,
+        "output": output_tokens,
+        "cache_read": cache_read_tokens,
+        "cache_write": cache_write_tokens,
+    }
+    monthly_cost = calculate_cost(tokens_by_type, model_family, rates)
+
+    # For daily, scale proportionally (DynamoDB only stores daily total, not per-type)
+    daily_tokens = usage.get("daily_tokens", 0)
+    if total_tokens > 0:
+        daily_ratio = daily_tokens / total_tokens
+        daily_cost = monthly_cost * daily_ratio
+    else:
+        daily_cost = 0.0
+
+    return {"monthly_cost": monthly_cost, "daily_cost": daily_cost}
 
 
 def build_response(status_code: int, body: dict) -> dict:

--- a/deployment/infrastructure/lambda-functions/quota_check/index.py
+++ b/deployment/infrastructure/lambda-functions/quota_check/index.py
@@ -270,7 +270,7 @@ def _calculate_usage_cost(usage: dict, model_family: str = "sonnet") -> dict:
         rates = get_pricing_rates()
     except ImportError:
         # Shared pricing not deployed — fall back to simple estimate
-        # Use sonnet input rate as approximation
+        print("WARNING: shared.pricing not available, using flat $3/MTok estimate")
         total_monthly = usage.get("total_tokens", 0)
         total_daily = usage.get("daily_tokens", 0)
         return {
@@ -293,7 +293,9 @@ def _calculate_usage_cost(usage: dict, model_family: str = "sonnet") -> dict:
     }
     monthly_cost = calculate_cost(tokens_by_type, model_family, rates)
 
-    # For daily, scale proportionally (DynamoDB only stores daily total, not per-type)
+    # For daily cost: DynamoDB stores daily total tokens but not per-type breakdown,
+    # so we scale monthly cost proportionally. This assumes similar token-type ratios
+    # throughout the month — acceptable for enforcement (not billing).
     daily_tokens = usage.get("daily_tokens", 0)
     if total_tokens > 0:
         daily_ratio = daily_tokens / total_tokens

--- a/deployment/infrastructure/lambda-functions/shared/__init__.py
+++ b/deployment/infrastructure/lambda-functions/shared/__init__.py
@@ -1,0 +1,1 @@
+# Shared utilities for Lambda functions

--- a/deployment/infrastructure/lambda-functions/shared/pricing.py
+++ b/deployment/infrastructure/lambda-functions/shared/pricing.py
@@ -19,6 +19,12 @@ import os
 # Current Bedrock pricing per 1M tokens (USD) — as of June 2026
 # Source: https://aws.amazon.com/bedrock/pricing/
 DEFAULT_RATES = {
+    "fable": {
+        "input": 10.00,
+        "output": 50.00,
+        "cache_read": 1.00,
+        "cache_write": 12.50,
+    },
     "opus": {
         "input": 5.00,
         "output": 25.00,
@@ -84,10 +90,13 @@ def get_model_family(model_id: str) -> str:
         "anthropic.claude-sonnet-4-6-20250514-v1:0" → "sonnet"
         "us.anthropic.claude-opus-4-8-20260301-v1:0" → "opus"
         "anthropic.claude-haiku-4-5-20250901-v1:0" → "haiku"
+        "anthropic.claude-fable-5-20260610-v1:0" → "fable"
         "claude-sonnet-4-6" → "sonnet"
     """
     model_lower = model_id.lower()
-    if "opus" in model_lower:
+    if "fable" in model_lower or "mythos" in model_lower:
+        return "fable"
+    elif "opus" in model_lower:
         return "opus"
     elif "haiku" in model_lower:
         return "haiku"

--- a/deployment/infrastructure/lambda-functions/shared/pricing.py
+++ b/deployment/infrastructure/lambda-functions/shared/pricing.py
@@ -1,0 +1,144 @@
+"""
+Shared Bedrock pricing utility for Claude Code with Bedrock.
+
+Provides per-model, per-token-type pricing rates. Used by:
+- Cost estimator Lambda (dashboard cost metrics)
+- Quota Lambda (cost-based enforcement mode)
+
+IMPORTANT: These are estimates based on published Bedrock on-demand rates.
+Actual costs may differ due to committed throughput discounts, pricing
+changes, or custom agreements. Use AWS Cost Explorer for billing truth.
+
+Rates are hardcoded and updated with each release. Admins can override
+via BEDROCK_PRICING_RATES_JSON environment variable without code changes.
+"""
+
+import json
+import os
+
+# Current Bedrock pricing per 1M tokens (USD) — as of June 2026
+# Source: https://aws.amazon.com/bedrock/pricing/
+DEFAULT_RATES = {
+    "opus": {
+        "input": 5.00,
+        "output": 25.00,
+        "cache_read": 0.50,
+        "cache_write": 6.25,
+    },
+    "sonnet": {
+        "input": 3.00,
+        "output": 15.00,
+        "cache_read": 0.30,
+        "cache_write": 3.75,
+    },
+    "haiku": {
+        "input": 1.00,
+        "output": 5.00,
+        "cache_read": 0.10,
+        "cache_write": 1.25,
+    },
+}
+
+# Environment variable for overriding rates (JSON string)
+PRICING_OVERRIDE_ENV = "BEDROCK_PRICING_RATES_JSON"
+
+
+def get_pricing_rates() -> dict:
+    """Get per-model, per-token-type pricing rates ($/MTok).
+
+    Checks BEDROCK_PRICING_RATES_JSON env var for overrides,
+    falls back to hardcoded DEFAULT_RATES.
+
+    Returns:
+        dict: {family: {input: float, output: float, cache_read: float, cache_write: float}}
+    """
+    override = os.environ.get(PRICING_OVERRIDE_ENV, "").strip()
+    if override:
+        try:
+            custom_rates = json.loads(override)
+            # Merge with defaults (custom rates override per-family)
+            merged = dict(DEFAULT_RATES)
+            for family, rates in custom_rates.items():
+                if family in merged:
+                    merged[family].update(rates)
+                else:
+                    merged[family] = rates
+            return merged
+        except (json.JSONDecodeError, TypeError, AttributeError):
+            # Invalid JSON — fall back to defaults
+            pass
+
+    return dict(DEFAULT_RATES)
+
+
+# Cross-region inference surcharge multiplier
+# Models invoked via cross-region inference profiles (us.anthropic.*, eu.anthropic.*)
+# incur a 10% surcharge over standard regional pricing.
+CROSS_REGION_MULTIPLIER = 1.1
+
+
+def get_model_family(model_id: str) -> str:
+    """Extract model family from a Bedrock model ID or CRIS profile.
+
+    Examples:
+        "anthropic.claude-sonnet-4-6-20250514-v1:0" → "sonnet"
+        "us.anthropic.claude-opus-4-8-20260301-v1:0" → "opus"
+        "anthropic.claude-haiku-4-5-20250901-v1:0" → "haiku"
+        "claude-sonnet-4-6" → "sonnet"
+    """
+    model_lower = model_id.lower()
+    if "opus" in model_lower:
+        return "opus"
+    elif "haiku" in model_lower:
+        return "haiku"
+    else:
+        # Default to sonnet (most common model)
+        return "sonnet"
+
+
+def is_cross_region(model_id: str) -> bool:
+    """Determine if a model ID is a cross-region inference profile.
+
+    Cross-region profiles are prefixed with a region code:
+        us.anthropic.claude-*  (US cross-region)
+        eu.anthropic.claude-*  (EU cross-region)
+
+    Standard regional models start with:
+        anthropic.claude-*
+    """
+    model_lower = model_id.lower()
+    # Cross-region profiles have a geo prefix before 'anthropic'
+    return bool(
+        model_lower.startswith(("us.", "eu.", "ap."))
+        and "anthropic" in model_lower
+    )
+
+
+def calculate_cost(tokens_by_type: dict, model_family: str, rates: dict = None,
+                   model_id: str = None) -> float:
+    """Calculate cost in USD for a set of token counts by type.
+
+    Args:
+        tokens_by_type: {token_type: count} e.g. {"input": 1000, "output": 500, ...}
+        model_family: "opus", "sonnet", or "haiku"
+        rates: pricing rates dict (default: get_pricing_rates())
+        model_id: optional full model ID — used to detect cross-region surcharge
+
+    Returns:
+        Estimated cost in USD (includes cross-region surcharge if applicable)
+    """
+    if rates is None:
+        rates = get_pricing_rates()
+
+    family_rates = rates.get(model_family, rates.get("sonnet", {}))
+    total_cost = 0.0
+
+    for token_type, count in tokens_by_type.items():
+        rate_per_mtok = family_rates.get(token_type, family_rates.get("input", 3.0))
+        total_cost += (count / 1_000_000) * rate_per_mtok
+
+    # Apply cross-region inference surcharge (10%) if applicable
+    if model_id and is_cross_region(model_id):
+        total_cost *= CROSS_REGION_MULTIPLIER
+
+    return total_cost

--- a/deployment/infrastructure/quota-monitoring.yaml
+++ b/deployment/infrastructure/quota-monitoring.yaml
@@ -426,6 +426,9 @@ Resources:
           DAILY_ENFORCEMENT_MODE: !Ref DailyEnforcementMode
           MONTHLY_ENFORCEMENT_MODE: !Ref MonthlyEnforcementMode
           ENABLE_FINEGRAINED_QUOTAS: !Ref EnableFinegrainedQuotas
+          QUOTA_MODE: !Ref QuotaMode
+          MONTHLY_COST_LIMIT_USD: !Ref MonthlyCostLimitUsd
+          DAILY_COST_LIMIT_USD: !Ref DailyCostLimitUsd
       Code: ./lambda-functions/quota_check/
 
   # HTTP API Gateway (v2 - cheaper and faster than REST API)

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -882,6 +882,9 @@ class DeployCommand(Command):
                     f"OidcClientId={oidc_client_id}",
                     f"EnableFinegrainedQuotas={str(enable_finegrained_quotas).lower()}",
                     f"EnableBypassDetection={str(enable_bypass_detection).lower()}",
+                    f"QuotaMode={getattr(profile, 'quota_mode', 'token')}",
+                    f"MonthlyCostLimitUsd={getattr(profile, 'monthly_cost_limit', 0)}",
+                    f"DailyCostLimitUsd={getattr(profile, 'daily_cost_limit', 0)}",
                 ]
 
                 # Package the template using AWS CLI
@@ -1163,6 +1166,9 @@ class DeployCommand(Command):
                 f"OidcClientId={profile.client_id}",
                 f"EnableFinegrainedQuotas={str(profile.enable_finegrained_quotas).lower()}",
                 f"EnableBypassDetection={str(getattr(profile, 'enable_bypass_detection', False)).lower()}",
+                f"QuotaMode={getattr(profile, 'quota_mode', 'token')}",
+                f"MonthlyCostLimitUsd={getattr(profile, 'monthly_cost_limit', 0)}",
+                f"DailyCostLimitUsd={getattr(profile, 'daily_cost_limit', 0)}",
             ]
             print_deploy_cmd("/tmp/quota-monitoring-packaged.yaml", stack_name, params)
 

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1127,6 +1127,35 @@ class InitCommand(Command):
                     config["quota"]["daily_enforcement_mode"] = daily_enforcement
                     config["quota"]["monthly_enforcement_mode"] = monthly_enforcement
 
+                    # Quota mode selection
+                    console.print("\n[bold]Quota Mode[/bold]")
+                    console.print("Choose how usage is measured against limits:")
+                    console.print("  • token: count raw tokens (simple, existing behavior)")
+                    console.print("  • cost: estimate USD spend using Bedrock rates (handles cache reads accurately)")
+                    quota_mode = questionary.select(
+                        "Quota enforcement mode:",
+                        choices=[
+                            questionary.Choice("token (count raw tokens)", value="token"),
+                            questionary.Choice("cost (estimate USD spend)", value="cost"),
+                        ],
+                        default=config.get("quota", {}).get("quota_mode", "token"),
+                    ).ask()
+                    config["quota"]["quota_mode"] = quota_mode
+
+                    if quota_mode == "cost":
+                        console.print("\n[dim]Set dollar limits. Costs are estimated from Bedrock on-demand rates.")
+                        console.print("Use AWS Cost Explorer for authoritative billing data.[/dim]")
+                        monthly_cost = questionary.text(
+                            "Monthly cost limit per user (USD, 0=unlimited):",
+                            default=str(config.get("quota", {}).get("monthly_cost_limit", 500)),
+                        ).ask()
+                        daily_cost = questionary.text(
+                            "Daily cost limit per user (USD, 0=unlimited):",
+                            default=str(config.get("quota", {}).get("daily_cost_limit", 50)),
+                        ).ask()
+                        config["quota"]["monthly_cost_limit"] = float(monthly_cost)
+                        config["quota"]["daily_cost_limit"] = float(daily_cost)
+
                     # Quota re-check interval
                     console.print("\n[bold]Quota Re-Check Interval[/bold]")
                     console.print("How often to re-check quota with cached credentials:")
@@ -2242,6 +2271,9 @@ class InitCommand(Command):
             "burst_buffer_percent": config_data.get("quota", {}).get("burst_buffer_percent", 10),
             "daily_enforcement_mode": config_data.get("quota", {}).get("daily_enforcement_mode", "alert"),
             "monthly_enforcement_mode": config_data.get("quota", {}).get("monthly_enforcement_mode", "block"),
+            "quota_mode": config_data.get("quota", {}).get("quota_mode", "token"),
+            "monthly_cost_limit": config_data.get("quota", {}).get("monthly_cost_limit", 0.0),
+            "daily_cost_limit": config_data.get("quota", {}).get("daily_cost_limit", 0.0),
             "quota_check_interval": config_data.get("quota", {}).get("check_interval", 30),
             "enable_bypass_detection": config_data.get("quota", {}).get("enable_bypass_detection", False),
             "cowork_3p_enabled": config_data.get("cowork_3p", {}).get("enabled", True),
@@ -2629,6 +2661,9 @@ class InitCommand(Command):
                     "monthly_limit": getattr(profile, "monthly_token_limit", 300000000),
                     "warning_threshold_80": getattr(profile, "warning_threshold_80", 240000000),
                     "warning_threshold_90": getattr(profile, "warning_threshold_90", 270000000),
+                    "quota_mode": getattr(profile, "quota_mode", "token"),
+                    "monthly_cost_limit": getattr(profile, "monthly_cost_limit", 0.0),
+                    "daily_cost_limit": getattr(profile, "daily_cost_limit", 0.0),
                 }
 
             # Add analytics configuration if present

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -78,6 +78,9 @@ class Profile:
     daily_enforcement_mode: str = "alert"  # Daily limit enforcement: "alert" or "block"
     monthly_enforcement_mode: str = "block"  # Monthly limit enforcement: "alert" or "block"
     enable_finegrained_quotas: bool = False  # Enable fine-grained quota policies (user/group/default)
+    quota_mode: str = "token"  # Quota enforcement mode: "token" (raw counts) or "cost" (USD-based)
+    monthly_cost_limit: float = 0.0  # Monthly cost limit per user in USD (cost mode only, 0=disabled)
+    daily_cost_limit: float = 0.0  # Daily cost limit per user in USD (cost mode only, 0=disabled)
     quota_policies_table: str | None = None  # DynamoDB table name for quota policies
     user_quota_metrics_table: str | None = None  # DynamoDB table name for user quota metrics
     quota_api_endpoint: str | None = None  # API Gateway endpoint for real-time quota checks

--- a/source/tests/test_cost_quota_enforcement.py
+++ b/source/tests/test_cost_quota_enforcement.py
@@ -13,6 +13,10 @@ sys.path.insert(0, os.path.join(
     os.path.dirname(__file__), "..", "..", "deployment", "infrastructure", "lambda-functions"
 ))
 
+# quota_check.index creates boto3 clients at module level — need a default region
+# to avoid NoRegionError in CI environments without AWS config.
+os.environ.setdefault("AWS_DEFAULT_REGION", "us-east-1")
+
 from quota_check.index import _calculate_usage_cost
 
 

--- a/source/tests/test_cost_quota_enforcement.py
+++ b/source/tests/test_cost_quota_enforcement.py
@@ -1,0 +1,101 @@
+# ABOUTME: Tests for cost-based quota enforcement mode
+# ABOUTME: Validates the _calculate_usage_cost function and cost-mode limit checking
+
+"""Tests for cost-based quota enforcement (#208 follow-up)."""
+
+import os
+import sys
+
+import pytest
+
+# Add lambda-functions to path
+sys.path.insert(0, os.path.join(
+    os.path.dirname(__file__), "..", "..", "deployment", "infrastructure", "lambda-functions"
+))
+
+from quota_check.index import _calculate_usage_cost
+
+
+class TestCalculateUsageCost:
+    """Tests for converting DynamoDB usage data to USD cost."""
+
+    def test_basic_sonnet_cost(self):
+        """Input-only usage at Sonnet rates."""
+        usage = {
+            "total_tokens": 1_000_000,
+            "daily_tokens": 500_000,
+            "input_tokens": 1_000_000,
+            "output_tokens": 0,
+            "cache_tokens": 0,
+        }
+        result = _calculate_usage_cost(usage, "sonnet")
+        # 1M input × $3/MTok = $3.00
+        assert result["monthly_cost"] == pytest.approx(3.0, rel=0.01)
+
+    def test_mixed_token_types(self):
+        """Realistic mix of token types."""
+        usage = {
+            "total_tokens": 17_000_000,  # input + output + cache_write + cache_read
+            "daily_tokens": 17_000_000,
+            "input_tokens": 23_000,
+            "output_tokens": 125_000,
+            "cache_tokens": 15_500_000,  # cache_read
+            # cache_write derived: 17M - 23K - 125K - 15.5M = 1.352M
+        }
+        result = _calculate_usage_cost(usage, "sonnet")
+        # 23K×$3 + 125K×$15 + 15.5M×$0.30 + 1.352M×$3.75 (all per MTok)
+        # = $0.069 + $1.875 + $4.65 + $5.07 = $11.664
+        assert result["monthly_cost"] == pytest.approx(11.664, rel=0.05)
+
+    def test_cache_heavy_usage_is_cheap(self):
+        """Cache-dominated usage should be much cheaper than raw token count suggests."""
+        usage = {
+            "total_tokens": 16_000_000,
+            "daily_tokens": 16_000_000,
+            "input_tokens": 100_000,
+            "output_tokens": 100_000,
+            "cache_tokens": 15_800_000,  # 99% cache reads
+        }
+        result = _calculate_usage_cost(usage, "sonnet")
+        # If all were input-priced: 16M × $3 = $48
+        # Actual: 100K×$3 + 100K×$15 + 15.8M×$0.30 + 0 cache_write
+        # = $0.30 + $1.50 + $4.74 = $6.54
+        assert result["monthly_cost"] < 10.0  # Much less than $48
+
+    def test_zero_usage(self):
+        """Zero tokens = zero cost."""
+        usage = {
+            "total_tokens": 0,
+            "daily_tokens": 0,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_tokens": 0,
+        }
+        result = _calculate_usage_cost(usage, "sonnet")
+        assert result["monthly_cost"] == 0.0
+        assert result["daily_cost"] == 0.0
+
+    def test_daily_cost_proportional(self):
+        """Daily cost is proportional to daily/monthly token ratio."""
+        usage = {
+            "total_tokens": 10_000_000,
+            "daily_tokens": 1_000_000,  # 10% of monthly
+            "input_tokens": 10_000_000,
+            "output_tokens": 0,
+            "cache_tokens": 0,
+        }
+        result = _calculate_usage_cost(usage, "sonnet")
+        assert result["daily_cost"] == pytest.approx(result["monthly_cost"] * 0.1, rel=0.01)
+
+    def test_opus_more_expensive(self):
+        """Same usage should cost more on Opus than Sonnet."""
+        usage = {
+            "total_tokens": 1_000_000,
+            "daily_tokens": 1_000_000,
+            "input_tokens": 500_000,
+            "output_tokens": 500_000,
+            "cache_tokens": 0,
+        }
+        sonnet_result = _calculate_usage_cost(usage, "sonnet")
+        opus_result = _calculate_usage_cost(usage, "opus")
+        assert opus_result["monthly_cost"] > sonnet_result["monthly_cost"]

--- a/source/tests/test_cost_quota_enforcement.py
+++ b/source/tests/test_cost_quota_enforcement.py
@@ -99,3 +99,32 @@ class TestCalculateUsageCost:
         sonnet_result = _calculate_usage_cost(usage, "sonnet")
         opus_result = _calculate_usage_cost(usage, "opus")
         assert opus_result["monthly_cost"] > sonnet_result["monthly_cost"]
+
+    def test_negative_cache_write_clamped_to_zero(self):
+        """If token counts are inconsistent, cache_write derivation won't go negative."""
+        usage = {
+            "total_tokens": 100_000,  # Less than sum of parts (inconsistent data)
+            "daily_tokens": 100_000,
+            "input_tokens": 50_000,
+            "output_tokens": 50_000,
+            "cache_tokens": 50_000,  # Sum = 150K > total
+        }
+        result = _calculate_usage_cost(usage, "sonnet")
+        # Should not raise, cache_write = max(0, 100K-50K-50K-50K) = 0
+        assert result["monthly_cost"] >= 0
+
+
+class TestTokenModeUnchanged:
+    """Regression tests: token mode behavior must not change."""
+
+    def test_quota_mode_defaults_to_token(self):
+        """QUOTA_MODE defaults to 'token' when not set."""
+        from quota_check.index import QUOTA_MODE
+        # In test environment, env var isn't set → should be 'token'
+        assert QUOTA_MODE == "token"
+
+    def test_cost_limits_default_to_zero(self):
+        """Cost limits default to 0 (disabled) so token mode isn't affected."""
+        from quota_check.index import MONTHLY_COST_LIMIT, DAILY_COST_LIMIT
+        assert MONTHLY_COST_LIMIT == 0
+        assert DAILY_COST_LIMIT == 0


### PR DESCRIPTION
## Summary

Adds cost-based quota enforcement as an alternative to raw token counting. When `QuotaMode=cost`, the quota Lambda converts accumulated token usage to estimated USD using Bedrock pricing rates and enforces dollar-denominated limits.

This solves the core confusion where a user at "191% of token quota" has actually spent ~$11 — because cache reads (90% of volume) are 90% cheaper than input tokens.

## Why Server-Side Cost Calculation?

Claude Code already emits `claude_code.cost.usage` as a native OTEL metric (counter, in USD, per session). So why does this PR calculate cost separately?

| Question | Client-native `claude_code.cost.usage` | This PR (server-side `_calculate_usage_cost`) |
|----------|----------------------------------------|----------------------------------------------|
| **Where does it run?** | In the Claude Code client, exported via OTEL | In the quota Lambda, at credential-issuance time |
| **Data source** | Real-time token counts from the current API response | Accumulated DynamoDB records (days/months of usage) |
| **Can enforce limits?** | ❌ No — it's an async metric in CloudWatch/Prometheus | ✅ Yes — runs synchronously before credentials are issued |
| **Cross-region pricing?** | ❌ Uses Anthropic API rates (no CRIS surcharge) | ✅ Applies 10% multiplier for `us.`/`eu.`/`ap.` profiles |
| **Queryable at enforcement time?** | ❌ CloudWatch metric — not available inside Lambda | ✅ Reads directly from DynamoDB token counts |
| **Custom pricing?** | ❌ Hardcoded in client | ✅ Override via `BEDROCK_PRICING_RATES_JSON` env var |
| **Handles cache types separately?** | ❓ Emits total cost (unclear if cache_read vs cache_write priced differently) | ✅ Explicit: input/output/cache_read/cache_write each at different $/MTok |

**The key constraint:** Quota enforcement happens in the `quota_check` Lambda at credential-issuance time. It cannot query CloudWatch metrics — it must compute cost from the DynamoDB token accumulations. The client-native metric is useful for **dashboards** but cannot drive **enforcement**.

### Relationship to PR #208

- **#208** = visibility Lambda (publishes `claude_code.cost.estimated` for dashboard widgets). May be redundant given `claude_code.cost.usage` already exists natively.
- **#482 (this PR)** = enforcement (blocks users at $X/month). Required regardless of #208 — enforcement needs server-side calculation from DynamoDB.
- Both share `shared/pricing.py` (hardcoded rate table with env-var override).

### Dashboard Note

This PR adds dashboard widgets querying `claude_code.cost.estimated.total` (from #208's Lambda). The existing dashboard already has a widget querying the native `claude_code.cost.usage`. Both may coexist — the native metric provides real-time per-session cost while the server-side metric would provide hourly aggregated cost with CRIS adjustment.

If #208 is not deployed, the new dashboard widgets show "No data" gracefully. The enforcement functionality in this PR works independently of any dashboard metrics.

```
User runs Claude Code
  → credential-process calls quota API
  → quota Lambda reads per-user usage from DynamoDB
  → if QUOTA_MODE == "cost":
      → imports shared/pricing.py
      → calculates: cost = input×$3 + output×$15 + cache_write×$3.75 + cache_read×$0.30 (per MTok)
      → applies cross-region 1.1x multiplier if applicable
      → compares cost against monthly/daily USD limits
      → returns allowed/blocked with "$X.XX / $Y.YY (Z%)" message
  → if QUOTA_MODE == "token" (default):
      → existing behavior unchanged (raw token comparison)
```

### Token Type Resolution from DynamoDB

DynamoDB stores: `input_tokens`, `output_tokens`, `cache_tokens` (cache reads), `total_tokens`

Cache writes derived: `total_tokens - input_tokens - output_tokens - cache_tokens`

Daily cost calculated proportionally: `monthly_cost × (daily_tokens / total_tokens)`

## CLI Integration

### Init Wizard

```
Quota Mode
Choose how usage is measured against limits:
  • token: count raw tokens (simple, existing behavior)
  • cost: estimate USD spend using Bedrock rates (handles cache reads accurately)
❯ cost (estimate USD spend)

Monthly cost limit per user (USD, 0=unlimited): 500
Daily cost limit per user (USD, 0=unlimited): 50
```

### Deploy

Automatically passes `QuotaMode`, `MonthlyCostLimitUsd`, `DailyCostLimitUsd` to the quota-monitoring CF stack. Works in both deploy and dry-run modes.

### Profile

New fields in `config.py`:
- `quota_mode: str = "token"` 
- `monthly_cost_limit: float = 0.0`
- `daily_cost_limit: float = 0.0`

Preserved on re-init via `_check_existing_deployment`.

## Configuration

### CloudFormation Parameters

| Parameter | Default | Description |
|-----------|---------|-------------|
| `QuotaMode` | `token` | `token` (existing) or `cost` (new) |
| `MonthlyCostLimitUsd` | `0` | Monthly $ limit per user (0 = no limit) |
| `DailyCostLimitUsd` | `0` | Daily $ limit per user (0 = no limit) |

## Shared Pricing Utility

`deployment/infrastructure/lambda-functions/shared/pricing.py` — reusable module providing:
- `get_pricing_rates()` — returns current rates (checks env override, falls back to hardcoded)
- `calculate_cost(tokens_by_type, model_family, rates, model_id)` — converts tokens to USD
- `get_model_family(model_id)` — extracts opus/sonnet/haiku from Bedrock model IDs
- `is_cross_region(model_id)` — detects cross-region inference profiles (1.1x surcharge)

Override rates without code changes via `BEDROCK_PRICING_RATES_JSON` environment variable.

## Backward Compatibility

| Scenario | Behavior |
|----------|----------|
| Existing deployment (no change) | `QuotaMode=token` by default → zero behavior change |
| Existing deployment, switch to cost | Re-run `ccwb init` or update stack params |
| New deployment choosing cost | Select in wizard during first init |
| Cost mode but no limits set | Both = 0 → all requests allowed |
| Old profiles missing new fields | `getattr` with defaults → graceful fallback |
| `shared/pricing.py` import fails | Graceful fallback to Sonnet input rate estimate |

**No migration required.** DynamoDB schema unchanged. Same usage data, different math.

## Risks

| Risk | Severity | Mitigation |
|------|----------|------------|
| **Cost is approximate** — DynamoDB doesn't store per-type daily breakdown | Medium | Daily cost uses proportional scaling. Acceptable for enforcement. |
| **Model family unknown at check time** | Low | Defaults to Sonnet rates (most common). Multi-model deployments get approximate cost. |
| **Pricing drift between releases** | Low | Admin override via env var. Rates change rarely (~1-2x/year). |
| **Cache write derivation** — calculated as remainder | Low | `max(0, ...)` prevents negative values from inconsistent data. |
| **Token mode regression** | Low | 2 regression tests verify defaults remain `token` mode with zero cost limits. |

## Testing

```
9 passed in 0.36s

TestCalculateUsageCost (7):
  - Basic sonnet cost, mixed types, cache-heavy, zero usage
  - Daily proportional, opus vs sonnet, negative cache write clamped

TestTokenModeUnchanged (2):
  - QUOTA_MODE defaults to "token"
  - Cost limits default to 0 (disabled)
```

## Files Changed

| File | Change |
|------|--------|
| `lambda-functions/quota_check/index.py` | Cost mode branch + `_calculate_usage_cost()` |
| `lambda-functions/shared/pricing.py` | New — shared pricing utility |
| `lambda-functions/shared/__init__.py` | New — module init |
| `quota-monitoring.yaml` | 3 new CF parameters + Lambda env vars |
| `config.py` | 3 new Profile fields |
| `cli/commands/init.py` | Quota mode wizard + cost limit prompts + re-init preservation |
| `cli/commands/deploy.py` | Pass new params to CF (deploy + dry-run) |
| `assets/docs/QUOTA_MONITORING.md` | Quota Modes documentation section |
| `tests/test_cost_quota_enforcement.py` | 9 unit tests |

## Relationship to PR #208

PR #208 (cost tracking Lambda) uses the same `shared/pricing.py` for hourly dashboard cost metrics. This PR uses it for real-time enforcement. Either can merge first — both include the shared utility. Whichever merges second will be a no-op for the shared files.

## Related PRs

- **PR #208** (cost tracking Lambda) — hourly dashboard cost metrics using the same `shared/pricing.py`. Provides visibility; this PR provides enforcement.
- **PR #404** (cache read disclosure) — adds text disclosure that token limits include cache reads. Serves as an immediate band-aid for token-mode users. Cost mode eliminates the need for this disclosure entirely since cache reads are priced at 10% of input.

## Dashboard

Adds an **Estimated Cost** section to the CloudWatch dashboard between Token Usage and Developer Productivity:

```
## Estimated Cost
[Total $] [Avg $/User] [Top Spender]              ← 3 sparkline cards
[Cost Over Time (area)] [Cost by User Top 10]      ← 2 detail charts
```

Also fixes the existing broken "Estimated Cost by User" widget that referenced a non-existent `claude_code.cost.usage` metric — now correctly queries `claude_code.cost.estimated`.

Widgets show "No data" gracefully until the cost tracking Lambda (PR #208) is deployed and publishing metrics.

> **Note:** The existing dashboard already has a "Cost by User" widget querying `claude_code.cost.usage` — a metric that may be emitted by the Claude Code client itself. Our new widgets query `claude_code.cost.estimated` (server-side). Both may coexist; the client-emitted metric provides real-time per-session cost while the server-side metric provides hourly aggregated cost.


Addresses #263