### PR TITLE
fix(otel): disable logs exporter so the collector stops 4xx-ing /v1/logs

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -2996,7 +2996,10 @@ Available metrics include:
                         {
                             "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
                             "OTEL_METRICS_EXPORTER": "otlp",
-                            "OTEL_LOGS_EXPORTER": "otlp",
+                            # The collector defines only a metrics pipeline, so /v1/logs is
+                            # dropped (4xx). Explicitly disable logs export rather than deleting
+                            # the key so a global/user default can't re-enable "otlp".
+                            "OTEL_LOGS_EXPORTER": "none",
                             "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
                             "OTEL_EXPORTER_OTLP_ENDPOINT": endpoint,
                             "OTEL_RESOURCE_ATTRIBUTES": resource_attrs,

--- a/source/claude_code_with_bedrock/cli/commands/package_cb.py
+++ b/source/claude_code_with_bedrock/cli/commands/package_cb.py
@@ -461,7 +461,10 @@ class PackageCbCommand(Command):
                             {
                                 "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
                                 "OTEL_METRICS_EXPORTER": "otlp",
-                                "OTEL_LOGS_EXPORTER": "otlp",
+                                # The collector defines only a metrics pipeline, so /v1/logs is
+                                # dropped (4xx). Explicitly disable logs export rather than
+                                # deleting the key so a global/user default can't re-enable "otlp".
+                                "OTEL_LOGS_EXPORTER": "none",
                                 "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
                                 "OTEL_EXPORTER_OTLP_ENDPOINT": endpoint,
                                 "OTEL_RESOURCE_ATTRIBUTES": resource_attrs,

--- a/source/tests/cli/commands/test_package_logs_exporter.py
+++ b/source/tests/cli/commands/test_package_logs_exporter.py
@@ -1,0 +1,94 @@
+# ABOUTME: Regression tests for OTEL_LOGS_EXPORTER in generated settings.json
+# ABOUTME: The collector defines only a metrics pipeline, so logs export must be disabled
+
+"""Regression tests: generated settings.json disables OTLP logs export.
+
+The OTEL collector config (otel-collector.yaml) defines only a metrics pipeline
+in both SSM service-config variants. When settings.json sets
+OTEL_LOGS_EXPORTER=otlp, Claude Code POSTs /v1/logs to the collector, which has
+no logs pipeline to route them -> the OTLP receiver drops them and the ALB
+returns HTTPCode_Target_4XX. Disabling logs export (OTEL_LOGS_EXPORTER=none)
+removes that traffic while leaving metrics unaffected.
+
+Both the standard package command and the Cowork (CodeBuild) variant must set
+"none" explicitly -- deleting the key could let a global/user default re-enable
+"otlp".
+"""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from claude_code_with_bedrock.cli.commands.package import PackageCommand
+from claude_code_with_bedrock.cli.commands.package_cb import PackageCbCommand
+from claude_code_with_bedrock.config import Profile
+
+
+def _monitoring_profile() -> Profile:
+    return Profile(
+        name="test",
+        provider_domain="test.okta.com",
+        client_id="test-client-id",
+        credential_storage="keyring",
+        aws_region="us-east-1",
+        identity_pool_name="test-pool",
+        allowed_bedrock_regions=["us-east-1", "us-west-2"],
+        cross_region_profile="us",
+        monitoring_enabled=True,
+        otel_collector_endpoint="https://collector.example.com",
+        stack_names={"monitoring": "test-pool-otel-collector"},
+    )
+
+
+def _read_settings_env(output_dir: Path) -> dict:
+    settings_path = output_dir / "claude-settings" / "settings.json"
+    with open(settings_path, encoding="utf-8") as f:
+        return json.load(f)["env"]
+
+
+class TestLogsExporterDisabled:
+    """OTEL_LOGS_EXPORTER must be 'none' so the collector stops 4xx-ing /v1/logs."""
+
+    def test_standard_package_disables_logs_exporter(self):
+        command = PackageCommand()
+        profile = _monitoring_profile()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            command._create_claude_settings(output_dir, profile)
+            env = _read_settings_env(output_dir)
+
+        # Telemetry is on (endpoint resolved from profile) ...
+        assert env["CLAUDE_CODE_ENABLE_TELEMETRY"] == "1"
+        # ... metrics still export ...
+        assert env["OTEL_METRICS_EXPORTER"] == "otlp"
+        # ... but logs export is explicitly disabled (not deleted).
+        assert env["OTEL_LOGS_EXPORTER"] == "none"
+
+    def test_cowork_package_disables_logs_exporter(self):
+        command = PackageCbCommand()
+        profile = _monitoring_profile()
+
+        cfn_outputs = json.dumps(
+            [{"OutputKey": "CollectorEndpoint", "OutputValue": "https://collector.example.com"}]
+        )
+
+        class _FakeResult:
+            returncode = 0
+            stdout = cfn_outputs
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            with patch(
+                "claude_code_with_bedrock.cli.commands.package_cb.subprocess.run",
+                return_value=_FakeResult(),
+            ):
+                command._create_claude_settings(
+                    output_dir, profile, include_coauthored_by=True, profile_name="ClaudeCode"
+                )
+            env = _read_settings_env(output_dir)
+
+        assert env["CLAUDE_CODE_ENABLE_TELEMETRY"] == "1"
+        assert env["OTEL_METRICS_EXPORTER"] == "otlp"
+        assert env["OTEL_LOGS_EXPORTER"] == "none"


### PR DESCRIPTION
> 🟡 **Maintainer decision requested — proposal, not a unilateral change.** This implements **Option B** (disable logs export). It is a behavior decision, not a clear-cut bug fix: if you prefer **Option A** (add a logs pipeline) or want to keep logs export for a future consumer, please **close this PR freely** — no attachment. See #522 for the A-vs-B trade-off.

## Description

Generated `settings.json` set `OTEL_LOGS_EXPORTER=otlp`, but the collector defines only a `metrics` pipeline, so Claude Code's `/v1/logs` POSTs are dropped and the OTEL ALB returns `HTTPCode_Target_4XX` for each. This sets `OTEL_LOGS_EXPORTER=none` in both packaging paths (standard `package.py` and Cowork `package_cb.py`), removing the failing traffic. No consumer in this repo reads OTLP log/events — quota, analytics, and dashboards all read the metrics channel (`claude_code.token.usage`) — so nothing used today is lost.

## Why is this change needed

The collector 4xx-s every `/v1/logs` POST (≈88% of collector-reaching requests, ~537/72h observed live), inflating the OTEL ALB error rate and dropping data with no consumer. `none` is a documented valid value for `OTEL_LOGS_EXPORTER` (Claude Code monitoring docs: `console, otlp, none`).

Fixes #522

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `source/claude_code_with_bedrock/cli/commands/package.py`: `OTEL_LOGS_EXPORTER` → `"none"` (was `"otlp"`), with a comment explaining the collector has no logs pipeline.
- `source/claude_code_with_bedrock/cli/commands/package_cb.py` (Cowork): same change — both paths must match or Cowork packages keep 4xx-ing.
- Use explicit `"none"` rather than deleting the key, so a global/user/managed default cannot re-enable `otlp`.
- `source/tests/cli/commands/test_package_logs_exporter.py` (new): asserts generated `settings.json` has `OTEL_LOGS_EXPORTER == "none"` (metrics exporter still `otlp`) for **both** standard and Cowork packaging.

## Additional Notes

- This does not retroactively fix already-distributed `settings.json`; users re-run `ccwb package`. Collector config is untouched → zero metrics-path risk.
- Option A (add a logs pipeline) is deferred: it adds recurring CloudWatch Logs cost, a different endpoint (`logs.<region>`) + headers + IAM, and edits to both SSM variants — appropriate only once a real logs consumer exists. See #522.

## Testing Checklist

### What was tested

- [x] Unit/integration tests pass (`ccwb test` / `poetry run pytest tests/`)
- [x] CLI commands tested (`ccwb init/deploy/build/package/test`)

## Testing Evidence

**Test Environment:** ap-southeast-2, Python 3.12, macOS (Apple silicon)

**Test Results:**

```text
# 1. Full unit suite (rebased on beta) — pass
$ cd source && poetry run pytest tests/ -q
919 passed, 22 skipped, 1 xfailed, 1 xpassed

# 2. New regression tests (standard + Cowork) on the fix
$ poetry run pytest tests/cli/commands/test_package_logs_exporter.py -q
2 passed

# 3. FALSIFICATION — same tests against beta's package files (no fix):
#    both tests FAIL (settings.json still emits OTEL_LOGS_EXPORTER=otlp)
#    => proves the tests catch the bug and the fix resolves it.

# 4. Premise re-verified on current beta:
#    otel-collector.yaml service.pipelines defines only `metrics` in BOTH
#    service-config variants — no `logs` pipeline — so /v1/logs is dropped.

# 5. Live evidence (collector ALB, ap-southeast-2, 72h):
#    RequestCount 608  =  HTTPCode_Target_4XX 537 (~88%, the /v1/logs POSTs)
#                       + HTTPCode_Target_2XX 71  (the /v1/metrics POSTs)

# 6. CI gates verified locally (incl. main-only): bandit (no new findings vs beta on
#    either package file), semgrep --config auto (0 findings), detect-secrets (no new
#    secrets). cfn_nag/validate-regions/go-tests N/A (no CFN/region/Go change).
```
