### PR TITLE
fix: enable CGO for macOS credential-process to fix keyring caching

### DIFF
--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -108,13 +108,15 @@ jobs:
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
-          CGO_ENABLED: '0'
+          # macOS credential-process needs cgo for keychain access (99designs/keyring)
+          CGO_ENABLED: ${{ matrix.goos == 'darwin' && '1' || '0' }}
         run: |
           cd source/go
           EXT=""
           if [ "$GOOS" = "windows" ]; then EXT=".exe"; fi
+          # credential-process uses CGO_ENABLED from env; otel-helper never needs cgo
           go build -ldflags="-s -w" -o ../../credential-process-${{ matrix.artifact_prefix }}${EXT} ./cmd/credential-process/
-          go build -ldflags="-s -w" -o ../../otel-helper-${{ matrix.artifact_prefix }}${EXT} ./cmd/otel-helper/
+          CGO_ENABLED=0 go build -ldflags="-s -w" -o ../../otel-helper-${{ matrix.artifact_prefix }}${EXT} ./cmd/otel-helper/
 
       - name: Generate checksums
         shell: bash

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -707,7 +707,10 @@ class PackageCommand(Command):
 
                 self.line(f"  Building <comment>{output_name}</comment>...")
 
-                env = {**os.environ, "GOOS": goos, "GOARCH": goarch, "CGO_ENABLED": "0"}
+                # macOS credential-process needs CGO_ENABLED=1 for keychain access
+                # (99designs/keyring's keychain backend requires cgo).
+                cgo = "1" if goos == "darwin" and binary == "credential-process" else "0"
+                env = {**os.environ, "GOOS": goos, "GOARCH": goarch, "CGO_ENABLED": cgo}
                 # Windows: do NOT strip (-s -w). Defender cloud ML (Wacatac.B!ml)
                 # flags stripped Go binaries. The .syso PE version-info files in
                 # cmd/*/ are auto-linked by the Go compiler to help further.

--- a/source/go/Makefile
+++ b/source/go/Makefile
@@ -24,12 +24,12 @@ clean:
 
 macos-arm64:
 	@mkdir -p $(OUT)
-	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -trimpath -ldflags "$(LDFLAGS)" -o $(OUT)/credential-process-macos-arm64 ./cmd/credential-process/
+	CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build -trimpath -ldflags "$(LDFLAGS)" -o $(OUT)/credential-process-macos-arm64 ./cmd/credential-process/
 	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -trimpath -ldflags "$(LDFLAGS)" -o $(OUT)/otel-helper-macos-arm64 ./cmd/otel-helper/
 
 macos-intel:
 	@mkdir -p $(OUT)
-	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -trimpath -ldflags "$(LDFLAGS)" -o $(OUT)/credential-process-macos-intel ./cmd/credential-process/
+	CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -trimpath -ldflags "$(LDFLAGS)" -o $(OUT)/credential-process-macos-intel ./cmd/credential-process/
 	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -trimpath -ldflags "$(LDFLAGS)" -o $(OUT)/otel-helper-macos-intel ./cmd/otel-helper/
 
 linux-x64:


### PR DESCRIPTION
## Description

Enable `CGO_ENABLED=1` for macOS builds of `credential-process` so the `99designs/keyring` Keychain backend is included in the binary.

## Why is this change needed

The `99designs/keyring` library's macOS Keychain backend has the build constraint `//go:build darwin && cgo`. With `CGO_ENABLED=0`, this backend is excluded from compilation entirely. At runtime, `keyring.Open()` falls through all backends to `FileBackend`, which fails immediately with "No directory provided for file keyring" on every write.

This means **`credential_storage: "keyring"` is completely non-functional on macOS** — credentials are never cached, forcing a full browser-based OIDC flow on every single invocation of `credential-process`.

Linux is unaffected: its Secret Service and keyctl backends only require `//go:build linux` (pure Go, no cgo needed).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] CI/CD changes

## Changes Made

- `source/go/Makefile`: `CGO_ENABLED=1` for macOS `credential-process` targets (arm64 + intel)
- `source/claude_code_with_bedrock/cli/commands/package.py`: Conditional `CGO_ENABLED=1` when building `credential-process` for darwin
- `.github/workflows/release-main.yml`: Dynamic `CGO_ENABLED` based on `matrix.goos == 'darwin'` for credential-process; otel-helper stays at `CGO_ENABLED=0`

## Additional Notes

- `otel-helper` does not use keyring, so it remains `CGO_ENABLED=0` for all platforms (no cgo dependency, simpler cross-compilation)
- macOS CI runners (macos-latest) have Xcode/clang available, so cgo compilation works without additional setup
- The resulting macOS binary links `Security.framework` and `CoreFoundation.framework` (standard system frameworks, no extra dependencies)

---

## Testing Checklist

### What was tested

- [x] End-to-end authentication flow tested

### Special cases

- [ ] This PR only modifies GitHub workflows (auto-exempt from testing validation)

## Testing Evidence

**Test Environment:** macOS (arm64), Go 1.24, `credential_storage: "keyring"` profile with Azure AD (direct federation)

**Test Results:**

```text
# Before fix (CGO_ENABLED=0 binary):
$ go version -m ~/claude-code-with-bedrock/credential-process | grep CGO
        build   CGO_ENABLED=0

$ COGNITO_AUTH_DEBUG=1 ~/claude-code-with-bedrock/credential-process --profile prod-eu-central-1
Debug: Authenticating with azure for profile 'prod-eu-central-1'...
Debug: Exchanging token for AWS credentials...
Debug: Failed to save credentials: No directory provided for file keyring
{"Version":1,...}
# ^ Every invocation triggers browser auth, credentials never cached

# After fix (CGO_ENABLED=1 binary):
$ go version -m ~/claude-code-with-bedrock/credential-process | grep CGO
        build   CGO_ENABLED=1

$ COGNITO_AUTH_DEBUG=1 ~/claude-code-with-bedrock/credential-process --profile prod-eu-central-1
Debug: Authenticating with azure for profile 'prod-eu-central-1'...
Debug: Exchanging token for AWS credentials...
{"Version":1,...}
# ^ No "Failed to save credentials" error

# Second run — cache hit, no auth flow:
$ COGNITO_AUTH_DEBUG=1 ~/claude-code-with-bedrock/credential-process --profile prod-eu-central-1
{"Version":1,...}
# ^ Instant return from keychain cache
```