### PR TITLE
style: apply ruff format to Python source

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/builds.py
+++ b/source/claude_code_with_bedrock/cli/commands/builds.py
@@ -328,6 +328,7 @@ class BuildsCommand(Command):
                             except PermissionError:
                                 if attempt < 2:
                                     import time
+
                                     time.sleep(1)
                                 else:
                                     raise

--- a/source/claude_code_with_bedrock/cli/commands/context.py
+++ b/source/claude_code_with_bedrock/cli/commands/context.py
@@ -221,7 +221,11 @@ class ContextShowCommand(Command):
             console.print("\n[bold cyan]Bedrock Configuration:[/bold cyan]")
             if profile.selected_model:
                 console.print(f"  Selected Model:       {profile.selected_model}")
-            for tier, attr in [("Opus", "inference_profile_opus_arn"), ("Sonnet", "inference_profile_sonnet_arn"), ("Haiku", "inference_profile_haiku_arn")]:
+            for tier, attr in [
+                ("Opus", "inference_profile_opus_arn"),
+                ("Sonnet", "inference_profile_sonnet_arn"),
+                ("Haiku", "inference_profile_haiku_arn"),
+            ]:
                 arn = getattr(profile, attr, None)
                 if arn:
                     console.print(f"  {tier} Inference Profile: {arn}")

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -30,9 +30,7 @@ from claude_code_with_bedrock.config import Config
 #   login.microsoftonline.com/{tenant-id}/v2.0
 #   https://login.microsoftonline.com/{tenant-id}
 #   {tenant-id} (bare GUID)
-_AZURE_GUID_PATTERN = re.compile(
-    r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
-)
+_AZURE_GUID_PATTERN = re.compile(r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}")
 
 
 def _extract_azure_tenant_id(domain: str) -> str:
@@ -141,7 +139,9 @@ class DeployCommand(Command):
                     console.print("[yellow]Monitoring is not enabled in your configuration.[/yellow]")
                     return 1
                 if getattr(profile, "monitoring_mode", "central") == "sidecar":
-                    console.print("[yellow]CoWork dashboard requires central monitoring mode (Cowork cannot export telemetry in sidecar mode).[/yellow]")
+                    console.print(
+                        "[yellow]CoWork dashboard requires central monitoring mode (Cowork cannot export telemetry in sidecar mode).[/yellow]"
+                    )
                     return 1
                 stacks_to_deploy.append(("cowork-dashboard", "CoWork CloudWatch Dashboard"))
             elif stack_arg == "analytics":
@@ -244,8 +244,7 @@ class DeployCommand(Command):
                             "SSO authentication (per-user JWT tokens) but SSO is disabled in this profile.[/yellow]"
                         )
                         console.print(
-                            "[dim]Re-run 'ccwb init' with SSO enabled to deploy quota monitoring. "
-                            "See issue #454.[/dim]"
+                            "[dim]Re-run 'ccwb init' with SSO enabled to deploy quota monitoring. See issue #454.[/dim]"
                         )
             # Check if CodeBuild is enabled
             if getattr(profile, "enable_codebuild", False):
@@ -504,6 +503,7 @@ class DeployCommand(Command):
                 bedrock_regions = profile.allowed_bedrock_regions
                 if not bedrock_regions:
                     from claude_code_with_bedrock.models import get_all_bedrock_regions
+
                     bedrock_regions = [r for r in get_all_bedrock_regions() if "gov" not in r]
 
                 params.extend(
@@ -775,9 +775,7 @@ class DeployCommand(Command):
                 params = [
                     f"MetricsRegion={profile.aws_region}",
                 ]
-                return deploy_with_cf(
-                    template, stack_name, params, task_description="Deploying CoWork dashboard..."
-                )
+                return deploy_with_cf(template, stack_name, params, task_description="Deploying CoWork dashboard...")
 
             elif stack_type == "analytics":
                 template = project_root / "deployment" / "infrastructure" / "analytics-pipeline.yaml"
@@ -894,9 +892,13 @@ class DeployCommand(Command):
             elif stack_type == "codebuild":
                 # WINDOWS_SERVER_2022_CONTAINER is only available in select regions
                 codebuild_supported_regions = [
-                    "us-east-1", "us-east-2", "us-west-2",
-                    "eu-central-1", "eu-west-1",
-                    "ap-northeast-1", "ap-southeast-2",
+                    "us-east-1",
+                    "us-east-2",
+                    "us-west-2",
+                    "eu-central-1",
+                    "eu-west-1",
+                    "ap-northeast-1",
+                    "ap-southeast-2",
                     "sa-east-1",
                 ]
                 if profile.aws_region not in codebuild_supported_regions:
@@ -946,6 +948,7 @@ class DeployCommand(Command):
             bedrock_regions = profile.allowed_bedrock_regions
             if not bedrock_regions:
                 from claude_code_with_bedrock.models import get_all_bedrock_regions
+
                 bedrock_regions = [r for r in get_all_bedrock_regions() if "gov" not in r]
 
             stack_name = profile.stack_names.get("auth", f"{profile.identity_pool_name}-stack")
@@ -987,16 +990,20 @@ class DeployCommand(Command):
                         if "." in profile.provider_domain
                         else profile.provider_domain
                     )
-                    params.extend([
-                        f"CognitoUserPoolId={profile.cognito_user_pool_id}",
-                        f"CognitoUserPoolClientId={profile.client_id}",
-                        f"CognitoUserPoolDomain={cognito_domain}",
-                    ])
-                params.extend([
-                    f"IdentityPoolName={profile.identity_pool_name}",
-                    f"AllowedBedrockRegions={','.join(bedrock_regions)}",
-                    f"EnableMonitoring={str(profile.monitoring_enabled).lower()}",
-                ])
+                    params.extend(
+                        [
+                            f"CognitoUserPoolId={profile.cognito_user_pool_id}",
+                            f"CognitoUserPoolClientId={profile.client_id}",
+                            f"CognitoUserPoolDomain={cognito_domain}",
+                        ]
+                    )
+                params.extend(
+                    [
+                        f"IdentityPoolName={profile.identity_pool_name}",
+                        f"AllowedBedrockRegions={','.join(bedrock_regions)}",
+                        f"EnableMonitoring={str(profile.monitoring_enabled).lower()}",
+                    ]
+                )
                 print_deploy_cmd(template, stack_name, params, ["CAPABILITY_NAMED_IAM"])
 
         elif stack_type == "networking":
@@ -1308,6 +1315,7 @@ class DeployCommand(Command):
                     console.print("[green]✓ ECS service linked role created[/green]")
                     # Wait for IAM propagation before proceeding with ECS cluster creation
                     import time
+
                     console.print("[dim]Waiting for IAM role propagation...[/dim]")
                     time.sleep(10)
                 except iam_client.exceptions.InvalidInputException as e:

--- a/source/claude_code_with_bedrock/cli/commands/distribute.py
+++ b/source/claude_code_with_bedrock/cli/commands/distribute.py
@@ -259,7 +259,9 @@ class DistributeCommand(Command):
 
                 result = subprocess.run(
                     ["tasklist", "/FI", "IMAGENAME eq ZSATunnel.exe", "/NH"],
-                    capture_output=True, text=True, timeout=5,
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
                 )
                 if "ZSATunnel" in result.stdout:
                     corporate_proxy_detected = True
@@ -267,7 +269,9 @@ class DistributeCommand(Command):
                 else:
                     result = subprocess.run(
                         ["tasklist", "/FI", "IMAGENAME eq nscommon.exe", "/NH"],
-                        capture_output=True, text=True, timeout=5,
+                        capture_output=True,
+                        text=True,
+                        timeout=5,
                     )
                     if "nscommon" in result.stdout:
                         corporate_proxy_detected = True
@@ -280,8 +284,12 @@ class DistributeCommand(Command):
                 f"\n[yellow]Note: {proxy_name} detected. If S3 uploads fail with 'Access Denied' or SSL errors, "
                 f"use one of these fixes:[/yellow]"
             )
-            console.print(f"  Option 1: [cyan]pip install truststore[/cyan]  (makes Python trust the {proxy_name} CA from the OS store)")
-            console.print(f"  Option 2: [cyan]set AWS_CA_BUNDLE=C:\\path\\to\\{proxy_name}RootCA.pem[/cyan]  (ask IT for the .pem file)")
+            console.print(
+                f"  Option 1: [cyan]pip install truststore[/cyan]  (makes Python trust the {proxy_name} CA from the OS store)"
+            )
+            console.print(
+                f"  Option 2: [cyan]set AWS_CA_BUNDLE=C:\\path\\to\\{proxy_name}RootCA.pem[/cyan]  (ask IT for the .pem file)"
+            )
             console.print()
 
     def handle(self) -> int:
@@ -691,7 +699,9 @@ class DistributeCommand(Command):
                     for source_file, archive_name in files:
                         source_path = package_path / source_file
                         if source_path.exists():
-                            zipf.writestr(f"claude-code-package/{archive_name}", self._read_file_with_retry(source_path))
+                            zipf.writestr(
+                                f"claude-code-package/{archive_name}", self._read_file_with_retry(source_path)
+                            )
 
                     # Include claude-settings if it exists
                     settings_dir = package_path / "claude-settings"
@@ -699,7 +709,9 @@ class DistributeCommand(Command):
                         for file in settings_dir.rglob("*"):
                             if file.is_file():
                                 rel_path = file.relative_to(package_path)
-                                zipf.writestr(f"claude-code-package/{rel_path.as_posix()}", self._read_file_with_retry(file))
+                                zipf.writestr(
+                                    f"claude-code-package/{rel_path.as_posix()}", self._read_file_with_retry(file)
+                                )
 
                 # Upload to S3 at packages/{platform}/latest.zip
                 s3_key = f"packages/{platform}/latest.zip"
@@ -1245,7 +1257,9 @@ class DistributeCommand(Command):
             if s3 and bucket_name:
                 package_key = f"packages/{timestamp}/{filename}"
                 try:
-                    self._upload_file_with_retry(s3, str(archive_path), bucket_name, package_key, config=self.S3_TRANSFER_CONFIG)
+                    self._upload_file_with_retry(
+                        s3, str(archive_path), bucket_name, package_key, config=self.S3_TRANSFER_CONFIG
+                    )
                     url = s3.generate_presigned_url(
                         "get_object",
                         Params={"Bucket": bucket_name, "Key": package_key},
@@ -1305,11 +1319,11 @@ class DistributeCommand(Command):
             )
             console.print("[yellow]Fixes:[/yellow]")
             console.print("  1. [cyan]pip install truststore[/cyan]  (makes Python trust your corporate CA)")
-            console.print("  2. [cyan]set AWS_CA_BUNDLE=C:\\path\\to\\corporate-root-ca.pem[/cyan]  (ask IT for the .pem file)")
-        elif "access denied" in error_str or "accessdenied" in error_str or isinstance(error, PermissionError):
             console.print(
-                "\n[yellow]This may be caused by:[/yellow]"
+                "  2. [cyan]set AWS_CA_BUNDLE=C:\\path\\to\\corporate-root-ca.pem[/cyan]  (ask IT for the .pem file)"
             )
