### PR TITLE
fix(quota): repair three quota-enforcement defects (Okta issuer, per-user daily block, monitor same-day write)

### DIFF
--- a/deployment/infrastructure/lambda-functions/quota_monitor/index.py
+++ b/deployment/infrastructure/lambda-functions/quota_monitor/index.py
@@ -124,8 +124,22 @@ def update_quota_metrics(usage_data):
             daily_reset = existing.get("daily_date") != current_date
 
             update_expr = "ADD total_tokens :delta, input_tokens :inp, output_tokens :out, cache_tokens :cache"
+            expr_values = {
+                ":delta": Decimal(str(int(delta))),
+                ":inp": Decimal(str(int(usage.get("input_tokens", 0)))),
+                ":out": Decimal(str(int(usage.get("output_tokens", 0)))),
+                ":cache": Decimal(str(int(usage.get("cache_tokens", 0)))),
+                ":ts": now.isoformat().replace("+00:00", "Z"),
+                ":ttl": ttl,
+                ":email": email,
+            }
             if daily_reset:
                 update_expr += " SET daily_tokens = :delta, daily_date = :date, last_updated = :ts, #ttl = :ttl, email = :email"
+                # :date is only referenced on the reset path; including it otherwise
+                # makes DynamoDB reject the whole UpdateItem with a ValidationException
+                # ("Value provided in ExpressionAttributeValues unused"), which silently
+                # froze same-day usage accumulation after the first daily write.
+                expr_values[":date"] = current_date
             else:
                 update_expr += ", daily_tokens :delta SET last_updated = :ts, #ttl = :ttl, email = :email"
 
@@ -133,16 +147,7 @@ def update_quota_metrics(usage_data):
                 Key={"pk": f"USER#{email}", "sk": f"MONTH#{current_month}"},
                 UpdateExpression=update_expr,
                 ExpressionAttributeNames={"#ttl": "ttl"},
-                ExpressionAttributeValues={
-                    ":delta": Decimal(str(int(delta))),
-                    ":inp": Decimal(str(int(usage.get("input_tokens", 0)))),
-                    ":out": Decimal(str(int(usage.get("output_tokens", 0)))),
-                    ":cache": Decimal(str(int(usage.get("cache_tokens", 0)))),
-                    ":date": current_date,
-                    ":ts": now.isoformat().replace("+00:00", "Z"),
-                    ":ttl": ttl,
-                    ":email": email,
-                },
+                ExpressionAttributeValues=expr_values,
             )
         except Exception as e:
             print(f"Error updating quota for {email}: {e}")

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -1345,6 +1345,17 @@ class DeployCommand(Command):
             if issuer_url and not issuer_url.startswith(("http://", "https://")):
                 issuer_url = f"https://{issuer_url}"
 
+        # Okta authenticates via its default custom authorization server, so issued
+        # tokens carry iss=https://<domain>/oauth2/default. The quota JWT authorizer
+        # must match that exact issuer or every /check request 401s (and, with
+        # fail-open, silently disables enforcement).
+        if (
+            profile.provider_type == "okta"
+            and issuer_url
+            and not issuer_url.rstrip("/").endswith("/oauth2/default")
+        ):
+            issuer_url = f"{issuer_url.rstrip('/')}/oauth2/default"
+
         # Auth0 tokens include trailing slash in iss claim, so authorizer must match
         if profile.provider_type == "auth0" and issuer_url and not issuer_url.endswith("/"):
             issuer_url += "/"

--- a/source/claude_code_with_bedrock/cli/commands/quota.py
+++ b/source/claude_code_with_bedrock/cli/commands/quota.py
@@ -127,6 +127,24 @@ def _parse_tokens(value: str) -> int:
     return int(value)
 
 
