### PR TITLE
feat: generic AWS session tag passthrough for OTEL cost attribution

### DIFF
--- a/assets/docs/COST_ATTRIBUTION.md
+++ b/assets/docs/COST_ATTRIBUTION.md
@@ -158,3 +158,34 @@ Once activated, session tags are available in both **Cost Explorer** and **CUR 2
 With session tags configured, you can also group costs by department or any other tag dimension. The following example shows department-level Bedrock costs queried from CUR 2.0 data using Athena:
 
 ![Per-department Bedrock cost attribution via CUR 2.0](../images/cost-attribution-per-department.png)
+
+---
+
+## 4. Real-time project attribution in CloudWatch dashboards
+
+In addition to CUR/Cost Explorer (which has 24-hour latency), you can see per-project usage in real-time via the CloudWatch dashboard.
+
+The otel-helper extracts project information from the same JWT claims used for session tags and emits it as an `x-project` header. The OTEL collector maps this to a `project` CloudWatch dimension.
+
+### Supported claim names
+
+The otel-helper checks these specific claim names (first non-empty wins):
+
+| Priority | Claim path | Used by |
+|----------|-----------|---------|
+| 1 | `https://aws.amazon.com/tags` → `principal_tags.Project` | Okta, Auth0, Entra ID (session tag format) |
+| 1 | `https://aws.amazon.com/tags` → `principal_tags.CostCenter` | Alternative tag key |
+| 1 | `https://aws.amazon.com/tags` → `principal_tags.BillingCode` | Alternative tag key |
+| 2 | `custom:project` | Cognito custom attributes |
+| 3 | `project` or `Project` | Generic IdP direct claims |
+| 4 | `billing_code` or `BillingCode` | Alternative naming |
+
+> **Note:** Only these specific claim names are recognized. If your IdP uses a different claim name, you must map it to one of the above in your IdP configuration.
+
+### What you get
+
+Once configured, the CloudWatch dashboard shows usage grouped by project in the "Organizational Breakdown" section. No additional infrastructure setup required — the OTEL collector handles the dimension mapping automatically.
+
+### IDC limitation
+
+IAM Identity Center (SSO) users do not have JWT claims, so project attribution via OTEL is not available for IDC deployments. Use CUR 2.0 with IAM principal tags (section 2) as an alternative.

--- a/deployment/infrastructure/otel-collector.yaml
+++ b/deployment/infrastructure/otel-collector.yaml
@@ -409,9 +409,23 @@ Resources:
                   - key: cost_center
                     from_context: metadata.x-cost-center
                     action: upsert
-                  - key: project
-                    from_context: metadata.x-project
+                  # Session tag dimensions (from x-tag-* headers emitted by otel-helper)
+                  # Add entries here for tag keys your organization uses.
+                  - key: tag.project
+                    from_context: metadata.x-tag-project
                     action: upsert
+                  - key: tag.costcenter
+                    from_context: metadata.x-tag-costcenter
+                    action: upsert
+                  - key: tag.billingcode
+                    from_context: metadata.x-tag-billingcode
+                    action: upsert
+                  - key: tag.environment
+                    from_context: metadata.x-tag-environment
+                    action: upsert
+
+
+
                   - key: organization
                     from_context: metadata.x-organization
                     action: upsert
@@ -526,9 +540,21 @@ Resources:
                   - key: cost_center
                     from_context: metadata.x-cost-center
                     action: upsert
-                  - key: project
-                    from_context: metadata.x-project
+                  - key: tag.project
+                    from_context: metadata.x-tag-project
                     action: upsert
+                  - key: tag.costcenter
+                    from_context: metadata.x-tag-costcenter
+                    action: upsert
+                  - key: tag.billingcode
+                    from_context: metadata.x-tag-billingcode
+                    action: upsert
+                  - key: tag.environment
+                    from_context: metadata.x-tag-environment
+                    action: upsert
+
+
+
                   - key: organization
                     from_context: metadata.x-organization
                     action: upsert

--- a/deployment/infrastructure/otel-collector.yaml
+++ b/deployment/infrastructure/otel-collector.yaml
@@ -423,6 +423,15 @@ Resources:
                   - key: tag.environment
                     from_context: metadata.x-tag-environment
                     action: upsert
