### PR TITLE
fix: correct IAM action-prefix allow-list in cfn contract test

### DIFF
--- a/source/tests/e2e/test_cfn_contracts.py
+++ b/source/tests/e2e/test_cfn_contracts.py
@@ -99,7 +99,7 @@ class TestIAMPolicyValidity:
 
     # Valid IAM action prefixes for services used in this project
     VALID_ACTION_PREFIXES = {
-        "bedrock", "bedrock-runtime", "cognito-identity", "cognito-idp", "sts", "logs",
+        "bedrock", "cloudtrail", "cognito-identity", "cognito-idp", "sts", "logs",
         "cloudwatch", "s3", "s3express", "s3-object-lambda", "s3outposts",
         "dynamodb", "lambda", "iam", "ssm",
         "firehose", "glue", "athena", "kms", "codebuild", "ec2",


### PR DESCRIPTION
## Why
The cfn contract test's `VALID_ACTION_PREFIXES` allow-list has two errors that together (a) turn beta CI red and (b) silently disable the #375 guard:

1. **Missing `cloudtrail`** — `quota-monitoring.yaml` legitimately uses `cloudtrail:LookupEvents` (added in #438 for sidecar bypass detection), but the allow-list never gained `cloudtrail`, so the test fails deterministically:
   ```
   AssertionError: Invalid IAM action prefix 'cloudtrail' in quota-monitoring.yaml: cloudtrail:LookupEvents.
   ```
2. **Spurious `bedrock-runtime`** — the test is documented to *catch* the bogus `bedrock-runtime:` prefix (#375, see `.claude/rules/iam-actions.md`), yet lists it as valid, so `bedrock-runtime:InvokeModel` would pass straight through.

Verified against the AWS Service Authorization Reference:
- `cloudtrail` is a valid IAM prefix — `cloudtrail:LookupEvents` is a real Read action.
- Amazon Bedrock's only IAM prefix is `bedrock` (singular). `bedrock-runtime` is an SDK/API endpoint name, **not** an IAM namespace.

## What
One-line correction to `VALID_ACTION_PREFIXES`: add `cloudtrail`, remove `bedrock-runtime`.

## Testing
- **Repro:** `quota-monitoring.yaml` parametrization failed before, passes after.
- **Regression — guard restored:** no template uses `bedrock-runtime:` (grep), so removal surfaces no hidden violation; re-injecting a `bedrock-runtime:InvokeModel` action into a template now correctly **fails** the test again (it would have passed before).
- Full `test_cfn_contracts.py` suite green (88 passed).

Credit: `cloudtrail:LookupEvents` introduced by @avivenk in #438; the test allow-list introduced by @wirjo in #410.