### PR TITLE
feat: add Claude Opus 4.8 model support

### DIFF
--- a/source/claude_code_with_bedrock/models.py
+++ b/source/claude_code_with_bedrock/models.py
@@ -153,6 +153,108 @@ _CLAUDE_MODELS_RAW = {
             },
         },
     },
+    "opus-4-8": {
+        "name": "Claude Opus 4.8",
+        "base_model_id": "anthropic.claude-opus-4-8",
+        "profiles": {
+            "us": {
+                "model_id": "us.anthropic.claude-opus-4-8",
+                "description": "US CRIS - US and Canada regions",
+                "source_regions": [
+                    "us-east-1",
+                    "us-east-2",
+                    "us-west-1",
+                    "us-west-2",
+                    "ca-central-1",
+                    "ca-west-1",
+                ],
+                "destination_regions": [
+                    "us-east-1",
+                    "us-east-2",
+                    "us-west-1",
+                    "us-west-2",
+                    "ca-central-1",
+                    "ca-west-1",
+                ],
+            },
+            "global": {
+                "model_id": "global.anthropic.claude-opus-4-8",
+                "description": "Global CRIS - All commercial AWS regions worldwide",
+                "source_regions": [
+                    # North America
+                    "us-east-1",
+                    "us-east-2",
+                    "us-west-1",
+                    "us-west-2",
+                    "ca-central-1",
+                    "ca-west-1",
+                    # Europe
+                    "eu-central-1",
+                    "eu-central-2",
+                    "eu-north-1",
+                    "eu-south-1",
+                    "eu-south-2",
+                    "eu-west-1",
+                    "eu-west-2",
+                    "eu-west-3",
+                    # Asia Pacific
+                    "ap-east-2",
+                    "ap-northeast-1",
+                    "ap-northeast-2",
+                    "ap-northeast-3",
+                    "ap-south-1",
+                    "ap-south-2",
+                    "ap-southeast-1",
+                    "ap-southeast-2",
+                    "ap-southeast-3",
+                    "ap-southeast-4",
+                    # Middle East & Africa
+                    "me-south-1",
+                    "me-central-1",
+                    "af-south-1",
+                    "il-central-1",
+                    # South America
+                    "sa-east-1",
+                ],
+                "destination_regions": [
+                    # North America
+                    "us-east-1",
+                    "us-east-2",
+                    "us-west-1",
+                    "us-west-2",
+                    "ca-central-1",
+                    "ca-west-1",
+                    # Europe
+                    "eu-central-1",
+                    "eu-central-2",
+                    "eu-north-1",
+                    "eu-south-1",
+                    "eu-south-2",
+                    "eu-west-1",
+                    "eu-west-2",
+                    "eu-west-3",
+                    # Asia Pacific
+                    "ap-east-2",
+                    "ap-northeast-1",
+                    "ap-northeast-2",
+                    "ap-northeast-3",
+                    "ap-south-1",
+                    "ap-south-2",
+                    "ap-southeast-1",
+                    "ap-southeast-2",
+                    "ap-southeast-3",
+                    "ap-southeast-4",
+                    # Middle East & Africa
+                    "me-south-1",
+                    "me-central-1",
+                    "af-south-1",
+                    "il-central-1",
+                    # South America
+                    "sa-east-1",
+                ],
+            },
+        },
+    },
     "opus-4-7": {
         "name": "Claude Opus 4.7",
         "base_model_id": "anthropic.claude-opus-4-7",
@@ -1191,7 +1293,7 @@ def get_throttle_metrics() -> list[dict]:
 MODEL_TIER_PREFERENCES = {
     "haiku": ["haiku-4-5", "sonnet-4-6", "sonnet-4-5", "sonnet-4", "sonnet-3-7"],
     "sonnet": ["sonnet-4-6", "sonnet-4-5", "sonnet-4", "sonnet-3-7"],
-    "opus": ["opus-4-7", "opus-4-6", "opus-4-5", "opus-4-1", "opus-4"],
+    "opus": ["opus-4-8", "opus-4-7", "opus-4-6", "opus-4-5", "opus-4-1", "opus-4"],
 }
 
 

--- a/source/tests/test_models.py
+++ b/source/tests/test_models.py
@@ -37,6 +37,7 @@ class TestModelConfiguration:
         """Test that CLAUDE_MODELS has the expected structure."""
         expected_models = {
             "sonnet-4-6",
+            "opus-4-8",
             "opus-4-7",
             "opus-4-6",
             "opus-4-5",


### PR DESCRIPTION
Resolves #529

### Summary
Adds Claude Opus 4.8 to the centralized model catalog, following the same pattern used for Opus 4.7 (#276) and 4.6 (#109).

### Changes
- **`source/claude_code_with_bedrock/models.py`**
  - Add `opus-4-8` to `_CLAUDE_MODELS_RAW` with `us` and `global` CRIS profiles, mirroring the Opus 4.7 entry (`base_model_id: anthropic.claude-opus-4-8`, IDs `us.anthropic.claude-opus-4-8` / `global.anthropic.claude-opus-4-8`).
  - Prepend `opus-4-8` to `MODEL_TIER_PREFERENCES["opus"]` so it resolves as the latest Opus tier model.
- **`source/tests/test_models.py`**
  - Add `opus-4-8` to the expected-models set in the structural test.

### Pricing
No analytics change needed: `opus-4-8` is covered by the existing generic `%opus-4%` clause in `analytics-pipeline.yaml`, consistent with how Opus 4.7 is handled (4.7 has no dedicated pricing line either).

### Testing
All model-related tests pass locally (`test_models.py`, `test_config_models.py`, `test_source_regions.py`, `test_init_source_regions.py`, `test_init_models.py`, `test_package_models.py`, `test_regression_429_441.py` — 91 passed).

### Open question
Confirming the canonical Bedrock model ID and the exact supported CRIS profiles/regions for Opus 4.8. The implementation mirrors Opus 4.7 (`anthropic.claude-opus-4-8`, `us`/`global`) — happy to adjust to match the official Bedrock IDs once published.

No version bump included, as this is an additive catalog entry that does not change the package API or behavior contract.