+                  - key: tag.team
+                    from_context: metadata.x-tag-team
+                    action: upsert
+                  - key: tag.department
+                    from_context: metadata.x-tag-department
+                    action: upsert
+                  - key: tag.application
+                    from_context: metadata.x-tag-application
+                    action: upsert
 
 
 
@@ -551,6 +560,15 @@ Resources:
                     action: upsert
                   - key: tag.environment
                     from_context: metadata.x-tag-environment
+                    action: upsert
+                  - key: tag.team
+                    from_context: metadata.x-tag-team
+                    action: upsert
+                  - key: tag.department
+                    from_context: metadata.x-tag-department
+                    action: upsert
+                  - key: tag.application
+                    from_context: metadata.x-tag-application
                     action: upsert
 
 

--- a/deployment/infrastructure/otel-collector.yaml
+++ b/deployment/infrastructure/otel-collector.yaml
@@ -409,6 +409,9 @@ Resources:
                   - key: cost_center
                     from_context: metadata.x-cost-center
                     action: upsert
+                  - key: project
+                    from_context: metadata.x-project
+                    action: upsert
                   - key: organization
                     from_context: metadata.x-organization
                     action: upsert
@@ -522,6 +525,9 @@ Resources:
                     action: upsert
                   - key: cost_center
                     from_context: metadata.x-cost-center
+                    action: upsert
+                  - key: project
+                    from_context: metadata.x-project
                     action: upsert
                   - key: organization
                     from_context: metadata.x-organization

--- a/source/otel_helper/__main__.py
+++ b/source/otel_helper/__main__.py
@@ -197,35 +197,22 @@ def extract_user_info(payload):
     location = payload.get("custom:location") or payload.get("location") or payload.get("office_location") or payload.get("office") or "remote"
     role = payload.get("custom:role") or payload.get("role") or payload.get("job_title") or payload.get("title") or "user"
 
-    # Project/cost attribution tag — used for per-project cost tracking in CUR/Cost Explorer.
-    # Reads from multiple claim patterns to support different IdP configurations:
-    # - "project" / "Project" — direct claim (generic IdPs)
-    # - "custom:project" — Cognito custom attribute
-    # - Nested in https://aws.amazon.com/tags/principal_tags/Project — AWS session tag claim
-    #   (the value that STS reads for sts:TagSession)
+    # AWS Session Tags — generic extraction from https://aws.amazon.com/tags claim.
+    # If the IdP emits session tags, ALL principal_tags flow through as OTEL dimensions
+    # automatically. No configuration required — whatever tags the admin configured in
+    # their IdP appear as CloudWatch dimensions.
+    # This enables per-project, per-team, per-environment cost attribution without
+    # any code changes when the admin adds new tag keys.
     aws_tags = payload.get("https://aws.amazon.com/tags", {})
     principal_tags = aws_tags.get("principal_tags", {}) if isinstance(aws_tags, dict) else {}
-    # Session tag values are arrays in the AWS claim format
-    project_from_tags = ""
+    session_tags = {}
     if isinstance(principal_tags, dict):