+        elif "access denied" in error_str or "accessdenied" in error_str or isinstance(error, PermissionError):
+            console.print("\n[yellow]This may be caused by:[/yellow]")
             console.print("  1. Corporate security tool (Zscaler, Netskope) intercepting S3 traffic")
             console.print("  2. Insufficient S3 permissions")
             console.print("  3. Antivirus scanning the ZIP file")
@@ -1345,7 +1359,16 @@ class DistributeCommand(Command):
                     ) from e
 
     @staticmethod
-    def _upload_file_with_retry(s3_client, file_path: str, bucket: str, key: str, extra_args=None, config=None, callback=None, max_attempts: int = 5):
+    def _upload_file_with_retry(
+        s3_client,
+        file_path: str,
+        bucket: str,
+        key: str,
+        extra_args=None,
+        config=None,
+        callback=None,
+        max_attempts: int = 5,
+    ):
         """Upload a file to S3 with retry for Windows Defender scan locks.
 
         boto3.upload_file internally opens the file for reading. On Windows,
@@ -1663,6 +1686,7 @@ class DistributeCommand(Command):
                             except PermissionError:
                                 if attempt < 2:
                                     import time
+
                                     time.sleep(1)
                                 else:
                                     raise

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -293,7 +293,9 @@ class InitCommand(Command):
         console.print("")
         return True
 
-    def _gather_configuration(self, progress: WizardProgress, existing_config: dict[str, Any] = None, profile_name: str | None = None) -> dict[str, Any]:
+    def _gather_configuration(
+        self, progress: WizardProgress, existing_config: dict[str, Any] = None, profile_name: str | None = None
+    ) -> dict[str, Any]:
         """Gather configuration from user."""
         console = Console()
         # Use existing config as base if provided, otherwise use saved progress
@@ -347,8 +349,9 @@ class InitCommand(Command):
 
             provider_domain = questionary.text(
                 "Enter your OIDC provider domain:",
-                validate=lambda x: validate_oidc_provider_domain(x)
-                or "Invalid provider domain format (e.g., company.okta.com)",
+                validate=lambda x: (
+                    validate_oidc_provider_domain(x) or "Invalid provider domain format (e.g., company.okta.com)"
+                ),
                 instruction=(
                     "(e.g., company.okta.com, company.auth0.com, "
                     "login.microsoftonline.com/{tenant-id}/v2.0, "
@@ -408,9 +411,7 @@ class InitCommand(Command):
             # If auto-detection failed (custom domain, Keycloak, PingFederate, etc.)
             # ask the user to select the provider type manually so deploy never gets None
             if provider_type is None:
-                console.print(
-                    "\n[yellow]Could not auto-detect provider type from domain.[/yellow]"
-                )
+                console.print("\n[yellow]Could not auto-detect provider type from domain.[/yellow]")
                 provider_type = questionary.select(
                     "Select your identity provider type:",
                     choices=[
@@ -483,7 +484,8 @@ class InitCommand(Command):
 
                 # Construct issuer URL from the domain entered earlier; let the user override.
                 default_issuer = (
-                    provider_domain if provider_domain.startswith(("http://", "https://"))
+                    provider_domain
+                    if provider_domain.startswith(("http://", "https://"))
                     else f"https://{provider_domain}"
                 ).rstrip("/")
 
@@ -542,11 +544,7 @@ class InitCommand(Command):
                 oidc_jwks_uri = questionary.text(
                     "JWKS URI:",
                     validate=lambda x: bool(x) or "JWKS URI cannot be empty",
-                    default=(
-                        discovered.get("jwks_uri")
-                        or config.get("oidc_jwks_uri")
-                        or f"{oidc_issuer_url}/pf/JWKS"
-                    ),
+                    default=(discovered.get("jwks_uri") or config.get("oidc_jwks_uri") or f"{oidc_issuer_url}/pf/JWKS"),
                     instruction="(full URL)",
                 ).ask()
                 if not oidc_jwks_uri:
@@ -569,7 +567,11 @@ class InitCommand(Command):
                 oidc_thumbprint = questionary.text(
                     "JWKS TLS cert SHA-1 thumbprint:",
                     validate=lambda x: (
-                        bool(x and len(x.replace(":", "")) == 40 and all(c in "0123456789abcdefABCDEF" for c in x.replace(":", "")))
+                        bool(
+                            x
+                            and len(x.replace(":", "")) == 40
+                            and all(c in "0123456789abcdefABCDEF" for c in x.replace(":", ""))
+                        )
                         or "Thumbprint must be 40 hex characters (colons optional)"
                     ),
                     default=computed_thumbprint or config.get("oidc_thumbprint", ""),
@@ -606,7 +608,9 @@ class InitCommand(Command):
                     choices=[
                         questionary.Choice("Public client (default, no secret required)", value="public"),
                         questionary.Choice("Confidential client — client secret", value="secret"),
-                        questionary.Choice("Confidential client — certificate (recommended for enterprise)", value="certificate"),
+                        questionary.Choice(
+                            "Confidential client — certificate (recommended for enterprise)", value="certificate"
+                        ),
                     ],
                     default=config.get("azure_auth_mode", "public"),
                 ).ask()
@@ -624,6 +628,7 @@ class InitCommand(Command):
                     if not profile_name:
                         raise ValueError("profile_name is required to store client secret in keyring")
                     import keyring as _keyring
+
                     _keyring.set_password("claude-code-with-bedrock", f"{profile_name}-client-secret", client_secret)
                     console.print("[dim]  ✓ Client secret stored in OS secure storage (not written to config)[/dim]")
                     console.print(
@@ -701,7 +706,9 @@ class InitCommand(Command):
             if use_custom_port:
                 redirect_port_str = questionary.text(
                     "Enter OAuth callback port:",
-                    validate=lambda x: (x.isdigit() and 1024 <= int(x) <= 65535) or "Must be a number between 1024 and 65535",
+                    validate=lambda x: (
+                        (x.isdigit() and 1024 <= int(x) <= 65535) or "Must be a number between 1024 and 65535"
+                    ),
                     default=str(config.get("redirect_port", 8400)),
                     instruction="(must match the port in your IdP's registered redirect URI)",
                 ).ask()
@@ -920,8 +927,7 @@ class InitCommand(Command):
                         hosted_zones, zones_error = self._get_hosted_zones()
                         if hosted_zones:
                             zone_choices = [
-                                f"{zone['Name'].rstrip('.')} ({zone['Id'].split('/')[-1]})"
-                                for zone in hosted_zones
+                                f"{zone['Name'].rstrip('.')} ({zone['Id'].split('/')[-1]})" for zone in hosted_zones
                             ]
 
                             default_zone = None
@@ -939,9 +945,7 @@ class InitCommand(Command):
 
                             zone_id = selected_zone.split("(")[-1].rstrip(")")
                             config["monitoring"]["hosted_zone_id"] = zone_id
-                            console.print(
-                                f"[green]✓[/green] HTTPS will be enabled with domain: {custom_domain}"
-                            )
+                            console.print(f"[green]✓[/green] HTTPS will be enabled with domain: {custom_domain}")
                         else:
                             if zones_error:
                                 console.print(f"[yellow]Could not list Route53 hosted zones: {zones_error}[/yellow]")
@@ -954,9 +958,13 @@ class InitCommand(Command):
                             ).ask()
                             if manual_zone_id and manual_zone_id.strip():
                                 config["monitoring"]["hosted_zone_id"] = manual_zone_id.strip()
-                                console.print(f"[green]✓[/green] HTTPS configured: {custom_domain} (zone: {manual_zone_id.strip()})")
+                                console.print(
+                                    f"[green]✓[/green] HTTPS configured: {custom_domain} (zone: {manual_zone_id.strip()})"
+                                )
                             else:
-                                console.print("[yellow]⚠[/yellow] Domain saved but no zone ID set. Update before deploying.")
+                                console.print(
+                                    "[yellow]⚠[/yellow] Domain saved but no zone ID set. Update before deploying."
+                                )
                     else:
                         config["monitoring"]["custom_domain"] = None
                         config["monitoring"]["hosted_zone_id"] = None
@@ -974,15 +982,11 @@ class InitCommand(Command):
                     config["analytics"]["enabled"] = enable_analytics
 
                     if enable_analytics:
-                        console.print(
-                            "[green]✓[/green] Analytics pipeline will be deployed with your monitoring stack"
-                        )
+                        console.print("[green]✓[/green] Analytics pipeline will be deployed with your monitoring stack")
 
                 else:
                     # Sidecar mode: no VPC, no HTTPS, no Athena pipeline (PromQL dashboards still deployed)
-                    console.print(
-                        "[green]✓[/green] Metrics will be sent directly to CloudWatch via local OTEL sidecar"
-                    )
+                    console.print("[green]✓[/green] Metrics will be sent directly to CloudWatch via local OTEL sidecar")
                     config["monitoring"]["vpc_config"] = None
                     config["monitoring"]["custom_domain"] = None
                     config["monitoring"]["hosted_zone_id"] = None
@@ -1008,9 +1012,7 @@ class InitCommand(Command):
                     console.print("Track per-user token consumption, set limits, and receive alerts")
                     console.print("when users approach or exceed their quotas.")
                     console.print("[dim]Features: per-user/group limits, SNS alerts, access blocking[/dim]")
-                    console.print(
-                        "[dim]Note: Quota monitoring requires the monitoring stack (enabled above)[/dim]"
-                    )
+                    console.print("[dim]Note: Quota monitoring requires the monitoring stack (enabled above)[/dim]")
                     enable_quota_monitoring = questionary.confirm(
                         "Enable quota monitoring?",
                         default=config.get("quota", {}).get("enabled", True),
@@ -1396,8 +1398,9 @@ class InitCommand(Command):
             custom_domain = questionary.text(
                 "Custom domain (e.g., downloads.company.com):",
                 default=config.get("distribution", {}).get("custom_domain", ""),
-                validate=lambda text: len(text.strip()) > 0
-                or "Custom domain is required for authenticated landing page",
+                validate=lambda text: (
+                    len(text.strip()) > 0 or "Custom domain is required for authenticated landing page"
+                ),
             ).ask()
 
             # Check for Route53 hosted zones
@@ -1791,11 +1794,7 @@ class InitCommand(Command):
             table.add_row("OIDC Provider", okta_domain or "—")
             table.add_row(
                 "OIDC Client ID",
-                (
-                    okta_client_id[:20] + "..."
-                    if len(okta_client_id) > 20
-                    else (okta_client_id or "—")
-                ),
+                (okta_client_id[:20] + "..." if len(okta_client_id) > 20 else (okta_client_id or "—")),
             )
         else:
             table.add_row("Authentication", "AWS SSO / IAM Identity Center (no OIDC)")
@@ -1839,7 +1838,10 @@ class InitCommand(Command):
                 table.add_row("Athena SQL Pipeline", "N/A (sidecar mode — PromQL dashboards included)")
 
         # Show VPC config if monitoring is enabled in central mode
-        if config.get("monitoring", {}).get("enabled") and config.get("monitoring", {}).get("mode", "sidecar") == "central":
+        if (
+            config.get("monitoring", {}).get("enabled")
+            and config.get("monitoring", {}).get("mode", "sidecar") == "central"
+        ):
             vpc_config = config.get("monitoring", {}).get("vpc_config", {})
             if vpc_config.get("create_vpc"):
                 table.add_row("Monitoring VPC", "New VPC will be created")
@@ -1852,12 +1854,17 @@ class InitCommand(Command):
         # Show selected model
         selected_model = config["aws"].get("selected_model", "")
         from claude_code_with_bedrock.models import get_all_model_display_names
+
         model_display = get_all_model_display_names()
         if selected_model:
             table.add_row("Claude Model", model_display.get(selected_model, selected_model))
 
         # Show application inference profiles if configured
-        for tier, key in [("Opus", "inference_profile_opus_arn"), ("Sonnet", "inference_profile_sonnet_arn"), ("Haiku", "inference_profile_haiku_arn")]:
+        for tier, key in [
+            ("Opus", "inference_profile_opus_arn"),
+            ("Sonnet", "inference_profile_sonnet_arn"),
+            ("Haiku", "inference_profile_haiku_arn"),
+        ]:
             arn = config["aws"].get(key)
             if arn:
                 table.add_row(f"{tier} Inference Profile", arn)
@@ -2473,7 +2480,11 @@ class InitCommand(Command):
                 existing_config["aws"]["cross_region_profile"] = profile.cross_region_profile
 
             # Add application inference profile ARNs if present
-            for arn_key in ["inference_profile_opus_arn", "inference_profile_sonnet_arn", "inference_profile_haiku_arn"]:
+            for arn_key in [
+                "inference_profile_opus_arn",
+                "inference_profile_sonnet_arn",
+                "inference_profile_haiku_arn",
+            ]:
                 if getattr(profile, arn_key, None):
                     existing_config["aws"][arn_key] = getattr(profile, arn_key)
 
@@ -2558,11 +2569,16 @@ class InitCommand(Command):
         selected_model = config["aws"].get("selected_model")
         if selected_model:
             from claude_code_with_bedrock.models import get_all_model_display_names
+
             model_names = get_all_model_display_names()
             console.print(f"• Claude Model: [cyan]{model_names.get(selected_model, selected_model)}[/cyan]")
 
         # Show application inference profiles if configured
-        for tier, key in [("Opus", "inference_profile_opus_arn"), ("Sonnet", "inference_profile_sonnet_arn"), ("Haiku", "inference_profile_haiku_arn")]:
+        for tier, key in [
+            ("Opus", "inference_profile_opus_arn"),
+            ("Sonnet", "inference_profile_sonnet_arn"),
+            ("Haiku", "inference_profile_haiku_arn"),
+        ]:
             arn = config["aws"].get(key)
             if arn:
                 console.print(f"• {tier} Inference Profile: [cyan]{arn}[/cyan]")
@@ -2828,7 +2844,7 @@ class InitCommand(Command):
             # Validate profile name
             if not Config._is_valid_profile_name(profile_name):
                 console.print(
-                    "[red]Invalid profile name.[/red] " "Must be alphanumeric with hyphens only, max 64 characters.\n"
+                    "[red]Invalid profile name.[/red] Must be alphanumeric with hyphens only, max 64 characters.\n"
                 )
                 continue
 

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -77,6 +77,7 @@ def _ensure_cross_arch_venv(arch: str, universal2_python: Path, runtime_packages
             return venv_dir
         # Wrong arch — rebuild
         import shutil
+
         console.print(f"[yellow]Rebuilding {arch} build venv (wrong architecture detected)[/yellow]")
         shutil.rmtree(venv_dir, ignore_errors=True)
 
@@ -85,7 +86,8 @@ def _ensure_cross_arch_venv(arch: str, universal2_python: Path, runtime_packages
 
     create = subprocess.run(  # nosec B603 B607
         ["/usr/bin/arch", f"-{arch}", str(universal2_python), "-m", "venv", str(venv_dir)],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     if create.returncode != 0:
         raise RuntimeError(f"Failed to create {arch} build venv: {create.stderr}")
@@ -93,7 +95,8 @@ def _ensure_cross_arch_venv(arch: str, universal2_python: Path, runtime_packages
     pip = venv_dir / "bin" / "pip"
     install = subprocess.run(  # nosec B603 B607
         ["/usr/bin/arch", f"-{arch}", str(pip), "install", "--quiet", _PYINSTALLER_PIN, *runtime_packages],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     if install.returncode != 0:
         raise RuntimeError(f"Failed to install deps into {arch} build venv: {install.stderr or install.stdout}")
@@ -163,8 +166,16 @@ class PackageCommand(Command):
         option("build-local", description="Build binaries locally instead of downloading pre-built", flag=True),
         option("no-cache", description="Force re-download of pre-built binaries", flag=True),
         option("build-verbose", description="Enable verbose logging for build processes", flag=True),
-        option("regenerate-installers", description="Regenerate installer scripts using existing binaries from latest dist", flag=True),
-        option("go", description="Build binaries using Go cross-compilation (native binaries, no AV false positives)", flag=True),
+        option(
+            "regenerate-installers",
+            description="Regenerate installer scripts using existing binaries from latest dist",
+            flag=True,
+        ),
+        option(
+            "go",
+            description="Build binaries using Go cross-compilation (native binaries, no AV false positives)",
+            flag=True,
+        ),
     ]
 
     def handle(self) -> int:
@@ -254,8 +265,7 @@ class PackageCommand(Command):
                 cost_center = questionary.text("Cost center:", default="default").ask()
                 organization = questionary.text("Organization:", default="default").ask()
                 otel_resource_attributes = (
-                    f"department={department},team.id={team_id},"
-                    f"cost_center={cost_center},organization={organization}"
+                    f"department={department},team.id={team_id},cost_center={cost_center},organization={organization}"
                 )
 
         # Validate platform
@@ -479,7 +489,9 @@ class PackageCommand(Command):
                     else:
                         built_executables.append((platform_name, executable_path))
                 except Exception as e:
-                    console.print(f"[yellow]Warning: Could not build credential process for {platform_name}: {e}[/yellow]")
+                    console.print(
+                        f"[yellow]Warning: Could not build credential process for {platform_name}: {e}[/yellow]"
+                    )
 
                 # Build OTEL helper if monitoring is enabled
                 if profile.monitoring_enabled:
@@ -494,7 +506,9 @@ class PackageCommand(Command):
                             if otel_helper_path is not None:
                                 built_otel_helpers.append((platform_name, otel_helper_path))
                         except Exception as e:
-                            console.print(f"[yellow]Warning: Could not build OTEL helper for {platform_name}: {e}[/yellow]")
+                            console.print(
+                                f"[yellow]Warning: Could not build OTEL helper for {platform_name}: {e}[/yellow]"
+                            )
 
         # A Windows build runs asynchronously in CodeBuild and produces no local
         # binary now (_build_executable returns None), so built_executables can be
@@ -686,8 +700,7 @@ class PackageCommand(Command):
             self.line(f"  <info>{result.stdout.strip()}</info>")
         except (FileNotFoundError, subprocess.CalledProcessError):
             raise RuntimeError(
-                "Go is not installed or not in PATH. Install from https://go.dev/dl/ "
-                "or run: brew install go"
+                "Go is not installed or not in PATH. Install from https://go.dev/dl/ or run: brew install go"
             )
 
         platform_map = {
@@ -733,10 +746,13 @@ class PackageCommand(Command):
                 # cmd/*/ are auto-linked by the Go compiler to help further.
                 ldflags = "" if plat == "windows" else "-s -w"
                 cmd = [
-                    "go", "build",
+                    "go",
+                    "build",
                     "-trimpath",
-                    "-ldflags", ldflags,
-                    "-o", str(output_path),
+                    "-ldflags",
+                    ldflags,
+                    "-o",
+                    str(output_path),
                     f"./cmd/{binary}/",
                 ]
                 result = subprocess.run(cmd, cwd=str(go_src), env=env, capture_output=True, text=True)
@@ -1029,9 +1045,12 @@ class PackageCommand(Command):
             work_root = Path.home() / ".ccwb" / "build-work"
             work_root.mkdir(parents=True, exist_ok=True)
             cmd = [
-                "/usr/bin/arch", f"-{arch}",
+                "/usr/bin/arch",
+                f"-{arch}",
                 str(venv_dir / "bin" / "pyinstaller"),
-                "--onefile", "--clean", "--noconfirm",
+                "--onefile",
+                "--clean",
+                "--noconfirm",
                 f"--name={binary_name}",
                 f"--distpath={str(output_dir)}",
                 f"--workpath={str(work_root / arch)}",
@@ -1047,8 +1066,12 @@ class PackageCommand(Command):
         else:
             # Native build: use Poetry environment directly
             cmd = [
-                "poetry", "run", "pyinstaller",
-                "--onefile", "--clean", "--noconfirm",
+                "poetry",
+                "run",
+                "pyinstaller",
+                "--onefile",
+                "--clean",
+                "--noconfirm",
                 f"--target-arch={arch}",
                 f"--name={binary_name}",
                 f"--distpath={str(output_dir)}",
@@ -1792,15 +1815,20 @@ RUN pyinstaller \
             # Cross-arch build: need a per-arch venv seeded from a universal2 Python
             universal2_python = _find_universal2_python()
             if universal2_python is None:
-                console.print(f"[yellow]Warning: Skipping {binary_name} — cross-arch build requires universal2 Python (not found)[/yellow]")
+                console.print(
+                    f"[yellow]Warning: Skipping {binary_name} — cross-arch build requires universal2 Python (not found)[/yellow]"
+                )
                 return output_dir / binary_name
             venv_dir = _ensure_cross_arch_venv(arch, universal2_python, _OTEL_HELPER_RUNTIME_DEPS, console)
             work_root = Path.home() / ".ccwb" / "build-work"
             work_root.mkdir(parents=True, exist_ok=True)
             cmd = [
-                "/usr/bin/arch", f"-{arch}",
+                "/usr/bin/arch",
+                f"-{arch}",
                 str(venv_dir / "bin" / "pyinstaller"),
-                "--onefile", "--clean", "--noconfirm",
+                "--onefile",
+                "--clean",
+                "--noconfirm",
                 f"--name={binary_name}",
                 f"--distpath={str(output_dir)}",
                 f"--workpath={str(work_root / arch)}",
@@ -1810,8 +1838,12 @@ RUN pyinstaller \
             ]
         else:
             cmd = [
-                "poetry", "run", "pyinstaller",
-                "--onefile", "--clean", "--noconfirm",
+                "poetry",
+                "run",
+                "pyinstaller",
+                "--onefile",
+                "--clean",
+                "--noconfirm",
                 f"--name={binary_name}",
                 f"--distpath={str(output_dir)}",
                 "--workpath=/tmp/pyinstaller",
@@ -2057,17 +2089,14 @@ RUN pyinstaller \
 
         otel_resource_attributes = None
         if profile.monitoring_enabled:
-            customize_otel = questionary.confirm(
-                "Customize telemetry resource attributes?", default=False
-            ).ask()
+            customize_otel = questionary.confirm("Customize telemetry resource attributes?", default=False).ask()
             if customize_otel:
                 department = questionary.text("Department:", default="engineering").ask()
                 team_id = questionary.text("Team ID:", default="default").ask()
                 cost_center = questionary.text("Cost center:", default="default").ask()
                 organization = questionary.text("Organization:", default="default").ask()
                 otel_resource_attributes = (
-                    f"department={department},team.id={team_id},"
-                    f"cost_center={cost_center},organization={organization}"
+                    f"department={department},team.id={team_id},cost_center={cost_center},organization={organization}"
                 )
 
         # Regenerate config.json
@@ -2099,7 +2128,9 @@ RUN pyinstaller \
         if (output_dir / "claude-settings" / "settings.json").exists():
             console.print("  • claude-settings/settings.json")
         console.print(f"\nBinaries copied from: [dim]{source_dir}[/dim]")
-        console.print("\n[bold]Next: Run '[cyan]poetry run ccwb distribute --per-os[/cyan]' to create distribution packages.[/bold]")
+        console.print(
+            "\n[bold]Next: Run '[cyan]poetry run ccwb distribute --per-os[/cyan]' to create distribution packages.[/bold]"
+        )
         return 0
 
     def _create_config(
@@ -2174,9 +2205,7 @@ RUN pyinstaller \
                     "\n[yellow]Warning: certificate paths in config.json are absolute and will not "
                     "resolve on machines where the files are stored elsewhere.[/yellow]"
                 )
-                console.print(
-                    "[yellow]Instruct end users to set the following environment variables:[/yellow]"
-                )
+                console.print("[yellow]Instruct end users to set the following environment variables:[/yellow]")
                 console.print("[dim]  AZURE_CLIENT_CERTIFICATE_PATH=<path/to/cert.pem>[/dim]")
                 console.print("[dim]  AZURE_CLIENT_CERTIFICATE_KEY_PATH=<path/to/key.pem>[/dim]\n")
 
@@ -2234,7 +2263,11 @@ RUN pyinstaller \
             # Check for exact domain match or subdomain match
             # Using endswith with leading dot prevents bypass attacks
             okta_domains = (".okta.com", ".oktapreview.com", ".okta-emea.com")
-            if hostname_lower.endswith(okta_domains) or hostname_lower in ("okta.com", "oktapreview.com", "okta-emea.com"):
+            if hostname_lower.endswith(okta_domains) or hostname_lower in (
+                "okta.com",
+                "oktapreview.com",
+                "okta-emea.com",
+            ):
                 return "okta"
             elif hostname_lower.endswith(".auth0.com") or hostname_lower == "auth0.com":
                 return "auth0"
@@ -2848,7 +2881,7 @@ Available metrics include:
 """
             readme_content += analytics_section
 
