### PR TITLE
feat(security): add fail-closed enforcement hooks (PII guard, HMAC audit, budget breaker)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
       "description": "Frontend design skill for UI/UX implementation",
       "category": "skill"
     },
-        {
+    {
       "name": "requirements",
       "version": "1.0.0",
       "source": "./assets/claude-code-plugins/plugins/requirements",
@@ -34,7 +34,7 @@
       "source": "./assets/claude-code-plugins/plugins/troubleshooting",
       "description": "Troubleshooting command to assist with complex problems",
       "category": "troubleshooting"
-    },    
+    },
     {
       "name": "documentation",
       "version": "1.0.0",
@@ -51,9 +51,9 @@
     },
     {
       "name": "security",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "source": "./assets/claude-code-plugins/plugins/security",
-      "description": "Security scanning, auditing, and compliance validation with 4 specialized agents for automated security gates and analysis",
+      "description": "Security scanning, auditing, and compliance validation with 4 specialized agents, plus fail-closed hooks: PII/secrets guard, HMAC-chained tamper-evident audit (CloudWatch dual-write), token-budget circuit breaker",
       "category": "security"
     },
     {

--- a/assets/claude-code-plugins/plugins/security/.claude-plugin/plugin.json
+++ b/assets/claude-code-plugins/plugins/security/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "security",
-  "version": "1.0.0",
-  "description": "Security scanning, auditing, and compliance validation with 4 specialized agents for automated security gates and analysis",
+  "version": "1.1.0",
+  "description": "Security scanning, auditing, and compliance validation with 4 specialized agents, plus fail-closed enforcement hooks: PII/secrets prompt guard, tamper-evident HMAC-chained audit log with CloudWatch dual-write, and a per-session token-budget circuit breaker",
   "author": {
     "name": "AWS Solutions Library"
   }

--- a/assets/claude-code-plugins/plugins/security/hooks/README.md
+++ b/assets/claude-code-plugins/plugins/security/hooks/README.md
@@ -1,0 +1,53 @@
+# Security Hooks
+
+This plugin ships two complementary hook configurations. They can be used independently or together.
+
+## `security_gates.json` — advisory file/command validation
+
+The original hooks: `security_check.py` (PreToolUse on Write/Edit/MultiEdit — sensitive-file and secret-in-content checks) and `command_security_check.sh` (PreToolUse on Bash — dangerous-command blocking). See that file's `usage` block.
+
+## `fail_closed_gates.json` — fail-closed enforcement
+
+Adds three enforcement hooks plus a telemetry shim. Every hook is invoked through `hook_wrapper.sh`, which converts a silent hook crash or timeout into an explicit `exit 2` (denial) — a broken control fails *safe*, not *open*.
+
+| Hook | Events | Enforces |
+|---|---|---|
+| `pii_prompt_guard.sh` | UserPromptSubmit, PreToolUse | Blocks prompts/tool inputs containing secrets (AWS keys, private keys, JWTs, DB connection strings, credit cards) and national identifiers (US SSN/ITIN, UK NINO/NHS, JP My Number, KR RRN, SG NRIC/FIN, EU IBAN, AU TFN/Medicare) **before they reach the model**. Each pattern is individually disable-able. |
+| `audit_chain_logger.sh` | UserPromptSubmit, PostToolUse | Tamper-evident **HMAC-SHA256 hash-chained** JSONL audit log. Any post-hoc edit/delete/reorder/insert breaks the chain forward. Optional dual-write to the CloudWatch logging this guidance already provisions. |
+| `token_budget_guard.sh` | PreToolUse, PostToolUse | Per-session circuit breaker: blocks further tool calls once a token or call budget is exceeded — a backstop against runaway agent loops. |
+| `hook_wrapper.sh` | (wraps the above) | Telemetry + fail-closed shim. |
+| `chain_verify.sh` | (operator tool) | Verifies an audit log's hash chain; `exit 0` = intact, `exit 1` = tampered. |
+
+### Quick start
+
+```bash
+# 1. Make hooks executable
+chmod +x hooks/*.sh
+
+# 2. Provide an HMAC key for the tamper-evident audit chain
+export AUDIT_HMAC_KEY="$(openssl rand -hex 32)"   # or provision /etc/claude-code/audit-key
+
+# 3. Reference fail_closed_gates.json hooks from your .claude/settings.json
+#    (see the file's usage.setup_instructions)
+
+# 4. Verify the audit chain at any time
+bash hooks/chain_verify.sh ~/.claude/claude-code-security/audit.jsonl
+```
+
+### CloudWatch dual-write
+
+`audit_chain_logger.sh` can ship audit events to CloudWatch alongside the metrics this guidance already exports:
+
+```bash
+export CLAUDE_AUDIT_CLOUDWATCH_GROUP=/aws/claude-code/audit
+# instance/user role needs logs:CreateLogStream + logs:PutLogEvents on that group
+# optional: export CLAUDE_AUDIT_SIEM_REQUIRED=1   # refuse to run without a working forwarder
+```
+
+### Per-project vs. fleet enforcement
+
+Installed per-project, these hooks run with **your** user permissions and can be removed by the user — fine for evaluation and individual developers. For **un-removable, fleet-wide** enforcement, deploy the same hooks via `managed-settings.json` with root-owned paths. The hook logic is identical; only the trust boundary and default paths change.
+
+### Attribution
+
+Contributed via [issue #494](https://github.com/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock/issues/494). Upstream source and a 76-assertion test suite: [timwukp/claude-code-on-aws-bedrock-best-practices](https://github.com/timwukp/claude-code-on-aws-bedrock-best-practices) (Apache-2.0; this copy relicensed MIT-0 to match the repository).

--- a/assets/claude-code-plugins/plugins/security/hooks/audit_chain_logger.sh
+++ b/assets/claude-code-plugins/plugins/security/hooks/audit_chain_logger.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Audit Logger — Tamper-evident, fail-closed audit log for Claude Code
+# =============================================================================
+# Hook version: 2.0.0
+# Last updated: 2026-05-29
+# Compatible with: claude-code 2.1.150+
+# Dependencies: bash 4+, jq, openssl (HMAC), aws CLI (optional, for CloudWatch)
+# Maintainer: AWS Solutions Library (contributed via #494)
+# Change log:
+#   2.0.0 (2026-05-29) — HMAC chain, fail-closed, mandatory SIEM, CloudWatch dual-write,
+#                        prev_hash stored under /var/lib/claude-code/audit-state
+#   1.0.0 (2026-05-28) — initial release
+# =============================================================================
+# Each event line is a JSON object that includes:
+#   - prev_hash: HMAC-SHA256 of the previous event line (or "GENESIS")
+#   - hmac:      HMAC-SHA256(key, prev_hash || event_body_canonical)
+# Verifying the chain (chain_verify.sh) detects ANY post-hoc edit, deletion,
+# reorder, or insertion (the smallest tamper breaks the hash chain forward).
+#
+# Key sources (in order):
+#   1. AUDIT_HMAC_KEY env (must be set in managed-settings, NOT user-readable)
+#   2. /etc/claude-code/audit-key (root:audit 0640)
+#   3. AWS Secrets Manager (audit-hmac-key) — fetched if neither above present
+#
+# Fail-closed: if we cannot append to the local log AND cannot ship to
+# CloudWatch, exit 2 to block the tool. Audit-evasion is treated as a
+# deny-worthy condition by default. Set CLAUDE_AUDIT_FAIL_OPEN=1 to override
+# (NOT recommended in production).
+#
+# Mandatory SIEM check (P0-2):
+#   Set CLAUDE_AUDIT_SIEM_REQUIRED=1 to refuse startup unless either:
+#     - CLAUDE_AUDIT_CLOUDWATCH_GROUP is set AND aws CLI works, OR
+#     - CLAUDE_AUDIT_ALERT_CMD is set
+# =============================================================================
+
+set -u
+input=$(cat)
+
+# Defaults are user-writable for plugin / opt-in mode. For enterprise
+# fail-closed enforcement, override these in managed-settings to root-owned
+# paths (/var/log/claude-code, /var/lib/claude-code) — see the full repo.
+LOG_FILE="${CLAUDE_AUDIT_LOG:-$HOME/.claude/claude-code-security/audit.jsonl}"
+STATE_DIR="${CLAUDE_AUDIT_STATE:-$HOME/.claude/claude-code-security/audit-state}"
+CW_GROUP="${CLAUDE_AUDIT_CLOUDWATCH_GROUP:-}"
+CW_STREAM="${CLAUDE_AUDIT_CLOUDWATCH_STREAM:-$(hostname 2>/dev/null || echo unknown)}"
+ALERT_CMD="${CLAUDE_AUDIT_ALERT_CMD:-}"
+SIEM_REQ="${CLAUDE_AUDIT_SIEM_REQUIRED:-0}"
+FAIL_OPEN="${CLAUDE_AUDIT_FAIL_OPEN:-0}"
+
+mkdir -p "$(dirname "$LOG_FILE")" "$STATE_DIR" 2>/dev/null || true
+
+# --- Mandatory SIEM check -----------------------------------------------------
+if [[ "$SIEM_REQ" == "1" ]]; then
+  ok=0
+  [[ -n "$CW_GROUP" ]] && command -v aws >/dev/null 2>&1 && ok=1
+  [[ -n "$ALERT_CMD" ]] && ok=1
+  if [[ "$ok" != "1" ]]; then
+    echo "audit-logger: SIEM forwarding required but no working forwarder configured" >&2
+    [[ "$FAIL_OPEN" != "1" ]] && exit 2
+  fi
+fi
+
+# --- Resolve HMAC key ---------------------------------------------------------
+get_key() {
+  if [[ -n "${AUDIT_HMAC_KEY:-}" ]]; then printf '%s' "$AUDIT_HMAC_KEY"; return; fi
+  if [[ -r /etc/claude-code/audit-key ]]; then cat /etc/claude-code/audit-key; return; fi
+  if command -v aws >/dev/null 2>&1; then
+    aws secretsmanager get-secret-value --secret-id audit-hmac-key \
+      --query SecretString --output text 2>/dev/null && return
+  fi
+  # Final fallback: derive from hostname+install marker (NOT cryptographically
+  # secure but lets unit tests and dev environments run). Marker can be created
+  # at install time so the same machine produces a stable key.
+  if [[ -r "$STATE_DIR/key.dev" ]]; then cat "$STATE_DIR/key.dev"; return; fi
+  return 1
+}
+
+KEY=$(get_key 2>/dev/null || true)
+if [[ -z "$KEY" ]]; then
+  # Generate a dev key on first run so the chain is stable per machine
+  if command -v openssl >/dev/null 2>&1; then
+    openssl rand -hex 32 > "$STATE_DIR/key.dev" 2>/dev/null || true
+    chmod 0600 "$STATE_DIR/key.dev" 2>/dev/null || true
+    KEY=$(cat "$STATE_DIR/key.dev" 2>/dev/null || true)
+  fi
+fi
+if [[ -z "$KEY" ]]; then
+  echo "audit-logger: no HMAC key available" >&2
+  [[ "$FAIL_OPEN" != "1" ]] && exit 2
+fi
+
+# --- Parse fields -------------------------------------------------------------
+event=""; session_id=""; cwd=""; tool_name=""; command_str=""
+if command -v jq >/dev/null 2>&1; then
+  event=$(printf '%s' "$input" | jq -r '.hook_event_name // empty')
+  session_id=$(printf '%s' "$input" | jq -r '.session_id // empty')
+  cwd=$(printf '%s' "$input" | jq -r '.cwd // empty')
+  tool_name=$(printf '%s' "$input" | jq -r '.tool_name // empty')
+  case "$event" in
+    PostToolUse) command_str=$(printf '%s' "$input" | jq -r '.tool_input.command // .tool_input.file_path // empty') ;;
+    UserPromptSubmit) command_str=$(printf '%s' "$input" | jq -r '.prompt // empty' | head -c 500) ;;
+  esac
+fi
+
+ts=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ" 2>/dev/null || date -u +"%Y-%m-%dT%H:%M:%SZ")
+user=$(whoami 2>/dev/null || echo unknown)
+host=$(hostname 2>/dev/null || echo unknown)
+
+# --- Read previous hash -------------------------------------------------------
+PREV_FILE="$STATE_DIR/last-hmac"
+[[ ! -e "$PREV_FILE" ]] && echo "GENESIS" > "$PREV_FILE" 2>/dev/null
+prev_hash=$(cat "$PREV_FILE" 2>/dev/null || echo "GENESIS")
+
+# --- Build canonical body, compute HMAC ---------------------------------------
+body=$(jq -nc \
+  --arg ts "$ts" --arg user "$user" --arg host "$host" \
+  --arg event "$event" --arg session "$session_id" --arg cwd "$cwd" \
+  --arg tool "$tool_name" --arg cmd "$command_str" --arg prev "$prev_hash" \
+  '{ts:$ts,user:$user,host:$host,event:$event,session_id:$session,cwd:$cwd,tool:$tool,action:$cmd,prev_hash:$prev}')
+
+hmac=$(printf '%s' "$body" | openssl dgst -sha256 -hmac "$KEY" 2>/dev/null \
+       | awk '{print $NF}')
+if [[ -z "$hmac" ]]; then
+  echo "audit-logger: HMAC computation failed" >&2
+  [[ "$FAIL_OPEN" != "1" ]] && exit 2
+fi
+
+entry=$(printf '%s' "$body" | jq -c --arg h "$hmac" '. + {hmac:$h}')
+
+# --- Write locally (best-effort) ---------------------------------------------
+local_ok=0
+if echo "$entry" >> "$LOG_FILE" 2>/dev/null; then
+  echo "$hmac" > "$PREV_FILE" 2>/dev/null
+  local_ok=1
+fi
+# Try fallback path if root path failed
+if [[ "$local_ok" != "1" ]]; then
+  fb="$HOME/.claude/audit-fallback.jsonl"
+  mkdir -p "$(dirname "$fb")" 2>/dev/null || true
+  if echo "$entry" >> "$fb" 2>/dev/null; then
+    echo "$hmac" > "$PREV_FILE" 2>/dev/null
+    local_ok=1
+  fi
+fi
+
+# --- Ship to CloudWatch (best-effort) ----------------------------------------
+cw_ok=0
+if [[ -n "$CW_GROUP" ]] && command -v aws >/dev/null 2>&1; then
+  ts_ms=$(python3 -c 'import time;print(int(time.time()*1000))' 2>/dev/null || echo 0)
+  aws logs put-log-events \
+    --log-group-name "$CW_GROUP" --log-stream-name "$CW_STREAM" \
+    --log-events "timestamp=$ts_ms,message=$(printf '%s' "$entry" | sed 's/"/\\"/g')" \
+    >/dev/null 2>&1 && cw_ok=1
+fi
+
+# --- Optional alert webhook --------------------------------------------------
+if [[ -n "$ALERT_CMD" ]]; then
+  printf '%s\n' "$entry" | bash -c "$ALERT_CMD" >/dev/null 2>&1 || true
+fi
+
+# --- Fail-closed if both local AND remote failed ------------------------------
+if [[ "$local_ok" != "1" && "$cw_ok" != "1" ]]; then
+  echo "audit-logger: cannot persist event locally or remotely; blocking tool" >&2
+  [[ "$FAIL_OPEN" != "1" ]] && exit 2
+fi
+
+exit 0

