### PR TITLE
fix: enable quota monitoring wizard and deploy for IAM Identity Center users

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -151,13 +151,13 @@ class DeployCommand(Command):
                     console.print("[yellow]Analytics requires monitoring to be enabled in your configuration.[/yellow]")
                     return 1
             elif stack_arg == "quota":
-                if profile.effective_auth_type not in ("oidc",):
+                if profile.effective_auth_type not in ("oidc", "idc"):
                     console.print(
-                        "[yellow]Quota monitoring requires OIDC authentication "
-                        "(per-user JWT tokens) and cannot be deployed for IDC/none auth types.[/yellow]"
+                        "[yellow]Quota monitoring requires user authentication "
+                        "(OIDC or IAM Identity Center) and cannot be deployed without it.[/yellow]"
                     )
                     console.print(
-                        "[dim]See issue #454. Use OIDC authentication to deploy quota monitoring.[/dim]"
+                        "[dim]See issue #454. Enable OIDC or IDC authentication to deploy quota monitoring.[/dim]"
                     )
                     return 1
                 if profile.monitoring_enabled:
@@ -236,16 +236,15 @@ class DeployCommand(Command):
                 # has no valid issuer URL otherwise. Skip with a warning rather
                 # than letting CloudFormation fail mid-deploy (issue #454).
                 if getattr(profile, "quota_monitoring_enabled", False):
-                    if profile.effective_auth_type == "oidc":
+                    if profile.effective_auth_type in ("oidc", "idc"):
                         stacks_to_deploy.append(("quota", "Quota Monitoring (Per-User Token Limits)"))
                     else:
                         console.print(
                             "[yellow]⚠ Skipping quota monitoring stack: quota enforcement requires "
-                            "OIDC authentication (per-user JWT tokens) but auth type is not OIDC.[/yellow]"
+                            "user authentication (OIDC or IAM Identity Center).[/yellow]"
                         )
                         console.print(
-                            "[dim]Re-run 'ccwb init' with OIDC authentication to deploy quota monitoring. "
-                            "See issue #454.[/dim]"
+                            "[dim]Re-run 'ccwb init' with OIDC or IDC authentication to deploy quota monitoring.[/dim]"
                         )
             # Check if CodeBuild is enabled
             if getattr(profile, "enable_codebuild", False):

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1180,17 +1180,18 @@ sso_registration_scopes = sso:account:access"""
                     config["analytics"]["enabled"] = False
 
                 # Quota monitoring configuration (both modes)
-                # Quota enforcement requires per-user JWT tokens from an OIDC provider —
-                # the API Gateway authorizer cannot validate requests without one.
-                # Skip the prompt entirely when auth_type is not OIDC (issue #454).
-                if config.get("auth_type") not in ("oidc",):
+                # Quota enforcement works with both auth types:
+                # - OIDC: API Gateway JWT authorizer validates ID token
+                # - IDC: SigV4-signed requests with email from STS identity (PR #461)
+                # Skip only when auth_type is 'none' (no user identity available).
+                if config.get("auth_type") not in ("oidc", "idc"):
                     if "quota" not in config:
                         config["quota"] = {}
                     config["quota"]["enabled"] = False
                     console.print("\n[bold]Quota Monitoring[/bold]")
                     console.print(
-                        "[dim]Skipped — quota monitoring requires OIDC authentication "
-                        "(per-user JWT tokens) and is disabled for IDC/none auth types.[/dim]"
+                        "[dim]Skipped — quota monitoring requires user authentication "
+                        "(OIDC or IAM Identity Center) and is disabled for this profile.[/dim]"
                     )
                 else:
                     console.print("\n[bold]Quota Monitoring[/bold]")


### PR DESCRIPTION
## Problem

The `ccwb init` wizard skips quota configuration entirely when `auth_type != 'oidc'`. IAM Identity Center users (auth_type='idc') see:

> *Skipped — quota monitoring requires OIDC authentication (per-user JWT tokens) and is disabled for IDC/none auth types.*

Since PR #461 added SigV4-based quota checks for IDC users (`CheckWithIAM()`), quota enforcement now works with both auth methods. The wizard just wasn't updated to allow it.

## Fix

Change the gate from `auth_type in ('oidc',)` to `auth_type in ('oidc', 'idc')` in three places:

1. **`init.py`** — allow quota configuration prompts for IDC users
2. **`deploy.py` (explicit deploy)** — allow `ccwb deploy quota` for IDC profiles
3. **`deploy.py` (auto deploy)** — include quota stack in deploy-all for IDC profiles

## Backward Compatibility

- `auth_type='none'` still skips quota (correct — no user identity available)
- OIDC behavior unchanged
- Only IDC users gain access to the quota wizard

## Testing Evidence

Code-level change only (3 conditional checks relaxed). No new logic — the quota stack and IDC integration already exist from #461.

Fixes https://github.com/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock/issues/401#issuecomment-4680462795