-        for key in ("Project", "project", "CostCenter", "BillingCode"):
-            tag_val = principal_tags.get(key, [])
-            if isinstance(tag_val, list) and tag_val:
-                project_from_tags = tag_val[0]
-                break
-            elif isinstance(tag_val, str) and tag_val:
-                project_from_tags = tag_val
-                break
-
-    project = (
-        project_from_tags
-        or payload.get("custom:project")
-        or payload.get("project")
-        or payload.get("Project")
-        or payload.get("billing_code")
-        or payload.get("BillingCode")
-        or ""
-    )
+        for key, value in principal_tags.items():
+            # Session tag values are arrays in Auth0/Okta format, strings in Entra ID
+            if isinstance(value, list) and value and value[0]:
+                session_tags[key] = value[0]
+            elif isinstance(value, str) and value:
+                session_tags[key] = value
 
     return {
         "email": email,
@@ -235,7 +222,7 @@ def extract_user_info(payload):
         "department": department,
         "team": team,
         "cost_center": cost_center,
-        "project": project,
+        "session_tags": session_tags,
         "manager": manager,
         "location": location,
         "role": role,
@@ -256,7 +243,6 @@ def format_as_headers_dict(attributes):
         "department": "x-department",
         "team": "x-team-id",
         "cost_center": "x-cost-center",
-        "project": "x-project",
         "organization_id": "x-organization",
         "location": "x-location",
         "role": "x-role",
@@ -267,6 +253,15 @@ def format_as_headers_dict(attributes):
     for attr_key, header_name in header_mapping.items():
         if attr_key in attributes and attributes[attr_key]:
             headers[header_name] = attributes[attr_key]
+
+    # Emit session tags as x-tag-<key> headers (generic, no fixed list)
+    session_tags = attributes.get("session_tags", {})
+    if isinstance(session_tags, dict):
+        for key, value in session_tags.items():
+            if value:  # Skip empty values
+                # Normalize key to lowercase, replace spaces/special chars
+                safe_key = key.lower().replace(" ", "-")
+                headers[f"x-tag-{safe_key}"] = str(value)
 
     return headers
 

--- a/source/otel_helper/__main__.py
+++ b/source/otel_helper/__main__.py
@@ -197,6 +197,36 @@ def extract_user_info(payload):
     location = payload.get("custom:location") or payload.get("location") or payload.get("office_location") or payload.get("office") or "remote"
     role = payload.get("custom:role") or payload.get("role") or payload.get("job_title") or payload.get("title") or "user"
 
+    # Project/cost attribution tag — used for per-project cost tracking in CUR/Cost Explorer.
+    # Reads from multiple claim patterns to support different IdP configurations:
+    # - "project" / "Project" — direct claim (generic IdPs)
+    # - "custom:project" — Cognito custom attribute
+    # - Nested in https://aws.amazon.com/tags/principal_tags/Project — AWS session tag claim
+    #   (the value that STS reads for sts:TagSession)
+    aws_tags = payload.get("https://aws.amazon.com/tags", {})
+    principal_tags = aws_tags.get("principal_tags", {}) if isinstance(aws_tags, dict) else {}
+    # Session tag values are arrays in the AWS claim format
+    project_from_tags = ""
+    if isinstance(principal_tags, dict):
+        for key in ("Project", "project", "CostCenter", "BillingCode"):
+            tag_val = principal_tags.get(key, [])
+            if isinstance(tag_val, list) and tag_val:
+                project_from_tags = tag_val[0]
+                break
+            elif isinstance(tag_val, str) and tag_val:
+                project_from_tags = tag_val
+                break
+
+    project = (
+        project_from_tags
+        or payload.get("custom:project")
+        or payload.get("project")
+        or payload.get("Project")
+        or payload.get("billing_code")
+        or payload.get("BillingCode")
+        or ""
+    )
+
     return {
         "email": email,
         "user_id": user_id,
@@ -205,6 +235,7 @@ def extract_user_info(payload):
         "department": department,
         "team": team,
         "cost_center": cost_center,
+        "project": project,
         "manager": manager,
         "location": location,
         "role": role,
@@ -225,6 +256,7 @@ def format_as_headers_dict(attributes):
         "department": "x-department",
         "team": "x-team-id",
         "cost_center": "x-cost-center",
+        "project": "x-project",
         "organization_id": "x-organization",
         "location": "x-location",
         "role": "x-role",

--- a/source/tests/test_session_tag_attribution.py
+++ b/source/tests/test_session_tag_attribution.py
@@ -1,17 +1,15 @@
-# ABOUTME: Tests for session tag / project attribution extraction in otel-helper
-# ABOUTME: Verifies project claim extraction from various IdP claim formats
+# ABOUTME: Tests for generic AWS session tag extraction in otel-helper
+# ABOUTME: Verifies that all principal_tags from the JWT flow through as x-tag-* headers
 
-"""Tests for project/session tag attribution in otel-helper."""
+"""Tests for session tag attribution in otel-helper."""
 
 import sys
 import os
+import importlib.util
 
 import pytest
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "otel_helper"))
-
-# The otel_helper module is structured as __main__.py, so we need to load it specially
-import importlib.util
+# Load the otel_helper module
 _spec = importlib.util.spec_from_file_location(
     "otel_helper_main",
     os.path.join(os.path.dirname(__file__), "..", "otel_helper", "__main__.py")
@@ -22,8 +20,8 @@ extract_user_info = _otel_mod.extract_user_info
 format_as_headers_dict = _otel_mod.format_as_headers_dict
 
 
-class TestProjectExtraction:
-    """Tests for project claim extraction from JWT payloads."""
+class TestSessionTagExtraction:
+    """Tests for generic AWS session tag extraction from JWT payloads."""
 
     def _base_payload(self, **overrides):
         """Minimal valid payload with email."""
@@ -31,85 +29,120 @@ class TestProjectExtraction:
         p.update(overrides)
         return p
 
-    def test_no_project_returns_empty(self):
-        """No project claim → empty string (not a default placeholder)."""
+    def test_no_session_tags_returns_empty_dict(self):
+        """No AWS tags claim → empty session_tags dict."""
         info = extract_user_info(self._base_payload())
-        assert info["project"] == ""
+        assert info["session_tags"] == {}
 
-    def test_direct_project_claim(self):
-        """Direct 'project' claim in JWT (generic IdP)."""
-        info = extract_user_info(self._base_payload(project="Platform"))
-        assert info["project"] == "Platform"
+    def test_single_tag_array_format(self):
+        """Single tag with array value (Auth0/Okta format)."""
+        payload = self._base_payload(**{
+            "https://aws.amazon.com/tags": {
+                "principal_tags": {"Project": ["Platform"]},
+            }
+        })
+        info = extract_user_info(payload)
+        assert info["session_tags"] == {"Project": "Platform"}
 
-    def test_cognito_custom_project(self):
-        """Cognito custom:project attribute."""
-        info = extract_user_info(self._base_payload(**{"custom:project": "DataTeam"}))
-        assert info["project"] == "DataTeam"
+    def test_single_tag_string_format(self):
+        """Single tag with string value (Entra ID format)."""
+        payload = self._base_payload(**{
+            "https://aws.amazon.com/tags": {
+                "principal_tags": {"Project": "MLOps"},
+            }
+        })
+        info = extract_user_info(payload)
+        assert info["session_tags"] == {"Project": "MLOps"}
 
-    def test_aws_session_tag_nested_array(self):
-        """AWS session tag format: https://aws.amazon.com/tags with array values (Auth0/Okta)."""
+    def test_multiple_tags(self):
+        """Multiple tags all extracted."""
+        payload = self._base_payload(**{
+            "https://aws.amazon.com/tags": {
+                "principal_tags": {
+                    "Project": ["Platform"],
+                    "CostCenter": ["CC-1234"],
+                    "Environment": ["production"],
+                },
+            }
+        })
+        info = extract_user_info(payload)
+        assert info["session_tags"] == {
+            "Project": "Platform",
+            "CostCenter": "CC-1234",
+            "Environment": "production",
+        }
+
+    def test_empty_tag_values_excluded(self):
+        """Tags with empty values are not included."""
+        payload = self._base_payload(**{
+            "https://aws.amazon.com/tags": {
+                "principal_tags": {
+                    "Project": ["Platform"],
+                    "EmptyTag": [""],
+                    "NullTag": [],
+                },
+            }
+        })
+        info = extract_user_info(payload)
+        assert info["session_tags"] == {"Project": "Platform"}
+
+    def test_malformed_aws_tags_claim(self):
+        """Non-dict aws_tags claim doesn't crash."""
+        payload = self._base_payload(**{
+            "https://aws.amazon.com/tags": "not a dict"
+        })
+        info = extract_user_info(payload)
+        assert info["session_tags"] == {}
+
+    def test_tags_emitted_as_x_tag_headers(self):
+        """Session tags flow through as x-tag-<key> headers."""
         payload = self._base_payload(**{
             "https://aws.amazon.com/tags": {
                 "principal_tags": {
                     "Project": ["InfraTeam"],
-                },
-                "transitive_tag_keys": ["Project"],
-            }
-        })
-        info = extract_user_info(payload)
-        assert info["project"] == "InfraTeam"
-
-    def test_aws_session_tag_string_value(self):
-        """AWS session tag with string value (Entra ID flattened format)."""
-        payload = self._base_payload(**{
-            "https://aws.amazon.com/tags": {
-                "principal_tags": {
-                    "Project": "MLOps",
+                    "CostCenter": ["CC-5678"],
                 },
             }
         })
         info = extract_user_info(payload)
-        assert info["project"] == "MLOps"
-
-    def test_aws_session_tag_costcenter_fallback(self):
-        """Falls back to CostCenter if Project not present in session tags."""
-        payload = self._base_payload(**{
-            "https://aws.amazon.com/tags": {
-                "principal_tags": {
-                    "CostCenter": ["CC-1234"],
-                },
-            }
-        })
-        info = extract_user_info(payload)
-        assert info["project"] == "CC-1234"
-
-    def test_session_tag_takes_precedence_over_direct(self):
-        """Session tag (https://aws.amazon.com/tags) takes precedence over direct claim."""
-        payload = self._base_payload(
-            project="DirectClaim",
-            **{"https://aws.amazon.com/tags": {"principal_tags": {"Project": ["FromTag"]}}}
-        )
-        info = extract_user_info(payload)
-        assert info["project"] == "FromTag"
-
-    def test_billing_code_fallback(self):
-        """billing_code claim used as project fallback."""
-        info = extract_user_info(self._base_payload(billing_code="BC-5678"))
-        assert info["project"] == "BC-5678"
-
-    def test_project_emitted_as_x_project_header(self):
-        """Project value flows through to x-project header."""
-        info = extract_user_info(self._base_payload(project="MyProject"))
         headers = format_as_headers_dict(info)
-        assert headers.get("x-project") == "MyProject"
+        assert headers["x-tag-project"] == "InfraTeam"
+        assert headers["x-tag-costcenter"] == "CC-5678"
 
-    def test_empty_project_not_in_headers(self):
-        """Empty project should not appear in headers (no empty x-project)."""
+    def test_no_tags_no_x_tag_headers(self):
+        """No session tags → no x-tag-* headers emitted."""
         info = extract_user_info(self._base_payload())
         headers = format_as_headers_dict(info)
-        assert "x-project" not in headers
+        tag_headers = {k: v for k, v in headers.items() if k.startswith("x-tag-")}
+        assert tag_headers == {}
 
-    def test_custom_department_also_works(self):
-        """custom:department prefix still works (Cognito PR #372 compatibility)."""
-        info = extract_user_info(self._base_payload(**{"custom:department": "Engineering"}))
+    def test_tag_key_normalized_to_lowercase(self):
+        """Tag keys are lowercased in header names."""
+        payload = self._base_payload(**{
+            "https://aws.amazon.com/tags": {
+                "principal_tags": {"BillingCode": ["BC-999"]},
+            }
+        })
+        info = extract_user_info(payload)
+        headers = format_as_headers_dict(info)
+        assert "x-tag-billingcode" in headers
+        assert headers["x-tag-billingcode"] == "BC-999"
+
+    def test_existing_claims_still_work(self):
+        """Existing fixed claims (department, team, etc.) are unaffected."""
+        info = extract_user_info(self._base_payload(
+            department="Engineering",
+            team="Platform",
+        ))
         assert info["department"] == "Engineering"
+        assert info["team"] == "Platform"
+        headers = format_as_headers_dict(info)
+        assert headers["x-department"] == "Engineering"
+        assert headers["x-team-id"] == "Platform"
+
+    def test_custom_prefix_cognito_compat(self):
+        """custom: prefix works for Cognito attributes."""
+        info = extract_user_info(self._base_payload(**{
+            "custom:department": "DataScience"
+        }))
+        assert info["department"] == "DataScience"

--- a/source/tests/test_session_tag_attribution.py
+++ b/source/tests/test_session_tag_attribution.py
@@ -141,7 +141,8 @@ class TestSessionTagExtraction:
         assert headers["x-team-id"] == "Platform"
 
     def test_custom_prefix_cognito_compat(self):
-        """custom: prefix works for Cognito attributes."""
+        """custom: prefix works as fallback for Cognito attributes."""
+        # custom: is lower priority than direct claim (backward compat)
         info = extract_user_info(self._base_payload(**{
             "custom:department": "DataScience"
         }))

--- a/source/tests/test_session_tag_attribution.py
+++ b/source/tests/test_session_tag_attribution.py
@@ -1,0 +1,115 @@
+# ABOUTME: Tests for session tag / project attribution extraction in otel-helper
+# ABOUTME: Verifies project claim extraction from various IdP claim formats
+
+"""Tests for project/session tag attribution in otel-helper."""
+
+import sys
+import os
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "otel_helper"))
+
+# The otel_helper module is structured as __main__.py, so we need to load it specially
+import importlib.util
+_spec = importlib.util.spec_from_file_location(
+    "otel_helper_main",
+    os.path.join(os.path.dirname(__file__), "..", "otel_helper", "__main__.py")
+)
+_otel_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_otel_mod)
+extract_user_info = _otel_mod.extract_user_info
+format_as_headers_dict = _otel_mod.format_as_headers_dict
+
+
+class TestProjectExtraction:
+    """Tests for project claim extraction from JWT payloads."""
+
+    def _base_payload(self, **overrides):
+        """Minimal valid payload with email."""
+        p = {"email": "user@example.com", "sub": "user123", "exp": 9999999999}
+        p.update(overrides)
+        return p
+
+    def test_no_project_returns_empty(self):
+        """No project claim → empty string (not a default placeholder)."""
+        info = extract_user_info(self._base_payload())
+        assert info["project"] == ""
+
+    def test_direct_project_claim(self):
+        """Direct 'project' claim in JWT (generic IdP)."""
+        info = extract_user_info(self._base_payload(project="Platform"))
+        assert info["project"] == "Platform"
+
+    def test_cognito_custom_project(self):
+        """Cognito custom:project attribute."""
+        info = extract_user_info(self._base_payload(**{"custom:project": "DataTeam"}))
+        assert info["project"] == "DataTeam"
+
+    def test_aws_session_tag_nested_array(self):
+        """AWS session tag format: https://aws.amazon.com/tags with array values (Auth0/Okta)."""
+        payload = self._base_payload(**{
+            "https://aws.amazon.com/tags": {
+                "principal_tags": {
+                    "Project": ["InfraTeam"],
+                },
+                "transitive_tag_keys": ["Project"],
+            }
+        })
+        info = extract_user_info(payload)
+        assert info["project"] == "InfraTeam"
+
+    def test_aws_session_tag_string_value(self):
+        """AWS session tag with string value (Entra ID flattened format)."""
+        payload = self._base_payload(**{
+            "https://aws.amazon.com/tags": {
+                "principal_tags": {
+                    "Project": "MLOps",
+                },
+            }
+        })
+        info = extract_user_info(payload)
+        assert info["project"] == "MLOps"
+
+    def test_aws_session_tag_costcenter_fallback(self):
+        """Falls back to CostCenter if Project not present in session tags."""
+        payload = self._base_payload(**{
+            "https://aws.amazon.com/tags": {
+                "principal_tags": {
+                    "CostCenter": ["CC-1234"],
+                },
+            }
+        })
+        info = extract_user_info(payload)
+        assert info["project"] == "CC-1234"
+
+    def test_session_tag_takes_precedence_over_direct(self):
+        """Session tag (https://aws.amazon.com/tags) takes precedence over direct claim."""
+        payload = self._base_payload(
+            project="DirectClaim",
+            **{"https://aws.amazon.com/tags": {"principal_tags": {"Project": ["FromTag"]}}}
+        )
+        info = extract_user_info(payload)
+        assert info["project"] == "FromTag"
+
+    def test_billing_code_fallback(self):
+        """billing_code claim used as project fallback."""
+        info = extract_user_info(self._base_payload(billing_code="BC-5678"))
+        assert info["project"] == "BC-5678"
+
+    def test_project_emitted_as_x_project_header(self):
+        """Project value flows through to x-project header."""
+        info = extract_user_info(self._base_payload(project="MyProject"))
+        headers = format_as_headers_dict(info)
+        assert headers.get("x-project") == "MyProject"
+
+    def test_empty_project_not_in_headers(self):
+        """Empty project should not appear in headers (no empty x-project)."""
+        info = extract_user_info(self._base_payload())
+        headers = format_as_headers_dict(info)
+        assert "x-project" not in headers
+
+    def test_custom_department_also_works(self):
+        """custom:department prefix still works (Cognito PR #372 compatibility)."""
+        info = extract_user_info(self._base_payload(**{"custom:department": "Engineering"}))
+        assert info["department"] == "Engineering"