--- a/assets/claude-code-plugins/plugins/security/hooks/chain_verify.sh
+++ b/assets/claude-code-plugins/plugins/security/hooks/chain_verify.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Verify the HMAC chain in an audit log. Exits 0 if intact, 1 if broken.
+# Usage: chain_verify.sh <log-file> [--key-file <path>]
+set -u
+LOG="${1:-}"
+KEY_FILE="${2:-}"
+[[ -z "$LOG" || ! -r "$LOG" ]] && { echo "usage: $0 <log> [--key-file path]"; exit 2; }
+
+if [[ -n "${AUDIT_HMAC_KEY:-}" ]]; then
+  KEY="$AUDIT_HMAC_KEY"
+elif [[ -n "$KEY_FILE" && -r "$KEY_FILE" ]]; then
+  KEY=$(cat "$KEY_FILE")
+elif [[ -r /etc/claude-code/audit-key ]]; then
+  KEY=$(cat /etc/claude-code/audit-key)
+elif [[ -r "${CLAUDE_AUDIT_STATE:-$HOME/.claude/claude-code-security/audit-state}/key.dev" ]]; then
+  KEY=$(cat "${CLAUDE_AUDIT_STATE:-$HOME/.claude/claude-code-security/audit-state}/key.dev")
+else
+  echo "no key" >&2; exit 2
+fi
+
+prev="GENESIS"
+n=0; bad=0
+while IFS= read -r line; do
+  n=$((n+1))
+  body=$(printf '%s' "$line" | jq -c 'del(.hmac)')
+  expected=$(printf '%s' "$line" | jq -r '.hmac')
+  prev_in=$(printf '%s' "$line" | jq -r '.prev_hash')
+  if [[ "$prev_in" != "$prev" ]]; then
+    echo "line $n: prev_hash mismatch (expected $prev, got $prev_in)" >&2
+    bad=1
+  fi
+  computed=$(printf '%s' "$body" | openssl dgst -sha256 -hmac "$KEY" | awk '{print $NF}')
+  if [[ "$computed" != "$expected" ]]; then
+    echo "line $n: hmac mismatch" >&2
+    bad=1
+  fi
+  prev="$expected"
+done < "$LOG"
+
+if [[ "$bad" == "1" ]]; then
+  echo "CHAIN BROKEN ($n lines verified, failures detected)"; exit 1
+else
+  echo "chain intact ($n lines verified)"; exit 0
+fi

