### PR TITLE
feat: add deployment scope selector (cowork/code/both)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ FEEDBACK.md
 .claudeignore
 .mcp.json
 source/go/credential-process
+__pycache__/

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -247,8 +247,8 @@ class DeployCommand(Command):
                             "[dim]Re-run 'ccwb init' with OIDC authentication to deploy quota monitoring. "
                             "See issue #454.[/dim]"
                         )
-            # Check if CodeBuild is enabled
-            if getattr(profile, "enable_codebuild", False):
+            # Check if CodeBuild is enabled (skip for cowork-only scope)
+            if getattr(profile, "enable_codebuild", False) and getattr(profile, "deployment_scope", "both") != "cowork":
                 stacks_to_deploy.append(("codebuild", "CodeBuild for Windows binary builds"))
 
         # Initialize CloudFormation manager

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -312,6 +312,20 @@ class InitCommand(Command):
             skip_monitoring = last_step in ["monitoring_complete", "bedrock_complete"]
             skip_bedrock = last_step in ["bedrock_complete"]
 
+        # Deployment Scope
+        console.print("\n[bold blue]Deployment Scope[/bold blue]")
+        console.print("Choose what you are deploying:")
+        deployment_scope = questionary.select(
+            "Deployment scope:",
+            choices=[
+                questionary.Choice("both (Cowork + Code)", value="both"),
+                questionary.Choice("cowork (Desktop only)", value="cowork"),
+                questionary.Choice("code (CLI only)", value="code"),
+            ],
+            default=config.get("deployment_scope", "both"),
+        ).ask()
+        config["deployment_scope"] = deployment_scope
+
         # SSO Authentication Configuration
         if not skip_okta:
             console.print("\n[bold blue]Step 1: Authentication Configuration[/bold blue]")
@@ -2247,6 +2261,7 @@ sso_registration_scopes = sso:account:access"""
             monthly_enforcement_mode=config_data.get("quota", {}).get("monthly_enforcement_mode", "block"),
             quota_check_interval=config_data.get("quota", {}).get("check_interval", 30),
             cowork_3p_enabled=config_data.get("cowork_3p", {}).get("enabled", True),
+            deployment_scope=config_data.get("deployment_scope", "both"),
             tags=config_data.get("tags", {}),
             redirect_port=config_data.get("redirect_port"),
         )
@@ -2588,6 +2603,8 @@ sso_registration_scopes = sso:account:access"""
 
             # Add CoWork 3P configuration
             existing_config["cowork_3p"] = {"enabled": profile.cowork_3p_enabled}
+            if hasattr(profile, "deployment_scope"):
+                existing_config["deployment_scope"] = profile.deployment_scope
 
             # Add distribution configuration if present
             if hasattr(profile, "enable_distribution"):

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -124,6 +124,7 @@ class Profile:
 
     # Claude Cowork 3P MDM configuration
     cowork_3p_enabled: bool = True  # Generate CoWork 3P MDM configs during packaging
+    deployment_scope: str = "both"  # Deployment scope: "cowork" (Desktop only), "code" (CLI only), or "both" (default)
 
     # Legacy field support
     @property


### PR DESCRIPTION
## Summary

Adds a `deployment_scope` config field to control which stacks get deployed. Replaces the positioning/doc changes from closed PR #306 with a pure functional scope selector.

## What it does

Init wizard asks as the first question:
```
Deployment scope:
❯ both (Cowork + Code)
  cowork (Desktop only)
  code (CLI only)
```

Deploy respects the scope:
- `cowork`: skips CodeBuild (no CLI binaries needed for Desktop-only)
- `code`: full CLI deployment (future: skip Cowork-specific stacks)
- `both`: existing behavior unchanged

## Backward Compatible

- Default is `both` — existing profiles unaffected
- `getattr(profile, 'deployment_scope', 'both')` everywhere with safe fallback
- Preserved on re-init via `_check_existing_deployment`
- No default stack name changes
- No README/doc positioning changes

## What's NOT in this PR (vs closed #306)

- No README reordering or Cowork-first positioning
- No default stack name change (`claude-auth`)
- No IDC content (already on feature branch)
- No doc changes

## Files

| File | Change |
|------|--------|
| `config.py` | `deployment_scope` field (default `"both"`) |
| `init.py` | Scope selector question + save + re-init preservation |
| `deploy.py` | Skip CodeBuild when scope is cowork-only |
| `.gitignore` | Added `__pycache__/` |