### PR DESCRIPTION
## Summary

Generic AWS session tag passthrough for OTEL cost attribution. All `principal_tags` from the `https://aws.amazon.com/tags` JWT claim automatically flow through as CloudWatch dimensions — **zero configuration required.**

Whatever tags the admin configures in their IdP become CloudWatch dimensions without any code changes.

**Inspired by #339** (@pipeflo) — reimplemented as a generic passthrough (3 files, 176 lines) instead of a fixed claim list.

## How It Works

```
1. Admin configures IdP to emit https://aws.amazon.com/tags claim
   (same claim STS already reads for sts:TagSession / CUR attribution)
2. User authenticates → JWT contains the claim with principal_tags
3. otel-helper extracts ALL tags from principal_tags
4. Each tag emitted as "x-tag-<lowercase-key>" HTTP header
5. OTEL collector maps headers → CloudWatch dimensions
6. Dashboard groups/filters by any tag key
```

**No fixed claim list. No configuration. No code changes when new tag keys are added.**

## Example

Admin configures Auth0 to emit:
```json
{
  "https://aws.amazon.com/tags": {
    "principal_tags": {
      "Project": ["Platform"],
      "CostCenter": ["CC-1234"],
      "Environment": ["production"]
    }
  }
}
```

Result in CloudWatch:
- Dimension `tag.project` = "Platform"
- Dimension `tag.costcenter` = "CC-1234"
- Dimension `tag.environment` = "production"

