### PR TITLE
fix(monitoring): add ALB auth bypass for CoWork 3P telemetry

### DIFF
--- a/deployment/infrastructure/otel-collector.yaml
+++ b/deployment/infrastructure/otel-collector.yaml
@@ -46,11 +46,27 @@ Parameters:
     AllowedValues: ['true', 'false']
     Description: Enable dual-export (OTLP + EMF) for analytics pipeline. When false, only OTLP export is used.
 
+  CoWorkServiceToken:
+    Type: String
+    Default: ''
+    NoEcho: true
+    Description: >-
+      Optional static token for CoWork (Claude Desktop) telemetry.
+      When set, a listener rule allows requests with header
+      X-Cowork-Token matching this value to bypass JWT validation.
+      CoWork cannot perform OIDC auth (no browser/helper), so this
+      provides an alternative auth path for its OTLP events.
+
 Conditions:
   HasCustomDomain: !Not [!Equals [!Ref CustomDomainName, '']]
   NoCustomDomain: !Equals [!Ref CustomDomainName, '']
   HasJwtAuth: !Not [!Equals [!Ref OidcIssuerUrl, '']]
   HasOidcClientId: !Not [!Equals [!Ref OidcClientId, '']]
+  HasCoWorkToken: !Not [!Equals [!Ref CoWorkServiceToken, '']]
+  HasCoWorkAuthBypass: !And
+    - !Condition HasCustomDomain
+    - !Condition HasJwtAuth
+    - !Condition HasCoWorkToken
   AnalyticsEnabled: !Equals [!Ref EnableAnalytics, 'true']
 
 # Rules section removed - validation handled by deployment script
@@ -250,6 +266,25 @@ Resources:
         - - Type: forward
             TargetGroupArn: !Ref HTTPTargetGroup
       SslPolicy: ELBSecurityPolicy-TLS-1-2-2017-01
+
+  # CoWork auth bypass: allows CoWork traffic (which cannot do OIDC) to reach
+  # the collector by presenting a static service token in a custom header.
+  # Only created when CoWorkServiceToken parameter is set AND JWT auth is enabled.
+  CoWorkListenerRule:
+    Type: AWS::ElasticLoadBalancingV2::ListenerRule
+    Condition: HasCoWorkAuthBypass
+    Properties:
+      ListenerArn: !Ref HTTPSListener
+      Priority: 1
+      Conditions:
+        - Field: http-header
+          HttpHeaderConfig:
+            HttpHeaderName: X-Cowork-Token
+            Values:
+              - !Ref CoWorkServiceToken
+      Actions:
+        - Type: forward
+          TargetGroupArn: !Ref HTTPTargetGroup
 
   # IAM Roles
   TaskExecutionRole:

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1195,6 +1195,22 @@ class InitCommand(Command):
                 console.print("[dim]To add custom MDM keys (e.g. coworkWebSearchEnabled), edit your profile JSON directly.[/dim]")
                 console.print("[dim]See: assets/docs/COWORK_3P.md → Custom MDM Keys[/dim]")
             config["cowork_3p"]["extra_keys"] = existing_extra
+
+            # Generate CoWork service token for ALB auth bypass (central mode only).
+            # CoWork can't do OIDC, so this static token in X-Cowork-Token header
+            # bypasses JWT validation on the ALB listener.
+            monitoring_mode = config.get("monitoring", {}).get("mode", "central")
+            if monitoring_mode == "central":
+                existing_token = config.get("cowork_3p", {}).get("service_token", "")
+                if not existing_token:
+                    import uuid
+                    token = str(uuid.uuid4())
+                    config["cowork_3p"]["service_token"] = token
+                    console.print("[green]✓[/green] Generated CoWork service token for ALB auth bypass")
+                    console.print("[dim]  Pass this as CoWorkServiceToken parameter when deploying the monitoring stack[/dim]")
+                else:
+                    console.print("[dim]CoWork service token already configured[/dim]")
+
         # Package distribution support
         console.print("\n[bold]Package Distribution[/bold]")
         console.print("Choose how to distribute Claude Code packages to end users:")

--- a/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
+++ b/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
@@ -102,6 +102,13 @@ def add_monitoring_config(mdm_config: dict, profile, console: Console) -> None:
         mdm_config["otlpEndpoint"] = endpoint
         mdm_config["otlpProtocol"] = "http/protobuf"
         console.print(f"[dim]OTLP endpoint: {endpoint}[/dim]")