-        readme_content += "\n" ""
+        readme_content += "\n"
 
         with open(output_dir / "README.md", "w", encoding="utf-8") as f:
             f.write(readme_content)
@@ -2933,8 +2966,12 @@ Available metrics include:
                     # Try multiple possible stack name patterns
                     possible_stacks = [
                         profile.stack_names.get("monitoring"),
-                        f"{profile.identity_pool_name}-otel-collector" if hasattr(profile, "identity_pool_name") and profile.identity_pool_name else None,
-                        f"{profile.stack_names.get('auth', '')}-otel-collector" if profile.stack_names.get("auth") else None,
+                        f"{profile.identity_pool_name}-otel-collector"
+                        if hasattr(profile, "identity_pool_name") and profile.identity_pool_name
+                        else None,
+                        f"{profile.stack_names.get('auth', '')}-otel-collector"
+                        if profile.stack_names.get("auth")
+                        else None,
                     ]
                     # Remove None/empty entries
                     possible_stacks = [s for s in possible_stacks if s]
@@ -2970,19 +3007,27 @@ Available metrics include:
                             profile.otel_collector_endpoint = endpoint
                             try:
                                 from claude_code_with_bedrock.config import Config
+
                                 config = Config.load()
                                 config.save_profile(profile)
-                                console.print(f"[dim]Found endpoint from stack '{monitoring_stack}', saved to profile[/dim]")
+                                console.print(
+                                    f"[dim]Found endpoint from stack '{monitoring_stack}', saved to profile[/dim]"
+                                )
                             except Exception:
                                 pass
                             break
 
                 if not endpoint:
                     # Monitoring stack not deployed or endpoint not found
