### PR TITLE
fix(package): treat Windows-only CodeBuild build as success, not failure

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -496,11 +496,28 @@ class PackageCommand(Command):
                         except Exception as e:
                             console.print(f"[yellow]Warning: Could not build OTEL helper for {platform_name}: {e}[/yellow]")
 
-        # Check if any binaries were built
-        if not built_executables:
+        # A Windows build runs asynchronously in CodeBuild and produces no local
+        # binary now (_build_executable returns None), so built_executables can be
+        # empty even though the build was submitted successfully. Treat that as a
+        # success and still generate the config/installer for distribution.
+        windows_codebuild_pending = any(
+            platform_name == "windows" and platform_name not in [p for p, _ in built_executables]
+            for platform_name in platforms_to_build
+        ) and bool(profile and getattr(profile, "enable_codebuild", False))
+
+        # Check if any binaries were built (or are pending in CodeBuild)
+        if not built_executables and not windows_codebuild_pending:
             console.print("\n[red]Error: No binaries were successfully built.[/red]")
             console.print("Please check the error messages above.")
             return 1
+
+        if windows_codebuild_pending and not built_executables:
+            console.print("\n[bold cyan]Windows binaries are building in AWS CodeBuild[/bold cyan]")
+            console.print("Local configuration files will be generated now for distribution.")
+            console.print("\nTo check build status:")
+            console.print("  [cyan]poetry run ccwb builds[/cyan]")
+            console.print("\nOnce complete, retrieve binaries with:")
+            console.print("  [cyan]poetry run ccwb distribute[/cyan]\n")
 
         # Create configuration
         console.print("\n[cyan]Creating configuration...[/cyan]")

