### PR TITLE
fix: wire fine-grained quota support into QuotaCheckFunction

### DIFF
--- a/deployment/infrastructure/quota-monitoring.yaml
+++ b/deployment/infrastructure/quota-monitoring.yaml
@@ -180,6 +180,7 @@ Resources:
                 Action:
                   - dynamodb:Query
                   - dynamodb:PutItem
+                  - dynamodb:UpdateItem
                   - dynamodb:GetItem
                   - dynamodb:Scan
                 Resource:
@@ -397,6 +398,7 @@ Resources:
           DAILY_TOKEN_LIMIT: !Ref DailyTokenLimit
           DAILY_ENFORCEMENT_MODE: !Ref DailyEnforcementMode
           MONTHLY_ENFORCEMENT_MODE: !Ref MonthlyEnforcementMode
+          ENABLE_FINEGRAINED_QUOTAS: !Ref EnableFinegrainedQuotas
       Code: ./lambda-functions/quota_check/
 
   # HTTP API Gateway (v2 - cheaper and faster than REST API)

--- a/source/tests/e2e/test_cfn_contracts.py
+++ b/source/tests/e2e/test_cfn_contracts.py
@@ -168,7 +168,7 @@ class TestQuotaMonitoringTemplateContract:
             if resource.get("Type") == "AWS::Lambda::Function":
                 props = resource.get("Properties", {})
                 handler = props.get("Handler", "")
-                if "quota_check" in handler or "quota_check" in resource_name.lower():
+                if "quota_check" in handler or "quotacheck" in resource_name.lower():
                     quota_lambda = props
                     break
 
@@ -183,12 +183,35 @@ class TestQuotaMonitoringTemplateContract:
             "QUOTA_TABLE",
             "MONTHLY_TOKEN_LIMIT",
             "MONTHLY_ENFORCEMENT_MODE",
+            "ENABLE_FINEGRAINED_QUOTAS",
         }
 
         for var in expected_vars:
             assert var in env_vars, (
                 f"quota_check Lambda missing env var '{var}' that the code reads at import time"
             )
+
+    def test_quota_monitor_role_has_update_item(self):
+        """QuotaMonitorRole must have dynamodb:UpdateItem for atomic counter upserts."""
+        template = _load_template("quota-monitoring.yaml")
+        resources = template.get("Resources", {})
+
+        monitor_role = resources.get("QuotaMonitorRole", {})
+        policies = monitor_role.get("Properties", {}).get("Policies", [])
+
+        all_actions = []
+        for policy in policies:
+            statements = policy.get("PolicyDocument", {}).get("Statement", [])
+            for stmt in statements:
+                actions = stmt.get("Action", [])
+                if isinstance(actions, str):
+                    actions = [actions]
+                all_actions.extend(actions)
+
+        assert "dynamodb:UpdateItem" in all_actions, (
+            "QuotaMonitorRole missing dynamodb:UpdateItem — quota_monitor Lambda uses "
+            "table.update_item() for atomic counter upserts"
+        )
 
     def test_dynamodb_table_schema_matches_code(self):
         """DynamoDB table key schema matches what Lambda code uses for queries."""


### PR DESCRIPTION
## Summary

Fixes two infrastructure bugs that prevent fine-grained quota enforcement from working (#499).

Based on the fix proposed by @gubaruch in #500 — this PR adds regression tests on top.

### Bug 1: Missing `dynamodb:UpdateItem` on QuotaMonitorRole

The monitor Lambda calls `table.update_item()` with `ADD` semantics for atomic per-user counter upserts. The IAM policy only granted `PutItem`, causing silent `AccessDeniedException` failures — `UserQuotaMetrics` stayed empty.

### Bug 2: Missing `ENABLE_FINEGRAINED_QUOTAS` env var on QuotaCheckFunction

The check Lambda reads this env var at import time (line 24) and defaults to `"false"` when absent. Without it, `resolve_quota_for_user()` short-circuits to env-default policy at line 269, never consulting DynamoDB for per-user/group policies.

### Changes

- `deployment/infrastructure/quota-monitoring.yaml`: +1 IAM action, +1 env var (2 lines)
- `source/tests/e2e/test_cfn_contracts.py`: +2 regression tests, fix resource name matching

### Credits

Fix originally proposed by @gubaruch in #500. This PR incorporates the same fix with added regression tests.

Closes #499
Supersedes #500