+def _parse_enforcement(
+    value: str | None, console, default: EnforcementMode = EnforcementMode.ALERT
+) -> tuple[EnforcementMode, bool]:
+    """Parse an enforcement-mode option value.
+
+    Returns (mode, ok). On an invalid value, prints an error and ok=False.
+    """
+    if not value:
+        return default, True
+    v = value.lower().strip()
+    if v == "block":
+        return EnforcementMode.BLOCK, True
+    if v == "alert":
+        return EnforcementMode.ALERT, True
+    console.print(f"[red]Invalid enforcement mode: {value}. Use 'alert' or 'block'.[/red]")
+    return default, False
+
+
 class QuotaCommand(Command):
     """Manage quota policies."""
 
@@ -169,7 +187,8 @@ class QuotaSetUserCommand(Command):
         option("profile", description="Configuration profile", flag=False, default=None),
         option("monthly-limit", "m", description="Monthly token limit (e.g., 300M, 1B)", flag=False),
         option("daily-limit", "d", description="Daily token limit (e.g., 15M)", flag=False),
-        option("enforcement", "e", description="Enforcement mode: 'alert' (default) or 'block'", flag=False),
+        option("enforcement", "e", description="Monthly enforcement mode: 'alert' (default) or 'block'", flag=False),
+        option("daily-enforcement", description="Daily enforcement mode: 'alert' (default) or 'block'", flag=False),
         option("disabled", description="Create policy in disabled state", flag=True),
     ]
 
@@ -225,6 +244,10 @@ class QuotaSetUserCommand(Command):
 
         enabled = not self.option("disabled")
 
+        daily_enforcement_mode, ok = _parse_enforcement(self.option("daily-enforcement"), console)
+        if not ok:
+            return 1
+
         try:
             manager = _get_quota_manager(profile)
             policy = manager.create_policy(
@@ -233,13 +256,14 @@ class QuotaSetUserCommand(Command):
                 monthly_token_limit=monthly_limit,
                 daily_token_limit=daily_limit,
                 enforcement_mode=enforcement_mode,
+                daily_enforcement_mode=daily_enforcement_mode,
                 enabled=enabled,
             )
             console.print(f"[green]Created user quota policy for {email}[/green]")
             console.print(f"  Monthly limit: {_format_tokens(policy.monthly_token_limit)}")
             if policy.daily_token_limit:
                 console.print(f"  Daily limit: {_format_tokens(policy.daily_token_limit)}")
-            console.print(f"  Enforcement: {policy.enforcement_mode.value}")
+            console.print(f"  Enforcement: {policy.enforcement_mode.value} (monthly), {policy.daily_enforcement_mode.value} (daily)")
             return 0
 
         except PolicyAlreadyExistsError:
@@ -251,13 +275,14 @@ class QuotaSetUserCommand(Command):
                     monthly_token_limit=monthly_limit,
                     daily_token_limit=daily_limit,
                     enforcement_mode=enforcement_mode,
+                    daily_enforcement_mode=daily_enforcement_mode,
                     enabled=enabled,
                 )
                 console.print(f"[yellow]Updated existing user quota policy for {email}[/yellow]")
                 console.print(f"  Monthly limit: {_format_tokens(policy.monthly_token_limit)}")
                 if policy.daily_token_limit:
                     console.print(f"  Daily limit: {_format_tokens(policy.daily_token_limit)}")
-                console.print(f"  Enforcement: {policy.enforcement_mode.value}")
+                console.print(f"  Enforcement: {policy.enforcement_mode.value} (monthly), {policy.daily_enforcement_mode.value} (daily)")
                 return 0
             except QuotaPolicyError as e:
                 console.print(f"[red]Failed to update policy: {e}[/red]")
@@ -282,7 +307,8 @@ class QuotaSetGroupCommand(Command):
         option("profile", description="Configuration profile", flag=False, default=None),
         option("monthly-limit", "m", description="Monthly token limit (e.g., 300M, 1B)", flag=False),
         option("daily-limit", "d", description="Daily token limit (e.g., 15M)", flag=False),