--- a/assets/claude-code-plugins/plugins/security/hooks/fail_closed_gates.json
+++ b/assets/claude-code-plugins/plugins/security/hooks/fail_closed_gates.json
@@ -1,0 +1,103 @@
+{
+  "name": "Fail-Closed Security Gates Configuration",
+  "description": "Fail-closed enforcement hooks: PII/secrets prompt guard, tamper-evident HMAC-chained audit log with optional CloudWatch dual-write, and a per-session token-budget circuit breaker. All hooks run through hook_wrapper.sh, which converts silent hook crashes/timeouts into explicit denials (exit 2) so a broken control fails safe instead of failing open. Complements security_gates.json (file-write and bash-command validation).",
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/hooks/hook_wrapper.sh $CLAUDE_PROJECT_DIR/hooks/pii_prompt_guard.sh",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/hooks/hook_wrapper.sh $CLAUDE_PROJECT_DIR/hooks/audit_chain_logger.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/hooks/hook_wrapper.sh $CLAUDE_PROJECT_DIR/hooks/pii_prompt_guard.sh",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/hooks/hook_wrapper.sh $CLAUDE_PROJECT_DIR/hooks/token_budget_guard.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/hooks/hook_wrapper.sh $CLAUDE_PROJECT_DIR/hooks/audit_chain_logger.sh",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/hooks/hook_wrapper.sh $CLAUDE_PROJECT_DIR/hooks/token_budget_guard.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  },
+  "configuration": {
+    "fail_closed": true,
+    "telemetry_log": "~/.claude/claude-code-security/hooks.jsonl (override: CLAUDE_HOOK_TELEMETRY)",
+    "audit_log": "~/.claude/claude-code-security/audit.jsonl (override: CLAUDE_AUDIT_LOG)",
+    "token_budget_default": 1000000,
+    "call_budget_default": 500
+  },
+  "cloudwatch_integration": {
+    "description": "audit_chain_logger.sh can dual-write audit events to the CloudWatch logging this guidance provisions, keeping agent-action audit alongside the existing /aws/claude-code/metrics telemetry.",
+    "setup": [
+      "1. Create or choose a log group, e.g. /aws/claude-code/audit",
+      "2. export CLAUDE_AUDIT_CLOUDWATCH_GROUP=/aws/claude-code/audit",
+      "3. Ensure the instance/user role allows logs:CreateLogStream and logs:PutLogEvents on that group",
+      "4. Optional: set CLAUDE_AUDIT_SIEM_REQUIRED=1 to refuse startup without a working forwarder"
+    ]
+  },
+  "usage": {
+    "description": "Fail-closed enforcement layer for prompts, agent actions, and session budgets",
+    "setup_instructions": [
+      "1. Copy hook_wrapper.sh, pii_prompt_guard.sh, audit_chain_logger.sh, token_budget_guard.sh, chain_verify.sh to your project hooks/ directory",
+      "2. Make scripts executable: chmod +x hooks/*.sh",
+      "3. Add the hooks configuration above to your .claude/settings.json",
+      "4. Set AUDIT_HMAC_KEY (or provision /etc/claude-code/audit-key) for the tamper-evident chain",
+      "5. Verify the audit chain anytime: bash hooks/chain_verify.sh ~/.claude/claude-code-security/audit.jsonl"
+    ],
+    "testing": {
+      "pii_guard": [
+        "claude 'my AWS key is AKIAIOSFODNN7EXAMPLE'  # Should block before reaching the model",
+        "claude 'summarize this design doc'  # Should pass"
+      ],
+      "audit_chain": [
+        "bash hooks/chain_verify.sh ~/.claude/claude-code-security/audit.jsonl  # exit 0 = intact",
+        "sed -i '2d' ~/.claude/claude-code-security/audit.jsonl && bash hooks/chain_verify.sh ...  # exit 1 = tamper detected"
+      ],
+      "token_budget": [
+        "CLAUDE_TOKEN_BUDGET=1000 claude '<long agentic task>'  # Should trip the circuit breaker"
+      ]
+    }
+  },
+  "customization": {
+    "pii_prompt_guard_sh": "Each PII/secret pattern is one LABEL:::REGEX line — comment out to disable a region (covers US SSN/ITIN, UK NINO/NHS, JP My Number, KR RRN, SG NRIC/FIN, EU IBAN, AU TFN/Medicare, plus AWS keys, private keys, JWTs, DB strings, credit cards)",
+    "audit_chain_logger_sh": "Key sources: AUDIT_HMAC_KEY env, /etc/claude-code/audit-key, or AWS Secrets Manager; set CLAUDE_AUDIT_FAIL_OPEN=1 to soften (not recommended)",
+    "token_budget_guard_sh": "CLAUDE_TOKEN_BUDGET and CLAUDE_CALL_BUDGET env vars",
+    "hook_wrapper_sh": "CLAUDE_HOOK_TIMEOUT_MS (default 5000); telemetry path via CLAUDE_HOOK_TELEMETRY"
+  },
+  "enterprise_note": "Installed per-project these hooks run with user permissions and can be removed by the user — appropriate for evaluation and individual developers. For un-removable fleet-wide enforcement, deploy the same hooks via managed-settings.json with root-owned paths.",
+  "note": "Contributed via issue #494. Upstream source and 76-assertion test suite: https://github.com/timwukp/claude-code-on-aws-bedrock-best-practices (Apache-2.0; this copy relicensed MIT to match the repository)."
+}

