### PR TITLE
docs: document data latency expectations for analytics pipeline

### DIFF
--- a/assets/docs/QUOTA_MONITORING.md
+++ b/assets/docs/QUOTA_MONITORING.md
@@ -713,6 +713,27 @@ ccwb deploy quota --parameters EnableBypassDetection=true
 - Group membership requires JWT group claims from identity provider
 - Enforcement only at credential issuance (see [Enforcement Timing](#enforcement-timing) for mitigation)
 
+## Data Latency
+
+Different data paths have different latency characteristics:
+
+| Data path | Latency | Use case |
+| --- | --- | --- |
+| Quota enforcement (DynamoDB) | ~1-5 seconds | Real-time quota checks |
+| CloudWatch metrics/dashboards | ~1-5 minutes | Live operational monitoring |
+| Analytics (Firehose → S3 → Athena) | Up to 15 minutes | Historical reporting, cost analysis |
+
+The analytics pipeline uses Kinesis Firehose with a configurable buffer interval
+(`FirehoseBufferInterval` parameter, default 900 seconds / 15 minutes). Firehose
+accumulates records before flushing to S3 to reduce cost and API calls.
+
+To reduce analytics latency, lower the buffer interval (minimum 60 seconds) at
+the cost of more frequent S3 writes:
+
+```bash
+ccwb deploy analytics --parameters FirehoseBufferInterval=60
+```
+
 ## Future Enhancements
 
 - **Tamper-proof enforcement**: Source quota usage from Bedrock model invocation


### PR DESCRIPTION
## Why

Users expect real-time data in dashboards (#193) but the analytics pipeline uses Kinesis Firehose with a 15-minute buffer by default. This is by design (cost optimization) but wasn't documented.

## Change

Adds a concise "Data Latency" section to `QUOTA_MONITORING.md` with:
- Table comparing latency across data paths (quota, dashboards, analytics)
- Explanation of Firehose buffer interval
- Command to lower the interval if faster analytics are needed

Closes #193