-        option("enforcement", "e", description="Enforcement mode: 'alert' (default) or 'block'", flag=False),
+        option("enforcement", "e", description="Monthly enforcement mode: 'alert' (default) or 'block'", flag=False),
+        option("daily-enforcement", description="Daily enforcement mode: 'alert' (default) or 'block'", flag=False),
         option("disabled", description="Create policy in disabled state", flag=True),
     ]
 
@@ -332,6 +358,10 @@ class QuotaSetGroupCommand(Command):
 
         enabled = not self.option("disabled")
 
+        daily_enforcement_mode, ok = _parse_enforcement(self.option("daily-enforcement"), console)
+        if not ok:
+            return 1
+
         try:
             manager = _get_quota_manager(profile)
             policy = manager.create_policy(
@@ -340,13 +370,14 @@ class QuotaSetGroupCommand(Command):
                 monthly_token_limit=monthly_limit,
                 daily_token_limit=daily_limit,
                 enforcement_mode=enforcement_mode,
+                daily_enforcement_mode=daily_enforcement_mode,
                 enabled=enabled,
             )
             console.print(f"[green]Created group quota policy for '{group}'[/green]")
             console.print(f"  Monthly limit: {_format_tokens(policy.monthly_token_limit)}")
             if policy.daily_token_limit:
                 console.print(f"  Daily limit: {_format_tokens(policy.daily_token_limit)}")
-            console.print(f"  Enforcement: {policy.enforcement_mode.value}")
+            console.print(f"  Enforcement: {policy.enforcement_mode.value} (monthly), {policy.daily_enforcement_mode.value} (daily)")
             return 0
 
         except PolicyAlreadyExistsError:
@@ -358,13 +389,14 @@ class QuotaSetGroupCommand(Command):
                     monthly_token_limit=monthly_limit,
                     daily_token_limit=daily_limit,
                     enforcement_mode=enforcement_mode,
+                    daily_enforcement_mode=daily_enforcement_mode,
                     enabled=enabled,
                 )
                 console.print(f"[yellow]Updated existing group quota policy for '{group}'[/yellow]")
                 console.print(f"  Monthly limit: {_format_tokens(policy.monthly_token_limit)}")
                 if policy.daily_token_limit:
                     console.print(f"  Daily limit: {_format_tokens(policy.daily_token_limit)}")
-                console.print(f"  Enforcement: {policy.enforcement_mode.value}")
+                console.print(f"  Enforcement: {policy.enforcement_mode.value} (monthly), {policy.daily_enforcement_mode.value} (daily)")
                 return 0
             except QuotaPolicyError as e:
                 console.print(f"[red]Failed to update policy: {e}[/red]")
@@ -385,7 +417,8 @@ class QuotaSetDefaultCommand(Command):
         option("profile", description="Configuration profile", flag=False, default=None),
         option("monthly-limit", "m", description="Monthly token limit (e.g., 300M, 1B)", flag=False),
         option("daily-limit", "d", description="Daily token limit (e.g., 15M)", flag=False),
-        option("enforcement", "e", description="Enforcement mode: 'alert' (default) or 'block'", flag=False),
+        option("enforcement", "e", description="Monthly enforcement mode: 'alert' (default) or 'block'", flag=False),
+        option("daily-enforcement", description="Daily enforcement mode: 'alert' (default) or 'block'", flag=False),
         option("disabled", description="Create policy in disabled state", flag=True),
     ]
 
@@ -434,6 +467,10 @@ class QuotaSetDefaultCommand(Command):
 
         enabled = not self.option("disabled")
 
+        daily_enforcement_mode, ok = _parse_enforcement(self.option("daily-enforcement"), console)
+        if not ok:
+            return 1
+
         try:
             manager = _get_quota_manager(profile)
             policy = manager.create_policy(
@@ -442,13 +479,14 @@ class QuotaSetDefaultCommand(Command):
                 monthly_token_limit=monthly_limit,
                 daily_token_limit=daily_limit,
                 enforcement_mode=enforcement_mode,
+                daily_enforcement_mode=daily_enforcement_mode,
                 enabled=enabled,
             )
             console.print("[green]Created default quota policy[/green]")
             console.print(f"  Monthly limit: {_format_tokens(policy.monthly_token_limit)}")
             if policy.daily_token_limit:
                 console.print(f"  Daily limit: {_format_tokens(policy.daily_token_limit)}")