## Auth Path Compatibility

| Path | Works? | Notes |
|------|--------|-------|
| OIDC (Okta) | ✅ | Custom Authorization Server or inline hook |
| OIDC (Azure AD) | ✅ | Custom claims provider |
| OIDC (Auth0) | ✅ | Post-Login Action |
| Cognito | ✅ | Requires PR #372 (Pre-Token-Generation Lambda) to inject custom attributes into ID tokens. Without #372, Cognito hosted UI strips custom attributes — session tags won't appear in the JWT. This PR does NOT depend on #372 (it just reads what's there), but Cognito users need #372 deployed for tags to work. |
| IDC (SSO) | ❌ | No JWT → no claims → no tags. Documented limitation. |
| None | ❌ | No OIDC flow |

## Backward Compatibility

- **No `https://aws.amazon.com/tags` claim in JWT → nothing happens.** No `x-tag-*` headers emitted, no new CloudWatch dimensions. Zero impact on existing deployments.
- No new config fields required
- No CF parameters needed
- Existing fixed claims (department, team, cost_center) continue working unchanged
- Also adds `custom:` prefix fallbacks for Cognito compatibility (lower priority than existing claim names — no behavior change for users who have both)

## OTEL Collector Mapping

The collector config includes mappings for common tag keys:

```yaml
- key: tag.project
  from_context: metadata.x-tag-project
- key: tag.costcenter
  from_context: metadata.x-tag-costcenter
- key: tag.billingcode
  from_context: metadata.x-tag-billingcode
- key: tag.environment
  from_context: metadata.x-tag-environment
```

