### PR TITLE
Fix: Correct Milan region code from eu-south-2 to eu-south-1 in Claude Sonnet 4.5 cross-region inference profile

### DIFF
--- a/source/claude_code_with_bedrock/models.py
+++ b/source/claude_code_with_bedrock/models.py
@@ -600,7 +600,7 @@ _CLAUDE_MODELS_RAW = {
                     "eu-west-1",  # Ireland
                     "eu-west-2",  # London
                     "eu-west-3",  # Paris
-                    "eu-south-2",  # Milan
+                    "eu-south-1",  # Milan
                     "eu-south-2",  # Spain
                 ],
                 "destination_regions": [
@@ -610,7 +610,7 @@ _CLAUDE_MODELS_RAW = {
                     "eu-west-1",
                     "eu-west-2",
                     "eu-west-3",
-                    "eu-south-2",
+                    "eu-south-1",
                     "eu-south-2",
                 ],
             },
@@ -643,7 +643,7 @@ _CLAUDE_MODELS_RAW = {
                     "eu-west-1",  # Ireland
                     "eu-west-2",  # London
                     "eu-west-3",  # Paris
-                    "eu-south-2",  # Milan
+                    "eu-south-1",  # Milan
                     "eu-south-2",  # Spain
                     # Asia Pacific
                     "ap-southeast-3",  # Jakarta
@@ -672,7 +672,7 @@ _CLAUDE_MODELS_RAW = {
                     "eu-west-1",
                     "eu-west-2",
                     "eu-west-3",
-                    "eu-south-2",
+                    "eu-south-1",
                     "eu-south-2",
                     # Asia Pacific
                     "ap-southeast-3",


### PR DESCRIPTION
The Milan region identifier was incorrectly set to eu-south-2 (which is Spain). This fix corrects it to eu-south-1 for cross-region inference profiles.

## Description

The EU cross-region inference profile configuration for **Claude Sonnet 4.5** (`claude-sonnet-4-5-v1`) had `eu-south-2` (Spain) listed in place of `eu-south-1` (Milan) in both `source_regions` and `destination_regions`. This caused `eu-south-2` to appear twice and `eu-south-1` to be completely absent from the profile, leading to authorization failures when CRIS routes requests to Milan.

## Why is this change needed

When configuring CRIS with the EU profile for Claude Sonnet 4.5, requests fail with a `403` error:
Failed to authenticate. API Error: 403 {"Message":"User: arn:aws:sts::714007529877:assumed-role/BedrockAzureFederatedRole/claude-code-gaHYErJ8iwBbLnA5lbyLPsu2YKfqwAO9 is not authorized to perform: bedrock:InvokeModelWithResponseStream on resource: arn:aws:bedrock:eu-south-1::foundation-model/anthropic.claude-opus-4-6-v1 because no identity-based policy allows the bedrock:InvokeModelWithResponseStream action"}

The inference profile incorrectly maps Milan to `eu-south-2`, so when a request is routed to what should be `eu-south-1`, the IAM policy (correctly scoped) doesn't match and the call is denied.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Replaced `eu-south-2` (labeled as Milan) with the correct `eu-south-1` in the Claude Sonnet 4.5 EU cross-region inference profile (`source/claude_code_with_bedrock/models.py`)
- Affected both `source_regions` and `destination_regions` arrays

## Testing Checklist

### What was tested

- [x] End-to-end authentication flow tested

## Testing Evidence

**Test Results:**

After applying the fix, CRIS for Claude Sonnet 4.5 correctly includes `eu-south-1` (Milan) in the inference profile and the 403 authorization error no longer occurs when IAM policies are scoped to the correct EU regions.