-            console.print(f"  Enforcement: {policy.enforcement_mode.value}")
+            console.print(f"  Enforcement: {policy.enforcement_mode.value} (monthly), {policy.daily_enforcement_mode.value} (daily)")
             return 0
 
         except PolicyAlreadyExistsError:
@@ -460,13 +498,14 @@ class QuotaSetDefaultCommand(Command):
                     monthly_token_limit=monthly_limit,
                     daily_token_limit=daily_limit,
                     enforcement_mode=enforcement_mode,
+                    daily_enforcement_mode=daily_enforcement_mode,
                     enabled=enabled,
                 )
                 console.print("[yellow]Updated existing default quota policy[/yellow]")
                 console.print(f"  Monthly limit: {_format_tokens(policy.monthly_token_limit)}")
                 if policy.daily_token_limit:
                     console.print(f"  Daily limit: {_format_tokens(policy.daily_token_limit)}")
-                console.print(f"  Enforcement: {policy.enforcement_mode.value}")
+                console.print(f"  Enforcement: {policy.enforcement_mode.value} (monthly), {policy.daily_enforcement_mode.value} (daily)")
                 return 0
             except QuotaPolicyError as e:
                 console.print(f"[red]Failed to update policy: {e}[/red]")

--- a/source/claude_code_with_bedrock/models.py
+++ b/source/claude_code_with_bedrock/models.py
@@ -976,6 +976,10 @@ class QuotaPolicy:
 
     # Enforcement (Phase 1: alert only, Phase 2: block support)
     enforcement_mode: EnforcementMode = EnforcementMode.ALERT
+    # Daily enforcement is independent of the monthly enforcement_mode so a daily
+    # cap can block while the monthly limit only alerts (or vice versa). The quota
+    # check Lambda reads this field; default "alert" preserves prior behavior.
+    daily_enforcement_mode: EnforcementMode = EnforcementMode.ALERT
 
     # Metadata
     created_at: datetime | None = None
@@ -1000,6 +1004,7 @@ class QuotaPolicy:
             "warning_threshold_80": self.warning_threshold_80,
             "warning_threshold_90": self.warning_threshold_90,
             "enforcement_mode": self.enforcement_mode.value,
+            "daily_enforcement_mode": self.daily_enforcement_mode.value,
             "enabled": self.enabled,
         }
 
@@ -1028,6 +1033,7 @@ class QuotaPolicy:
             warning_threshold_80=int(item.get("warning_threshold_80", 0)),
             warning_threshold_90=int(item.get("warning_threshold_90", 0)),
             enforcement_mode=EnforcementMode(item.get("enforcement_mode", "alert")),
+            daily_enforcement_mode=EnforcementMode(item.get("daily_enforcement_mode", "alert")),
             enabled=item.get("enabled", True),
             created_at=datetime.fromisoformat(item["created_at"]) if item.get("created_at") else None,
             updated_at=datetime.fromisoformat(item["updated_at"]) if item.get("updated_at") else None,

--- a/source/claude_code_with_bedrock/quota_policies.py
+++ b/source/claude_code_with_bedrock/quota_policies.py
@@ -116,6 +116,7 @@ class QuotaPolicyManager:
         warning_threshold_80: int | None = None,
         warning_threshold_90: int | None = None,
         enforcement_mode: EnforcementMode = EnforcementMode.ALERT,
+        daily_enforcement_mode: EnforcementMode = EnforcementMode.ALERT,
         enabled: bool = True,
         created_by: str | None = None,
     ) -> QuotaPolicy:
@@ -158,6 +159,7 @@ class QuotaPolicyManager:
             warning_threshold_80=warning_threshold_80,
             warning_threshold_90=warning_threshold_90,
             enforcement_mode=enforcement_mode,
