### PR TITLE
fix(quota): make quota enforcement functional end-to-end

### DIFF
--- a/deployment/infrastructure/quota-monitoring.yaml
+++ b/deployment/infrastructure/quota-monitoring.yaml
@@ -154,6 +154,7 @@ Resources:
                 Action:
                   - dynamodb:Query
                   - dynamodb:PutItem
+                  - dynamodb:UpdateItem
                   - dynamodb:GetItem
                   - dynamodb:Scan
                 Resource:
@@ -273,6 +274,7 @@ Resources:
           DAILY_TOKEN_LIMIT: !Ref DailyTokenLimit
           DAILY_ENFORCEMENT_MODE: !Ref DailyEnforcementMode
           MONTHLY_ENFORCEMENT_MODE: !Ref MonthlyEnforcementMode
+          ENABLE_FINEGRAINED_QUOTAS: !Ref EnableFinegrainedQuotas
       Code: ./lambda-functions/quota_check/
 
   # HTTP API Gateway (v2 - cheaper and faster than REST API)

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -778,6 +778,15 @@ class DeployCommand(Command):
                     oidc_issuer_url = profile.provider_domain
                     if oidc_issuer_url and not oidc_issuer_url.startswith(("http://", "https://")):
                         oidc_issuer_url = f"https://{oidc_issuer_url}"
+                    # Okta authenticates via its custom default authorization server, so
+                    # issued tokens carry iss=https://<domain>/oauth2/default. The quota JWT
+                    # authorizer must match that exact issuer or every /check 401s (fail-open).
+                    if (
+                        profile.provider_type == "okta"
+                        and oidc_issuer_url
+                        and not oidc_issuer_url.rstrip("/").endswith("/oauth2/default")
+                    ):
+                        oidc_issuer_url = f"{oidc_issuer_url.rstrip('/')}/oauth2/default"
                 if profile.provider_type == "auth0" and oidc_issuer_url and not oidc_issuer_url.endswith("/"):
                     oidc_issuer_url = f"{oidc_issuer_url}/"
                 oidc_client_id = profile.client_id


### PR DESCRIPTION
## Summary

Per-user/group quota enforcement is currently non-functional. Three independent defects each break a different stage of the pipeline (record usage -> resolve policy -> authorize the check call). With all three present, a user who is far over their limit is never blocked.

## Root causes & fixes

**1. Monitor can't persist usage - missing `dynamodb:UpdateItem`**
`lambda-functions/quota_monitor/index.py` (`update_quota_metrics`) calls `update_item` for atomic increments, but `QuotaMonitorRole` in `quota-monitoring.yaml` only grants `Query/PutItem/GetItem/Scan`. Every roll-up fails with `AccessDeniedException ... dynamodb:UpdateItem on .../UserQuotaMetrics`.
Fix: add `dynamodb:UpdateItem` to the `UserQuotaMetrics` statement.

**2. `/check` ignores per-user policies - missing env var**
`quota_check/index.py` reads `ENABLE_FINEGRAINED_QUOTAS`, but the template sets it only on `QuotaMonitorFunction`, not `QuotaCheckFunction`. The check Lambda therefore always defaults to `false` and applies the global env limits, silently ignoring the `QuotaPolicies` table.
Fix: pass `ENABLE_FINEGRAINED_QUOTAS: !Ref EnableFinegrainedQuotas` to `QuotaCheckFunction`.

**3. Okta quota authorizer issuer mismatch**
`deploy.py` builds the quota JWT authorizer issuer from the bare `provider_domain` (`https://<domain>`), but Okta authenticates via the default custom authorization server, so tokens carry `iss=https://<domain>/oauth2/default` (consistent with `credential_provider`'s `/oauth2/default/v1/*` endpoints). The authorizer rejects every `/check` request; with `quota_fail_mode=open` this silently disables enforcement (and with `fail_mode=closed` it would block all access).
Fix: append `/oauth2/default` to the issuer for `provider_type == "okta"`.

## Reproduction

1. Deploy with quota monitoring + `enable_finegrained_quotas: true`, Okta provider.
2. Set a low per-user policy (`ccwb quota set-user <email> --monthly-limit 10K --enforcement block`).
3. Generate >10K tokens; observe the monitor log `AccessDenied` on `UpdateItem` (bug 1).
4. After fixing 1, invoke `/check` - it returns `allowed:true` with the global 225M limit, ignoring the policy (bug 2).
5. After fixing 2, the credential-process still issues credentials because the authorizer 401s the call (bug 3).
6. With all three fixed, `/check` returns `allowed:false / monthly_exceeded` and the credential-process prints `ACCESS BLOCKED - QUOTA EXCEEDED`.

## Changes

- `deployment/infrastructure/quota-monitoring.yaml` - add `dynamodb:UpdateItem`; add `ENABLE_FINEGRAINED_QUOTAS` to `QuotaCheckFunction`.
- `source/claude_code_with_bedrock/cli/commands/deploy.py` - Okta issuer `/oauth2/default`.

Verified end-to-end on a live deployment (Okta direct-IAM federation).