-                    console.print("[yellow]Warning: No OTel collector endpoint found in profile or CloudFormation.[/yellow]")
-                    console.print("[yellow]Run 'ccwb deploy' to deploy the monitoring stack, or enter the endpoint manually.[/yellow]")
+                    console.print(
+                        "[yellow]Warning: No OTel collector endpoint found in profile or CloudFormation.[/yellow]"
+                    )
+                    console.print(
+                        "[yellow]Run 'ccwb deploy' to deploy the monitoring stack, or enter the endpoint manually.[/yellow]"
+                    )
                     try:
                         import questionary
+
                         endpoint = questionary.text(
                             "OTel collector endpoint URL (leave blank to skip telemetry):",
                             default="",
@@ -2994,6 +3039,7 @@ Available metrics include:
                             profile.otel_collector_endpoint = endpoint
                             try:
                                 from claude_code_with_bedrock.config import Config
+
                                 config = Config.load()
                                 config.save_profile(profile)
                                 console.print(f"[dim]Saved endpoint to profile[/dim]")
@@ -3046,7 +3092,6 @@ Available metrics include:
 
         except Exception as e:
             console.print(f"[yellow]Warning: Could not create Claude Code settings: {e}[/yellow]")
-
 
     def _generate_cowork_3p_mdm_config(
         self,

--- a/source/claude_code_with_bedrock/cli/commands/package_cb.py
+++ b/source/claude_code_with_bedrock/cli/commands/package_cb.py
@@ -75,7 +75,11 @@ class PackageCbCommand(Command):
             default=None,
         ),
         option("build-verbose", description="Enable verbose logging for build processes", flag=True),
-        option("regenerate-installers", description="Regenerate installer scripts using existing binaries from latest dist", flag=True),
+        option(
+            "regenerate-installers",
+            description="Regenerate installer scripts using existing binaries from latest dist",
+            flag=True,
+        ),
     ]
 
     def handle(self) -> int:
@@ -153,8 +157,7 @@ class PackageCbCommand(Command):
                 cost_center = questionary.text("Cost center:", default="default").ask()
                 organization = questionary.text("Organization:", default="default").ask()
                 otel_resource_attributes = (
-                    f"department={department},team.id={team_id},"
-                    f"cost_center={cost_center},organization={organization}"
+                    f"department={department},team.id={team_id},cost_center={cost_center},organization={organization}"
                 )
 
         # Get CodeBuild stack outputs
@@ -272,9 +275,7 @@ class PackageCbCommand(Command):
                 pkg._create_documentation(output_dir, profile, timestamp)
 
         console.print("[cyan]Creating Claude Code settings...[/cyan]")
-        self._create_claude_settings(
-            output_dir, profile, include_coauthored_by, profile_name, otel_resource_attributes
-        )
+        self._create_claude_settings(output_dir, profile, include_coauthored_by, profile_name, otel_resource_attributes)
 
         # Show configuration
         console.print()
@@ -318,8 +319,8 @@ class PackageCbCommand(Command):
                     project_name = stack_outputs.get(plat_config["output_key"])
                     if not project_name:
                         console.print(
-                        f"[yellow]Project not found for {plat} — deploy codebuild stack to add it[/yellow]"
-                    )
+                            f"[yellow]Project not found for {plat} — deploy codebuild stack to add it[/yellow]"
+                        )
                         continue
 
                     task = progress.add_task(f"Starting {plat} build...", total=None)
@@ -424,22 +425,24 @@ class PackageCbCommand(Command):
                 settings["env"]["ANTHROPIC_MODEL"] = profile.selected_model
                 if "opus" in profile.selected_model:
                     prefix = profile.selected_model.split(".anthropic")[0]
-                    settings["env"]["ANTHROPIC_SMALL_FAST_MODEL"] = (
-                        f"{prefix}.anthropic.claude-3-5-haiku-20241022-v1:0"
-                    )
+                    settings["env"]["ANTHROPIC_SMALL_FAST_MODEL"] = f"{prefix}.anthropic.claude-3-5-haiku-20241022-v1:0"
                 else:
                     settings["env"]["ANTHROPIC_SMALL_FAST_MODEL"] = profile.selected_model
 
             if profile.monitoring_enabled:
-                monitoring_stack = profile.stack_names.get(
-                    "monitoring", f"{profile.identity_pool_name}-otel-collector"
-                )
+                monitoring_stack = profile.stack_names.get("monitoring", f"{profile.identity_pool_name}-otel-collector")
                 cmd = [
-                    "aws", "cloudformation", "describe-stacks",
-                    "--stack-name", monitoring_stack,
-                    "--region", profile.aws_region,
-                    "--query", "Stacks[0].Outputs",
-                    "--output", "json",
+                    "aws",
+                    "cloudformation",
+                    "describe-stacks",
+                    "--stack-name",
+                    monitoring_stack,
+                    "--region",
+                    profile.aws_region,
+                    "--query",
+                    "Stacks[0].Outputs",
+                    "--output",
+                    "json",
                 ]
 
                 result = subprocess.run(cmd, capture_output=True, text=True)
@@ -473,9 +476,7 @@ class PackageCbCommand(Command):
                         settings["otelHeadersHelper"] = "__OTEL_HELPER_PATH__"
 
                         is_https = endpoint.startswith("https://")
-                        console.print(
-                            f"[dim]Added monitoring with {'HTTPS' if is_https else 'HTTP'} endpoint[/dim]"
-                        )
+                        console.print(f"[dim]Added monitoring with {'HTTPS' if is_https else 'HTTP'} endpoint[/dim]")
                     else:
                         console.print("[yellow]Warning: No monitoring endpoint found in stack outputs[/yellow]")
                 else:
@@ -521,11 +522,13 @@ class PackageCbCommand(Command):
                 if stack_outputs.get(config["output_key"]):
                     choices.append(questionary.Choice(f"{plat} — {config['description']}", value=plat, checked=True))
                 else:
-                    choices.append(questionary.Choice(
-                        f"{plat} — {config['description']} (not deployed)",
-                        value=plat,
-                        disabled="deploy codebuild stack first",
-                    ))
+                    choices.append(
+                        questionary.Choice(
+                            f"{plat} — {config['description']} (not deployed)",
+                            value=plat,
+                            disabled="deploy codebuild stack first",
+                        )
+                    )
 
             selected = questionary.checkbox(
                 "Select platform(s) to build (space to select, enter to confirm):",

--- a/source/claude_code_with_bedrock/cli/commands/status.py
+++ b/source/claude_code_with_bedrock/cli/commands/status.py
@@ -238,9 +238,7 @@ class StatusCommand(Command):
             monitoring_mode = getattr(profile, "monitoring_mode", "central")
             if monitoring_mode == "central":
                 # Get monitoring endpoint from CloudFormation
-                monitoring_stack = profile.stack_names.get(
-                    "monitoring", f"{profile.identity_pool_name}-otel-collector"
-                )
+                monitoring_stack = profile.stack_names.get("monitoring", f"{profile.identity_pool_name}-otel-collector")
                 monitoring_outputs = get_stack_outputs(monitoring_stack, profile.aws_region)
                 if monitoring_outputs:
                     endpoints["monitoring_endpoint"] = monitoring_outputs.get("CollectorEndpoint")

--- a/source/claude_code_with_bedrock/cli/commands/test.py
+++ b/source/claude_code_with_bedrock/cli/commands/test.py
@@ -458,7 +458,9 @@ class TestCommand(Command):
                 "auth0": "Auth0",
                 "cognito": "AWS Cognito",
             }