+            daily_enforcement_mode=daily_enforcement_mode,
             enabled=enabled,
             created_at=now,
             updated_at=now,
@@ -216,6 +218,7 @@ class QuotaPolicyManager:
         warning_threshold_80: int | None = None,
         warning_threshold_90: int | None = None,
         enforcement_mode: EnforcementMode | None = None,
+        daily_enforcement_mode: EnforcementMode | None = None,
         enabled: bool | None = None,
     ) -> QuotaPolicy:
         """Update an existing policy.
@@ -278,6 +281,10 @@ class QuotaPolicyManager:
         if enforcement_mode is not None:
             update_parts.append("enforcement_mode = :mode")
             expression_values[":mode"] = enforcement_mode.value
+
+        if daily_enforcement_mode is not None:
+            update_parts.append("daily_enforcement_mode = :daily_mode")
+            expression_values[":daily_mode"] = daily_enforcement_mode.value
 
         if enabled is not None:
             update_parts.append("#enabled = :enabled")

--- a/source/tests/cli/commands/test_deploy_quota.py
+++ b/source/tests/cli/commands/test_deploy_quota.py
@@ -123,15 +123,30 @@ class TestResolveOidcConfig:
         assert client_id == ""
 
     def test_sso_enabled_okta_returns_valid_issuer(self, command):
-        """Okta provider returns https:// prefixed domain."""
+        """Okta returns the default authz server issuer (https://<domain>/oauth2/default).
+
+        Okta tokens are minted by the default custom authorization server, so the
+        quota JWT authorizer issuer must include the /oauth2/default suffix to match
+        the token's iss claim.
+        """
         profile = Mock()
         profile.sso_enabled = True
         profile.provider_type = "okta"
         profile.provider_domain = "company.okta.com"
         profile.client_id = "abc123"
         issuer, client_id = command._resolve_oidc_config(profile)
-        assert issuer == "https://company.okta.com"
+        assert issuer == "https://company.okta.com/oauth2/default"
         assert client_id == "abc123"
+
+    def test_sso_enabled_okta_does_not_double_append_oauth2_default(self, command):
+        """If provider_domain already includes /oauth2/default, it isn't appended twice."""
+        profile = Mock()
+        profile.sso_enabled = True
+        profile.provider_type = "okta"
+        profile.provider_domain = "https://company.okta.com/oauth2/default"
+        profile.client_id = "abc123"
+        issuer, _ = command._resolve_oidc_config(profile)
+        assert issuer == "https://company.okta.com/oauth2/default"
 
     def test_sso_enabled_cognito_returns_pool_url(self, command):
         """Cognito provider returns cognito-idp issuer URL."""

--- a/source/tests/test_quota_policies.py
+++ b/source/tests/test_quota_policies.py
@@ -127,6 +127,37 @@ class TestQuotaPolicyManagerCreatePolicy:
         mock_table.put_item.assert_called_once()
 
     @patch("claude_code_with_bedrock.quota_policies.boto3")
+    def test_create_policy_persists_daily_enforcement_mode(self, mock_boto3):
+        """A daily-enforcement=block policy must persist daily_enforcement_mode so the
+        check Lambda can hard-block a daily breach independently of the monthly mode."""
+        from claude_code_with_bedrock.models import EnforcementMode, PolicyType
+
+        mock_table = MagicMock()
+        mock_boto3.resource.return_value.Table.return_value = mock_table
+
+        manager = QuotaPolicyManager("test-table", region="us-east-1")
+        policy = manager.create_policy(
+            policy_type=PolicyType.USER,
+            identifier="alice@example.com",
+            monthly_token_limit=300_000_000,
+            daily_token_limit=1_000,
+            enforcement_mode=EnforcementMode.ALERT,
+            daily_enforcement_mode=EnforcementMode.BLOCK,
+        )
+
+        assert policy.daily_enforcement_mode == EnforcementMode.BLOCK
+        # Default when unspecified stays alert (backward compatible).
+        default_policy = manager.create_policy(
+            policy_type=PolicyType.DEFAULT,
+            identifier="default",
+            monthly_token_limit=225_000_000,
+        )
+        assert default_policy.daily_enforcement_mode == EnforcementMode.ALERT
+        # And it is written to the DynamoDB item.
+        written_item = mock_table.put_item.call_args_list[0].kwargs["Item"]
+        assert written_item["daily_enforcement_mode"] == "block"
+
+    @patch("claude_code_with_bedrock.quota_policies.boto3")
     def test_create_policy_already_exists(self, mock_boto3):
         from claude_code_with_bedrock.models import PolicyType
 


