### PR TITLE
feat: add Claude Fable 5 model support

### DIFF
--- a/source/claude_code_with_bedrock/models.py
+++ b/source/claude_code_with_bedrock/models.py
@@ -913,6 +913,52 @@ _CLAUDE_MODELS_RAW = {
             },
         },
     },
+    "fable-5": {
+        "name": "Claude Fable 5",
+        "base_model_id": "anthropic.claude-fable-5",
+        "profiles": {
+            "us": {
+                "model_id": "us.anthropic.claude-fable-5",
+                "description": "US CRIS - US and Canada regions",
+                "source_regions": [
+                    "us-east-1", "us-east-2", "us-west-1", "us-west-2",
+                    "ca-central-1", "ca-west-1",
+                ],
+                "destination_regions": [
+                    "us-east-1", "us-east-2", "us-west-1", "us-west-2",
+                    "ca-central-1", "ca-west-1",
+                ],
+            },
+            "global": {
+                "model_id": "global.anthropic.claude-fable-5",
+                "description": "Global CRIS - All commercial AWS regions worldwide",
+                "source_regions": [
+                    "us-east-1", "us-east-2", "us-west-1", "us-west-2",
+                    "ca-central-1", "ca-west-1",
+                    "eu-central-1", "eu-central-2", "eu-north-1",
+                    "eu-south-1", "eu-south-2", "eu-west-1", "eu-west-2", "eu-west-3",
+                    "ap-northeast-1", "ap-northeast-2", "ap-northeast-3",
+                    "ap-south-1", "ap-south-2",
+                    "ap-southeast-1", "ap-southeast-2", "ap-southeast-3", "ap-southeast-4",
+                    "me-south-1", "me-central-1",
+                    "af-south-1", "il-central-1", "sa-east-1",
+                ],
+                "destination_regions": ["all-commercial"],
+            },
+            "eu": {
+                "model_id": "eu.anthropic.claude-fable-5",
+                "description": "EU CRIS - European regions",
+                "source_regions": [
+                    "eu-central-1", "eu-central-2", "eu-north-1",
+                    "eu-south-1", "eu-south-2", "eu-west-1", "eu-west-3",
+                ],
+                "destination_regions": [
+                    "eu-central-1", "eu-central-2", "eu-north-1",
+                    "eu-south-1", "eu-south-2", "eu-west-1", "eu-west-3",
+                ],
+            },
+        },
+    },
     "sonnet-3-7-govcloud": {
         "name": "Claude 3.7 Sonnet (GovCloud)",
         "base_model_id": "anthropic.claude-3-7-sonnet-20250219-v1:0",
@@ -1300,6 +1346,7 @@ MODEL_TIER_PREFERENCES = {
     "haiku": ["haiku-4-5", "sonnet-4-6", "sonnet-4-5", "sonnet-4", "sonnet-3-7"],
     "sonnet": ["sonnet-4-6", "sonnet-4-5", "sonnet-4", "sonnet-3-7"],
     "opus": ["opus-4-8", "opus-4-7", "opus-4-6", "opus-4-5", "opus-4-1", "opus-4"],
+    "fable": ["fable-5"],
 }
 
 
@@ -1328,13 +1375,14 @@ TIER_TO_CLAUDE_CODE_ALIAS: dict[str, str] = {
     "sonnet": "sonnet",
     "opus": "opus",
     "haiku": "haiku",
+    "fable": "fable",
 }
 
 
 def get_claude_code_alias(model_id: str) -> str | None:
     """Given a full CRIS model ID, return the Claude Code tier alias.
 
-    Returns 'sonnet', 'opus', 'haiku', or None if model is unrecognised.
+    Returns 'sonnet', 'opus', 'haiku', 'fable', or None if model is unrecognised.
     Callers may override the returned alias (e.g. replace 'opus' with
     'opusplan') based on user preference stored in the profile.
     """
@@ -1357,7 +1405,7 @@ def resolve_model_for_tier(tier: str, cris_prefix: str) -> str | None:
     to avoid silently breaking data residency requirements.
 
     Args:
-        tier: 'haiku', 'sonnet', or 'opus'
+        tier: 'haiku', 'sonnet', 'opus', or 'fable'
         cris_prefix: e.g. 'eu', 'europe', 'us', 'global', 'au', 'apac', 'japan'
 
     Returns:
@@ -1381,8 +1429,8 @@ def resolve_model_for_tier(tier: str, cris_prefix: str) -> str | None:
     # e.g. jp.opus doesn't exist → fall back to jp.sonnet-4-6.
     if resolved_prefix in DATA_RESIDENCY_PREFIXES:
         # Search all models (newest first) for ANY model with this prefix
-        all_model_keys = ["sonnet-4-6", "sonnet-4-5", "sonnet-4", "opus-4-6", "opus-4-5",
-                          "haiku-4-5", "sonnet-3-7", "opus-4-1", "opus-4"]
+        all_model_keys = ["opus-4-8", "opus-4-7", "sonnet-4-6", "sonnet-4-5", "sonnet-4",
+                          "opus-4-6", "opus-4-5", "haiku-4-5", "fable-5", "sonnet-3-7", "opus-4-1", "opus-4"]
         for model_key in all_model_keys:
             if model_key in CLAUDE_MODELS:
                 profiles = CLAUDE_MODELS[model_key].get("profiles", {})

--- a/source/tests/test_models.py
+++ b/source/tests/test_models.py
@@ -36,6 +36,7 @@ class TestModelConfiguration:
     def test_claude_models_structure(self):
         """Test that CLAUDE_MODELS has the expected structure."""
         expected_models = {
+            "fable-5",
             "sonnet-4-6",
             "opus-4-8",
             "opus-4-7",
@@ -96,6 +97,9 @@ class TestModelConfiguration:
     def test_get_available_profiles_for_model(self):
         """Test getting available profiles for each model."""
         # Test valid models
+        fable_5_profiles = get_available_profiles_for_model("fable-5")
+        assert set(fable_5_profiles) == {"us", "eu", "global"}
+
         opus_4_6_profiles = get_available_profiles_for_model("opus-4-6")
         assert set(opus_4_6_profiles) == {"us", "eu", "au", "global"}  # Opus 4.6 has global and regional profiles
 
@@ -125,6 +129,11 @@ class TestModelConfiguration:
 
     def test_get_model_id_for_profile(self):
         """Test getting model IDs for specific profiles."""
+        # Test Fable profiles
+        assert get_model_id_for_profile("fable-5", "us") == "us.anthropic.claude-fable-5"
+        assert get_model_id_for_profile("fable-5", "global") == "global.anthropic.claude-fable-5"
+        assert get_model_id_for_profile("fable-5", "eu") == "eu.anthropic.claude-fable-5"
+
         # Test US profiles
         assert get_model_id_for_profile("opus-4-6", "us") == "us.anthropic.claude-opus-4-6-v1"
         assert get_model_id_for_profile("opus-4-1", "us") == "us.anthropic.claude-opus-4-1-20250805-v1:0"
@@ -208,6 +217,9 @@ class TestModelConfiguration:
         assert set(display_names.keys()) == expected_entries
 
         # Test specific display names
+        assert display_names["global.anthropic.claude-fable-5"] == "Claude Fable 5 (GLOBAL)"
+        assert display_names["us.anthropic.claude-fable-5"] == "Claude Fable 5"
+        assert display_names["eu.anthropic.claude-fable-5"] == "Claude Fable 5 (EU)"
         assert display_names["global.anthropic.claude-opus-4-6-v1"] == "Claude Opus 4.6 (GLOBAL)"
         assert display_names["us.anthropic.claude-opus-4-6-v1"] == "Claude Opus 4.6"
         assert display_names["us.anthropic.claude-opus-4-1-20250805-v1:0"] == "Claude Opus 4.1"
@@ -478,9 +490,22 @@ class TestResolveModelForTier:
         """Haiku CRIS model IDs resolve to 'haiku' alias."""
         assert get_claude_code_alias("us.anthropic.claude-haiku-4-5-20251001-v1:0") == "haiku"
 
+    def test_get_claude_code_alias_fable(self):
+        """Fable CRIS model IDs resolve to 'fable' alias."""
+        assert get_claude_code_alias("us.anthropic.claude-fable-5") == "fable"
+        assert get_claude_code_alias("eu.anthropic.claude-fable-5") == "fable"
+
     def test_get_claude_code_alias_unknown(self):
         """Unknown model IDs return None."""
         assert get_claude_code_alias("us.anthropic.claude-unknown-99") is None
+
+    def test_fable_tier_resolves(self):
+        """Fable tier resolves to correct CRIS model IDs."""
+        from claude_code_with_bedrock.models import resolve_model_for_tier
+
+        assert resolve_model_for_tier("fable", "eu") == "eu.anthropic.claude-fable-5"
+        assert resolve_model_for_tier("fable", "us") == "us.anthropic.claude-fable-5"
+        assert resolve_model_for_tier("fable", "global") == "global.anthropic.claude-fable-5"
 
     def test_data_residency_prefixes_match_api(self):
         """Every prefix from the live API should resolve all available tiers."""
@@ -488,7 +513,7 @@ class TestResolveModelForTier:
 
         # These must resolve to their own prefix (not global/us)
         for prefix in ["us", "eu", "au", "global"]:
-            for tier in ["haiku", "sonnet", "opus"]:
+            for tier in ["haiku", "sonnet", "opus", "fable"]:
                 result = resolve_model_for_tier(tier, prefix)
                 if result is not None:
                     assert f"{prefix}." in result, \


### PR DESCRIPTION
## Why

Claude Fable 5 is available on Bedrock but missing from the model catalog, so users can't select or resolve it via `ccwb`.

## What

- Add `fable-5` model entry with `us`, `eu`, and `global` CRIS profiles
- Register `"fable"` tier in `MODEL_TIER_PREFERENCES`, `TIER_TO_CLAUDE_CODE_ALIAS`, and the data-residency fallback list
- Update docstrings to mention the new tier
- Add tests for profile resolution, model IDs, display names, alias mapping, and tier resolution
- **Fix:** Reorder `fable-5` in data-residency fallback list (after opus/sonnet/haiku) to preserve expected fallback semantics
- **Rebase:** Rebased onto latest `beta` (resolves conflict with opus-4-8 addition)

Mirrors the pattern used for opus-4-7 and sonnet-4-6.

## Verification

```bash
cd source && poetry run pytest tests/test_models.py -q
```

---

Supersedes #536 (rebased + fallback fix applied). Credit to @spawnia for the original implementation.

🤖 Rebased and fixed by Wirclaw