### PR TITLE
fix(ci): use GITHUB_TOKEN directly in beta release workflow

### DIFF
--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Determine base version and next beta number
         id: version
@@ -130,7 +130,7 @@ jobs:
       - name: Publish GitHub Pre-release
         if: steps.check.outputs.skip != 'true'
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
Fixes the beta pre-release workflow failing with 'could not read Username' error. The `RELEASE_TOKEN` secret doesn't exist on this repo — replaced with `GITHUB_TOKEN` which is sufficient for tag creation and release publishing.