### PR TITLE
fix: active SSO auth for IDC users with quota enforcement and OTEL attribution

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -2135,7 +2135,18 @@ RUN pyinstaller \
 
         # Add the appropriate federation field based on type
         if not sso_enabled:
-            pass  # No OIDC/Cognito fields needed — credential-process uses ambient chain
+            # IDC path: include IDC fields so credential-process can drive SSO auth.
+            auth_type = getattr(profile, "auth_type", None)
+            if auth_type == "idc":
+                config[profile_name]["auth_type"] = "idc"
+                if getattr(profile, "idc_start_url", None):
+                    config[profile_name]["idc_start_url"] = profile.idc_start_url
+                if getattr(profile, "idc_account_id", None):
+                    config[profile_name]["idc_account_id"] = profile.idc_account_id
+                if getattr(profile, "idc_permission_set_name", None):
+                    config[profile_name]["idc_permission_set_name"] = profile.idc_permission_set_name
+                idc_region = getattr(profile, "idc_region", None) or profile.aws_region
+                config[profile_name]["idc_region"] = idc_region
         elif federation_type == "direct":
             config[profile_name]["federated_role_arn"] = federation_identifier
             config[profile_name]["federation_type"] = "direct"

--- a/source/credential_provider/__main__.py
+++ b/source/credential_provider/__main__.py
@@ -2229,6 +2229,18 @@ class MultiProviderAuth:
                   "Check your AWS CLI configuration or run 'aws sso login'.", file=sys.stderr)
             return 1
 
