### PR TITLE
fix(init): use API-returned ARN for distribution IdP secret

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1349,29 +1349,26 @@ class InitCommand(Command):
 
                     secret_name = f"{config['aws']['identity_pool_name']}-distribution-idp-secret"
 
-                    # Try to create or update secret
-                    try:
-                        secret_response = secrets_client.create_secret(
-                            Name=secret_name,
-                            SecretString=idp_client_secret,
-                            Description=f"IdP client secret for "
-                            f"{config['aws']['identity_pool_name']} distribution landing page",
-                        )
-                        secret_arn = secret_response["ARN"]
-                    except secrets_client.exceptions.ResourceExistsException:
-                        # Secret already exists, update it
-                        secret_response = secrets_client.update_secret(
-                            SecretId=secret_name,
-                            SecretString=idp_client_secret,
-                        )
-                        secret_arn = f"arn:aws:secretsmanager:{region}:{account_id}:secret:{secret_name}"
+                    secret_arn = self._store_idp_secret(
+                        secrets_client,
+                        secret_name,
+                        idp_client_secret,
+                        description=f"IdP client secret for "
+                        f"{config['aws']['identity_pool_name']} distribution landing page",
+                    )
 
                     console.print(f"[green]✓[/green] IdP client secret stored in Secrets Manager: {secret_name}")
 
                 except Exception as e:
                     console.print(f"[red]Error storing secret in Secrets Manager: {e}[/red]")
                     console.print("[yellow]You'll need to configure the secret manually before deployment[/yellow]")
-                    secret_arn = f"arn:aws:secretsmanager:{region}:{account_id}:secret:{secret_name}"
+                    # Storing failed, so we have no API response. Recover the real
+                    # ARN (with its random suffix) via describe_secret if the secret
+                    # exists; only fall back to a hand-built ARN as a last resort.
+                    try:
+                        secret_arn = secrets_client.describe_secret(SecretId=secret_name)["ARN"]
+                    except Exception:
+                        secret_arn = f"arn:aws:secretsmanager:{region}:{account_id}:secret:{secret_name}"
 
             # Custom domain (REQUIRED for authenticated landing page)
             console.print("\n[bold]Custom Domain Configuration (REQUIRED)[/bold]")
@@ -1732,6 +1729,30 @@ class InitCommand(Command):
             config["tags"] = config.get("tags", {})
 
         return config
+
+    @staticmethod
+    def _store_idp_secret(secrets_client, secret_name: str, secret_value: str, description: str = "") -> str:
+        """Create or update the distribution IdP client secret; return its full ARN.
+
+        Always returns the ARN from the Secrets Manager API response. Secrets
+        Manager appends a random 6-char suffix to every secret ARN (e.g.
+        ``-FhLi4n``); a hand-built ``arn:...:secret:<name>`` omits it, and the
+        ``{{resolve:secretsmanager:<arn>}}`` reference in the landing-page ALB
+        HTTPS listener then fails with ResourceNotFoundException. Using the
+        response ARN keeps create and update paths consistent.
+        """
+        try:
+            response = secrets_client.create_secret(
+                Name=secret_name,
+                SecretString=secret_value,
+                Description=description,
+            )
+        except secrets_client.exceptions.ResourceExistsException:
+            response = secrets_client.update_secret(
+                SecretId=secret_name,
+                SecretString=secret_value,
+            )
+        return response["ARN"]
 
     def _review_configuration(self, config: dict[str, Any]) -> bool:
         """Review configuration with user."""

--- a/source/tests/cli/commands/test_init.py
+++ b/source/tests/cli/commands/test_init.py
@@ -712,6 +712,57 @@ class TestLandingPageRegionResolution:
         assert region_name == "ap-southeast-1"
 
 
+class TestStoreIdpSecret:
+    """Regression tests for _store_idp_secret ARN handling.
+
+    Secrets Manager appends a random 6-char suffix to every secret ARN. A
+    hand-built ``arn:...:secret:<name>`` omits it, so the
+    ``{{resolve:secretsmanager:<arn>}}`` reference in the landing-page ALB
+    HTTPS listener fails with ResourceNotFoundException. _store_idp_secret must
+    return the suffixed ARN from the API response on BOTH create and update.
+    """
+
+    def _client(self, *, exists: bool):
+        from unittest.mock import MagicMock
+
+        client = MagicMock()
+
+        class _ResourceExists(Exception):
+            pass
+
+        client.exceptions.ResourceExistsException = _ResourceExists
+        suffixed = (
+            "arn:aws:secretsmanager:ap-southeast-1:111111111111:"
+            "secret:my-pool-distribution-idp-secret-FhLi4n"
+        )
+        if exists:
+            client.create_secret.side_effect = _ResourceExists()
+            client.update_secret.return_value = {"ARN": suffixed}
+        else:
+            client.create_secret.return_value = {"ARN": suffixed}
+        return client, suffixed
+
+    def test_create_path_returns_suffixed_arn(self):
+        from claude_code_with_bedrock.cli.commands.init import InitCommand
+
+        client, suffixed = self._client(exists=False)
+        arn = InitCommand._store_idp_secret(client, "my-pool-distribution-idp-secret", "secret-value")
+        assert arn == suffixed
+        assert arn.endswith("-FhLi4n")
+
+    def test_update_path_returns_suffixed_arn(self):
+        """The bug: existing secret -> update path must NOT hand-build a suffix-less ARN."""
+        from claude_code_with_bedrock.cli.commands.init import InitCommand
+
+        client, suffixed = self._client(exists=True)
+        arn = InitCommand._store_idp_secret(client, "my-pool-distribution-idp-secret", "secret-value")
+        assert arn == suffixed
+        assert arn.endswith("-FhLi4n")
+        # The pre-fix bug returned a bare ARN ending in the plain secret name.
+        assert not arn.endswith("-distribution-idp-secret")
+        client.update_secret.assert_called_once()
+
+
 if __name__ == "__main__":
     # Run the tests
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Description

Use the ARN returned by the Secrets Manager API (which includes its random suffix) for the distribution IdP client secret, on both the create and update paths, instead of hand-building it.

## Why is this change needed

When the IdP secret already exists, `init` took the `update_secret` path and then hand-built the secret ARN as `arn:...:secret:<name>`, omitting the random 6-char suffix AWS appends. The landing-page ALB HTTPS listener resolves the secret via `{{resolve:secretsmanager:<arn>}}`, which needs the full ARN, so `ccwb deploy` failed with `ResourceNotFoundException`. First-ever deploys worked (create path returns the correct ARN); this surfaced on any re-`init`.

Fixes #546

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Extract secret create/update into `_store_idp_secret()`, which always returns `response["ARN"]` from the API (create and update alike).
- The outer `except` now recovers the real ARN via `describe_secret` before falling back to a hand-built one.
- Add `TestStoreIdpSecret` covering create and update paths.

## Additional Notes

Storage (keyring vs Secrets Manager) and which IdPs use a confidential secret are unchanged — only the recorded ARN is corrected.

## Testing Checklist

### What was tested

- [x] `cd source && poetry run pytest tests/` — full suite green (935 passed).
- [x] New `TestStoreIdpSecret` fails against the prior hand-built-ARN behavior and passes on this change (falsified).
- [x] Verified locally: bandit (no new findings vs beta), semgrep (0), detect-secrets (0).
- [x] CI gates: pytest-ci + scanners apply; go-tests / cfn_nag / validate-regions are N/A (no `source/go/**`, no CloudFormation, no region data in this diff).