+
+        # Add CoWork service token for ALB auth bypass (if configured).
+        # CoWork cannot do OIDC — this static token header bypasses JWT validation.
+        cowork_token = getattr(profile, "cowork_service_token", None)
+        if cowork_token:
+            mdm_config["otlpHeaders"] = json.dumps({"X-Cowork-Token": cowork_token})
+            console.print("[dim]CoWork auth token configured for ALB bypass[/dim]")
     else:
         console.print("[dim]Monitoring endpoint not found — skipping OTLP config[/dim]")
 

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -114,6 +114,7 @@ class Profile:
     # Claude Cowork 3P MDM configuration
     cowork_3p_enabled: bool = True  # Generate CoWork 3P MDM configs during packaging
     cowork_3p_extra_keys: dict[str, str] = field(default_factory=dict)  # Custom MDM keys merged into CoWork 3P output
+    cowork_service_token: str = ""  # Static token for CoWork ALB auth bypass (set during init)
 
     # Legacy field support
     @property


### PR DESCRIPTION
## Problem

CoWork (Claude Desktop) telemetry is rejected with HTTP 401 by the ALB's JWT validation (#541, layer 1). CoWork has no browser or OIDC helper — it cannot obtain a JWT token. Every OTLP request from CoWork is blocked before reaching the collector.

## Solution

Add an optional **X-Cowork-Token** header-based ALB listener rule that bypasses JWT validation for CoWork traffic only.

### How it works

1. `ccwb init` generates a UUID service token (stored in profile config)
2. Admin passes `CoWorkServiceToken` parameter when deploying monitoring stack
3. ALB listener rule (priority 1) matches `X-Cowork-Token: <token>` → forwards to collector without JWT validation
4. CoWork receives the token via MDM `otlpHeaders` configuration
5. Normal OIDC traffic (without this header) falls through to JWT validation as before

## Changes

| File | Change |
|------|--------|
| `deployment/infrastructure/otel-collector.yaml` | `CoWorkServiceToken` parameter (NoEcho) + `HasCoWorkAuthBypass` condition + ListenerRule |
| `source/claude_code_with_bedrock/config.py` | Add `cowork_service_token` field |
| `source/claude_code_with_bedrock/cli/commands/init.py` | Auto-generate UUID token during init (central mode only) |
| `source/claude_code_with_bedrock/cli/utils/cowork_3p.py` | Set `otlpHeaders` with `X-Cowork-Token` in MDM config |

## Design Decisions

### Why a custom header (not path-based or OIDC audience)?
- **Path-based rejected:** A rule on `/v1/logs` without auth would allow ANY unauthenticated client to submit telemetry. The token restricts access to configured CoWork installs only.
- **OIDC audience rejected:** CoWork cannot obtain tokens from any OIDC provider — it has no browser or token exchange capability.
- **Custom header chosen:** Invisible to normal OIDC users (their requests don't have `X-Cowork-Token`), scoped to CoWork installs, rotatable via `ccwb init`.

### Why NoEcho for the parameter?
The token is effectively a static API key. `NoEcho: true` prevents it from appearing in CloudFormation console, CLI outputs, or stack event logs.

### What if the token is compromised?
- The token only grants write access to telemetry (log events) — no credential or quota bypass
- Can be rotated by re-running `ccwb init` + redeploying monitoring stack
- Defence in depth: WAF rules can restrict source IPs if needed

### Does this affect OIDC users?
**No.** The listener rule only matches requests with the `X-Cowork-Token` header set to the exact configured value. Normal Claude Code traffic uses `Authorization: Bearer <JWT>` without this header → falls through to the default JWT validation action unchanged.

## Impact

| Mode | Affected? | Detail |
|------|-----------|--------|
| Central + JWT auth | ✅ Yes | New optional listener rule (only when `CoWorkServiceToken` is set) |
| Central without JWT | ❌ No | Condition requires `HasJwtAuth` — rule not created without OIDC config |
| Sidecar | ❌ No | No ALB in sidecar mode |
| Existing deployments | ❌ No | Parameter defaults to empty → condition false → no rule created |

## Testing

```bash
# 1. Run ccwb init → should generate cowork_service_token in profile
ccwb init

# 2. Deploy monitoring with token
ccwb deploy --stack monitoring  # passes CoWorkServiceToken from profile

# 3. Verify listener rule exists
aws elbv2 describe-rules --listener-arn <https-listener-arn>
# Should show rule with X-Cowork-Token condition

# 4. Test CoWork can reach collector
curl -X POST https://telemetry.example.com/v1/logs \
  -H 'X-Cowork-Token: <token-from-profile>' \
  -H 'Content-Type: application/json' \
  -d '{}'
# Expected: 200 (not 401)

# 5. Test OIDC still works (no regression)
curl -X POST https://telemetry.example.com/v1/metrics \
  -H 'Authorization: Bearer <valid-jwt>'
# Expected: 200 (JWT validation still active)

# 6. Test without token (unauthorized)
curl -X POST https://telemetry.example.com/v1/logs
# Expected: 401 (falls through to JWT validation, fails)
```

Depends on #548 for full CoWork telemetry pipeline.
Addresses layer 1 of #541.