### PR TITLE
refactor(otel): correct the stale Layer-1 "avoids credential-process" comment

### DIFF
--- a/source/go/cmd/otel-helper/main.go
+++ b/source/go/cmd/otel-helper/main.go
@@ -68,7 +68,11 @@ func run(testMode bool) int {
 		profile = "ClaudeCode"
 	}
 
-	// Layer 1: Check file cache first (avoids credential-process entirely)
+	// Layer 1: Serve attribution from the file cache. The cache stores
+	// attribution headers only, never the token, so the Bearer is still
+	// resolved below (env var, then credential-process). credential-process
+	// is the correct fallback here — it owns token refresh, keyring storage,
+	// and serve-past-expiry, none of which a direct monitoring.json read does.
 	if !testMode {
 		headers, err := otel.ReadCachedHeaders(profile)
 		if err == nil && headers != nil {

--- a/source/otel_helper/__main__.py
+++ b/source/otel_helper/__main__.py
@@ -820,7 +820,11 @@ def main():
     # Ensure collector sidecar is running (no-op if not installed)
     ensure_collector_running()
 
-    # Layer 1: Check file cache first (avoids credential-process entirely)
+    # Layer 1: Serve attribution from the file cache. The cache stores
+    # attribution headers only, never the token, so the Bearer is still
+    # resolved below (env var, then credential-process). credential-process
+    # is the correct fallback here — it owns token refresh, keyring storage,
+    # and serve-past-expiry, none of which a direct monitoring.json read does.
     if not TEST_MODE:
         cached_headers = read_cached_headers()
         if cached_headers is not None:


### PR DESCRIPTION
## Description

The otel-helper Layer-1 (file-cache) fast path opens with a comment claiming it "avoids credential-process entirely." Since the Bearer-on-cache-hit work landed, the code immediately below resolves the token via credential-process when the env var is absent — so the comment is factually wrong in both the Go and Python helpers. This replaces it with an accurate comment that also records *why* credential-process is the correct fallback (it owns token refresh, keyring storage, and serve-past-expiry), so the misleading line can't seed a future regression.

## Why is this change needed

The Layer-1 path feeds the `Authorization: Bearer <jwt>` header the OTEL collector's ALB jwt-validation action checks. A comment that says this path "avoids credential-process entirely" invites the obvious-looking optimization — read `<profile>-monitoring.json` directly to skip the subprocess — which would actually break telemetry: the cache deliberately serves populated attribution past `token_exp`, so on an expired-but-populated cache hit credential-process is doing real work (silent refresh); a direct file read returns an empty token → no Bearer → ALB 401 → dropped per-user cost attribution. Making the comment honest removes that trap. (No live bug — behavior is correct today on every path.)

## Type of Change

- [x] Documentation update

## Changes Made

- `source/go/cmd/otel-helper/main.go`: replace the stale Layer-1 comment with an accurate one — cache holds attribution only, Bearer is resolved below, credential-process is the correct fallback (refresh + keyring + serve-past-expiry).
- `source/otel_helper/__main__.py`: same correction (Go↔Python parity).
- No logic changed; emitted bytes unchanged.

## Additional Notes

- This PR deliberately does **not** implement the perf optimization of skipping credential-process on cache hits. That was analyzed and rejected: it breaks the serve-past-expiry contract (ALB 401s) and the perf premise is wrong (Claude Code re-invokes the helper on a ~29-min debounce, not per export, so the cost is ~20ms once per ~29 min). Correcting the comment is the complete, correct resolution.

## Testing Checklist

### What was tested

- [x] Unit/integration tests pass (`ccwb test` / `poetry run pytest tests/`)
- [x] CLI commands tested (`ccwb test`)

## Testing Evidence

**Test Environment:** Python 3.12, Go (local), macOS (Apple silicon)

**Test Results:**

```text
# 1. Full unit suite (on fix branch, cut from beta) — pass
$ cd source && poetry run pytest tests/ -q
926 passed, 22 skipped, 1 xfailed, 1 xpassed in 182.48s

# 2. Go otel-helper + otel packages — pass
$ cd source/go && go vet ./cmd/otel-helper/ && go build ./cmd/otel-helper/ \
    && go test ./cmd/otel-helper/ ./internal/otel/
ok  	ccwb-go/cmd/otel-helper	1.052s
ok  	ccwb-go/internal/otel	(cached)

# 3. Stale comment fully removed (both languages):
$ grep -rn "avoids credential-process entirely" source/ | grep -v node_modules
(no output)

# 4. FALSIFICATION: N/A — comment-only change has no code path to red-green.
#    "Before" (stale comment) vs "after" (accurate comment) verified by grep;
#    the green suite proves zero behavior change (diff is 10 +, 2 -, comments only).

# 5. CI gates verified locally: go vet clean; bandit / semgrep / detect-secrets
#    N/A (no Python logic, no new strings/secrets — comment text only);
#    cfn_nag / validate-regions N/A (no CFN / region data).
```
