### PR TITLE
fix(test): resolve Windows CI failures in credential helpers and OTEL cache tests

### DIFF
--- a/source/go/internal/storage/refresh_test.go
+++ b/source/go/internal/storage/refresh_test.go
@@ -11,8 +11,11 @@ func TestSaveAndLoadRefreshToken(t *testing.T) {
 	// Use a temp dir as session dir
 	tmpDir := t.TempDir()
 	origHome := os.Getenv("HOME")
+	origUserProfile := os.Getenv("USERPROFILE")
 	os.Setenv("HOME", tmpDir)
+	os.Setenv("USERPROFILE", tmpDir) // Windows: os.UserHomeDir() uses USERPROFILE
 	defer os.Setenv("HOME", origHome)
+	defer os.Setenv("USERPROFILE", origUserProfile)
 
 	// Ensure session dir exists
 	os.MkdirAll(filepath.Join(tmpDir, ".claude-code-session"), 0700)

--- a/source/tests/cli/utils/test_helpers_wiring.py
+++ b/source/tests/cli/utils/test_helpers_wiring.py
@@ -11,7 +11,7 @@ class TestGetCodebuildRegionWiring:
 
     def test_builds_command_uses_helper(self):
         """builds.py uses get_codebuild_region instead of raw profile.aws_region for codebuild client."""
-        source = (Path(__file__).resolve().parents[3] / "claude_code_with_bedrock" / "cli" / "commands" / "builds.py").read_text()
+        source = (Path(__file__).resolve().parents[3] / "claude_code_with_bedrock" / "cli" / "commands" / "builds.py").read_text(encoding="utf-8")
         assert "from claude_code_with_bedrock.cli.utils.helpers import get_codebuild_region" in source
         assert "get_codebuild_region(profile)" in source
 
@@ -21,13 +21,13 @@ class TestClearCachedCredentialsWiring:
 
     def test_destroy_command_clears_credentials(self):
         """destroy.py calls clear_cached_credentials after successful stack destruction."""
-        source = (Path(__file__).resolve().parents[3] / "claude_code_with_bedrock" / "cli" / "commands" / "destroy.py").read_text()
+        source = (Path(__file__).resolve().parents[3] / "claude_code_with_bedrock" / "cli" / "commands" / "destroy.py").read_text(encoding="utf-8")
         assert "from claude_code_with_bedrock.cli.utils.helpers import clear_cached_credentials" in source
         assert "clear_cached_credentials(profile_name)" in source
 
     def test_credential_cleanup_after_stack_destroy(self):
         """Credential cleanup happens after stacks are destroyed, not before."""
-        source = (Path(__file__).resolve().parents[3] / "claude_code_with_bedrock" / "cli" / "commands" / "destroy.py").read_text()
+        source = (Path(__file__).resolve().parents[3] / "claude_code_with_bedrock" / "cli" / "commands" / "destroy.py").read_text(encoding="utf-8")
         idx_destroy = source.find("stack destroyed")
         idx_clear = source.find("clear_cached_credentials(profile_name)")
         assert idx_destroy < idx_clear, "Credentials should be cleared after stack destruction"

--- a/source/tests/test_otel_authorization_header.py
+++ b/source/tests/test_otel_authorization_header.py
@@ -35,6 +35,8 @@ def mock_cache_dir(tmp_path, monkeypatch):
     cache_dir = tmp_path / ".claude-code-session"
     cache_dir.mkdir(parents=True, exist_ok=True)
     monkeypatch.setenv("HOME", str(tmp_path))
+    # On Windows, Path.home() uses USERPROFILE instead of HOME
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     monkeypatch.setenv("AWS_PROFILE", "test-profile")
     return cache_dir
 


### PR DESCRIPTION
## Why

Windows CI is red on beta — 5 Python test failures + 1 Go test failure, all caused by platform-specific path/encoding differences.

## What

Three fixes (3 files, +8/-3 lines):

### 1. UnicodeDecodeError in credential helper tests (Python)

`test_helpers_wiring.py` uses `read_text()` without `encoding="utf-8"`. On Windows, Python defaults to `cp1252` which can't decode UTF-8 chars in `destroy.py`.

**Fix:** Add `encoding="utf-8"` to all `read_text()` calls.

### 2. OTEL cache path invisible on Windows (Python)

`test_otel_authorization_header.py`'s `mock_cache_dir` fixture sets `HOME` but not `USERPROFILE`. On Windows, `Path.home()` uses `USERPROFILE`, so the test's cache files are invisible to production code.

**Fix:** Add `monkeypatch.setenv("USERPROFILE", str(tmp_path))` to the fixture.

### 3. Go refresh token test path failure (Go)

`refresh_test.go` sets `HOME` but not `USERPROFILE`. On Windows, `os.UserHomeDir()` uses `USERPROFILE`, so `SaveRefreshToken` writes to the real home dir instead of the test temp dir.

**Fix:** Add `os.Setenv("USERPROFILE", tmpDir)` alongside `HOME`.

## Testing

- All 6 previously-failing tests pass locally
- All fixes are cross-platform safe (setting both env vars is harmless on Linux/macOS)
- 896 Python tests pass on Linux; Go tests pass

## Risk

Very low — test-only changes, no production code modified.