### PR TITLE
fix: remove deleted generate_credential_helper_wrapper from package.py

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -3041,7 +3041,6 @@ Available metrics include:
             build_mdm_config,
             derive_model_aliases,
             generate_all,
-            generate_credential_helper_wrapper,
         )
 
         console = Console()
@@ -3056,7 +3055,6 @@ Available metrics include:
                 profile_name=profile_name,
             )
 
-            generate_credential_helper_wrapper(profile_name, bedrock_region)
             add_monitoring_config(mdm_config, profile, console)
             generate_all(output_dir, mdm_config, console)
 


### PR DESCRIPTION
## Bug

`ccwb package` crashes with:
```
ImportError: cannot import name 'generate_credential_helper_wrapper' from 'claude_code_with_bedrock.cli.utils.cowork_3p'
```

## Root Cause

Commit cd9510e refactored CoWork 3P from credential-helper-wrapper (`inferenceCredentialHelper`) to AWS named-profile (`inferenceBedrockProfile`), deleting `generate_credential_helper_wrapper` from `cowork_3p.py`. The standalone `cowork.py` command was updated but `package.py` was missed.

## Fix

Removed the deleted function from package.py's import block and call site. The CoWork config still gets the correct profile pointer through `build_mdm_config(..., profile_name=profile_name)`, which writes `inferenceBedrockProfile`.

## Verification

- `package.py` parses cleanly
- All 4 remaining imported symbols confirmed present in `cowork_3p.py`
- 1 file changed, 2 deletions