-            provider_label = provider_labels.get(provider_type, provider_type.title() if provider_type else "your identity provider")
+            provider_label = provider_labels.get(
+                provider_type, provider_type.title() if provider_type else "your identity provider"
+            )
             console.print(f"• Ensure you have access to the {provider_label} application")
             console.print("• Check that the Cognito Identity Pool is deployed")
             console.print("• Verify IAM roles have correct permissions")
@@ -607,7 +609,9 @@ class TestCommand(Command):
         except Exception as e:
             return {"status": "✗", "details": str(e)}
 
-    def _test_bedrock_access(self, profile_name: str, region: str, with_api: bool = False, selected_model: str = None) -> dict:
+    def _test_bedrock_access(
+        self, profile_name: str, region: str, with_api: bool = False, selected_model: str = None
+    ) -> dict:
         """Test Bedrock access in a specific region."""
         try:
             # Clear AWS credentials from environment
@@ -852,7 +856,8 @@ class TestCommand(Command):
         try:
             proc = subprocess.Popen(
                 [str(binary), "--config", str(config)],
-                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
             )
             time.sleep(2)
             if proc.poll() is not None:
@@ -943,6 +948,7 @@ class TestCommand(Command):
     def _get_fallback_test_model() -> str:
         """Get a fallback test model using the cheapest available model."""
         from claude_code_with_bedrock.models import resolve_model_for_tier
+
         return resolve_model_for_tier("haiku", "us") or "anthropic.claude-haiku-4-5-20251001-v1:0"
 
     def _test_model_invocation(self, profile_name: str, region: str, selected_model: str = None) -> dict:
@@ -1146,7 +1152,9 @@ class TestCommand(Command):
             try:
                 resolved = manager.resolve_quota_for_user(test_email, groups=None)
                 if resolved and resolved.identifier == test_email:
-                    results.append({"name": "Resolve Quota", "status": "✓", "details": "User policy correctly resolved"})
+                    results.append(
+                        {"name": "Resolve Quota", "status": "✓", "details": "User policy correctly resolved"}
+                    )
                 else:
                     results.append(
                         {"name": "Resolve Quota", "status": "!", "details": "Policy resolved but not user-specific"}
@@ -1374,8 +1382,7 @@ class TestCommand(Command):
 
         console.print(
             Panel.fit(
-                "[bold cyan]Quota Monitoring Tests[/bold cyan]\n\n"
-                f"Testing profile: [bold]{profile_name}[/bold]",
+                f"[bold cyan]Quota Monitoring Tests[/bold cyan]\n\nTesting profile: [bold]{profile_name}[/bold]",
                 border_style="cyan",
                 padding=(1, 2),
             )
@@ -1398,7 +1405,9 @@ class TestCommand(Command):
             if endpoint:
                 task = progress.add_task("Testing quota API...", total=None)
                 api_result = self._test_quota_api(credential_binary, endpoint, package_dir, profile_name)
-                test_results.append({"name": "Quota API", "status": api_result["status"], "details": api_result["details"]})
+                test_results.append(
+                    {"name": "Quota API", "status": api_result["status"], "details": api_result["details"]}
+                )
                 progress.update(task, completed=True)
             else:
                 test_results.append({"name": "Quota API", "status": "!", "details": "No endpoint configured"})

--- a/source/claude_code_with_bedrock/cli/utils/cloudformation.py
+++ b/source/claude_code_with_bedrock/cli/utils/cloudformation.py
@@ -501,9 +501,9 @@ class CloudFormationManager:
                                 resource["Properties"]["TemplateURL"] = f"https://{s3_bucket}.{s3_domain}/{s3_key}"
                             except Exception:
                                 # Fallback to path-style URL which works across partitions
-                                resource["Properties"][
-                                    "TemplateURL"
-                                ] = f"https://s3.{self.region}.amazonaws.com/{s3_bucket}/{s3_key}"
+                                resource["Properties"]["TemplateURL"] = (
+                                    f"https://s3.{self.region}.amazonaws.com/{s3_bucket}/{s3_key}"
+                                )
 
         # Return packaged template as YAML with CloudFormation intrinsic functions preserved
         return cfn_flip.dump_yaml(template)

--- a/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
+++ b/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
@@ -76,7 +76,6 @@ def build_mdm_config(
     return config
 
 
-
 def add_monitoring_config(mdm_config: dict, profile, console: Console) -> None:
     """Add OTLP endpoint to MDM config if monitoring stack is deployed."""
     if not profile.monitoring_enabled:
@@ -91,9 +90,7 @@ def add_monitoring_config(mdm_config: dict, profile, console: Console) -> None:
     # Try to resolve collector endpoint from stack outputs first,
     # fall back to profile.otel_collector_endpoint if stack query fails.
     endpoint = None
-    monitoring_stack = profile.stack_names.get(
-        "monitoring", f"{profile.identity_pool_name}-otel-collector"
-    )
+    monitoring_stack = profile.stack_names.get("monitoring", f"{profile.identity_pool_name}-otel-collector")
     try:
         outputs = get_stack_outputs(monitoring_stack, profile.aws_region)
         endpoint = outputs.get("CollectorEndpoint")

--- a/source/claude_code_with_bedrock/cli/utils/helpers.py
+++ b/source/claude_code_with_bedrock/cli/utils/helpers.py
@@ -32,8 +32,7 @@ def clear_cached_credentials(profile_name: str) -> bool:
         # Only remove if it's a section created by this tool
         section_items = dict(config.items(profile_name))
         is_ours = any(
-            "credential-process" in v or "claude-code-with-bedrock" in v or "ccwb" in v
-            for v in section_items.values()
+            "credential-process" in v or "claude-code-with-bedrock" in v or "ccwb" in v for v in section_items.values()
         )
         if not is_ours:
             return False

--- a/source/claude_code_with_bedrock/cli/utils/oidc_discovery.py
+++ b/source/claude_code_with_bedrock/cli/utils/oidc_discovery.py
@@ -50,9 +50,7 @@ def discover_oidc_endpoints(issuer_url: str, timeout: float = 10.0) -> dict[str,
         raise OidcDiscoveryError(f"Could not reach {discovery_url}: {e}") from e
 
     if response.status_code != 200:
-        raise OidcDiscoveryError(
-            f"Discovery endpoint returned HTTP {response.status_code} from {discovery_url}"
-        )
+        raise OidcDiscoveryError(f"Discovery endpoint returned HTTP {response.status_code} from {discovery_url}")
 
     try:
         data: Any = response.json()

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -39,7 +39,9 @@ class Profile:
     updated_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
     provider_type: str | None = None  # Auto-detected: "okta", "auth0", "azure", "cognito", "google", "generic"
     cognito_user_pool_id: str | None = None  # Only for Cognito User Pool providers
-    okta_auth_server: str = ""  # Okta authorization server ID ("default" for dev/free plans, empty for Org server on paid plans)
+    okta_auth_server: str = (
+        ""  # Okta authorization server ID ("default" for dev/free plans, empty for Org server on paid plans)
+    )
 
     # Generic OIDC provider configuration (provider_type == "generic")
     # Required when the IdP isn't Okta/Auth0/Azure/Cognito (e.g. PingFederate, Keycloak, ForgeRock).
@@ -178,7 +180,11 @@ class Profile:
                         # Check for exact domain match or subdomain match
                         # Using endswith with leading dot prevents bypass attacks
                         okta_domains = (".okta.com", ".oktapreview.com", ".okta-emea.com")
-                        if hostname_lower.endswith(okta_domains) or hostname_lower in ("okta.com", "oktapreview.com", "okta-emea.com"):
+                        if hostname_lower.endswith(okta_domains) or hostname_lower in (
+                            "okta.com",
+                            "oktapreview.com",
+                            "okta-emea.com",
+                        ):
                             data["provider_type"] = "okta"
                         elif hostname_lower.endswith(".auth0.com") or hostname_lower == "auth0.com":
                             data["provider_type"] = "auth0"
@@ -324,8 +330,7 @@ class Config:
         # Validate profile name
         if not self._is_valid_profile_name(profile.name):
             raise ValueError(
-                f"Invalid profile name: {profile.name}. "
-                "Name must be alphanumeric with hyphens only, max 64 characters."
+                f"Invalid profile name: {profile.name}. Name must be alphanumeric with hyphens only, max 64 characters."
             )
 
         # Update timestamp

--- a/source/claude_code_with_bedrock/models.py
+++ b/source/claude_code_with_bedrock/models.py
@@ -18,6 +18,7 @@ from typing import Any
 @dataclass(frozen=True)
 class InferenceProfile:
     """A CRIS inference profile for a specific geography."""
+
     model_id: str
     description: str
     source_regions: tuple[str, ...]
@@ -43,6 +44,7 @@ class InferenceProfile:
 @dataclass(frozen=True)
 class ClaudeModel:
     """A Claude model with its available inference profiles."""
+
     name: str
     base_model_id: str
     profiles: dict[str, InferenceProfile]
@@ -94,7 +96,13 @@ def _build_model(data: dict) -> ClaudeModel:
     )
 
 
-DEFAULT_REGIONS = {"us": "us-east-1", "eu": "eu-west-1", "europe": "eu-west-1", "apac": "ap-northeast-1", "us-gov": "us-gov-west-1"}
+DEFAULT_REGIONS = {
+    "us": "us-east-1",
+    "eu": "eu-west-1",
+    "europe": "eu-west-1",
+    "apac": "ap-northeast-1",
+    "us-gov": "us-gov-west-1",
+}
 
 # Claude model configurations
 # Each model defines its availability across different cross-region profiles
@@ -107,26 +115,57 @@ _CLAUDE_MODELS_RAW = {
                 "model_id": "us.anthropic.claude-sonnet-4-6",
                 "description": "US CRIS - US and Canada regions",
                 "source_regions": [
-                    "us-east-1", "us-east-2", "us-west-1", "us-west-2",
-                    "ca-central-1", "ca-west-1",
+                    "us-east-1",
+                    "us-east-2",
+                    "us-west-1",
+                    "us-west-2",
+                    "ca-central-1",
+                    "ca-west-1",
                 ],
                 "destination_regions": [
-                    "us-east-1", "us-east-2", "us-west-2",
-                    "ca-central-1", "ca-west-1",
+                    "us-east-1",
+                    "us-east-2",
+                    "us-west-2",
+                    "ca-central-1",
+                    "ca-west-1",
                 ],
             },
             "global": {
                 "model_id": "global.anthropic.claude-sonnet-4-6",
                 "description": "Global CRIS - All commercial AWS regions worldwide",
                 "source_regions": [
-                    "af-south-1", "ap-east-2", "ap-northeast-1", "ap-northeast-2", "ap-northeast-3",
-                    "ap-south-1", "ap-south-2", "ap-southeast-1", "ap-southeast-2", "ap-southeast-3",
-                    "ap-southeast-4", "ap-southeast-5", "ap-southeast-7",
-                    "ca-central-1", "ca-west-1",
-                    "eu-central-1", "eu-central-2", "eu-north-1", "eu-south-1", "eu-south-2",
-                    "eu-west-1", "eu-west-2", "eu-west-3",
-                    "il-central-1", "me-central-1", "me-south-1", "mx-central-1", "sa-east-1",
-                    "us-east-1", "us-east-2", "us-west-1", "us-west-2",
+                    "af-south-1",
+                    "ap-east-2",
+                    "ap-northeast-1",
+                    "ap-northeast-2",
+                    "ap-northeast-3",
+                    "ap-south-1",
+                    "ap-south-2",
+                    "ap-southeast-1",
+                    "ap-southeast-2",
+                    "ap-southeast-3",
+                    "ap-southeast-4",
+                    "ap-southeast-5",
+                    "ap-southeast-7",
+                    "ca-central-1",
+                    "ca-west-1",
+                    "eu-central-1",
+                    "eu-central-2",
+                    "eu-north-1",
+                    "eu-south-1",
+                    "eu-south-2",
+                    "eu-west-1",
+                    "eu-west-2",
+                    "eu-west-3",
+                    "il-central-1",
+                    "me-central-1",
+                    "me-south-1",
+                    "mx-central-1",
+                    "sa-east-1",
+                    "us-east-1",
+                    "us-east-2",
+                    "us-west-1",
+                    "us-west-2",
                 ],
                 "destination_regions": ["all-commercial"],
             },
@@ -134,7 +173,14 @@ _CLAUDE_MODELS_RAW = {
                 "model_id": "eu.anthropic.claude-sonnet-4-6",
                 "description": "EU CRIS - European regions",
                 "source_regions": ["eu-central-1", "eu-north-1", "eu-south-1", "eu-south-2", "eu-west-1", "eu-west-3"],
-                "destination_regions": ["eu-central-1", "eu-north-1", "eu-south-1", "eu-south-2", "eu-west-1", "eu-west-3"],
+                "destination_regions": [
+                    "eu-central-1",
+                    "eu-north-1",
+                    "eu-south-1",
+                    "eu-south-2",
+                    "eu-west-1",
+                    "eu-west-3",
+                ],
             },
             "au": {
                 "model_id": "au.anthropic.claude-sonnet-4-6",
@@ -498,11 +544,16 @@ _CLAUDE_MODELS_RAW = {
                 "model_id": "us.anthropic.claude-opus-4-5-20251101-v1:0",
                 "description": "US CRIS - US and Canada regions",
                 "source_regions": [
-                    "us-east-1", "us-east-2", "us-west-1", "us-west-2",
+                    "us-east-1",
+                    "us-east-2",
+                    "us-west-1",
+                    "us-west-2",
                     "ca-central-1",
                 ],
                 "destination_regions": [
-                    "us-east-1", "us-east-2", "us-west-2",
+                    "us-east-1",
+                    "us-east-2",
+                    "us-west-2",
                     "ca-central-1",
                 ],
             },
@@ -510,14 +561,38 @@ _CLAUDE_MODELS_RAW = {
                 "model_id": "global.anthropic.claude-opus-4-5-20251101-v1:0",
                 "description": "Global CRIS - All commercial AWS regions worldwide",
                 "source_regions": [
-                    "af-south-1", "ap-east-2", "ap-northeast-1", "ap-northeast-2", "ap-northeast-3",
-                    "ap-south-1", "ap-south-2", "ap-southeast-1", "ap-southeast-2", "ap-southeast-3",
-                    "ap-southeast-4", "ap-southeast-5", "ap-southeast-7",
-                    "ca-central-1", "ca-west-1",
-                    "eu-central-1", "eu-central-2", "eu-north-1", "eu-south-1", "eu-south-2",
-                    "eu-west-1", "eu-west-2", "eu-west-3",
-                    "il-central-1", "me-central-1", "me-south-1", "mx-central-1", "sa-east-1",
-                    "us-east-1", "us-east-2", "us-west-1", "us-west-2",
+                    "af-south-1",
+                    "ap-east-2",
+                    "ap-northeast-1",
+                    "ap-northeast-2",
+                    "ap-northeast-3",
+                    "ap-south-1",
+                    "ap-south-2",
+                    "ap-southeast-1",
+                    "ap-southeast-2",
+                    "ap-southeast-3",
+                    "ap-southeast-4",
+                    "ap-southeast-5",
+                    "ap-southeast-7",
+                    "ca-central-1",
+                    "ca-west-1",
+                    "eu-central-1",
+                    "eu-central-2",
+                    "eu-north-1",
+                    "eu-south-1",
+                    "eu-south-2",
+                    "eu-west-1",
+                    "eu-west-2",
+                    "eu-west-3",
+                    "il-central-1",
+                    "me-central-1",
+                    "me-south-1",
+                    "mx-central-1",
+                    "sa-east-1",
+                    "us-east-1",
+                    "us-east-2",
+                    "us-west-1",
+                    "us-west-2",
                 ],
                 "destination_regions": ["all-commercial"],
             },
@@ -525,7 +600,14 @@ _CLAUDE_MODELS_RAW = {
                 "model_id": "eu.anthropic.claude-opus-4-5-20251101-v1:0",
                 "description": "EU CRIS - European regions",
                 "source_regions": ["eu-central-1", "eu-north-1", "eu-south-1", "eu-south-2", "eu-west-1", "eu-west-3"],
-                "destination_regions": ["eu-central-1", "eu-north-1", "eu-south-1", "eu-south-2", "eu-west-1", "eu-west-3"],
+                "destination_regions": [
+                    "eu-central-1",
+                    "eu-north-1",
+                    "eu-south-1",
+                    "eu-south-2",
+                    "eu-west-1",
+                    "eu-west-3",
+                ],
             },
         },
     },
@@ -879,14 +961,38 @@ _CLAUDE_MODELS_RAW = {
                 "model_id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
                 "description": "All commercial regions",
                 "source_regions": [
-                    "af-south-1", "ap-east-2", "ap-northeast-1", "ap-northeast-2", "ap-northeast-3",
-                    "ap-south-1", "ap-south-2", "ap-southeast-1", "ap-southeast-2", "ap-southeast-3",
-                    "ap-southeast-4", "ap-southeast-5", "ap-southeast-7",
-                    "ca-central-1", "ca-west-1",
-                    "eu-central-1", "eu-central-2", "eu-north-1", "eu-south-1", "eu-south-2",
-                    "eu-west-1", "eu-west-2", "eu-west-3",
-                    "il-central-1", "me-central-1", "me-south-1", "mx-central-1", "sa-east-1",
-                    "us-east-1", "us-east-2", "us-west-1", "us-west-2",
+                    "af-south-1",
+                    "ap-east-2",
+                    "ap-northeast-1",
+                    "ap-northeast-2",
+                    "ap-northeast-3",
+                    "ap-south-1",
+                    "ap-south-2",
+                    "ap-southeast-1",
+                    "ap-southeast-2",
+                    "ap-southeast-3",
+                    "ap-southeast-4",
+                    "ap-southeast-5",
+                    "ap-southeast-7",
+                    "ca-central-1",
+                    "ca-west-1",
+                    "eu-central-1",
+                    "eu-central-2",
+                    "eu-north-1",
+                    "eu-south-1",
+                    "eu-south-2",
+                    "eu-west-1",
+                    "eu-west-2",
+                    "eu-west-3",
+                    "il-central-1",
+                    "me-central-1",
+                    "me-south-1",
+                    "mx-central-1",
+                    "sa-east-1",
+                    "us-east-1",
+                    "us-east-2",
+                    "us-west-1",
+                    "us-west-2",
                 ],
                 "destination_regions": ["all-commercial"],
             },
@@ -894,7 +1000,14 @@ _CLAUDE_MODELS_RAW = {
                 "model_id": "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
                 "description": "EU CRIS - European regions",
                 "source_regions": ["eu-central-1", "eu-north-1", "eu-south-1", "eu-south-2", "eu-west-1", "eu-west-3"],
-                "destination_regions": ["eu-central-1", "eu-north-1", "eu-south-1", "eu-south-2", "eu-west-1", "eu-west-3"],
+                "destination_regions": [
+                    "eu-central-1",
+                    "eu-north-1",
+                    "eu-south-1",
+                    "eu-south-2",
+                    "eu-west-1",
+                    "eu-west-3",
+                ],
             },
             "au": {
                 "model_id": "au.anthropic.claude-haiku-4-5-20251001-v1:0",
@@ -1327,11 +1440,13 @@ def get_throttle_metrics() -> list[dict]:
                 suffix = f" ({region})"
                 if profile_key not in ("us",):
                     suffix = f" {profile_key.upper()} ({region})"
-                metrics.append({
-                    "model_id": model_id,
-                    "label": f"{name}{suffix}",
-                    "region": region,
-                })
+                metrics.append(
+                    {
+                        "model_id": model_id,
+                        "label": f"{name}{suffix}",
+                        "region": region,
+                    }
+                )
     return metrics
 
 
@@ -1362,9 +1477,7 @@ DATA_RESIDENCY_PREFIXES = {"au", "jp", "eu"}
 
 # Auto-derived from MODEL_TIER_PREFERENCES: model_key → tier
 MODEL_KEY_TO_TIER: dict[str, str] = {
-    model_key: tier
-    for tier, model_keys in MODEL_TIER_PREFERENCES.items()
-    for model_key in model_keys
+    model_key: tier for tier, model_keys in MODEL_TIER_PREFERENCES.items() for model_key in model_keys
 }
 
 # Maps tier → Claude Code model alias used in ANTHROPIC_MODEL env var
@@ -1426,8 +1539,20 @@ def resolve_model_for_tier(tier: str, cris_prefix: str) -> str | None:
     # e.g. jp.opus doesn't exist → fall back to jp.sonnet-4-6.
     if resolved_prefix in DATA_RESIDENCY_PREFIXES:
         # Search all models (newest first) for ANY model with this prefix
-        all_model_keys = ["opus-4-8", "opus-4-7", "sonnet-4-6", "sonnet-4-5", "sonnet-4",
-                          "opus-4-6", "opus-4-5", "haiku-4-5", "fable-5", "sonnet-3-7", "opus-4-1", "opus-4"]
+        all_model_keys = [
+            "opus-4-8",
+            "opus-4-7",
+            "sonnet-4-6",
+            "sonnet-4-5",
+            "sonnet-4",
+            "opus-4-6",
+            "opus-4-5",
+            "haiku-4-5",
+            "fable-5",
+            "sonnet-3-7",
+            "opus-4-1",
+            "opus-4",
+        ]
         for model_key in all_model_keys:
             if model_key in CLAUDE_MODELS:
                 profiles = CLAUDE_MODELS[model_key].get("profiles", {})

--- a/source/claude_code_with_bedrock/quota_policies.py
+++ b/source/claude_code_with_bedrock/quota_policies.py
@@ -177,16 +177,12 @@ class QuotaPolicyManager:
             )
         except ClientError as e:
             if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
-                raise PolicyAlreadyExistsError(
-                    f"Policy already exists for {policy_type.value}:{identifier}"
-                )
+                raise PolicyAlreadyExistsError(f"Policy already exists for {policy_type.value}:{identifier}")
             raise QuotaPolicyError(f"Failed to create policy: {e}") from e
 
         return policy
 
-    def get_policy(
-        self, policy_type: PolicyType, identifier: str
-    ) -> QuotaPolicy | None:
+    def get_policy(self, policy_type: PolicyType, identifier: str) -> QuotaPolicy | None:
         """Get a policy by type and identifier.
 
         Args:
@@ -243,9 +239,7 @@ class QuotaPolicyManager:
         # First get the existing policy
         existing = self.get_policy(policy_type, identifier)
         if not existing:
-            raise PolicyNotFoundError(
-                f"Policy not found for {policy_type.value}:{identifier}"
-            )
+            raise PolicyNotFoundError(f"Policy not found for {policy_type.value}:{identifier}")
 
         # Build update expression
         update_parts = []
@@ -304,9 +298,7 @@ class QuotaPolicyManager:
             )
         except ClientError as e:
             if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
-                raise PolicyNotFoundError(
-                    f"Policy not found for {policy_type.value}:{identifier}"
-                )
+                raise PolicyNotFoundError(f"Policy not found for {policy_type.value}:{identifier}")
             raise QuotaPolicyError(f"Failed to update policy: {e}") from e
 
         return QuotaPolicy.from_dynamodb_item(response["Attributes"])
@@ -336,9 +328,7 @@ class QuotaPolicyManager:
 
         return "Attributes" in response
 
-    def list_policies(
-        self, policy_type: PolicyType | None = None
-    ) -> list[QuotaPolicy]:
+    def list_policies(self, policy_type: PolicyType | None = None) -> list[QuotaPolicy]:
         """List all policies, optionally filtered by type.
 
         Args:
@@ -376,9 +366,7 @@ class QuotaPolicyManager:
 
         return policies
 
-    def resolve_quota_for_user(
-        self, email: str, groups: list[str] | None = None
-    ) -> QuotaPolicy | None:
+    def resolve_quota_for_user(self, email: str, groups: list[str] | None = None) -> QuotaPolicy | None:
         """Resolve the effective quota policy for a user.
 
         Precedence: user-specific > group (most restrictive) > default
@@ -447,18 +435,12 @@ class QuotaPolicyManager:
             }
 
         monthly_pct = (
-            (current_monthly_tokens / policy.monthly_token_limit * 100)
-            if policy.monthly_token_limit > 0
-            else 0
+            (current_monthly_tokens / policy.monthly_token_limit * 100) if policy.monthly_token_limit > 0 else 0
         )
 
         daily_pct = None
         if policy.daily_token_limit:
-            daily_pct = (
-                (current_daily_tokens / policy.daily_token_limit * 100)
-                if policy.daily_token_limit > 0
-                else 0
-            )
+            daily_pct = (current_daily_tokens / policy.daily_token_limit * 100) if policy.daily_token_limit > 0 else 0
 
         return {
             "email": email,
@@ -477,9 +459,7 @@ class QuotaPolicyManager:
             "warning_threshold_90": policy.warning_threshold_90,
         }
 
-    def export_policies(
-        self, policy_type: PolicyType | None = None
-    ) -> list[dict[str, Any]]:
+    def export_policies(self, policy_type: PolicyType | None = None) -> list[dict[str, Any]]:
         """Export policies as list of dicts with human-readable token values.
 
         Args:
@@ -557,12 +537,14 @@ class QuotaPolicyManager:
                 if existing:
                     if skip_existing:
                         results["skipped"] += 1
-                        results["details"].append({
-                            "action": "skip",
-                            "type": parsed["policy_type"].value,
-                            "identifier": parsed["identifier"],
-                            "reason": "already exists",
-                        })
+                        results["details"].append(
+                            {
+                                "action": "skip",
+                                "type": parsed["policy_type"].value,
+                                "identifier": parsed["identifier"],
+                                "reason": "already exists",
+                            }
+                        )
                     elif update_existing:
                         if not dry_run:
                             self.update_policy(
@@ -574,20 +556,24 @@ class QuotaPolicyManager:
                                 enabled=parsed.get("enabled", True),
                             )
                         results["updated"] += 1
-                        results["details"].append({
-                            "action": "update",
-                            "type": parsed["policy_type"].value,
-                            "identifier": parsed["identifier"],
-                            "monthly_limit": _format_tokens(parsed["monthly_token_limit"]),
-                        })
+                        results["details"].append(
+                            {
+                                "action": "update",
+                                "type": parsed["policy_type"].value,
+                                "identifier": parsed["identifier"],
+                                "monthly_limit": _format_tokens(parsed["monthly_token_limit"]),
+                            }
+                        )
                     else:
                         # Neither skip nor update - this is a conflict
-                        results["errors"].append({
-                            "row": i,
-                            "type": parsed["policy_type"].value,
-                            "identifier": parsed["identifier"],
-                            "error": "Policy already exists (use --skip-existing or --update)",
-                        })
+                        results["errors"].append(
+                            {
+                                "row": i,
+                                "type": parsed["policy_type"].value,
+                                "identifier": parsed["identifier"],
+                                "error": "Policy already exists (use --skip-existing or --update)",
+                            }
+                        )
                 else:
                     # Create new policy
                     if not dry_run:
@@ -600,18 +586,22 @@ class QuotaPolicyManager:
                             enabled=parsed.get("enabled", True),
                         )
                     results["created"] += 1
-                    results["details"].append({
-                        "action": "create",
-                        "type": parsed["policy_type"].value,
-                        "identifier": parsed["identifier"],
-                        "monthly_limit": _format_tokens(parsed["monthly_token_limit"]),
-                    })
+                    results["details"].append(
+                        {
+                            "action": "create",
+                            "type": parsed["policy_type"].value,
+                            "identifier": parsed["identifier"],
+                            "monthly_limit": _format_tokens(parsed["monthly_token_limit"]),
+                        }
+                    )
 
             except (ValueError, KeyError) as e:
-                results["errors"].append({
-                    "row": i,
-                    "error": str(e),
-                })
+                results["errors"].append(
+                    {
+                        "row": i,
+                        "error": str(e),
+                    }
+                )
 
         return results
 
@@ -692,7 +682,9 @@ class QuotaPolicyManager:
             elif enforcement_str in ("alert", ""):
                 result["enforcement_mode"] = EnforcementMode.ALERT
             else:
-                raise ValueError(f"Row {row_num}: Invalid enforcement_mode '{enforcement_str}'. Use 'alert' or 'block'.")
+                raise ValueError(
+                    f"Row {row_num}: Invalid enforcement_mode '{enforcement_str}'. Use 'alert' or 'block'."
+                )
 
         # Parse enabled status
         enabled_val = policy_dict.get("enabled", True)

--- a/source/claude_code_with_bedrock/validators.py
+++ b/source/claude_code_with_bedrock/validators.py
@@ -103,9 +103,7 @@ class ProfileValidator:
         # Validate profile name format
         name = profile_data.get("name", "")
         if not ProfileValidator._is_valid_profile_name(name):
-            errors.append(
-                f"Invalid profile name '{name}'. " "Must be alphanumeric with hyphens only, max 64 characters"
-            )
+            errors.append(f"Invalid profile name '{name}'. Must be alphanumeric with hyphens only, max 64 characters")
 
         # Validate provider domain format
         domain = profile_data.get("provider_domain", "")
@@ -165,7 +163,7 @@ class ProfileValidator:
         if distribution_type:
             if distribution_type not in ["presigned-s3", "landing-page"]:
                 errors.append(
-                    f"Invalid distribution_type: {distribution_type}. " "Must be 'presigned-s3' or 'landing-page'"
+                    f"Invalid distribution_type: {distribution_type}. Must be 'presigned-s3' or 'landing-page'"
                 )
 
             # Landing page requires additional fields
@@ -213,7 +211,7 @@ class ProfileValidator:
             valid_profiles = ["us", "europe", "apac", "global", "japan", "eu"]
             if cross_region not in valid_profiles:
                 warnings.append(
-                    f"Unknown cross_region_profile: {cross_region}. " f"Expected one of: {', '.join(valid_profiles)}"
+                    f"Unknown cross_region_profile: {cross_region}. Expected one of: {', '.join(valid_profiles)}"
                 )
 
         # Validate quota settings
@@ -242,7 +240,7 @@ class ProfileValidator:
                 errors.append("data_retention_days must be a positive integer")
             elif retention_days > 365:
                 warnings.append(
-                    f"data_retention_days ({retention_days}) is over 1 year. " "This may incur significant costs."
+                    f"data_retention_days ({retention_days}) is over 1 year. This may incur significant costs."
                 )
 
         # Validate schema version

--- a/source/credential_provider/__main__.py
+++ b/source/credential_provider/__main__.py
@@ -115,8 +115,7 @@ class MultiProviderAuth:
         # Fail clearly if provider type is unknown
         if self.provider_type not in PROVIDER_CONFIGS:
             raise ValueError(
-                f"Unknown provider type '{self.provider_type}'. "
-                f"Valid providers: {', '.join(PROVIDER_CONFIGS.keys())}"
+                f"Unknown provider type '{self.provider_type}'. Valid providers: {', '.join(PROVIDER_CONFIGS.keys())}"
             )
         self.provider_config = dict(PROVIDER_CONFIGS[self.provider_type])
 
@@ -126,8 +125,12 @@ class MultiProviderAuth:
         if self.provider_type == "okta":
             auth_server = self.config.get("okta_auth_server", "")
             if auth_server:
-                self.provider_config["authorize_endpoint"] = self.provider_config["authorize_endpoint"].format(auth_server=auth_server)
-                self.provider_config["token_endpoint"] = self.provider_config["token_endpoint"].format(auth_server=auth_server)
+                self.provider_config["authorize_endpoint"] = self.provider_config["authorize_endpoint"].format(
+                    auth_server=auth_server
+                )
+                self.provider_config["token_endpoint"] = self.provider_config["token_endpoint"].format(
+                    auth_server=auth_server
+                )
             else:
                 # Org auth server (paid plans) — no auth server ID in path
                 self.provider_config["authorize_endpoint"] = "/oauth2/v1/authorize"
@@ -349,7 +352,11 @@ class MultiProviderAuth:
             # Check for exact domain match or subdomain match
             # Using endswith with leading dot prevents bypass attacks
             okta_domains = (".okta.com", ".oktapreview.com", ".okta-emea.com")
-            if hostname_lower.endswith(okta_domains) or hostname_lower in ("okta.com", "oktapreview.com", "okta-emea.com"):
+            if hostname_lower.endswith(okta_domains) or hostname_lower in (
+                "okta.com",
+                "oktapreview.com",
+                "okta-emea.com",
+            ):
                 return "okta"
             elif hostname_lower.endswith(".auth0.com") or hostname_lower == "auth0.com":
                 return "auth0"
@@ -663,13 +670,15 @@ class MultiProviderAuth:
                             keyring.set_password("claude-code-with-bedrock", entry, expired_data)
                 else:
                     if keyring.get_password("claude-code-with-bedrock", f"{self.profile}-credentials"):
-                        expired_credential = json.dumps({
-                            "Version": 1,
-                            "AccessKeyId": "EXPIRED",
-                            "SecretAccessKey": "EXPIRED",
-                            "SessionToken": "EXPIRED",
-                            "Expiration": "2000-01-01T00:00:00Z",
-                        })
+                        expired_credential = json.dumps(
+                            {
+                                "Version": 1,
+                                "AccessKeyId": "EXPIRED",
+                                "SecretAccessKey": "EXPIRED",
+                                "SessionToken": "EXPIRED",
+                                "Expiration": "2000-01-01T00:00:00Z",
+                            }
+                        )
                         keyring.set_password(
                             "claude-code-with-bedrock", f"{self.profile}-credentials", expired_credential
                         )
@@ -1797,9 +1806,7 @@ class MultiProviderAuth:
             # Send JWT token in Authorization header for API Gateway JWT Authorizer validation
             # The API extracts email/groups from validated JWT claims, not query params
             response = requests.get(
-                f"{quota_api_endpoint}/check",
-                headers={"Authorization": f"Bearer {id_token}"},
-                timeout=timeout
+                f"{quota_api_endpoint}/check", headers={"Authorization": f"Bearer {id_token}"}, timeout=timeout
             )
 
             if response.status_code == 200:
@@ -1813,7 +1820,7 @@ class MultiProviderAuth:
                     return {
                         "allowed": False,
                         "reason": "jwt_invalid",
-                        "message": "Quota check authentication failed - invalid or expired token"
+                        "message": "Quota check authentication failed - invalid or expired token",
                     }
                 return {"allowed": True, "reason": "jwt_invalid"}
             else:
@@ -1823,18 +1830,14 @@ class MultiProviderAuth:
                     return {
                         "allowed": False,
                         "reason": "api_error",
-                        "message": f"Quota check failed with status {response.status_code}"
+                        "message": f"Quota check failed with status {response.status_code}",
                     }
                 return {"allowed": True, "reason": "api_error"}
 
         except requests.exceptions.Timeout:
             self._debug_print("Quota check timed out")
             if fail_mode == "closed":
-                return {
-                    "allowed": False,
-                    "reason": "timeout",
-                    "message": "Quota check timed out. Please try again."
-                }
+                return {"allowed": False, "reason": "timeout", "message": "Quota check timed out. Please try again."}
             return {"allowed": True, "reason": "timeout"}
 
         except requests.exceptions.RequestException as e:
@@ -1843,18 +1846,14 @@ class MultiProviderAuth:
                 return {
                     "allowed": False,
                     "reason": "connection_error",
-                    "message": f"Could not connect to quota service: {e}"
+                    "message": f"Could not connect to quota service: {e}",
                 }
             return {"allowed": True, "reason": "connection_error"}
 
         except Exception as e:
             self._debug_print(f"Quota check error: {e}")
             if fail_mode == "closed":
-                return {
-                    "allowed": False,
-                    "reason": "error",
-                    "message": f"Quota check failed: {e}"
-                }
+                return {"allowed": False, "reason": "error", "message": f"Quota check failed: {e}"}
             return {"allowed": True, "reason": "error"}
 
     def _handle_quota_blocked(self, quota_result: dict) -> int:
@@ -1880,9 +1879,15 @@ class MultiProviderAuth:
         if usage:
             print("Current Usage:", file=sys.stderr)
             if "monthly_tokens" in usage and "monthly_limit" in usage:
-                print(f"  Monthly: {usage['monthly_tokens']:,} / {usage['monthly_limit']:,} tokens ({usage.get('monthly_percent', 0):.1f}%)", file=sys.stderr)
+                print(
+                    f"  Monthly: {usage['monthly_tokens']:,} / {usage['monthly_limit']:,} tokens ({usage.get('monthly_percent', 0):.1f}%)",
+                    file=sys.stderr,
+                )
             if "daily_tokens" in usage and "daily_limit" in usage:
-                print(f"  Daily: {usage['daily_tokens']:,} / {usage['daily_limit']:,} tokens ({usage.get('daily_percent', 0):.1f}%)", file=sys.stderr)
+                print(
+                    f"  Daily: {usage['daily_tokens']:,} / {usage['daily_limit']:,} tokens ({usage.get('daily_percent', 0):.1f}%)",
+                    file=sys.stderr,
+                )
 
         if policy:
             print(f"\nPolicy: {policy.get('type', 'unknown')}:{policy.get('identifier', 'unknown')}", file=sys.stderr)
@@ -1922,11 +1927,11 @@ class MultiProviderAuth:
 
             def format_tokens(n):
                 if n >= 1_000_000_000:
-                    return f"{n/1_000_000_000:.1f}B"
+                    return f"{n / 1_000_000_000:.1f}B"
                 elif n >= 1_000_000:
-                    return f"{n/1_000_000:.1f}M"
+                    return f"{n / 1_000_000:.1f}M"
                 elif n >= 1_000:
-                    return f"{n/1_000:.1f}K"
+                    return f"{n / 1_000:.1f}K"
                 return str(int(n))
 
             # Determine status styling
@@ -2049,15 +2054,21 @@ class MultiProviderAuth:
             <div class="usage-section">
                 <div class="usage-label">
                     <span>Monthly Usage</span>
-                    <span class="usage-value">{format_tokens(monthly_tokens)} / {format_tokens(monthly_limit)} ({monthly_percent:.1f}%)</span>
+                    <span class="usage-value">{format_tokens(monthly_tokens)} / {format_tokens(monthly_limit)} ({
+                monthly_percent:.1f}%)</span>
                 </div>
                 <div class="progress-bar">
-                    <div class="progress-fill" style="width: {min(monthly_percent, 100)}%; background: {monthly_bar_color};">
+                    <div class="progress-fill" style="width: {min(monthly_percent, 100)}%; background: {
+                monthly_bar_color
+            };">
                         {monthly_percent:.0f}%
                     </div>
                 </div>
             </div>
