### PR TITLE
fix(ci): allowlist the otel-helper test fixture JWT for secret scanner

### DIFF
--- a/source/go/cmd/otel-helper/main_test.go
+++ b/source/go/cmd/otel-helper/main_test.go
@@ -329,7 +329,7 @@ func TestRun_CacheHit_ResolvesTokenFromEnv(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	envToken := "eyJhbGciOiJub25lIn0.eyJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJleHAiOjk5OTk5OTk5OTl9."
+	envToken := "eyJhbGciOiJub25lIn0.eyJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJleHAiOjk5OTk5OTk5OTl9." // pragma: allowlist secret
 	t.Setenv("CLAUDE_CODE_MONITORING_TOKEN", envToken)
 
 	r, w, _ := os.Pipe()


### PR DESCRIPTION
## Description

Marks the inert fixture JWT in `source/go/cmd/otel-helper/main_test.go` with an inline `// pragma: allowlist secret` comment so `detect-secrets` skips it, clearing the `Scanners / secrets-scanner` gate.

## Why is this change needed

The secrets-scanner gate is red on `beta`: detect-secrets flags the fixture JWT at `main_test.go:332`, and because the line is neither baselined nor allowlisted, the workflow's jq audit errors with `potential secrets in: ["source/go/cmd/otel-helper/main_test.go"]`. The file is under `source/go/`, outside the audit's `source/tests/` exemption.

Fixes #544

## Type of Change

- [x] CI/CD changes

## Changes Made

- Add `// pragma: allowlist secret` to the fixture JWT line in `main_test.go`.
- Matches the repo's existing convention (`test_credential_passthrough.py`, `confidential.go`) — preferred over a `.secrets.baseline` entry: it's local to the fixture, visible to reviewers, and survives line-number changes.

## Additional Notes

The token is an inert fixture — `alg:none`, no signature, payload `{"email":"test@example.com","exp":9999999999}` — used to drive the `CLAUDE_CODE_MONITORING_TOKEN` path. No real credential value.

## Testing Checklist

### What was tested

- [x] Ran the workflow gate locally (`detect-secrets scan --baseline .secrets.baseline` + the jq audit): errors on `beta`, exits 0 with this change; `.secrets.baseline` needs no edit.
- [x] `cd source/go && gofmt -l cmd/otel-helper/main_test.go` clean; `go vet` clean.
- [x] `go test -count=1 ./cmd/otel-helper/` -> `ok` (fixture still exercises its path).
- [x] `cd source && poetry run pytest tests/` — full suite green (950 passed).
