### PR TITLE
fix: remove duplicate import, unused import, and gitignore gap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ guidance-submission/
 tests/
 !source/tests/
 !source/tests/**
+source/tests/**/__pycache__/
 assets/docs/planning
 
 .pytest_cache/

--- a/source/claude_code_with_bedrock/models.py
+++ b/source/claude_code_with_bedrock/models.py
@@ -14,9 +14,6 @@ from decimal import Decimal
 from enum import Enum
 from typing import Any
 
-# Default regions for AWS profile based on cross-region profile
-from dataclasses import dataclass, field
-
 
 @dataclass(frozen=True)
 class InferenceProfile:

--- a/source/credential_provider/__main__.py
+++ b/source/credential_provider/__main__.py
@@ -1050,7 +1050,6 @@ class MultiProviderAuth:
         """
         from cryptography import x509
         from cryptography.hazmat.primitives import hashes, serialization
-        from cryptography.hazmat.primitives.asymmetric import padding
 
         # Env vars take precedence over config.json so paths stay portable across
         # machines (self-install and admin-push scenarios).  This follows the


### PR DESCRIPTION
## Why

Three housekeeping issues cause lint warnings and unexpected `git status` noise for all users.

## What

- **`source/claude_code_with_bedrock/models.py`**: remove duplicate `from dataclasses import dataclass, field` (already imported on line 11; line 18 is a copy with a misplaced comment)
- **`source/credential_provider/__main__.py`**: remove unused `from cryptography.hazmat.primitives.asymmetric import padding` (the name `padding` only appears in CSS strings, never as the imported module)
- **`.gitignore`**: add `source/tests/**/__pycache__/` after the `!source/tests/**` negation — without it, the negation overrides the global `__pycache__/` rule and users see untracked `.pyc` files after running pytest

## Verification

- `ruff check source/claude_code_with_bedrock/models.py` — no F811 (redefined unused)
- `ruff check source/credential_provider/__main__.py` — no F401 (unused import) for `padding`
- `git status` after running pytest shows no untracked `__pycache__` under `source/tests/`

🤖 Generated with Claude Code