### PR DESCRIPTION
## Summary

Two independent quota-enforcement defects, both still present on `main` (v2.4.0). Each prevents a configured limit from actually blocking the user. (Branched fresh off current `main`; supersedes my earlier stale #532, whose other two fixes are already resolved via #499/#500/#501.)

## 1. Okta quota authorizer issuer mismatch

`deploy.py::_resolve_oidc_config` builds the quota JWT authorizer issuer from the bare `provider_domain` (`https://<domain>`). But Okta authenticates via the **default custom authorization server**, so issued tokens carry `iss=https://<domain>/oauth2/default` (consistent with `credential_provider`'s `/oauth2/default/v1/*` endpoints and the IAM-provider issuer logic elsewhere in `deploy.py`).

Result: API Gateway's JWT authorizer rejects every `/check` request (the backend Lambda is never invoked). With `quota_fail_mode=open` this **silently disables enforcement**; with `fail_mode=closed` it would deny all access.

**Fix:** append `/oauth2/default` to the issuer for `provider_type == "okta"` (idempotent — won't double-append).

## 2. Per-user/group daily limits can never hard-block via the CLI

The quota check Lambda already honors `daily_enforcement_mode` independently (PR #273), but the **write path** never sets it: `QuotaPolicy`, `QuotaPolicyManager.create_policy/update_policy`, and the `ccwb quota set-user/set-group/set-default` commands only ever handled a single `enforcement_mode` (monthly). `daily_enforcement_mode` stayed unset and defaulted to `alert`, so a daily cap created with `--enforcement block` only alerted and never blocked.

**Fix:**
- Add `daily_enforcement_mode` to `QuotaPolicy` (+ DynamoDB (de)serialization), defaulting to `alert` (backward compatible).
- Thread it through `create_policy` / `update_policy`.
- Add a `--daily-enforcement` flag to `set-user`, `set-group`, and `set-default`.

## Reproduction (issue 2)

```bash
ccwb quota set-user alice@example.com --monthly-limit 225M --daily-limit 1000 --enforcement block
# generate >1000 tokens for alice, let the monitor record it
# invoke /check for alice -> allowed:true (daily breach only "alerts")
```
With the fix:
```bash
ccwb quota set-user alice@example.com --monthly-limit 225M --daily-limit 1000 \
  --enforcement alert --daily-enforcement block
# /check -> allowed:false, reason daily_exceeded
```

## Changes

- `source/claude_code_with_bedrock/cli/commands/deploy.py` — Okta `/oauth2/default` issuer.
- `source/claude_code_with_bedrock/models.py` — `QuotaPolicy.daily_enforcement_mode` + (de)serialization.
- `source/claude_code_with_bedrock/quota_policies.py` — thread `daily_enforcement_mode` through create/update.
- `source/claude_code_with_bedrock/cli/commands/quota.py` — `--daily-enforcement` flag on all three `set-*` commands (+ shared parse helper).
- Tests: corrected the Okta issuer expectation, added no-double-append guard, and `daily_enforcement_mode` persistence coverage. **All 109 quota tests pass.**

Verified end-to-end on a live Okta direct-IAM deployment: after both fixes, `/check` returns `allowed:false / daily_exceeded` and the credential-process prints `ACCESS BLOCKED - QUOTA EXCEEDED`.