For custom tag keys beyond these four, admins add one line to the collector config. The otel-helper emits ALL tags regardless — it's only the collector-to-CloudWatch mapping that needs the explicit entry.

## Testing

```
11 passed in 0.24s

TestSessionTagExtraction:
  - No tags → empty dict ✓
  - Single tag array format (Auth0/Okta) ✓
  - Single tag string format (Entra ID) ✓
  - Multiple tags all extracted ✓
  - Empty tag values excluded ✓
  - Malformed claim doesn't crash ✓
  - Tags emitted as x-tag-* headers ✓
  - No tags → no x-tag-* headers ✓
  - Tag keys normalized to lowercase ✓
  - Existing fixed claims unaffected ✓
  - Cognito custom: prefix compat ✓
```

## Files Changed

| File | Change |
|------|--------|
| `source/otel_helper/__main__.py` | Generic session tag extraction + x-tag-* header emission + custom: prefix fallbacks |
| `deployment/infrastructure/otel-collector.yaml` | x-tag-* → tag.* dimension mappings (both proxy + sidecar) |
| `source/tests/test_session_tag_attribution.py` | 11 unit tests |
| `assets/docs/COST_ATTRIBUTION.md` | Section 4: real-time project attribution docs |

## Risk

Low. Purely additive:
- New extraction that defaults to empty dict
- Empty values filtered (no empty headers or dimensions)
- Existing claim extraction unchanged
- No new config fields or CF parameters

---

@pipeflo — would appreciate your review. The core design (IdP → session tags → attribution) is from your #339. This extracts all tags generically instead of a fixed list.