+        # Quota enforcement (SigV4-signed — email resolved from IAM ARN server-side).
+        if self._should_check_quota():
+            self._debug_print("IDC/passthrough: performing SigV4 quota check")
+            quota_result = self._check_quota(token_claims={}, id_token=None)
+            if not quota_result.get("allowed", True):
+                reason = quota_result.get("reason", "quota exceeded")
+                message = quota_result.get("message", "Usage quota exceeded. Contact your administrator.")
+                print(f"Error: {message}", file=sys.stderr)
+                print(f"Reason: {reason}", file=sys.stderr)
+                return 1
+            self._save_quota_check_timestamp()
+
         output = {
             "Version": 1,
             "AccessKeyId": frozen.access_key,

--- a/source/go/cmd/credential-process/idc.go
+++ b/source/go/cmd/credential-process/idc.go
@@ -51,8 +51,18 @@ func (a *credentialApp) runIDC() int {
 	roleName := a.cfg.IDCPermissionSetName
 
 	if startURL == "" || accountID == "" || roleName == "" {
-		fmt.Fprintln(os.Stderr, "Error: incomplete IDC configuration.")
-		fmt.Fprintln(os.Stderr, "Required fields in config.json: idc_start_url, idc_account_id, idc_permission_set_name")
+		fmt.Fprintln(os.Stderr, "Error: incomplete IDC configuration in config.json.")
+		if startURL == "" {
+			fmt.Fprintln(os.Stderr, "  Missing: idc_start_url (e.g. https://d-xxxxxxxxxx.awsapps.com/start)")
+		}
+		if accountID == "" {
+			fmt.Fprintln(os.Stderr, "  Missing: idc_account_id (AWS account ID for role assumption)")
+		}
+		if roleName == "" {
+			fmt.Fprintln(os.Stderr, "  Missing: idc_permission_set_name (IAM role / permission set name)")
+		}
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Run 'ccwb init' to reconfigure, or edit config.json directly.")
 		return 1
 	}
 
@@ -119,10 +129,10 @@ func (a *credentialApp) runIDC() int {
 
 	// Output credential_process JSON.
 	out := passthroughOutput{
-		Version:        1,
-		AccessKeyID:    creds.AccessKeyID,
+		Version:         1,
+		AccessKeyID:     creds.AccessKeyID,
 		SecretAccessKey: creds.SecretAccessKey,
-		SessionToken:   creds.SessionToken,
+		SessionToken:    creds.SessionToken,
 	}
 	if creds.CanExpire {
 		out.Expiration = creds.Expires.UTC().Format(time.RFC3339)

--- a/source/go/cmd/credential-process/idc.go
+++ b/source/go/cmd/credential-process/idc.go
@@ -1,0 +1,138 @@
+package main
+
+// IAM Identity Center active SSO authentication.
+//
+// When config.json has auth_type=="idc" (or sso_enabled==false with idc_start_url
+// populated), credential-process drives the SSO OIDC device-authorization flow
+// directly via the AWS SDK. This opens the user's browser for approval — no
+// manual `aws sso login` required.
+//
+// Flow:
+//   1. Load SSO config from config.json (start_url, account, role)
+//   2. Check for cached SSO token (~/.aws/sso/cache/)
+//   3. If expired/missing → initiate SSO OIDC device auth (opens browser)
+//   4. Exchange SSO token for role credentials via STS
+//   5. Perform quota check (SigV4-signed, via CheckWithIAM)
+//   6. Write OTEL attribution cache (email from ARN session name)
+//   7. Output credential_process JSON
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials/ssocreds"
+	"github.com/aws/aws-sdk-go-v2/service/sso"
+	"github.com/aws/aws-sdk-go-v2/service/ssooidc"
+
+	"ccwb-go/internal/quota"
+)
+
+// runIDC performs active SSO authentication for IAM Identity Center users.
+// It uses the AWS SDK's ssocreds package to manage the SSO token lifecycle
+// (including opening the browser for device authorization when needed).
+func (a *credentialApp) runIDC() int {
+	debugPrint("IDC active SSO mode for profile '%s'", a.profile)
+
+	region := a.cfg.IDCRegion
+	if region == "" {
+		region = a.cfg.AWSRegion
+	}
+	if region == "" {
+		fmt.Fprintln(os.Stderr, "Error: no region configured for IDC. Set idc_region or aws_region in config.json.")
+		return 1
+	}
+
+	startURL := a.cfg.IDCStartURL
+	accountID := a.cfg.IDCAccountID
+	roleName := a.cfg.IDCPermissionSetName
+
+	if startURL == "" || accountID == "" || roleName == "" {
+		fmt.Fprintln(os.Stderr, "Error: incomplete IDC configuration.")
+		fmt.Fprintln(os.Stderr, "Required fields in config.json: idc_start_url, idc_account_id, idc_permission_set_name")
+		return 1
+	}
+
+	debugPrint("IDC config: start_url=%s account=%s role=%s region=%s", startURL, accountID, roleName, region)
+
+	// 120s timeout allows time for user to approve in browser.
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	// Load minimal AWS config for the SSO region.
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(region))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: failed to load AWS config for IDC: %v\n", err)
+		return 1
+	}
+
+	// Resolve the cached token file path for this SSO session.
+	tokenPath, err := ssocreds.StandardCachedTokenFilepath(startURL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: failed to resolve SSO token cache path: %v\n", err)
+		return 1
+	}
+
+	// Create SSO clients.
+	ssoClient := sso.NewFromConfig(awsCfg)
+	oidcClient := ssooidc.NewFromConfig(awsCfg)
+
+	// Create SSO role credentials provider with token lifecycle management.
+	// The SSOTokenProvider handles the full device-auth flow: checks
+	// ~/.aws/sso/cache/ for a valid token, and if expired/missing, initiates
+	// OIDC device authorization (opens browser for user approval).
+	credProvider := ssocreds.New(ssoClient, accountID, roleName, startURL, func(opts *ssocreds.Options) {
+		opts.SSOTokenProvider = ssocreds.NewSSOTokenProvider(oidcClient, tokenPath)
+	})
+
+	// Retrieve credentials — opens browser if SSO session expired.
+	debugPrint("Retrieving IDC credentials (may open browser for auth)...")
+	creds, err := credProvider.Retrieve(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: IDC authentication failed: %v\n", err)
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "If your browser did not open, ensure:")
+		fmt.Fprintln(os.Stderr, "  - idc_start_url is correct in config.json")
+		fmt.Fprintln(os.Stderr, "  - Your network can reach the SSO portal")
+		fmt.Fprintln(os.Stderr, "  - You have permission to assume the configured role")
+		return 1
+	}
+
+	debugPrint("IDC credentials retrieved successfully (key=%s...)", creds.AccessKeyID[:8])
+
+	// Quota check (SigV4-signed — empty token routes to CheckWithIAM).
+	if a.cfg.QuotaAPIEndpoint != "" {
+		debugPrint("Performing quota check via SigV4...")
+		qr := quota.Check(a.cfg.QuotaAPIEndpoint, "", a.cfg.QuotaCheckTimeout, a.cfg.QuotaFailMode)
+		if !qr.Allowed {
+			printQuotaBlocked(qr)
+			return 1
+		}
+		printQuotaWarning(qr)
+	}
+
+	// Write OTEL attribution cache (email from STS ARN session name).
+	a.writeOtelCacheFromSTS()
+
+	// Output credential_process JSON.
+	out := passthroughOutput{
+		Version:        1,
+		AccessKeyID:    creds.AccessKeyID,
+		SecretAccessKey: creds.SecretAccessKey,
+		SessionToken:   creds.SessionToken,
+	}
+	if creds.CanExpire {
+		out.Expiration = creds.Expires.UTC().Format(time.RFC3339)
+	}
+
+	data, err := json.Marshal(out)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: failed to marshal credentials: %v\n", err)
+		return 1
+	}
+	fmt.Println(string(data))
+	return 0
+}

