### PR TITLE
fix: pass resolved IDC credentials to quota SigV4 signing (fixes 403)

### DIFF
--- a/source/credential_provider/__main__.py
+++ b/source/credential_provider/__main__.py
@@ -1772,7 +1772,7 @@ class MultiProviderAuth:
 
         return list(set(groups))  # Remove duplicates
 
-    def _check_quota(self, token_claims: dict, id_token: str = None) -> dict:
+    def _check_quota(self, token_claims: dict, id_token: str = None, frozen_credentials=None) -> dict:
         """Check user quota via the quota check API.
 
         Supports two auth modes:
@@ -1783,6 +1783,10 @@ class MultiProviderAuth:
             token_claims: JWT token claims containing user info (for logging/fallback).
                           For IDC, may be empty — email is resolved from IAM ARN server-side.
             id_token: Raw JWT token for OIDC path. None for IDC path.
+            frozen_credentials: Pre-resolved boto credentials for SigV4 signing.
+                               When provided, used directly instead of resolving from
+                               ambient chain. Fixes 403 when ambient creds differ from
+                               the profile's SSO credentials.
 
         Returns:
             Quota check result dict with 'allowed' key
@@ -1814,13 +1818,25 @@ class MultiProviderAuth:
                     timeout=timeout
                 )
             else:
-                # IDC/IAM path: SigV4-signed request using current AWS credentials
+                # IDC/IAM path: SigV4-signed request using resolved credentials
                 import botocore.session
                 from botocore.auth import SigV4Auth
                 from botocore.awsrequest import AWSRequest
+                from botocore.credentials import Credentials
 
-                session = botocore.session.get_session()
-                credentials = session.get_credentials().get_frozen_credentials()
+                if frozen_credentials:
+                    # Use pre-resolved credentials (from passthrough/IDC path).
+                    # frozen_credentials is a ReadOnlyCredentials namedtuple;
+                    # wrap into botocore Credentials for SigV4Auth.
+                    credentials = Credentials(
+                        access_key=frozen_credentials.access_key,
+                        secret_key=frozen_credentials.secret_key,
+                        token=frozen_credentials.token,
+                    )
+                else:
+                    # Fallback: resolve from ambient chain (may differ from profile)
+                    session = botocore.session.get_session()
+                    credentials = session.get_credentials().get_frozen_credentials()
                 url = f"{quota_api_endpoint}/check"
                 request = AWSRequest(method="GET", url=url)
                 SigV4Auth(credentials, "execute-api", self.config.get("aws_region", "us-east-1")).add_auth(request)
@@ -2232,7 +2248,7 @@ class MultiProviderAuth:
         # Quota enforcement (SigV4-signed — email resolved from IAM ARN server-side).
         if self._should_check_quota():
             self._debug_print("IDC/passthrough: performing SigV4 quota check")
-            quota_result = self._check_quota(token_claims={}, id_token=None)
+            quota_result = self._check_quota(token_claims={}, id_token=None, frozen_credentials=frozen)
             if not quota_result.get("allowed", True):
                 reason = quota_result.get("reason", "quota exceeded")
                 message = quota_result.get("message", "Usage quota exceeded. Contact your administrator.")

--- a/source/go/cmd/credential-process/idc.go
+++ b/source/go/cmd/credential-process/idc.go
@@ -113,10 +113,16 @@ func (a *credentialApp) runIDC() int {
 
 	debugPrint("IDC credentials retrieved successfully (key=%s...)", creds.AccessKeyID[:8])
 
-	// Quota check (SigV4-signed — empty token routes to CheckWithIAM).
+	// Quota check (SigV4-signed with the IDC credentials we just resolved).
 	if a.cfg.QuotaAPIEndpoint != "" {
-		debugPrint("Performing quota check via SigV4...")
-		qr := quota.Check(a.cfg.QuotaAPIEndpoint, "", a.cfg.QuotaCheckTimeout, a.cfg.QuotaFailMode)
+		debugPrint("Performing quota check via SigV4 with IDC credentials...")
+		qr := quota.CheckWithResolvedCreds(
+			a.cfg.QuotaAPIEndpoint,
+			creds,
+			region,
+			a.cfg.QuotaCheckTimeout,
+			a.cfg.QuotaFailMode,
+		)
 		if !qr.Allowed {
 			printQuotaBlocked(qr)
 			return 1

--- a/source/go/internal/quota/quota.go
+++ b/source/go/internal/quota/quota.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 )
@@ -22,6 +23,7 @@ type Result struct {
 }
 
 // Check calls the quota API endpoint with the given JWT token.
+// When idToken is empty, falls back to IAM/SigV4 auth (IDC path).
 func Check(endpoint, idToken string, timeout int, failMode string) *Result {
 	if idToken == "" {
 		// No JWT token — try IAM auth (IDC path)
@@ -81,6 +83,20 @@ func CheckWithIAM(endpoint string, timeout int, failMode string) *Result {
 		return failResult(failMode, "iam_creds_error", fmt.Sprintf("Could not retrieve AWS credentials: %v", err))
 	}
 
+	return checkWithSigV4(endpoint, creds, cfg.Region, timeout, failMode)
+}
+
+// CheckWithResolvedCreds calls the quota API using pre-resolved AWS credentials.
+// Use this when credentials have already been obtained (e.g. from IDC SSO flow)
+// and the default credential chain may resolve a different principal.
+func CheckWithResolvedCreds(endpoint string, creds aws.Credentials, region string, timeout int, failMode string) *Result {
+	return checkWithSigV4(endpoint, creds, region, timeout, failMode)
+}
+
+// checkWithSigV4 signs and sends the quota check request using the provided credentials.
+func checkWithSigV4(endpoint string, creds aws.Credentials, region string, timeout int, failMode string) *Result {
+	ctx := context.Background()
+
 	url := endpoint + "/check"
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
@@ -90,7 +106,7 @@ func CheckWithIAM(endpoint string, timeout int, failMode string) *Result {
 	// Sign the request with SigV4 for execute-api service
 	signer := v4.NewSigner()
 	hash := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" // SHA256 of empty body
-	err = signer.SignHTTP(ctx, creds, req, hash, "execute-api", cfg.Region, time.Now())
+	err = signer.SignHTTP(ctx, creds, req, hash, "execute-api", region, time.Now())
 	if err != nil {
 		return failResult(failMode, "sigv4_error", fmt.Sprintf("Could not sign request: %v", err))
 	}


### PR DESCRIPTION
## Problem

The quota API Gateway returns 403 for IDC users because SigV4 signing uses the wrong credentials.

**Root cause:** Both Python and Go quota check paths resolve credentials from the default/ambient chain (`botocore.session.get_session()` / `awsconfig.LoadDefaultConfig`) rather than the SSO credentials that were just resolved for the profile. When ambient creds differ from the profile's SSO creds (common in multi-profile setups), the request is signed with the wrong principal → 403.

## Fix

### Python (`credential_provider/__main__.py`)
- `_check_quota()` now accepts optional `frozen_credentials` parameter
- `_run_passthrough()` passes the already-resolved `frozen` credentials directly
- Wraps `ReadOnlyCredentials` into botocore `Credentials` for SigV4Auth compatibility
- Fallback to ambient chain preserved when `frozen_credentials=None` (OIDC path unaffected)

### Go (`internal/quota/quota.go` + `cmd/credential-process/idc.go`)
- New `CheckWithResolvedCreds(endpoint, creds, region, timeout, failMode)` function
- `runIDC()` passes the `aws.Credentials` from `ssocreds.Retrieve()` directly
- Shared `checkWithSigV4()` helper avoids code duplication
- `CheckWithIAM()` preserved unchanged (used by legacy passthrough)

## Testing

```bash
# IDC profile with quota stack deployed:
./credential-process --profile <idc-profile>
# Expected: quota check succeeds (200), credentials output
# Before fix: quota check got 403, fail-open returned creds silently

# Verify with debug:
CCWB_DEBUG=1 ./credential-process --profile <idc-profile>
# Should show: "Performing quota check via SigV4 with IDC credentials..."
# Should NOT show: "iam_creds_error" or 403 status
```

## Backward Compatibility
- OIDC path: unaffected (uses JWT auth, not SigV4)
- Legacy passthrough (no IDC fields): uses `CheckWithIAM()` as before (ambient chain)
- New IDC path: now correctly signs with profile-resolved credentials