--- a/assets/claude-code-plugins/plugins/security/hooks/hook_wrapper.sh
+++ b/assets/claude-code-plugins/plugins/security/hooks/hook_wrapper.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Hook Telemetry Shim — wraps any hook to emit start/end JSON to a telemetry log.
+# =============================================================================
+# Hook version: 1.0.0
+# Last updated: 2026-05-29
+# Purpose: Make hook execution observable so SREs can detect crashes, latency
+#          regressions, and silent failures (the original audit-logger had
+#          `exit 0` even on failure which masked real issues).
+#
+# Usage in managed-settings.json hooks block:
+#   "command": "/usr/local/etc/claude-code/hooks/hook_wrapper.sh /usr/local/etc/claude-code/hooks/pii_prompt_guard.sh"
+#
+# Output: appends to $CLAUDE_HOOK_TELEMETRY (default /var/log/claude-code/hooks.jsonl)
+#         each line: {ts, host, user, hook, event, session, duration_ms, exit_code, status}
+#
+# Status:
+#   ok        — exit 0
+#   blocked   — exit 2 (policy block, expected)
+#   crashed   — exit other / non-zero with stderr captured (fail-closed)
+#   timeout   — exceeded $CLAUDE_HOOK_TIMEOUT_MS
+#
+# Fail-closed contract: if the wrapped hook crashes (exit != 0/2), we exit 2 to
+# block the tool. This converts silent hook failures into explicit denials, so
+# operators get an alert instead of a silent miss.
+# =============================================================================
+
+set -u
+HOOK="${1:-}"
+[[ -z "$HOOK" || ! -x "$HOOK" ]] && {
+  echo "hook-wrapper: missing or non-executable hook: $HOOK" >&2
+  exit 2
+}
+shift
+
+# Default is user-writable for plugin / opt-in mode; override in managed-settings
+# to a root-owned path (/var/log/claude-code/hooks.jsonl) for enterprise SRE observability.
+TELEMETRY="${CLAUDE_HOOK_TELEMETRY:-$HOME/.claude/claude-code-security/hooks.jsonl}"
+TIMEOUT_MS="${CLAUDE_HOOK_TIMEOUT_MS:-5000}"
+mkdir -p "$(dirname "$TELEMETRY")" 2>/dev/null || true
+[[ ! -e "$TELEMETRY" ]] && touch "$TELEMETRY" 2>/dev/null
+
+# Buffer stdin so we can both read it (extract event/session) and pass to hook
+input=$(cat)
+event=""
+session=""
+if command -v jq >/dev/null 2>&1; then
+  event=$(printf '%s' "$input" | jq -r '.hook_event_name // empty' 2>/dev/null || true)
+  session=$(printf '%s' "$input" | jq -r '.session_id // empty' 2>/dev/null || true)
+fi
+
+now_ms() { python3 -c 'import time;print(int(time.time()*1000))'; }
+start_ms=$(now_ms)
+
+# Invoke hook with timeout. macOS has no `timeout` by default; use Python.
+tmpout=$(mktemp); tmperr=$(mktemp)
+hook_name=$(basename "$HOOK")
+
+run_with_timeout() {
+  python3 - "$TIMEOUT_MS" "$HOOK" "$tmpout" "$tmperr" <<'PY' "$@"
+import os, sys, subprocess
+timeout_ms, hook = int(sys.argv[1]), sys.argv[2]
+out_path, err_path = sys.argv[3], sys.argv[4]
+extra = sys.argv[5:]
+data = sys.stdin.read()
+try:
+    p = subprocess.run([hook]+extra, input=data, timeout=timeout_ms/1000.0,
+                       capture_output=True, text=True)
+    open(out_path,'w').write(p.stdout)
+    open(err_path,'w').write(p.stderr)
+    sys.exit(p.returncode)
+except subprocess.TimeoutExpired:
+    open(err_path,'w').write(f'hook timeout after {timeout_ms}ms')
+    sys.exit(124)
+PY
+}
+
+printf '%s' "$input" | run_with_timeout "$@"
+rc=$?
+end_ms=$(now_ms)
+duration_ms=$((end_ms - start_ms))
+
+case "$rc" in
+  0)   status="ok" ;;
+  2)   status="blocked" ;;
+  124) status="timeout" ;;
+  *)   status="crashed" ;;
+esac
+
+# Emit telemetry (best-effort; never block on this)
+ts=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ" 2>/dev/null || date -u +"%Y-%m-%dT%H:%M:%SZ")
+host=$(hostname 2>/dev/null || echo unknown)
+user=$(whoami 2>/dev/null || echo unknown)
+err_excerpt=$(head -c 300 "$tmperr" 2>/dev/null || true)
+
+if command -v jq >/dev/null 2>&1; then
+  jq -nc \
+    --arg ts "$ts" --arg host "$host" --arg user "$user" \
+    --arg hook "$hook_name" --arg event "$event" --arg session "$session" \
+    --argjson duration "$duration_ms" --argjson exit "$rc" \
+    --arg status "$status" --arg err "$err_excerpt" \
+    '{ts:$ts,host:$host,user:$user,hook:$hook,event:$event,session_id:$session,duration_ms:$duration,exit_code:$exit,status:$status,stderr:$err}' \
+    >> "$TELEMETRY" 2>/dev/null || true
+fi
+
+# Pass stdout/stderr through to caller
+cat "$tmpout"
+cat "$tmperr" >&2
+rm -f "$tmpout" "$tmperr"
+
+# Fail-closed: convert crash/timeout into block (exit 2)
+case "$rc" in
+  0|2) exit "$rc" ;;
+  *)   exit 2 ;;
+esac