--- a/source/tests/cli/commands/test_package_windows_codebuild_pending.py
+++ b/source/tests/cli/commands/test_package_windows_codebuild_pending.py
@@ -1,0 +1,100 @@
+# ABOUTME: Regression test for Windows-only ccwb package falsely reporting build failure
+# ABOUTME: An async CodeBuild Windows build produces no local binary but is still a success
+
+"""Regression test: a Windows-only package on a non-Windows host must not error.
+
+When packaging only Windows from macOS/Linux with ``enable_codebuild=True``,
+``_build_executable("windows")`` starts an asynchronous CodeBuild build and
+returns ``None`` (no local binary yet). ``built_executables`` is therefore empty
+even though the build was submitted successfully.
+
+Commit 076da39 (#338, the Go rewrite) dropped the ``windows_codebuild_pending``
+escape hatch, so the bare ``if not built_executables`` guard fired and the
+command printed "Error: No binaries were successfully built." and returned 1 -
+even though the CodeBuild build was running fine (confirmed live: the command
+errored while ``ccwb builds`` showed the build In Progress). ``main`` still has
+the correct guard; this test pins it on ``beta``.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from cleo.testers.command_tester import CommandTester
+
+from claude_code_with_bedrock.cli.commands.package import PackageCommand
+from claude_code_with_bedrock.config import Config, Profile
+
+
+@pytest.fixture
+def mock_profile():
+    """Cognito profile with CodeBuild enabled and monitoring off (simplest path)."""
+    return Profile(
+        name="test",
+        provider_domain="test.auth.us-east-1.amazoncognito.com",
+        client_id="test-client-id",
+        credential_storage="keyring",
+        aws_region="us-east-1",
+        identity_pool_name="test-pool",
+        allowed_bedrock_regions=["us-east-1"],
+        enable_codebuild=True,  # Windows builds go to CodeBuild
+        monitoring_enabled=False,
+        cowork_3p_enabled=False,  # keep the test focused on the build-success guard
+    )
+
+
+@pytest.fixture
+def mock_config(mock_profile):
+    config = MagicMock(spec=Config)
+    config.get_profile.return_value = mock_profile
+    config.active_profile = "test"
+    return config
+
+
+def test_windows_only_async_build_is_not_a_failure(mock_config):
+    """Windows-only build started in CodeBuild (None binary) must exit 0, not 1.
+
+    ``_build_executable`` returns ``None`` for the async Windows path. The command
+    must treat that as success, still generate config/installer, and NOT print
+    "No binaries were successfully built".
+    """
+    command = PackageCommand()
+    tester = CommandTester(command)
+
+    with patch("claude_code_with_bedrock.config.Config.load", return_value=mock_config), patch(
+        "questionary.confirm"
+    ) as mock_confirm, patch.object(
+        # Simulate the async CodeBuild submission: no local binary produced.
+        PackageCommand, "_build_executable", return_value=None
+    ), patch.object(
+        PackageCommand, "_create_config"
+    ), patch.object(
+        PackageCommand, "_create_installer"
+    ):
+        mock_confirm.return_value.ask.return_value = False
+
+        result = tester.execute("--target-platform windows")
+
+    assert result == 0, "Windows-only async CodeBuild build must succeed (exit 0)"
+    assert "No binaries were successfully built" not in tester.io.fetch_output()
+
+
+def test_windows_only_without_codebuild_still_errors(mock_config, mock_profile):
+    """Guard sanity: if CodeBuild is disabled and no binary is produced, still error.
+
+    This confirms the fix narrows the success case to genuine async submissions and
+    does not blanket-suppress the real "nothing built" failure.
+    """
+    mock_profile.enable_codebuild = False
+    command = PackageCommand()
+    tester = CommandTester(command)
+
+    with patch("claude_code_with_bedrock.config.Config.load", return_value=mock_config), patch(
+        "questionary.confirm"
+    ) as mock_confirm, patch.object(
+        PackageCommand, "_build_executable", return_value=None
+    ):
+        mock_confirm.return_value.ask.return_value = False
+
+        result = tester.execute("--target-platform windows")
+
+    assert result == 1, "With CodeBuild disabled and no binary, package must still error"


### PR DESCRIPTION
## Description

A Windows-only `ccwb package` on a non-Windows host submits the build to CodeBuild asynchronously, so `_build_executable` returns `None` and `built_executables` is empty. The bare `if not built_executables:` guard then reports failure and exits 1, skipping config/installer generation. This PR restores the `windows_codebuild_pending` escape hatch (present on `main`): an async Windows submission is treated as success, the user is told the build is running, and the config/installer are still generated for distribution.

## Why is this change needed

Windows-only packaging on macOS/Linux is unusable on `beta`: it errors with `No binaries were successfully built` and produces no package, even though the CodeBuild build was started successfully. `main` is unaffected.

Fixes #520

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `source/claude_code_with_bedrock/cli/commands/package.py`: compute `windows_codebuild_pending` (true only when `windows` is in the build set AND `profile.enable_codebuild`); change the guard to `if not built_executables and not windows_codebuild_pending:`; print a "building in CodeBuild — run `ccwb builds` / `ccwb distribute`" message for the pending case and continue to config/installer generation.
- `source/tests/cli/commands/test_package_windows_codebuild_pending.py` (new): asserts a Windows-only async build (`_build_executable` → `None`, `enable_codebuild=True`) exits 0; and that a genuine "no binary + CodeBuild disabled" case still exits 1 (so the fix does not over-suppress real failures).

## Additional Notes

- The two cases are distinguished by `enable_codebuild`, so the existing behavior for genuine build failures is preserved (verified by the existing `test_package_executable_path_init.py`, which still passes).

## Testing Checklist

### What was tested

- [x] Unit/integration tests pass (`ccwb test` / `poetry run pytest tests/`)
- [x] CLI commands tested (`ccwb init/deploy/build/package/test`)

## Testing Evidence

**Test Environment:** ap-southeast-2, Python 3.12, macOS (Apple silicon)

**Test Results:**

```text
# 1. Full unit suite (rebased on beta) — pass
$ cd source && poetry run pytest tests/ -q
919 passed, 22 skipped, 1 xfailed, 1 xpassed

# 2. New regression tests (2/2 on the fix)
$ poetry run pytest tests/cli/commands/test_package_windows_codebuild_pending.py -q
2 passed

# 3. FALSIFICATION — the same tests run against beta's package.py (no fix):
#    test_windows_only_async_build_is_not_a_failure  -> FAILED  (assert 1 == 0)
#      stdout: "Error: No binaries were successfully built."   <- exact reported symptom
#    test_windows_only_without_codebuild_still_errors -> PASSED (genuine failure still errors)
#  => proves the test catches the bug and the fix resolves it.

# 4. Existing guard test unaffected
$ poetry run pytest tests/cli/commands/test_package_executable_path_init.py -q
1 passed

# 5. CI gates verified locally (incl. main-only): bandit (no new findings vs beta),
#    semgrep --config auto (0 findings), detect-secrets (no new secrets). cfn_nag /
#    validate-regions / go-tests are N/A (diff touches only package.py + a test).
```