--- a/source/go/cmd/credential-process/main.go
+++ b/source/go/cmd/credential-process/main.go
@@ -715,7 +715,8 @@ func (a *credentialApp) performQuotaRecheck() {
 // attribution for IDC users who don't have a JWT token.
 //
 // The email is extracted from the assumed-role ARN session name:
-//   arn:aws:sts::123456789012:assumed-role/RoleName/user@company.com
+//
+//	arn:aws:sts::123456789012:assumed-role/RoleName/user@company.com
 //
 // Returns true if the cache was written successfully.
 func (a *credentialApp) writeOtelCacheFromSTS() bool {

--- a/source/go/cmd/credential-process/main.go
+++ b/source/go/cmd/credential-process/main.go
@@ -75,28 +75,42 @@ func main() {
 		os.Exit(1)
 	}
 
-	// SSO-disabled (passthrough) mode. Resolve before provider-type detection
-	// because cfg.ProviderDomain is intentionally "none" for these profiles
-	// and would trip the auto-detect error otherwise. Mirrors Python PR #303.
+	// Build a minimal app for flag dispatch (works for all auth types).
+	app := &credentialApp{
+		profile: profile,
+		cfg:     cfg,
+	}
+
+	// Flag dispatch — must run before auth-type branching so IDC users
+	// can use --get-monitoring-token, --show-tags, etc.
+	if *clearCache {
+		app.clearCache()
+		os.Exit(0)
+	}
+	if *showTags {
+		os.Exit(app.showTags())
+	}
+	if *getTag != "" {
+		os.Exit(app.getTag(*getTag))
+	}
+	if *getMonitoring {
+		os.Exit(app.getMonitoringToken())
+	}
+	if *checkExpiration {
+		os.Exit(app.checkExpiration())
+	}
+
+	// Auth dispatch: IDC > legacy passthrough > OIDC
+	if cfg.IsIDC() {
+		os.Exit(app.runIDC())
+	}
 	if !cfg.IsSsoEnabled() {
-		// Build a minimal app — we don't need providerType or redirectPort for
-		// passthrough, only the ambient AWS chain.
-		app := &credentialApp{
-			profile: profile,
-			cfg:     cfg,
-		}
-		// Honor the small-but-useful flag set that doesn't depend on OIDC.
-		if *clearCache {
-			app.clearCache()
-			os.Exit(0)
-		}
+		// Legacy passthrough: no IDC fields, just ambient credential chain.
 		os.Exit(app.runPassthrough())
 	}
 
-	// Resolve provider type
+	// OIDC path — resolve provider type and redirect port
 	providerType := resolveProviderType(cfg)
-
-	// Resolve redirect port: REDIRECT_PORT env > config.json > 8400
 	redirectPort := 8400
 	if envPort := os.Getenv("REDIRECT_PORT"); envPort != "" {
 		if p, err := strconv.Atoi(envPort); err == nil && p > 0 {
@@ -105,34 +119,8 @@ func main() {
 	} else if cfg.RedirectPort > 0 {
 		redirectPort = cfg.RedirectPort
 	}
-
-	app := &credentialApp{
-		profile:      profile,
-		cfg:          cfg,
-		providerType: providerType,
-		redirectPort: redirectPort,
-	}
-
-	if *clearCache {
-		app.clearCache()
-		os.Exit(0)
-	}
-
-	if *showTags {
-		os.Exit(app.showTags())
-	}
-
-	if *getTag != "" {
-		os.Exit(app.getTag(*getTag))
-	}
-
-	if *getMonitoring {
-		os.Exit(app.getMonitoringToken())
-	}
-
-	if *checkExpiration {
-		os.Exit(app.checkExpiration())
-	}
+	app.providerType = providerType
+	app.redirectPort = redirectPort
 
 	if *refreshIfNeeded {
 		if cfg.CredentialStorage != "session" {
@@ -787,6 +775,8 @@ func extractEmailFromARN(arn string) string {
 		return sessionName
 	}
 	return ""
+}
+
 func printQuotaWarning(qr *quota.Result) {
 	usage := qr.Usage
 	if usage == nil {

--- a/source/go/cmd/credential-process/passthrough.go
+++ b/source/go/cmd/credential-process/passthrough.go
@@ -16,6 +16,8 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/config"
+
+	"ccwb-go/internal/quota"
 )
 
 // passthroughOutput is the credential_process output format used by the
@@ -48,7 +50,7 @@ func (a *credentialApp) runPassthrough() int {
 		loadOpts = append(loadOpts, config.WithRegion(region))
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	awsCfg, err := config.LoadDefaultConfig(ctx, loadOpts...)
@@ -70,6 +72,20 @@ func (a *credentialApp) runPassthrough() int {
 		fmt.Fprintln(os.Stderr, "Hint: check your AWS CLI configuration or run 'aws sso login'.")
 		return 1
 	}
+
+	// Quota check (SigV4-signed — empty token routes to CheckWithIAM).
+	if a.cfg.QuotaAPIEndpoint != "" {
+		debugPrint("Performing quota check via SigV4...")
+		qr := quota.Check(a.cfg.QuotaAPIEndpoint, "", a.cfg.QuotaCheckTimeout, a.cfg.QuotaFailMode)
+		if !qr.Allowed {
+			printQuotaBlocked(qr)
+			return 1
+		}
+		printQuotaWarning(qr)
+	}
+
+	// Write OTEL attribution cache (email from STS ARN session name).
+	a.writeOtelCacheFromSTS()
 
 	out := passthroughOutput{
 		Version:         1,

--- a/source/go/go.mod
+++ b/source/go/go.mod
@@ -14,7 +14,7 @@ require (
 
 require (
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
-	github.com/aws/aws-sdk-go-v2/credentials v1.19.12 // indirect
+	github.com/aws/aws-sdk-go-v2/credentials v1.19.12
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.20 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.20 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.20 // indirect
@@ -22,8 +22,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.20 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.8 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sso v1.30.13 // indirect
-	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.17 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sso v1.30.13
+	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.17
 	github.com/aws/smithy-go v1.24.2 // indirect
 	github.com/danieljoos/wincred v1.1.2 // indirect
 	github.com/dvsekhvalnov/jose2go v1.5.0 // indirect

--- a/source/go/internal/config/config.go
+++ b/source/go/internal/config/config.go
@@ -83,6 +83,15 @@ type ProfileConfig struct {
 	// as non-confidential for installed/native apps). Empty means PKCE-only.
 	ClientSecret string `json:"client_secret,omitempty"`
 
+	// IAM Identity Center fields (populated when auth_type == "idc").
+	// When present, credential-process drives the SSO OIDC device-auth flow
+	// directly (auto-opens browser) instead of relying on ambient credentials.
+	AuthType             string `json:"auth_type,omitempty"`              // "oidc" | "idc" | ""
+	IDCStartURL          string `json:"idc_start_url,omitempty"`         // e.g. https://d-xxxxxxxxxx.awsapps.com/start
+	IDCAccountID         string `json:"idc_account_id,omitempty"`        // AWS account ID for role assumption
+	IDCPermissionSetName string `json:"idc_permission_set_name,omitempty"` // IAM role name / permission set
+	IDCRegion            string `json:"idc_region,omitempty"`            // SSO endpoint region (defaults to aws_region)
+
 	// Legacy field names
 	OktaDomain   string `json:"okta_domain"`
 	OktaClientID string `json:"okta_client_id"`
@@ -276,4 +285,14 @@ func (p *ProfileConfig) IsSsoEnabled() bool {
 		return true
 	}
 	return *p.SsoEnabled
+}
+
+// IsIDC reports whether the profile uses IAM Identity Center active auth.
+// True when auth_type is explicitly "idc", or when SSO is disabled but IDC
+// fields are present (indicating an IDC deployment rather than pure passthrough).
+func (p *ProfileConfig) IsIDC() bool {
+	if p == nil {
+		return false
+	}
+	return p.AuthType == "idc" || (!p.IsSsoEnabled() && p.IDCStartURL != "")
 }

--- a/source/go/internal/config/config.go
+++ b/source/go/internal/config/config.go
@@ -86,11 +86,11 @@ type ProfileConfig struct {
 	// IAM Identity Center fields (populated when auth_type == "idc").
 	// When present, credential-process drives the SSO OIDC device-auth flow
 	// directly (auto-opens browser) instead of relying on ambient credentials.
-	AuthType             string `json:"auth_type,omitempty"`              // "oidc" | "idc" | ""
-	IDCStartURL          string `json:"idc_start_url,omitempty"`         // e.g. https://d-xxxxxxxxxx.awsapps.com/start
-	IDCAccountID         string `json:"idc_account_id,omitempty"`        // AWS account ID for role assumption
+	AuthType             string `json:"auth_type,omitempty"`               // "oidc" | "idc" | ""
+	IDCStartURL          string `json:"idc_start_url,omitempty"`           // e.g. https://d-xxxxxxxxxx.awsapps.com/start
+	IDCAccountID         string `json:"idc_account_id,omitempty"`          // AWS account ID for role assumption
 	IDCPermissionSetName string `json:"idc_permission_set_name,omitempty"` // IAM role name / permission set
-	IDCRegion            string `json:"idc_region,omitempty"`            // SSO endpoint region (defaults to aws_region)
+	IDCRegion            string `json:"idc_region,omitempty"`              // SSO endpoint region (defaults to aws_region)
 
 	// Legacy field names
 	OktaDomain   string `json:"okta_domain"`

--- a/source/go/internal/quota/quota_test.go
+++ b/source/go/internal/quota/quota_test.go
@@ -72,6 +72,9 @@ func TestCheck_FailClosed_BlocksOnError(t *testing.T) {
 	result := Check("http://localhost:1", "token", 1, "closed")
 	if result.Allowed {
 		t.Error("fail-closed mode should block on connection error")
+	}
+}
+
 func TestCheck_Allowed(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(Result{


### PR DESCRIPTION
## Problem

Three critical bugs in the IAM Identity Center credential path make it unusable for enterprise customers:

1. **credential-process hangs on every prompt** — passthrough mode uses ambient credential chain with 30s timeout. If SSO session is expired, the SDK hangs attempting to refresh, blocking Claude Code.

2. **Quota enforcement doesn't work** — the passthrough path never calls `quota.Check()`. Even with quota stack deployed and limits exceeded, IDC users are never blocked.

3. **OTEL helper hangs on startup** — `--get-monitoring-token` flag dispatch runs AFTER the passthrough early-exit. IDC users can never reach the monitoring token path.

Closes #401

## Solution

### Active SSO Auth (new `idc.go`)
Instead of relying on ambient credentials from a prior `aws sso login`, the credential-process now drives the full SSO OIDC device-authorization flow internally using the AWS SDK's `ssocreds` package:
- Checks `~/.aws/sso/cache/` for valid token
- If expired → opens browser for SSO device auth (exactly like `aws sso login`)
- No manual step required — seamless like the OIDC path

### Flag Dispatch Before Auth (`main.go` restructure)
All flags (`--get-monitoring-token`, `--show-tags`, `--check-expiration`, `--get-tag`, `--clear-cache`) now dispatch BEFORE auth-type branching. This fixes the otel-helper hang.

### Quota + OTEL in Both Paths
Both IDC and legacy passthrough now:
- Call `quota.Check()` with SigV4 auth (via `CheckWithIAM`)
- Call `writeOtelCacheFromSTS()` for per-user attribution

## Architecture

```
credential-process --profile X
  ├── Flag dispatch (--get-monitoring-token, etc.) ← runs for ALL auth types
  ├── cfg.IsIDC() → runIDC() (active SSO via ssocreds SDK)
  ├── !cfg.IsSsoEnabled() → runPassthrough() (legacy ambient chain, 10s timeout)
  └── else → run() (OIDC path, unchanged)
```

## Changes

| File | Change |
|------|--------|
| `source/go/internal/config/config.go` | Add IDC fields (`auth_type`, `idc_start_url`, `idc_account_id`, `idc_permission_set_name`, `idc_region`) + `IsIDC()` helper |
| `source/go/cmd/credential-process/main.go` | Restructure: flags first, then IDC → passthrough → OIDC |
| `source/go/cmd/credential-process/idc.go` (new) | Active SSO auth via `ssocreds` + quota + OTEL |
| `source/go/cmd/credential-process/passthrough.go` | Add quota check + OTEL write, reduce timeout 30s→10s |
| `source/go/go.mod` | Promote `credentials`, `sso`, `ssooidc` to direct deps |
| `source/claude_code_with_bedrock/cli/commands/package.py` | Write IDC fields to config.json |

## Backward Compatibility

| Scenario | Behavior |
|----------|----------|
| Existing OIDC deployments | **No change** — `run()` path untouched |
| Existing IDC (no `idc_start_url` in config.json) | Legacy passthrough (now with quota + OTEL) |
| New IDC deployments (`auth_type=idc` + IDC fields) | Full active SSO experience |

## Requirements for IDC quota attribution

- IDC permission set must use email as the role session name (default for most Identity Center setups)
- The email is extracted from the assumed-role ARN: `arn:aws:sts::ACCOUNT:assumed-role/ROLE/user@company.com`

## Testing

- [ ] Go compilation verified (requires Go 1.24 — CI will validate)
- [ ] Existing OIDC tests unaffected (no changes to `run()` path)
- [ ] Existing passthrough tests: passthrough still works, now with quota/OTEL additions
- [ ] IDC-specific tests to be added in follow-up