--- a/assets/claude-code-plugins/plugins/security/hooks/pii_prompt_guard.sh
+++ b/assets/claude-code-plugins/plugins/security/hooks/pii_prompt_guard.sh
@@ -1,0 +1,214 @@
+#!/bin/bash
+# =============================================================================
+# PII & Secrets Guard Hook for Claude Code
+# =============================================================================
+# Hook version: 2.0.1
+# Last updated: 2026-06-01
+# Compatible with: claude-code 2.1.150+
+# Dependencies: bash 4+, jq (preferred), grep, sed
+# Maintainer: AWS Solutions Library (contributed via #494)
+# Change log:
+#   2.0.1 (2026-06-01) — fix false positive: hyphenated UUID segments no longer
+#                         match CREDIT_CARD_16/AMEX or JP_MYNUMBER (boundary
+#                         classes now exclude '-')
+#   2.0.0 (2026-06-01) — multi-country national identifiers: US (SSN/ITIN),
+#                         UK (NINO, NHS), Japan (My Number), South Korea (RRN),
+#                         Singapore (NRIC/FIN), EU (IBAN), Australia (TFN, Medicare)
+#   1.0.0 (2026-05-28) — initial release: 15 PII/secret patterns
+# =============================================================================
+# Note on false positives: purely-numeric national IDs (e.g. JP My Number,
+# AU TFN/Medicare) are matched in their conventional separator-grouped form to
+# limit false positives, since ERE (grep -E) has no lookahead. All patterns are
+# configurable — comment out any LABEL:::REGEX line below to disable a region.
+# =============================================================================
+# Scans user prompts and tool inputs for sensitive data BEFORE they reach the
+# model. Blocks the request if PII or secrets are detected.
+#
+# Hook events supported:
+#   - UserPromptSubmit: scans user prompt text
+#   - PreToolUse: scans tool_input (file content being written, commands, etc.)
+#
+# Exit codes:
+#   0 = clean, allow through
+#   2 = sensitive data detected, BLOCK (stderr shown to user)
+#
+# Default deploy: referenced from security_gates.json via $CLAUDE_PROJECT_DIR/hooks/
+# Ownership: root:root 0755
+# =============================================================================
+
+set -u
+input=$(cat)
+
+# Extract the text to scan based on hook event
+if command -v jq >/dev/null 2>&1; then
+  event=$(printf '%s' "$input" | jq -r '.hook_event_name // empty')
+  case "$event" in
+    UserPromptSubmit)
+      text=$(printf '%s' "$input" | jq -r '.prompt // empty')
+      ;;
+    PreToolUse)
+      # Scan the entire tool_input as a string (catches file content, commands, etc.)
+      text=$(printf '%s' "$input" | jq -r '.tool_input | tostring')
+      ;;
+    *)
+      exit 0
+      ;;
+  esac
+else
+  # Fallback without jq: scan entire input
+  text="$input"
+fi
+
+# If text is empty or too short, skip
+if [[ ${#text} -lt 8 ]]; then
+  exit 0
+fi
+
+# =============================================================================
+# DETECTION PATTERNS
+# Each pattern: "LABEL:::REGEX"
+# =============================================================================
+patterns=(
+  # Credit card numbers — Visa/MC/Discover/JCB (16 digit, 4-4-4-4) and Amex (15 digit, 4-6-5)
+  # Standard: ISO/IEC 7812-1 (issuer numbering + Luhn/mod-10 check); industry rule PCI DSS.
+  # Boundaries exclude '-' so hyphenated UUID segments (8-4-4-4-12) don't false-match.
+  "CREDIT_CARD_16:::(^|[^0-9-])[3-6][0-9]{3}[- ]?[0-9]{4}[- ]?[0-9]{4}[- ]?[0-9]{4}([^0-9-]|$)"
+  "CREDIT_CARD_AMEX:::(^|[^0-9-])3[47][0-9]{2}[- ]?[0-9]{6}[- ]?[0-9]{5}([^0-9-]|$)"
+
+  # AWS Access Key ID
+  "AWS_ACCESS_KEY:::AKIA[0-9A-Z]{16}"
+
+  # AWS Secret Access Key (40 chars base64-ish after common prefixes)
+  "AWS_SECRET_KEY:::['\"][0-9a-zA-Z/+=]{40}['\"]"
+
+  # Generic API key patterns. NOTE: putting '-' at end of class avoids ERE range parse.
+  "API_KEY_ASSIGNMENT:::(api[_-]?key|api[_-]?secret|access[_-]?token|auth[_-]?token|secret[_-]?key)[ ]*[:=][ ]*['\"]?[A-Za-z0-9_/.+=-]{20,}['\"]?"
+
+  # Private key header
+  "PRIVATE_KEY:::-----BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----"
+
+  # JWT token (3 base64url segments separated by dots). '-' placed at end of class.
+  "JWT_TOKEN:::eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}"
+
+  # Database connection strings
+  "DB_CONNECTION_STRING:::(mongodb(\+srv)?|postgres(ql)?|mysql|mssql|redis|amqp)://[^ '\"]{10,}"
+
+  # Password in common assignment formats
+  "PASSWORD_ASSIGNMENT:::(password|passwd|pwd|pass)[ ]*[:=][ ]*['\"]?[^ '\"]{8,}['\"]?"
+
+  # --- National identifiers (multi-country) --------------------------------
+  # Each line can be disabled by commenting it out. Format authority cited per
+  # region (the body that issues/defines the number). Full compliance mapping
+  # (data-protection & financial regulators) is in README.md. These patterns
+  # validate FORMAT only (digit count / grouping), not government check-digit
+  # algorithms — several of which (AU TFN/Medicare, SG NRIC, KR RRN) are not
+  # officially published. Links are official sources; re-verify before relying.
+
+  # United States — SSN (AAA-GG-SSSS), no check digit.
+  # Authority: Social Security Administration — ssa.gov/employer/structure.html
+  # (legal basis 20 CFR 422.103). Require grouping to avoid bare 9-digit IDs.
+  "US_SSN:::(^|[^0-9])[0-9]{3}[- ][0-9]{2}[- ][0-9]{4}([^0-9]|$)"
+  # United States — ITIN (9XX-7X/8X-XXXX).
+  # Authority: IRS, Instructions for Form W-7 — irs.gov/instructions/iw7
+  "US_ITIN:::(^|[^0-9])9[0-9]{2}[- ](7[0-9]|8[0-8])[- ][0-9]{4}([^0-9]|$)"
+
+  # United Kingdom — National Insurance Number (2 letters, 6 digits, suffix A-D).
+  # Authority: HMRC/DWP via GOV.UK — gov.uk/national-insurance/your-national-insurance-number
+  "UK_NINO:::(^|[^A-Za-z0-9])[A-CEGHJ-PR-TW-Z]{2}[0-9]{6}[A-D]([^A-Za-z0-9]|$)"
+  # United Kingdom — NHS number (10 digits, 3-3-4; Modulus-11 check, published).
+  # Authority: NHS England Data Dictionary — datadictionary.nhs.uk/attributes/nhs_number.html
+  "UK_NHS:::(^|[^0-9])[0-9]{3}[- ][0-9]{3}[- ][0-9]{4}([^0-9]|$)"
+
+  # Japan — My Number (個人番号), 12 digits, conventionally grouped 4-4-4.
+  # Authority: Digital Agency / J-LIS — digital.go.jp/policies/mynumber
+  # Boundaries exclude '-' so hyphenated UUID segments don't false-match.
+  "JP_MYNUMBER:::(^|[^0-9-])[0-9]{4}[- ][0-9]{4}[- ][0-9]{4}([^0-9-]|$)"
+
+  # South Korea — Resident Registration Number (RRN), YYMMDD-Sxxxxxx (13 digits).
+  # Authority: Ministry of the Interior and Safety (MOIS) — mois.go.kr
+  "KR_RRN:::(^|[^0-9])[0-9]{6}[- ][1-4][0-9]{6}([^0-9]|$)"
+
+  # Singapore — NRIC/FIN (prefix + 7 digits + check letter).
+  # Authority: Immigration & Checkpoints Authority (ICA) — ica.gov.sg
+  "SG_NRIC:::[STFGM][0-9]{7}[A-Z]"
+
+  # European Union — IBAN (country code + 2 check digits + BBAN; mod-97 published).
+  # Standard: ISO 13616, registry by SWIFT — swift.com/standards/data-standards/iban-international-bank-account-number
+  "EU_IBAN:::(^|[^A-Za-z0-9])(AT|BE|BG|HR|CY|CZ|DK|EE|FI|FR|DE|GR|HU|IE|IT|LV|LT|LU|MT|NL|PL|PT|RO|SK|SI|ES|SE)[0-9]{2}[ ]?([0-9A-Z]{4}[ ]?){2,7}[0-9A-Z]{1,4}"
+
+  # Australia — Tax File Number (8-9 digits, 3-3-3) and Medicare (10 digits, 4-5-1).
+  # Authority: Australian Taxation Office — ato.gov.au/individuals-and-families/tax-file-number
+  #            Services Australia — servicesaustralia.gov.au/your-medicare-card
+  "AU_TFN:::(^|[^0-9])[0-9]{3}[- ][0-9]{3}[- ][0-9]{3}([^0-9]|$)"
+  "AU_MEDICARE:::(^|[^0-9])[0-9]{4}[- ][0-9]{5}[- ][0-9]([^0-9]|$)"
+
+  # Email
+  "EMAIL_ADDRESS:::[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}"
+
+  # Phone numbers (international, allows internal spaces or hyphens between digit groups)
+  "PHONE_INTL:::\+[0-9]{1,3}([-. ][0-9]{2,5}){2,4}"
+
+  # Passport numbers
+  "PASSPORT_NUMBER:::[A-Z]{1,2}[0-9]{6,9}"
+
+  # GitHub/GitLab tokens
+  "GIT_TOKEN:::(ghp_[A-Za-z0-9]{36}|glpat-[A-Za-z0-9-]{20,})"
+
+  # Slack tokens
+  "SLACK_TOKEN:::xox[bpras]-[0-9]{10,}-[A-Za-z0-9-]+"
+
+  # Generic hex secrets — 32+ hex chars containing at least one a-f letter
+  # (rejects pure-decimal IDs and 0b binary literals which would otherwise match [0-9a-f]+).
+  "HEX_SECRET:::(^|[^A-Za-z0-9_])[0-9a-f]*[a-f][0-9a-f]*[a-f][0-9a-f]{28,}([^A-Za-z0-9_]|$)"
+)
+
+# =============================================================================
+# SCAN
+# =============================================================================
+detected=()
+
+for entry in "${patterns[@]}"; do
+  label="${entry%%:::*}"
+  regex="${entry#*:::}"
+  # Identifiers whose letters are defined uppercase — match case-sensitive to
+  # avoid e.g. lowercase IBAN country prefixes inflating false positives.
+  case "$label" in
+    PASSPORT_NUMBER|SG_NRIC|AWS_ACCESS_KEY|UK_NINO|EU_IBAN)
+      if echo "$text" | grep -qE -- "$regex"; then
+        detected+=("$label")
+      fi
+      ;;
+    *)
+      if echo "$text" | grep -qiE -- "$regex"; then
+        detected+=("$label")
+      fi
+      ;;
+  esac
+done
+
+# =============================================================================
+# RESULT
+# =============================================================================
+if [[ ${#detected[@]} -gt 0 ]]; then
+  matches=$(IFS=', '; echo "${detected[*]}")
+  cat >&2 <<EOF
+🚨 PII/SECRETS GUARD: Sensitive data detected — request BLOCKED before reaching the model.
+
+Detected patterns: $matches
+
+This content contains what appears to be sensitive information (credentials,
+PII, or secrets). To protect against data leakage, this request has been
+blocked at the hook layer and was NOT sent to the AI model.
+
+Actions:
+  • Remove the sensitive data from your prompt or file content
+  • Use environment variables or secret references instead of literal values
+  • If this is a false positive, contact your IT security team to adjust
+    the detection patterns in the PII guard hook
+
+Hook: pii_prompt_guard.sh | Event: $event
+EOF
+  exit 2
+fi
+
+exit 0

--- a/assets/claude-code-plugins/plugins/security/hooks/token_budget_guard.sh
+++ b/assets/claude-code-plugins/plugins/security/hooks/token_budget_guard.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Token Budget Guard — circuit breaker for runaway agent loops
+# =============================================================================
+# Hook version: 1.0.0
+# Hook events: PreToolUse (decides whether to allow next tool call)
+#              PostToolUse (records actual token usage if available)
+#
+# Maintains per-session running token totals at:
+#   $CLAUDE_TOKEN_STATE/<session_id>.tokens     (cumulative input+output)
+#   $CLAUDE_TOKEN_STATE/<session_id>.calls      (tool call count)
+#
+# When either threshold is exceeded the next PreToolUse blocks with exit 2,
+# requiring a fresh session.
+#
+# Configuration (env, set in managed-settings):
+#   CLAUDE_TOKEN_STATE     — state directory (default /var/lib/claude-code/sessions)
+#   CLAUDE_TOKEN_BUDGET    — max cumulative tokens per session (default 1000000)
+#   CLAUDE_CALL_BUDGET     — max tool calls per session (default 500)
+#
+# This is the circuit breaker for ungoverned agent loops the architect review
+# flagged. Agents that legitimately need more should request budget increase.
+# =============================================================================
+
+set -u
+input=$(cat)
+
+# Default is user-writable for plugin / opt-in mode; override in managed-settings
+# to a root-owned path (/var/lib/claude-code/sessions) for enterprise enforcement.
+STATE_DIR="${CLAUDE_TOKEN_STATE:-$HOME/.claude/claude-code-security/sessions}"
+TOKEN_BUDGET="${CLAUDE_TOKEN_BUDGET:-1000000}"
+CALL_BUDGET="${CLAUDE_CALL_BUDGET:-500}"
+mkdir -p "$STATE_DIR" 2>/dev/null || true
+
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0  # jq missing → cannot enforce; pass through
+fi
+
+session=$(printf '%s' "$input" | jq -r '.session_id // empty')
+event=$(printf '%s' "$input"   | jq -r '.hook_event_name // empty')
+[[ -z "$session" ]] && exit 0
+
+token_file="$STATE_DIR/${session}.tokens"
+call_file="$STATE_DIR/${session}.calls"
+[[ ! -e "$token_file" ]] && echo 0 > "$token_file" 2>/dev/null
+[[ ! -e "$call_file"  ]] && echo 0 > "$call_file"  2>/dev/null
+
+cur_tokens=$(cat "$token_file" 2>/dev/null || echo 0)
+cur_calls=$(cat "$call_file"  2>/dev/null || echo 0)
+
+case "$event" in
+  PreToolUse)
+    # Block if either budget exhausted
+    if [[ "$cur_tokens" -ge "$TOKEN_BUDGET" ]]; then
+      cat >&2 <<EOF
+🛑 TOKEN BUDGET GUARD: session $session has consumed $cur_tokens tokens
+   (budget: $TOKEN_BUDGET). Tool execution blocked.
+
+This protects against runaway agent loops. Start a new session, or contact
+your team lead to request a temporary budget increase.
+EOF
+      exit 2
+    fi
+    if [[ "$cur_calls" -ge "$CALL_BUDGET" ]]; then
+      cat >&2 <<EOF
+🛑 TOKEN BUDGET GUARD: session $session has executed $cur_calls tool calls
+   (budget: $CALL_BUDGET). Tool execution blocked.
+EOF
+      exit 2
+    fi
+    # Increment call counter; we do not have token usage at PreToolUse time
+    echo $((cur_calls + 1)) > "$call_file" 2>/dev/null
+    ;;
+
+  PostToolUse)
+    # Token totals — Claude Code reports usage in tool_response.usage if available
+    in_tokens=$(printf '%s' "$input" | jq -r '.tool_response.usage.input_tokens // 0' 2>/dev/null)
+    out_tokens=$(printf '%s' "$input" | jq -r '.tool_response.usage.output_tokens // 0' 2>/dev/null)
+    delta=$((in_tokens + out_tokens))
+    if [[ "$delta" -gt 0 ]]; then
+      echo $((cur_tokens + delta)) > "$token_file" 2>/dev/null
+    fi
+    ;;
+esac
+
+exit 0


### PR DESCRIPTION
Implements #494 (scoped follow-up to #419, opened at maintainer @wirjo's suggestion).

## What this adds

The guidance already ships a `security` plugin (4 agents + `security_gates.json` file/command checks). This PR adds the **fail-closed enforcement layer** the guidance currently stops short of — controls on *what the agent does*, at the hook layer — without touching anything that already exists.

New under `assets/claude-code-plugins/plugins/security/hooks/`, wired through a new `fail_closed_gates.json`:

| Hook | Events | Enforces |
|---|---|---|
| `pii_prompt_guard.sh` | UserPromptSubmit, PreToolUse | Blocks secrets (AWS keys, private keys, JWTs, DB strings, credit cards) and national IDs (US/UK/JP/KR/SG/EU/AU) **before they reach the model**; every pattern individually disable-able |
| `audit_chain_logger.sh` | UserPromptSubmit, PostToolUse | Tamper-evident **HMAC-SHA256 hash-chained** JSONL audit log, with optional dual-write to the **CloudWatch** logging this guidance already provisions |
| `token_budget_guard.sh` | PreToolUse, PostToolUse | Per-session token/call **circuit breaker** against runaway agent loops |
| `hook_wrapper.sh` | wraps the above | Converts silent hook crashes/timeouts into explicit `exit 2` denials — a broken control fails **safe**, not open |
| `chain_verify.sh` | operator tool | Verifies the audit chain (`exit 0` intact / `exit 1` tampered) |

## Scope & compatibility

- **Additive only.** `security_gates.json`, `security_check.py`, `command_security_check.sh`, and the 4 agents are untouched. New behavior lives in a separate `fail_closed_gates.json` you opt into.
- Plugin + marketplace entry bumped `1.0.0 → 1.1.0`.
- Follows the existing plugin layout and `$CLAUDE_PROJECT_DIR/hooks/...` convention; snake_case filenames to match the directory.

## Testing

Smoke-tested locally: PII guard blocks an AWS key (exit 2) and passes benign prompts (exit 0); the wrapper turns a crashing hook into exit 2 (fail-closed); the audit chain writes HMAC-linked entries that verify intact (exit 0) and a deleted line is caught as tampered (exit 1). Upstream source carries a 76-assertion suite: https://github.com/timwukp/claude-code-on-aws-bedrock-best-practices

## Licensing

Source is Apache-2.0; as offered in #494 I'm contributing this copy under **MIT-0** to match the repository. Happy to scope down further (e.g. audit-to-CloudWatch hook only) if you'd prefer a smaller first addition.