-            {"" if not daily_limit else f'''
+            {
+                ""
+                if not daily_limit
+                else f'''
             <div class="usage-section">
                 <div class="usage-label">
                     <span>Daily Usage</span>
@@ -2069,9 +2080,18 @@ class MultiProviderAuth:
                     </div>
                 </div>
             </div>
-            '''}
+            '''
+            }
             <div class="message">
-                {html_module.escape(message) if message else ("Your access has been blocked due to quota limits." if is_blocked else "You're approaching your quota limit.")}
+                {
+                html_module.escape(message)
+                if message
+                else (
+                    "Your access has been blocked due to quota limits."
+                    if is_blocked
+                    else "You're approaching your quota limit."
+                )
+            }
                 {" Contact your administrator for assistance." if is_blocked else ""}
             </div>
         </div>
@@ -2139,9 +2159,15 @@ class MultiProviderAuth:
 
         if usage:
             if "monthly_tokens" in usage and "monthly_limit" in usage:
-                print(f"  Monthly: {usage['monthly_tokens']:,} / {usage['monthly_limit']:,} tokens ({monthly_percent:.1f}%)", file=sys.stderr)
+                print(
+                    f"  Monthly: {usage['monthly_tokens']:,} / {usage['monthly_limit']:,} tokens ({monthly_percent:.1f}%)",
+                    file=sys.stderr,
+                )
             if "daily_tokens" in usage and "daily_limit" in usage:
-                print(f"  Daily: {usage['daily_tokens']:,} / {usage['daily_limit']:,} tokens ({daily_percent:.1f}%)", file=sys.stderr)
+                print(
+                    f"  Daily: {usage['daily_tokens']:,} / {usage['daily_limit']:,} tokens ({daily_percent:.1f}%)",
+                    file=sys.stderr,
+                )
 
         print("=" * 60 + "\n", file=sys.stderr)
 
@@ -2191,14 +2217,19 @@ class MultiProviderAuth:
         session = boto3.Session()
         creds = session.get_credentials()
         if creds is None:
-            print("Error: sso_enabled=false but no ambient AWS credentials found. "
-                  "Log in via 'aws sso login' first.", file=sys.stderr)
+            print(
+                "Error: sso_enabled=false but no ambient AWS credentials found. Log in via 'aws sso login' first.",
+                file=sys.stderr,
+            )
             return 1
 
         frozen = creds.get_frozen_credentials()
         if not frozen.access_key:
-            print("Error: ambient credentials resolved but access key is empty. "
-                  "Check your AWS CLI configuration or run 'aws sso login'.", file=sys.stderr)
+            print(
+                "Error: ambient credentials resolved but access key is empty. "
+                "Check your AWS CLI configuration or run 'aws sso login'.",
+                file=sys.stderr,
+            )
             return 1
 
         output = {
@@ -2295,9 +2326,7 @@ class MultiProviderAuth:
                 # Authenticate with OIDC provider (browser popup - only when id_token is also expired).
                 # Hand the still-bound lock socket to the OAuth callback server so
                 # the port is never released between the lock check and the callback.
-                self._debug_print(
-                    f"Authenticating with {self.provider_config['name']} for profile '{self.profile}'..."
-                )
+                self._debug_print(f"Authenticating with {self.provider_config['name']} for profile '{self.profile}'...")
                 id_token, token_claims = self.authenticate_oidc(lock_socket=lock_socket)
             finally:
                 try:
@@ -2339,6 +2368,7 @@ class MultiProviderAuth:
             return 1
         except Exception as e:
             import traceback
+
             error_msg = str(e)
             # Only print actual errors to stderr
             if "timeout" not in error_msg.lower():
@@ -2420,9 +2450,7 @@ def main():
                 sys.exit(1)
             secret = env_secret
         else:
-            secret = getpass.getpass(
-                f"Enter client secret for profile '{args.profile}' (press Enter to clear): "
-            )
+            secret = getpass.getpass(f"Enter client secret for profile '{args.profile}' (press Enter to clear): ")
 
         try:
             if not secret:
@@ -2506,6 +2534,7 @@ if __name__ == "__main__":
         main()
     except Exception as e:
         import traceback
+
         print(f"Error: {e}", file=sys.stderr)
         traceback.print_exc(file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
## Why

Consistent formatting reduces noise in diffs and lets contributors focus on logic changes.

## What

- Apply `ruff format` to all Python source files (18 files)
- No logic changes — purely whitespace/formatting

Rebased onto latest `beta` (resolves conflicts with recent merges including fable-5, cowork-3p, opus-4-8).

---

Supersedes #535. Credit to @spawnia for the original PR.

🤖 Rebased by Wirclaw