### PR TITLE
fix: CI failures blocking beta→main promotion

### DIFF
--- a/.github/workflows/pytest-ci.yml
+++ b/.github/workflows/pytest-ci.yml
@@ -108,6 +108,8 @@ jobs:
 
           for f in $CHANGED_PY; do
             [ -f "$f" ] || continue
+            # Skip test files — they reference unsafe patterns in assertions/docstrings
+            if echo "$f" | grep -qE '(^|/)tests?/'; then continue; fi
 
             # 1. SO_REUSEADDR without platform guard (HIGH — causes silent behavioral differences)
             if grep -n 'SO_REUSEADDR' "$f" > /tmp/matches 2>/dev/null; then

--- a/source/go/internal/storage/refresh_test.go
+++ b/source/go/internal/storage/refresh_test.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"encoding/json"
 	"os"
+	"runtime"
 	"path/filepath"
 	"testing"
 )
@@ -38,7 +39,7 @@ func TestSaveAndLoadRefreshToken(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Stat failed: %v", err)
 	}
-	if info.Mode().Perm() != 0600 {
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0600 {
 		t.Errorf("File permissions = %o, want 0600", info.Mode().Perm())
 	}
 


### PR DESCRIPTION
Fixes two CI failures that block PR #508 (Release v2.4.0):

1. **Cross-platform lint false positives on test files** — Test files reference `os.rename` in docstrings and assertions (explaining *why* we use `os.replace`). The lint was triggering on these strings. Fix: skip files under `tests/` directories.

2. **Go test fails on Windows** — `TestSaveAndLoadRefreshToken` asserts 0600 file permissions but Windows doesn't support Unix permissions (`os.Chmod` is a no-op). Fix: skip permission check when `runtime.GOOS == "windows"`.

Both are CI-only fixes. No production code changed.