### PR TITLE
refactor(otel): centralize the Bearer-attach literal into one helper per language

### DIFF
--- a/source/go/cmd/otel-helper/main.go
+++ b/source/go/cmd/otel-helper/main.go
@@ -45,6 +45,16 @@ func debugPrint(format string, args ...interface{}) {
 	}
 }
 
+// attachBearer sets the Authorization header. Intentionally exp-AGNOSTIC:
+// the Layer-1 cache-hit path never decodes the token, so token validation
+// lives at the token source (see storage.GetMonitoringToken), NOT here.
+// Do not add an exp check inside this function.
+func attachBearer(headers map[string]string, token string) {
+	if token != "" {
+		headers["authorization"] = "Bearer " + token
+	}
+}
+
 func main() {
 	testMode := flag.Bool("test", false, "Run in test mode with verbose output")
 	verboseFlag := flag.Bool("verbose", false, "Show verbose output")
@@ -76,9 +86,9 @@ func run(testMode bool) int {
 			// Resolve Bearer fresh — the cache stores attribution headers only,
 			// never the token itself. Try env var (free) then credential-process (~20ms).
 			if t := os.Getenv("CLAUDE_CODE_MONITORING_TOKEN"); t != "" {
-				headers["authorization"] = "Bearer " + t
+				attachBearer(headers, t)
 			} else if t, err := getTokenViaCredentialProcess(profile); err == nil && t != "" {
-				headers["authorization"] = "Bearer " + t
+				attachBearer(headers, t)
 			} else {
 				// No token from env var or credential-process. Emit cached attribution
 				// anyway (otelHeadersHelper contract), but log so an ALB 401 is
@@ -133,7 +143,7 @@ func run(testMode bool) int {
 
 	if testMode {
 		// Include Bearer in test output so --test shows the full header set.
-		headers["authorization"] = "Bearer " + token
+		attachBearer(headers, token)
 		printTestOutput(userInfo, headers)
 	} else {
 		// Cache attribution headers only — Bearer token must never be persisted
@@ -146,7 +156,7 @@ func run(testMode bool) int {
 		} else {
 			debugPrint("JWT has no exp claim, skipping cache write")
 		}
-		headers["authorization"] = "Bearer " + token
+		attachBearer(headers, token)
 		outputJSON(headers)
 	}
 

--- a/source/go/cmd/otel-helper/main_test.go
+++ b/source/go/cmd/otel-helper/main_test.go
@@ -8,6 +8,41 @@ import (
 	"testing"
 )
 
+// TestAttachBearer is the behavioral half of the Go↔Python Bearer parity check
+// (the static half lives in tests/test_otel_bearer_parity.py). It pins the
+// contract the single attachBearer choke point must hold: a non-empty token
+// yields exactly "Bearer <token>" under the "authorization" key, and an empty
+// token attaches nothing (sending "Bearer " with no JWT is worse than omitting
+// the header — the ALB would 401 on it).
+func TestAttachBearer(t *testing.T) {
+	t.Run("non-empty token sets Bearer header", func(t *testing.T) {
+		headers := map[string]string{}
+		attachBearer(headers, "abc.def.ghi")
+		if got := headers["authorization"]; got != "Bearer abc.def.ghi" {
+			t.Errorf("authorization = %q, want %q", got, "Bearer abc.def.ghi")
+		}
+	})
+
+	t.Run("empty token omits the key", func(t *testing.T) {
+		headers := map[string]string{}
+		attachBearer(headers, "")
+		if _, ok := headers["authorization"]; ok {
+			t.Errorf("empty token must not set 'authorization', got %q", headers["authorization"])
+		}
+	})
+
+	t.Run("existing attribution is preserved", func(t *testing.T) {
+		headers := map[string]string{"x-user-email": "a@b.com"}
+		attachBearer(headers, "tok")
+		if headers["x-user-email"] != "a@b.com" {
+			t.Errorf("attachBearer clobbered attribution: x-user-email = %q", headers["x-user-email"])
+		}
+		if headers["authorization"] != "Bearer tok" {
+			t.Errorf("authorization = %q, want 'Bearer tok'", headers["authorization"])
+		}
+	})
+}
+
 // TestRun_NoToken_EmitsEmptyHeadersAndExitsZero is the regression test for the
 // Windows symptom "otelHeadersHelper did not return a valid value": when no
 // monitoring token is available the helper must still print a valid JSON object

--- a/source/otel_helper/__main__.py
+++ b/source/otel_helper/__main__.py
@@ -239,6 +239,12 @@ def format_as_headers_dict(attributes):
     return headers
 
 
+def _attach_bearer(headers, token):
+    """Set the Authorization header. Exp-AGNOSTIC by design — see attachBearer in main.go."""
+    if token:
+        headers["authorization"] = f"Bearer {token}"
+
+
 def get_cache_path():
     """Get the path to the OTEL headers cache file."""
     cache_dir = Path.home() / ".claude-code-session"
@@ -644,7 +650,7 @@ def build_proxy_user_headers() -> dict:
 
     headers = format_as_headers_dict(user_info)
     if token:
-        headers["authorization"] = f"Bearer {token}"
+        _attach_bearer(headers, token)
     return headers
 
 
@@ -828,7 +834,7 @@ def main():
             # never the token itself. Try env var (free) then credential-process (~20ms).
             _bearer_token = os.environ.get("CLAUDE_CODE_MONITORING_TOKEN") or get_token_via_credential_process()
             if _bearer_token:
-                cached_headers["authorization"] = f"Bearer {_bearer_token}"
+                _attach_bearer(cached_headers, _bearer_token)
             else:
                 # No token from env var or credential-process. Emit cached attribution
                 # anyway (otelHeadersHelper contract), but log so an ALB 401 is
@@ -875,7 +881,7 @@ def main():
             # it before printTestOutput). Added only on this branch — test mode never
             # writes the cache, so the token stays off disk.
             if token:
-                headers_dict["authorization"] = f"Bearer {token}"
+                _attach_bearer(headers_dict, token)
             print("===== TEST MODE OUTPUT =====\n")
             if token:
                 print("Mode: Authenticated (JWT Token)")
@@ -925,7 +931,7 @@ def main():
                 # Anonymous mode: cache with a synthetic TTL (5 minutes)
                 write_cached_headers(headers_dict, int(time.time()) + _STS_CACHE_TTL_SECONDS)
             if token:
-                headers_dict["authorization"] = f"Bearer {token}"
+                _attach_bearer(headers_dict, token)
             print(json.dumps(headers_dict))
 
         if DEBUG_MODE or TEST_MODE:

--- a/source/tests/e2e/test_cross_platform.py
+++ b/source/tests/e2e/test_cross_platform.py
@@ -718,8 +718,9 @@ class TestAuthContractAlignment:
         # In the main auth flow (not Layer 1 cache hit), WriteCachedHeaders
         # must appear BEFORE the authorization header is added to output.
         # Look for the pattern: WriteCachedHeaders(profile, headers, ...)
-        # followed later by headers["authorization"] = "Bearer " + token
-        # and then outputJSON(headers)
+        # followed later by the Bearer attach — either the inline
+        # headers["authorization"] = "Bearer " + token or the centralized
+        # attachBearer(headers, token) helper call — and then outputJSON(headers).
         main_cache_write_line = None
         main_auth_line = None
         in_main_flow = False
@@ -731,7 +732,11 @@ class TestAuthContractAlignment:
             if in_main_flow:
                 if "WriteCachedHeaders" in line and main_cache_write_line is None:
                     main_cache_write_line = i
-                if '"authorization"' in line and "Bearer" in line and main_auth_line is None:
+                # The Bearer attach is the centralized attachBearer() call; the
+                # inline literal form is also matched so the ordering guard holds
+                # regardless of which form the helper uses.
+                is_attach = ('"authorization"' in line and "Bearer" in line) or "attachBearer(" in line
+                if is_attach and main_auth_line is None:
                     main_auth_line = i
 
         assert main_cache_write_line is not None, (

--- a/source/tests/test_otel_bearer_parity.py
+++ b/source/tests/test_otel_bearer_parity.py
@@ -1,0 +1,95 @@
+# ABOUTME: Parity + single-choke-point guard for the otel-helper Bearer literal.
+# ABOUTME: Pins Go attachBearer ↔ Python _attach_bearer to one definition each.
+
+"""Bearer-attach parity and single-occurrence guard.
+
+The `Authorization: Bearer <jwt>` header is what the OTEL collector's ALB
+jwt-validation action checks. A wrong or missing value yields a 401, the
+telemetry batch is dropped, and per-user cost attribution goes dark. That
+literal was historically hand-written at 8 sites (4 Go, 4 Python); a single
+setter per language makes the contract impossible to half-break and gives the
+Go↔Python parity check one assertion point.
+
+Two layers, mirroring the repo's existing parity convention
+(test_credential_process_contract.py — static analysis, no binary spawned):
+
+  * behavioral — call _attach_bearer directly; mirror of Go's TestAttachBearer.
+  * static guard — the Bearer literal appears exactly once per language in
+    non-test source, so the dedup cannot silently regress.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from otel_helper.__main__ import _attach_bearer
+
+SOURCE_ROOT = Path(__file__).parent.parent
+GO_HELPER = SOURCE_ROOT / "go" / "cmd" / "otel-helper" / "main.go"
+PY_HELPER = SOURCE_ROOT / "otel_helper" / "__main__.py"
+
+
+class TestAttachBearer:
+    """Behavioral half of parity — the Python side of the contract Go's
+    TestAttachBearer pins on its side."""
+
+    def test_non_empty_token_sets_bearer_header(self):
+        headers = {}
+        _attach_bearer(headers, "abc.def.ghi")
+        assert headers["authorization"] == "Bearer abc.def.ghi"
+
+    @pytest.mark.parametrize("empty", ["", None])
+    def test_empty_token_omits_key(self, empty):
+        # Sending "Bearer " with no JWT is worse than omitting the header — the
+        # ALB would 401 on it. Matches Go attachBearer's token != "" guard.
+        headers = {}
+        _attach_bearer(headers, empty)
+        assert "authorization" not in headers
+
+    def test_existing_attribution_preserved(self):
+        headers = {"x-user-email": "a@b.com"}
+        _attach_bearer(headers, "tok")
+        assert headers["x-user-email"] == "a@b.com"
+        assert headers["authorization"] == "Bearer tok"
+
+
+class TestBearerSingleChokePoint:
+    """Static guard: the Bearer literal must live at exactly one site per
+    language, so a future edit cannot reintroduce a hand-rolled copy that
+    drifts from the other implementation."""
+
+    def test_go_has_single_bearer_literal(self):
+        # The Go literal is the byte sequence `"Bearer "` (with the trailing
+        # space + quote), only ever inside attachBearer.
+        go_code = GO_HELPER.read_text(encoding="utf-8")
+        count = go_code.count('"Bearer "')
+        assert count == 1, (
+            f'Go helper must contain the `"Bearer "` literal exactly once '
+            f"(inside attachBearer); found {count}. A new hand-rolled copy "
+            f"would split the Go↔Python parity contract."
+        )
+
+    def test_python_has_single_bearer_literal(self):
+        # The Python literal is the f-string `f"Bearer {`, only ever inside
+        # _attach_bearer.
+        py_code = PY_HELPER.read_text(encoding="utf-8")
+        count = py_code.count('f"Bearer {')
+        assert count == 1, (
+            f'Python helper must contain the `f"Bearer {{` literal exactly once '
+            f"(inside _attach_bearer); found {count}. A new hand-rolled copy "
+            f"would split the Go↔Python parity contract."
+        )
+
+    def test_both_helpers_emit_identical_format(self):
+        """Cross-language parity: both choke points emit the same wire format
+        under the same lowercase 'authorization' key."""
+        go_code = GO_HELPER.read_text(encoding="utf-8")
+        py_code = PY_HELPER.read_text(encoding="utf-8")
+
+        # Same prefix literal.
+        assert '"Bearer "' in go_code
+        assert 'f"Bearer {' in py_code
+        # Same (lowercase) header key on both sides — the OTEL collector matches
+        # headers case-sensitively in lowercase.
+        assert 'headers["authorization"]' in go_code
+        assert 'headers["authorization"]' in py_code


### PR DESCRIPTION
> 🟡 **Maintainer decision requested — proposal, not a unilateral change.** This is a preventive DRY refactor with **no live bug** behind it (Option B in #525). It touches the Tier-1 Go helper and Tier-2 Python helper for zero functional change. If you'd rather keep the 8 inline copies (Option A) — e.g. "don't churn critical files without a functional reason" — please **close this PR freely**, no attachment.

## Description

The `Authorization: Bearer <jwt>` literal and its omit-on-empty rule were hand-written at 8 sites (4 in the Go otel-helper, 4 in the Python otel-helper). This introduces one setter per language — Go `attachBearer`, Python `_attach_bearer` — and routes every site through it, so the contract has a single source of truth and the Go↔Python parity check has a single assertion point.

The setters are intentionally **exp-agnostic**: token-expiry buffers diverge across the codebase (600s in `storage/monitoring.go`, 60s in the credential provider, shell wrapper, and `read_cached_headers`), so folding an expiry check into the shared setter would create a parity hazard. Expiry validation stays at the token source, where it already lives.

## Why is this change needed

The literal feeds the header the OTEL collector's ALB jwt-validation action checks; when it's wrong or missing the ALB 401s, the telemetry batch is dropped, and per-user cost attribution goes dark. Eight inline copies are eight independent chances for a future edit to skew or drop one while the other seven still pass tests — a silent attribution split. This is a *preventive* hardening: current `beta` emits the header correctly on every path.

Fixes #525

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- `source/go/cmd/otel-helper/main.go`: add `attachBearer(headers, token)` (exp-agnostic, documented); replace the 4 inline literals. Call-site ordering preserved — the post-`WriteCachedHeaders` attach stays after the cache write, so the token still never lands in the cached map.
- `source/otel_helper/__main__.py`: add `_attach_bearer(headers, token)`; replace the 4 inline literals. Surrounding `if token:` guards left intact (no control-flow simplification).
- `source/go/cmd/otel-helper/main_test.go`: new `TestAttachBearer` — non-empty token sets `Bearer <token>`, empty token omits the key, existing attribution preserved.
- `source/tests/test_otel_bearer_parity.py` (new): behavioral `_attach_bearer` test (mirror of the Go side) + cross-language static parity guard + single-choke-point guard (the literal must appear exactly once per language in non-test source).
- `source/tests/e2e/test_cross_platform.py`: teach the existing "Bearer added after `WriteCachedHeaders`" ordering guard to recognize the centralized `attachBearer(` call. The security property is unchanged; only the pattern matcher was updated (and re-verified to still fire if the attach is moved before the cache write).

## Additional Notes

- Two look-alike Bearer sites are deliberately **left untouched**: the quota-check call in `credential_provider/__main__.py` (unrelated HTTP request) and the shell splice in `otel-helper.sh` (a shell wrapper can't share a Go/Python function, and it has its own `token_exp > now+60` gate). Centralizing those would be over-DRYing.

---

## Testing Checklist

### What was tested

- [x] Unit/integration tests pass (`ccwb test` / `poetry run pytest tests/`)
- [x] CLI commands tested (`ccwb test`)

## Testing Evidence

**Test Environment:** Python 3.12, Go 1.26, macOS arm64; live test against an Azure-federated profile (ap-southeast-2).

**Test Results:**

```text
# 1. Full unit suite (rebased on beta) — pass
$ cd source && poetry run pytest tests/ -q
923 passed, 22 skipped, 1 xfailed, 1 xpassed

# 2. Go otel-helper package — pass (incl. new TestAttachBearer)
$ cd source/go && go test ./cmd/otel-helper/...
ok   ccwb-go/cmd/otel-helper

# 3. New parity + guard tests — pass
$ poetry run pytest tests/test_otel_bearer_parity.py -q
7 passed

# 4. ZERO-BEHAVIOR-CHANGE proof (real Azure JWT, deployed profile):
#    otel-helper normal-mode JSON is BYTE-IDENTICAL before vs after the refactor.
#    (The --test diff was non-deterministic Go map-iteration order in
#    printTestOutput — the SAME binary differs from itself run-to-run — and is
#    identical once sorted. Not a behavior change.)

# 5. FALSIFICATION:
#    a) new tests vs beta's pre-refactor files -> ImportError (_attach_bearer
#       absent) + literal count == 4 (guard asserts == 1): all fail on beta,
#       pass only on the fix.
#    b) the updated e2e ordering guard still FIRES when attachBearer is moved
#       before WriteCachedHeaders (auth_line < cache_write_line -> assert fails),
#       proving the security check wasn't defanged.

# 6. End-to-end on real infra: ccwb package (native Go build) + ccwb test
$ poetry run ccwb test --profile <azure-profile>
   Found OTEL helper: otel-helper-macos-arm64
   Summary: 6 passed, 0 warnings, 0 failed   (Auth, IAM Role, Bedrock, Inference
   Profiles, Quota Monitoring) — packaged binary attaches Bearer + attribution
   against a real monitoring token.

# 7. CI gates verified locally (incl. main-only): bandit on changed Python ->
#    no issues; semgrep --config auto -> only a pre-existing urllib finding on a
#    line not in this diff (baseline noise); detect-secrets --baseline -> no new
#    secrets (test JWTs are alg:none unsigned). go vet clean.
#    cfn_nag / validate-regions N/A (no CFN / region-data change).
```
