### PR TITLE
fix: quota stack works in fine-grained mode

### DIFF
--- a/deployment/infrastructure/quota-monitoring.yaml
+++ b/deployment/infrastructure/quota-monitoring.yaml
@@ -154,6 +154,7 @@ Resources:
                 Action:
                   - dynamodb:Query
                   - dynamodb:PutItem
+                  - dynamodb:UpdateItem
                   - dynamodb:GetItem
                   - dynamodb:Scan
                 Resource:
@@ -273,6 +274,7 @@ Resources:
           DAILY_TOKEN_LIMIT: !Ref DailyTokenLimit
           DAILY_ENFORCEMENT_MODE: !Ref DailyEnforcementMode
           MONTHLY_ENFORCEMENT_MODE: !Ref MonthlyEnforcementMode
+          ENABLE_FINEGRAINED_QUOTAS: !Ref EnableFinegrainedQuotas
       Code: ./lambda-functions/quota_check/
 
   # HTTP API Gateway (v2 - cheaper and faster than REST API)


### PR DESCRIPTION
## Summary

Two-line fix to `deployment/infrastructure/quota-monitoring.yaml` so the quota stack actually enforces per-user policies in fine-grained mode.

- Adds `dynamodb:UpdateItem` to `QuotaMonitorRole`, so the monitor Lambda can write per-user counters into `UserQuotaMetrics` instead of silently failing with `AccessDeniedException` on every run.
- Sets `ENABLE_FINEGRAINED_QUOTAS: !Ref EnableFinegrainedQuotas` in `QuotaCheckFunction`'s `Environment.Variables`, so `quota_check/index.py:resolve_quota_for_user` actually reads from `QuotaPolicies` instead of short-circuiting to the env-default policy and ignoring user/group policies.

The monitor Lambda block already passed this env var; the check Lambda block didn't. PR #280 fixed the deploy-side wiring (parameter flips correctly with profile), but the missing env var on the check Lambda meant the parameter never reached the runtime that actually applies it.

Closes #499

## Test plan

- [x] `ccwb deploy quota` with `enable_finegrained_quotas: true` succeeds (UPDATE_COMPLETE)
- [x] Verified IAM role now contains `UpdateItem` action via `aws iam get-role-policy`
- [x] Verified Lambda env via `aws lambda get-function-configuration` shows `ENABLE_FINEGRAINED_QUOTAS: true`
- [x] Set `ccwb quota set-user alice@amazon.com --monthly-limit 50K --enforcement block`
- [x] Pushed ~200K synthetic tokens for alice via OTLP collector
- [x] Triggered monitor Lambda — `UserQuotaMetrics` now populated, `ccwb quota usage alice@amazon.com` reports `204K / 50K (408%)` instead of `0`
- [x] Invoked `claude-code-quota-check` with alice's JWT claim — response is now `{"allowed": false, "reason": "monthly_exceeded", "policy": {"type": "user", "identifier": "alice@amazon.com"}, ...}` instead of falling through to the default env policy
- [x] Bob (under cap, alert-only) still returns `{"allowed": true, "reason": "within_quota", "policy": {"type": "user", "identifier": "bob@amazon.com"}, ...}`

## By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.