### PR TITLE
feat(codebuild): cross-region CodeBuild deployment for unsupported regions

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/builds.py
+++ b/source/claude_code_with_bedrock/cli/commands/builds.py
@@ -70,7 +70,7 @@ class BuildsCommand(Command):
         """Get all CodeBuild project names from stack outputs."""
         stack_name = profile.stack_names.get("codebuild", f"{profile.identity_pool_name}-codebuild")
         try:
-            stack_outputs = get_stack_outputs(stack_name, profile.aws_region)
+            stack_outputs = get_stack_outputs(stack_name, get_codebuild_region(profile))
         except Exception:
             return {}
 
@@ -268,7 +268,7 @@ class BuildsCommand(Command):
         # Get CodeBuild bucket
         stack_name = profile.stack_names.get("codebuild", f"{profile.identity_pool_name}-codebuild")
         try:
-            stack_outputs = get_stack_outputs(stack_name, profile.aws_region)
+            stack_outputs = get_stack_outputs(stack_name, get_codebuild_region(profile))
         except Exception:
             console.print("[red]CodeBuild stack not found.[/red]")
             return 1
@@ -294,7 +294,7 @@ class BuildsCommand(Command):
         console.print(f"[bold]Downloading to:[/bold] {display_path}")
         console.print()
 
-        s3 = boto3.client("s3", region_name=profile.aws_region)
+        s3 = boto3.client("s3", region_name=get_codebuild_region(profile))
         downloaded = []
         download_failed = []
 

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -24,6 +24,11 @@ from claude_code_with_bedrock.cli.utils.cf_exceptions import (
     StackRollbackError,
 )
 from claude_code_with_bedrock.cli.utils.cloudformation import CloudFormationManager
+from claude_code_with_bedrock.cli.utils.helpers import (
+    CODEBUILD_WINDOWS_REGIONS,
+    find_nearest_codebuild_region,
+    get_codebuild_region,
+)
 from claude_code_with_bedrock.config import Config
 
 # Azure tenant ID GUID pattern — matches UUIDs in various URL formats:
@@ -262,7 +267,13 @@ class DeployCommand(Command):
 
         for stack_type, description in stacks_to_deploy:
             stack_name = profile.stack_names.get(stack_type, f"{profile.identity_pool_name}-{stack_type}")
-            status = cf_manager.get_stack_status(stack_name)
+            # CodeBuild may live in a different region than the main infrastructure.
+            status_manager = cf_manager
+            if stack_type == "codebuild":
+                cb_region = get_codebuild_region(profile)
+                if cb_region != profile.aws_region:
+                    status_manager = CloudFormationManager(region=cb_region)
+            status = status_manager.get_stack_status(stack_name)
             if status and status in ["CREATE_COMPLETE", "UPDATE_COMPLETE", "UPDATE_ROLLBACK_COMPLETE"]:
                 status_display = "[green]Update[/green]"
             else:
@@ -292,7 +303,13 @@ class DeployCommand(Command):
                 for stack_type, stack_name, _status in reversed(orphaned_stacks):
                     try:
                         console.print(f"[yellow]Deleting {stack_type} stack: {stack_name}...[/yellow]")
-                        cf_manager.delete_stack(stack_name)
+                        # CodeBuild may be cross-region; delete it where it lives.
+                        del_mgr = cf_manager
+                        if stack_type == "codebuild":
+                            cb_region = get_codebuild_region(profile)
+                            if cb_region != profile.aws_region:
+                                del_mgr = CloudFormationManager(region=cb_region)
+                        del_mgr.delete_stack(stack_name)
                         console.print(f"[green]✓ {stack_type} stack deletion initiated[/green]")
                     except Exception as e:
                         console.print(f"[red]✗ Failed to delete {stack_type} stack: {e}[/red]")
@@ -355,9 +372,14 @@ class DeployCommand(Command):
         ) as progress:
             # Common deployment function
             def deploy_with_cf(
-                template_path, stack_name, params, capabilities=None, task_description="Deploying stack..."
+                template_path, stack_name, params, capabilities=None, task_description="Deploying stack...", cf=None
             ):
-                """Helper function to deploy a stack with CloudFormation manager."""
+                """Helper function to deploy a stack with CloudFormation manager.
+
+                ``cf`` overrides the shared region-bound manager (used for the
+                CodeBuild stack when it deploys to a different region).
+                """
+                manager = cf or cf_manager
                 task = progress.add_task(task_description, total=None)
 
                 try:
@@ -365,7 +387,7 @@ class DeployCommand(Command):
                     boto3_params = self._convert_params_to_boto3(params) if params else None
 
                     # Deploy stack
-                    result = cf_manager.deploy_stack(
+                    result = manager.deploy_stack(
                         stack_name=stack_name,
                         template_path=template_path,
                         parameters=boto3_params,
@@ -890,28 +912,40 @@ class DeployCommand(Command):
                             pass
 
             elif stack_type == "codebuild":
-                # WINDOWS_SERVER_2022_CONTAINER is only available in select regions
-                codebuild_supported_regions = [
-                    "us-east-1",
-                    "us-east-2",
-                    "us-west-2",
-                    "eu-central-1",
-                    "eu-west-1",
-                    "ap-northeast-1",
-                    "ap-southeast-2",
-                    "sa-east-1",
-                ]
-                if profile.aws_region not in codebuild_supported_regions:
+                # CodeBuild region is chosen in `ccwb init` (the Windows container
+                # fleet only exists in some regions). Deploy just executes that
+                # choice. If a legacy profile still resolves to an unsupported
+                # region — e.g. it predates the init region picker — skip with a
+                # pointer to init rather than failing the whole deploy.
+                codebuild_region = get_codebuild_region(profile)
+                if codebuild_region not in CODEBUILD_WINDOWS_REGIONS:
+                    nearest = find_nearest_codebuild_region(profile.aws_region)
                     console.print(
-                        f"[red]Windows CodeBuild is not available in {profile.aws_region}.[/red]\n"
-                        f"Supported regions: {', '.join(codebuild_supported_regions)}"
+                        f"[yellow]⚠ Skipping CodeBuild: Windows containers aren't available in "
+                        f"{codebuild_region}.[/yellow]"
                     )
-                    return 1
+                    console.print(
+                        f"[dim]Re-run [cyan]ccwb init[/cyan] to pick a supported CodeBuild region "
+                        f"(nearest: {nearest}), then deploy again.[/dim]"
+                    )
+                    return 0
+
+                # Deploy to the (possibly cross-region) CodeBuild region. Build a
+                # dedicated manager when it differs from the main region.
+                cf = (
+                    cf_manager
+                    if codebuild_region == profile.aws_region
+                    else CloudFormationManager(region=codebuild_region)
+                )
                 template = project_root / "deployment" / "infrastructure" / "codebuild-windows.yaml"
                 stack_name = profile.stack_names.get("codebuild", f"{profile.identity_pool_name}-codebuild")
                 params = [f"ProjectNamePrefix={profile.identity_pool_name}"]
                 return deploy_with_cf(
-                    template, stack_name, params, task_description="Deploying CodeBuild for Windows builds..."
+                    template,
+                    stack_name,
+                    params,
+                    task_description=f"Deploying CodeBuild for Windows builds in {codebuild_region}...",
+                    cf=cf,
                 )
 
             else:
@@ -928,7 +962,9 @@ class DeployCommand(Command):
     def _show_deployment_commands(self, stack_type: str, profile, console: Console) -> None:
         """Show AWS CLI commands for manual deployment."""
         project_root = Path(__file__).parents[4]
-        region = profile.aws_region
+        # CodeBuild may deploy to a different region than the main infrastructure;
+        # print the command for the region it actually deploys to.
+        region = get_codebuild_region(profile) if stack_type == "codebuild" else profile.aws_region
 
         def print_deploy_cmd(template, stack_name, params, capabilities=None):
             caps_str = " ".join(capabilities or ["CAPABILITY_IAM"])
@@ -1287,9 +1323,16 @@ class DeployCommand(Command):
         orphaned = []
         for stack_type in all_stack_types:
             if stack_type not in deploying_types:
-                # This stack type is not being deployed - check if it exists
+                # This stack type is not being deployed - check if it exists.
+                # CodeBuild may live in a different region (cross-region builds), so
+                # check it there or a cross-region orphan is never detected.
                 stack_name = profile.stack_names.get(stack_type, f"{profile.identity_pool_name}-{stack_type}")
-                status = cf_manager.get_stack_status(stack_name)
+                mgr = cf_manager
+                if stack_type == "codebuild":
+                    cb_region = get_codebuild_region(profile)
+                    if cb_region != profile.aws_region:
+                        mgr = CloudFormationManager(region=cb_region)
+                status = mgr.get_stack_status(stack_name)
 
                 if status and status not in ["DELETE_COMPLETE", "DELETE_IN_PROGRESS"]:
                     orphaned.append((stack_type, stack_name, status))
@@ -1357,11 +1400,7 @@ class DeployCommand(Command):
         # tokens carry iss=https://<domain>/oauth2/default. The quota JWT authorizer
         # must match that exact issuer or every /check request 401s (and, with
         # fail-open, silently disables enforcement).
-        if (
-            profile.provider_type == "okta"
-            and issuer_url
-            and not issuer_url.rstrip("/").endswith("/oauth2/default")
-        ):
+        if profile.provider_type == "okta" and issuer_url and not issuer_url.rstrip("/").endswith("/oauth2/default"):
             issuer_url = f"{issuer_url.rstrip('/')}/oauth2/default"
 
         # Auth0 tokens include trailing slash in iss claim, so authorizer must match

--- a/source/claude_code_with_bedrock/cli/commands/destroy.py
+++ b/source/claude_code_with_bedrock/cli/commands/destroy.py
@@ -11,7 +11,7 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.prompt import Confirm
 
 from claude_code_with_bedrock.cli.utils.cloudformation import CloudFormationManager
-from claude_code_with_bedrock.cli.utils.helpers import clear_cached_credentials
+from claude_code_with_bedrock.cli.utils.helpers import clear_cached_credentials, get_codebuild_region
 from claude_code_with_bedrock.config import Config
 
 
@@ -146,12 +146,16 @@ class DestroyCommand(Command):
                 continue
 
             stack_name = profile.stack_names.get(stack, f"{profile.identity_pool_name}-{stack}")
+            # CodeBuild may have been deployed cross-region (Windows container fleet
+            # isn't in every region); delete it where it actually lives, or it's
+            # silently orphaned in the build region while the destroy reports success.
+            stack_region = get_codebuild_region(profile) if stack == "codebuild" else profile.aws_region
             console.print(f"Destroying {stack} stack: [cyan]{stack_name}[/cyan]")
 
-            result = self._delete_stack(stack_name, profile.aws_region, console)
+            result = self._delete_stack(stack_name, stack_region, console)
             if result != 0:
                 # Don't break - collect failed resources and continue
-                failed = self._get_failed_resources(stack_name, profile.aws_region)
+                failed = self._get_failed_resources(stack_name, stack_region)
                 if failed:
                     all_failed_resources.extend(failed)
                     stacks_with_failures.append(stack_name)
@@ -165,7 +169,7 @@ class DestroyCommand(Command):
                 console.print()
             else:
                 # Check for silently retained resources (DeletionPolicy: Retain)
-                retained = self._get_retained_resources(stack_name, profile.aws_region)
+                retained = self._get_retained_resources(stack_name, stack_region)
                 if retained:
                     all_retained_resources.extend(retained)
                     console.print(f"[yellow]ℹ {stack.capitalize()} stack — retained resources (by policy):[/yellow]")
@@ -174,6 +178,28 @@ class DestroyCommand(Command):
                     console.print()
                 else:
                     console.print(f"[green]✓ {stack.capitalize()} stack destroyed[/green]\n")
+
+        # Clean up CodeBuild stacks left in regions the build region was moved away
+        # from (cross-region was reconfigured via re-init). Without this they're
+        # orphaned: the loop above only deletes in the *current* codebuild region.
+        # NOT gated on enable_codebuild — disabling CodeBuild (init "Skip") is
+        # exactly when an old cross-region stack needs cleaning, and the main loop
+        # skips codebuild when it's disabled. prior_regions is only populated when
+        # there's an orphan to clean, so iterating it unconditionally is safe.
+        current_cb_region = get_codebuild_region(profile)
+        cb_stack_name = profile.stack_names.get("codebuild", f"{profile.identity_pool_name}-codebuild")
+        for prior in getattr(profile, "codebuild_prior_regions", []) or []:
+            if prior == current_cb_region:
+                continue  # already handled by the main loop (if enabled)
+            console.print(f"Destroying orphaned CodeBuild stack in [cyan]{prior}[/cyan]: {cb_stack_name}")
+            if self._delete_stack(cb_stack_name, prior, console) == 0:
+                console.print(f"[green]✓ CodeBuild stack in {prior} destroyed[/green]\n")
+            else:
+                failed = self._get_failed_resources(cb_stack_name, prior)
+                if failed:
+                    all_failed_resources.extend(failed)
+                    stacks_with_failures.append(f"{cb_stack_name} ({prior})")
+                console.print(f"[yellow]⚠ CodeBuild stack in {prior} needs manual cleanup[/yellow]\n")
 
         # Clean up cached credentials for this profile
         if clear_cached_credentials(profile_name):

--- a/source/claude_code_with_bedrock/cli/commands/distribute.py
+++ b/source/claude_code_with_bedrock/cli/commands/distribute.py
@@ -20,6 +20,7 @@ from rich.panel import Panel
 from rich.progress import BarColumn, DownloadColumn, Progress, SpinnerColumn, TextColumn, TimeRemainingColumn
 
 from claude_code_with_bedrock.cli.utils.aws import get_stack_outputs
+from claude_code_with_bedrock.cli.utils.helpers import get_codebuild_region
 from claude_code_with_bedrock.config import Config
 
 
@@ -537,7 +538,7 @@ class DistributeCommand(Command):
             # Check if Windows build is completed and download it
             try:
                 project_name = f"{profile.identity_pool_name}-windows-build"
-                codebuild = boto3.client("codebuild", region_name=profile.aws_region)
+                codebuild = boto3.client("codebuild", region_name=get_codebuild_region(profile))
 
                 # List recent builds
                 response = codebuild.list_builds_for_project(projectName=project_name, sortOrder="DESCENDING")
@@ -802,7 +803,7 @@ class DistributeCommand(Command):
             try:
                 # Get CodeBuild project name from profile
                 project_name = f"{profile.identity_pool_name}-windows-build"
-                codebuild = boto3.client("codebuild", region_name=profile.aws_region)
+                codebuild = boto3.client("codebuild", region_name=get_codebuild_region(profile))
 
                 # List recent builds
                 response = codebuild.list_builds_for_project(projectName=project_name, sortOrder="DESCENDING")
@@ -843,7 +844,7 @@ class DistributeCommand(Command):
             # First check for any completed builds
             try:
                 project_name = f"{profile.identity_pool_name}-windows-build"
-                codebuild = boto3.client("codebuild", region_name=profile.aws_region)
+                codebuild = boto3.client("codebuild", region_name=get_codebuild_region(profile))
 
                 # List recent builds
                 response = codebuild.list_builds_for_project(projectName=project_name, sortOrder="DESCENDING")
@@ -885,7 +886,7 @@ class DistributeCommand(Command):
 
                     # Check build status
                     try:
-                        codebuild = boto3.client("codebuild", region_name=profile.aws_region)
+                        codebuild = boto3.client("codebuild", region_name=get_codebuild_region(profile))
                         response = codebuild.batch_get_builds(ids=[build_info["build_id"]])
                         if response.get("builds"):
                             build = response["builds"][0]
@@ -1642,7 +1643,7 @@ class DistributeCommand(Command):
                 return False
 
             codebuild_stack_name = profile.stack_names.get("codebuild", f"{profile.identity_pool_name}-codebuild")
-            codebuild_outputs = get_stack_outputs(codebuild_stack_name, profile.aws_region)
+            codebuild_outputs = get_stack_outputs(codebuild_stack_name, get_codebuild_region(profile))
 
             if not codebuild_outputs:
                 console.print("[red]CodeBuild stack not found[/red]")
@@ -1655,8 +1656,8 @@ class DistributeCommand(Command):
                 console.print("[red]Could not get CodeBuild bucket or project name from stack outputs[/red]")
                 return False
 
-            # Download from S3
-            s3 = boto3.client("s3", region_name=profile.aws_region)
+            # Download from S3 (CodeBuild BuildBucket, in the codebuild region)
+            s3 = boto3.client("s3", region_name=get_codebuild_region(profile))
             zip_path = package_path / "windows-binaries.zip"
 
             # CodeBuild stores artifacts at root of bucket

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -65,6 +65,21 @@ def validate_cognito_user_pool_id(value: str) -> bool | str:
     return "Invalid User Pool ID format"
 
 
+def _remember_prior_codebuild_region(config: dict, prior_region: str) -> None:
+    """Record a CodeBuild region being abandoned, so destroy can clean its orphan.
+
+    When the user changes the CodeBuild region during re-init, a stack may still
+    exist in the old region. ``ccwb destroy`` reads the *current* region, so it
+    can't reach the old one — we persist abandoned regions in
+    ``config["codebuild"]["prior_regions"]`` and have destroy iterate them.
+    Deduped, and never includes the region that is now current.
+    """
+    cb = config.setdefault("codebuild", {})
+    priors = cb.setdefault("prior_regions", [])
+    if prior_region and prior_region not in priors:
+        priors.append(prior_region)
+
+
 class InitCommand(Command):
     name = "init"
     description = "Interactive setup wizard for first-time deployment"
@@ -1173,6 +1188,88 @@ class InitCommand(Command):
         if enable_codebuild:
             console.print("[green]✓[/green] CodeBuild for Windows builds will be deployed")
 
+            # The Windows Server 2022 container fleet only exists in some regions.
+            # CodeBuild is build-only tooling (not user-facing), so when the main
+            # region is unsupported we let the user pick a nearby supported region
+            # here in the wizard — deploy then just executes that choice.
+            from claude_code_with_bedrock.cli.utils.helpers import (
+                CODEBUILD_WINDOWS_REGIONS,
+                find_nearest_codebuild_region,
+            )
+
+            selected_region = config.get("aws", {}).get("region")
+            if selected_region and selected_region not in CODEBUILD_WINDOWS_REGIONS:
+                nearest = find_nearest_codebuild_region(selected_region)
+                # "nearest" can cross continents when no supported region shares the
+                # main region's continent (e.g. af-*/me-* -> us-east-1). Surface that
+                # explicitly so a data-residency-sensitive user doesn't accept a
+                # cross-continent deployment by reflexively pressing Enter.
+                cross_continent = nearest.split("-", 1)[0] != selected_region.split("-", 1)[0]
+                console.print(
+                    f"\n[yellow]⚠ Windows CodeBuild containers are not available in {selected_region}.[/yellow]"
+                )
+                console.print(
+                    "[dim]CodeBuild is build-only tooling (not user-facing), so deploying it to a "
+                    "nearby region is fine — your main infrastructure stays put.[/dim]"
+                )
+                if cross_continent:
+                    console.print(
+                        f"[yellow]Note: no supported region shares your continent, so the nearest is "
+                        f"{nearest} (different geography). Your source code is uploaded to an S3 bucket "
+                        f"there during builds — confirm this is acceptable for data-residency.[/yellow]"
+                    )
+                nearest_label = (
+                    f"{nearest} (nearest supported — DIFFERENT continent)"
+                    if cross_continent
+                    else f"{nearest} (nearest supported)"
+                )
+                cb_choice = questionary.select(
+                    "Which region should CodeBuild deploy to?",
+                    choices=[
+                        questionary.Choice(nearest_label, value=nearest),
+                        *[questionary.Choice(r, value=r) for r in CODEBUILD_WINDOWS_REGIONS if r != nearest],
+                        questionary.Choice("Skip CodeBuild (build Windows binaries manually)", value=None),
+                    ],
+                ).ask()
+
+                prior_region = config["codebuild"].get("region")
+                config["codebuild"]["region"] = cb_choice
+                if cb_choice:
+                    console.print(
+                        f"[green]✓[/green] CodeBuild will deploy to {cb_choice} "
+                        f"(main infrastructure stays in {selected_region})"
+                    )
+                    if prior_region and prior_region != cb_choice:
+                        _remember_prior_codebuild_region(config, prior_region)
+                        console.print(
+                            f"[yellow]⚠ A CodeBuild stack may still exist in {prior_region}; "
+                            f"it will be cleaned up on the next [cyan]ccwb destroy[/cyan].[/yellow]"
+                        )
+                else:
+                    # Skipping/disabling CodeBuild. If a stack was already deployed
+                    # cross-region, record it so destroy still cleans it up — otherwise
+                    # disabling here orphans it (destroy can't reach a region the config
+                    # no longer names).
+                    if prior_region:
+                        _remember_prior_codebuild_region(config, prior_region)
+                        console.print(
+                            f"[yellow]⚠ A CodeBuild stack may still exist in {prior_region}; "
+                            f"it will be cleaned up on the next [cyan]ccwb destroy[/cyan].[/yellow]"
+                        )
+                    config["codebuild"]["enabled"] = False
+                    console.print("[yellow]CodeBuild disabled — build Windows binaries manually.[/yellow]")
+            else:
+                # Supported region: CodeBuild deploys alongside the main stacks.
+                prior_region = config["codebuild"].get("region")
+                if prior_region and prior_region != selected_region:
+                    _remember_prior_codebuild_region(config, prior_region)
+                    console.print(
+                        f"[yellow]⚠ CodeBuild now deploys to the main region {selected_region}. "
+                        f"A CodeBuild stack may still exist in {prior_region}; it will be cleaned up "
+                        f"on the next [cyan]ccwb destroy[/cyan].[/yellow]"
+                    )
+                config["codebuild"]["region"] = None
+
         # Claude Cowork 3P MDM configuration
         console.print("\n[bold]Claude Cowork (Desktop) Support[/bold]")
         console.print("Generate MDM configuration for Claude Cowork with third-party platforms")
@@ -1194,7 +1291,9 @@ class InitCommand(Command):
             if existing_extra:
                 console.print(f"[dim]Custom MDM keys configured: {len(existing_extra)} key(s)[/dim]")
             else:
-                console.print("[dim]To add custom MDM keys (e.g. coworkWebSearchEnabled), edit your profile JSON directly.[/dim]")
+                console.print(
+                    "[dim]To add custom MDM keys (e.g. coworkWebSearchEnabled), edit your profile JSON directly.[/dim]"
+                )
                 console.print("[dim]See: assets/docs/COWORK_3P.md → Custom MDM Keys[/dim]")
             config["cowork_3p"]["extra_keys"] = existing_extra
 
@@ -1206,10 +1305,13 @@ class InitCommand(Command):
                 existing_token = config.get("cowork_3p", {}).get("service_token", "")
                 if not existing_token:
                     import uuid
+
                     token = str(uuid.uuid4())
                     config["cowork_3p"]["service_token"] = token
                     console.print("[green]✓[/green] Generated CoWork service token for ALB auth bypass")
-                    console.print("[dim]  Pass this as CoWorkServiceToken parameter when deploying the monitoring stack[/dim]")
+                    console.print(
+                        "[dim]  Pass this as CoWorkServiceToken parameter when deploying the monitoring stack[/dim]"
+                    )
                 else:
                     console.print("[dim]CoWork service token already configured[/dim]")
 
@@ -2118,6 +2220,8 @@ class InitCommand(Command):
             "client_certificate_path": config_data.get("client_certificate_path"),
             "client_certificate_key_path": config_data.get("client_certificate_key_path"),
             "enable_codebuild": config_data.get("codebuild", {}).get("enabled", False),
+            "codebuild_region": config_data.get("codebuild", {}).get("region"),
+            "codebuild_prior_regions": config_data.get("codebuild", {}).get("prior_regions", []),
             "enable_distribution": config_data.get("distribution", {}).get("enabled", False),
             "distribution_type": config_data.get("distribution", {}).get("type"),
             "distribution_idp_provider": config_data.get("distribution", {}).get("idp_provider"),
@@ -2491,6 +2595,10 @@ class InitCommand(Command):
             # Add CodeBuild configuration if present
             if hasattr(profile, "enable_codebuild"):
                 existing_config["codebuild"] = {"enabled": profile.enable_codebuild}
+                if getattr(profile, "codebuild_region", None):
+                    existing_config["codebuild"]["region"] = profile.codebuild_region
+                if getattr(profile, "codebuild_prior_regions", None):
+                    existing_config["codebuild"]["prior_regions"] = profile.codebuild_prior_regions
 
             # Add CoWork 3P configuration
             cowork_3p_config = {"enabled": profile.cowork_3p_enabled}

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -19,6 +19,7 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from claude_code_with_bedrock.cli.utils.aws import get_stack_outputs
 from claude_code_with_bedrock.cli.utils.display import display_configuration_info
+from claude_code_with_bedrock.cli.utils.helpers import get_codebuild_region
 from claude_code_with_bedrock.config import Config
 from claude_code_with_bedrock.models import (
     get_source_region_for_profile,
@@ -635,7 +636,7 @@ class PackageCommand(Command):
                 console.print("[red]No configuration found. Run 'poetry run ccwb init' first.[/red]")
                 return 1
 
-            codebuild = boto3.client("codebuild", region_name=profile.aws_region)
+            codebuild = boto3.client("codebuild", region_name=get_codebuild_region(profile))
             response = codebuild.batch_get_builds(ids=[build_id])
 
             if not response.get("builds"):
@@ -1565,7 +1566,7 @@ RUN pyinstaller \
 
             if profile:
                 project_name = f"{profile.identity_pool_name}-windows-build"
-                codebuild = boto3.client("codebuild", region_name=profile.aws_region)
+                codebuild = boto3.client("codebuild", region_name=get_codebuild_region(profile))
 
                 # List recent builds
                 response = codebuild.list_builds_for_project(projectName=project_name, sortOrder="DESCENDING")
@@ -1603,7 +1604,7 @@ RUN pyinstaller \
         # Get CodeBuild stack outputs
         stack_name = profile.stack_names.get("codebuild", f"{profile.identity_pool_name}-codebuild")
         try:
-            stack_outputs = get_stack_outputs(stack_name, profile.aws_region)
+            stack_outputs = get_stack_outputs(stack_name, get_codebuild_region(profile))
         except Exception:
             console.print(f"[red]CodeBuild stack not found: {stack_name}[/red]")
             console.print("Run: poetry run ccwb deploy codebuild")
@@ -1625,7 +1626,7 @@ RUN pyinstaller \
 
             # Upload to S3
             progress.update(task, description="Uploading source to S3...")
-            s3 = boto3.client("s3", region_name=profile.aws_region)
+            s3 = boto3.client("s3", region_name=get_codebuild_region(profile))
             try:
                 s3.upload_file(str(source_zip), bucket_name, "source.zip")
             except ClientError as e:
@@ -1634,7 +1635,7 @@ RUN pyinstaller \
 
             # Start build
             progress.update(task, description="Starting CodeBuild project...")
-            codebuild = boto3.client("codebuild", region_name=profile.aws_region)
+            codebuild = boto3.client("codebuild", region_name=get_codebuild_region(profile))
             try:
                 response = codebuild.start_build(projectName=project_name)
                 build_id = response["build"]["id"]

--- a/source/claude_code_with_bedrock/cli/commands/package_cb.py
+++ b/source/claude_code_with_bedrock/cli/commands/package_cb.py
@@ -21,6 +21,7 @@ from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from claude_code_with_bedrock.cli.utils.aws import get_stack_outputs
+from claude_code_with_bedrock.cli.utils.helpers import get_codebuild_region
 from claude_code_with_bedrock.config import Config
 from claude_code_with_bedrock.models import get_source_region_for_profile
 
@@ -163,7 +164,7 @@ class PackageCbCommand(Command):
         # Get CodeBuild stack outputs
         stack_name = profile.stack_names.get("codebuild", f"{profile.identity_pool_name}-codebuild")
         try:
-            stack_outputs = get_stack_outputs(stack_name, profile.aws_region)
+            stack_outputs = get_stack_outputs(stack_name, get_codebuild_region(profile))
         except Exception:
             console.print(f"[red]CodeBuild stack not found: {stack_name}[/red]")
             console.print("Run: poetry run ccwb deploy codebuild")
@@ -180,7 +181,7 @@ class PackageCbCommand(Command):
             console.print("[yellow]No CodeBuild platforms selected.[/yellow]")
 
         # Check for in-progress builds
-        codebuild = boto3.client("codebuild", region_name=profile.aws_region)
+        codebuild = boto3.client("codebuild", region_name=get_codebuild_region(profile))
         for plat in list(selected_platforms):
             project_name = stack_outputs.get(CODEBUILD_PLATFORMS[plat]["output_key"])
             if not project_name:
@@ -302,7 +303,7 @@ class PackageCbCommand(Command):
                 progress.update(task, completed=True)
 
                 task = progress.add_task("Uploading source to S3...", total=None)
-                s3 = boto3.client("s3", region_name=profile.aws_region)
+                s3 = boto3.client("s3", region_name=get_codebuild_region(profile))
                 try:
                     s3.upload_file(str(source_zip), bucket_name, "source.zip")
                 except ClientError as e:

--- a/source/claude_code_with_bedrock/cli/utils/helpers.py
+++ b/source/claude_code_with_bedrock/cli/utils/helpers.py
@@ -49,9 +49,57 @@ def clear_cached_credentials(profile_name: str) -> bool:
 def get_codebuild_region(profile) -> str:
     """Get the region where CodeBuild resources are deployed.
 
-    Currently returns profile.aws_region. Extracted as a helper so
-    future cross-region CodeBuild support has a single point of change.
+    Returns profile.codebuild_region when set (cross-region builds),
+    otherwise profile.aws_region. Single point of change for all
+    CodeBuild client/stack/bucket lookups.
 
     Co-authored-by: peepeepopapapeepeepo (from PR #330)
     """
     return getattr(profile, "codebuild_region", None) or profile.aws_region
+
+
+# Regions where CodeBuild offers the Windows Server 2022 container fleet.
+# CodeBuild is build-only tooling (not user-facing, not latency-sensitive), so
+# deploying it cross-region from the main infrastructure is acceptable.
+CODEBUILD_WINDOWS_REGIONS = (
+    "us-east-1",
+    "us-east-2",
+    "us-west-2",
+    "eu-central-1",
+    "eu-west-1",
+    "ap-northeast-1",
+    "ap-southeast-2",
+    "sa-east-1",
+)
+
+
+def find_nearest_codebuild_region(region: str) -> str:
+    """Find the supported Windows-CodeBuild region geographically closest to ``region``.
+
+    Matches on the AWS geography prefix (the continent token, e.g. ``ap``/``eu``/``us``,
+    then the finer ``ap-southeast`` grouping) and picks the supported region with the
+    longest matching prefix: ``ap-southeast-1`` -> ``ap-southeast-2``,
+    ``eu-south-1`` -> ``eu-central-1``, ``us-west-1`` -> ``us-west-2``. Falls back to
+    ``us-east-1`` when no supported region shares the continent (e.g. ``af-south-1``,
+    ``me-central-1``). Heuristic, not true distance, but keeps builds in-continent
+    wherever a supported region exists.
+    """
+    if region in CODEBUILD_WINDOWS_REGIONS:
+        return region
+
+    continent = region.split("-", 1)[0]  # "ap", "eu", "us", "af", ...
+
+    def group_match_len(candidate: str) -> int:
+        # Only count a match within the same continent; compare token-by-token
+        # ("ap","southeast","1") so "af" never matches "ap".
+        if candidate.split("-", 1)[0] != continent:
+            return 0
+        n = 0
+        for ra, rc in zip(region.split("-"), candidate.split("-")):
+            if ra != rc:
+                break
+            n += 1
+        return n
+
+    best = max(CODEBUILD_WINDOWS_REGIONS, key=group_match_len)
+    return best if group_match_len(best) > 0 else "us-east-1"

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -52,6 +52,10 @@ class Profile:
     oidc_jwks_uri: str | None = None  # Full URL to JWKS endpoint
     oidc_thumbprint: str | None = None  # SHA-1 thumbprint of root cert in JWKS TLS chain
     enable_codebuild: bool = False  # Enable CodeBuild for Windows binary builds
+    codebuild_region: str | None = None  # Region for CodeBuild stack/builds; falls back to aws_region when unset
+    codebuild_prior_regions: list[str] = field(
+        default_factory=list
+    )  # Regions a CodeBuild stack was previously deployed to (so destroy can clean orphans after a region change)
     enable_distribution: bool = False  # Enable package distribution features (legacy, use distribution_type)
 
     # Distribution platform configuration

--- a/source/tests/cli/commands/test_deploy_orphan_region.py
+++ b/source/tests/cli/commands/test_deploy_orphan_region.py
@@ -1,0 +1,66 @@
+# ABOUTME: Regression tests for cross-region CodeBuild orphan detection in deploy
+# ABOUTME: Ensures _check_orphaned_stacks queries the codebuild stack in its own region
+
+"""A cross-region CodeBuild stack must be checked for orphan status in its own
+region, not the main infrastructure region. Otherwise `ccwb deploy` checks the
+wrong region, never finds the orphan, and never offers to delete it."""
+
+from unittest.mock import MagicMock, patch
+
+from claude_code_with_bedrock.cli.commands.deploy import DeployCommand
+
+
+def _profile(**overrides):
+    p = MagicMock()
+    p.identity_pool_name = "test-pool"
+    p.stack_names = {}
+    p.aws_region = "ap-southeast-1"
+    p.codebuild_region = None
+    for k, v in overrides.items():
+        setattr(p, k, v)
+    return p
+
+
+def test_orphan_check_uses_codebuild_region_for_codebuild_stack():
+    """When codebuild is cross-region, the orphan status check must hit that region."""
+    profile = _profile(codebuild_region="us-east-1")
+    main_mgr = MagicMock()
+    main_mgr.get_stack_status.return_value = None  # nothing in main region
+
+    # The region-specific manager built for codebuild reports an existing stack.
+    cb_mgr = MagicMock()
+    cb_mgr.get_stack_status.return_value = "CREATE_COMPLETE"
+
+    captured_regions = []
+
+    def _mgr_factory(region):
+        captured_regions.append(region)
+        return cb_mgr
+
+    cmd = DeployCommand()
+    # Deploy nothing, so every stack type is a candidate orphan.
+    with patch("claude_code_with_bedrock.cli.commands.deploy.CloudFormationManager", side_effect=_mgr_factory):
+        orphaned = cmd._check_orphaned_stacks([], profile, main_mgr, MagicMock())
+
+    # A region-specific manager was built for us-east-1 (the codebuild region).
+    assert "us-east-1" in captured_regions
+    # codebuild is reported orphaned because it was found in us-east-1, not main.
+    assert any(stack_type == "codebuild" for stack_type, _, _ in orphaned)
+
+
+def test_orphan_check_no_extra_manager_when_codebuild_same_region():
+    """No region-specific manager is built when codebuild uses the main region."""
+    profile = _profile(codebuild_region=None)  # -> aws_region
+    main_mgr = MagicMock()
+    main_mgr.get_stack_status.return_value = None
+
+    built = []
+    cmd = DeployCommand()
+    with patch(
+        "claude_code_with_bedrock.cli.commands.deploy.CloudFormationManager",
+        side_effect=lambda region: built.append(region) or MagicMock(),
+    ):
+        cmd._check_orphaned_stacks([], profile, main_mgr, MagicMock())
+
+    # codebuild_region resolves to aws_region, so no separate manager is constructed.
+    assert built == []

--- a/source/tests/cli/commands/test_destroy_skip_logic.py
+++ b/source/tests/cli/commands/test_destroy_skip_logic.py
@@ -27,6 +27,8 @@ def _profile(**overrides):
     p.enable_distribution = False
     p.enable_codebuild = False
     p.aws_region = "us-east-1"
+    p.codebuild_region = None  # explicit: Mock would otherwise auto-create a truthy attr
+    p.codebuild_prior_regions = []  # explicit: Mock would otherwise be a non-iterable truthy attr
     for k, v in overrides.items():
         setattr(p, k, v)
     return p
@@ -58,6 +60,55 @@ def _run_destroy(profile, stack_arg=None):
 
     # Map stack_names (test-pool-<stack>) back to stack keys for readability.
     return exit_code, {name.replace("test-pool-", "") for name in deleted}
+
+
+def _run_destroy_capturing_regions(profile):
+    """Run `destroy --force`; return {stack_key: region} that _delete_stack used."""
+    regions = {}
+
+    with (
+        patch("claude_code_with_bedrock.cli.commands.destroy.Config") as MockConfig,
+        patch.object(DestroyCommand, "_delete_stack", return_value=0) as mock_delete,
+        patch.object(DestroyCommand, "_get_failed_resources", return_value=[]),
+        patch.object(DestroyCommand, "_get_retained_resources", return_value=[]),
+        patch.object(DestroyCommand, "_show_cleanup_summary"),
+    ):
+        MockConfig.load.return_value.get_profile.return_value = profile
+        MockConfig.load.return_value.active_profile = "test"
+
+        mock_delete.side_effect = lambda stack_name, region, console: (
+            regions.__setitem__(stack_name.replace("test-pool-", ""), region) or 0
+        )
+
+        tester = CommandTester(DestroyCommand())
+        tester.execute("--force")
+
+    return regions
+
+
+def _run_destroy_capturing_calls(profile):
+    """Run `destroy --force`; return the list of (stack_key, region) delete calls,
+    preserving duplicates (e.g. codebuild deleted in multiple regions)."""
+    calls = []
+
+    with (
+        patch("claude_code_with_bedrock.cli.commands.destroy.Config") as MockConfig,
+        patch.object(DestroyCommand, "_delete_stack", return_value=0) as mock_delete,
+        patch.object(DestroyCommand, "_get_failed_resources", return_value=[]),
+        patch.object(DestroyCommand, "_get_retained_resources", return_value=[]),
+        patch.object(DestroyCommand, "_show_cleanup_summary"),
+    ):
+        MockConfig.load.return_value.get_profile.return_value = profile
+        MockConfig.load.return_value.active_profile = "test"
+
+        mock_delete.side_effect = lambda stack_name, region, console: (
+            calls.append((stack_name.replace("test-pool-", ""), region)) or 0
+        )
+
+        tester = CommandTester(DestroyCommand())
+        tester.execute("--force")
+
+    return calls
 
 
 class TestSkipGuards:
@@ -117,3 +168,71 @@ class TestSingleStackArg:
         exit_code, deleted = _run_destroy(_profile(), stack_arg="nonexistent")
         assert exit_code == 1
         assert deleted == set()
+
+
+class TestCodebuildCrossRegionDeletion:
+    """Regression: CodeBuild deployed cross-region must be deleted in ITS region.
+
+    If destroy uses profile.aws_region for the codebuild stack, a cross-region
+    CodeBuild stack (Windows fleet not in the main region) is silently orphaned
+    in the build region while destroy reports success.
+    """
+
+    def test_codebuild_deleted_in_its_own_region(self):
+        regions = _run_destroy_capturing_regions(
+            _profile(enable_codebuild=True, aws_region="ap-southeast-1", codebuild_region="us-east-1")
+        )
+        # main stacks use the main region...
+        assert regions["auth"] == "ap-southeast-1"
+        # ...but codebuild is deleted where it actually lives.
+        assert regions["codebuild"] == "us-east-1"
+
+    def test_codebuild_uses_main_region_when_not_cross_region(self):
+        regions = _run_destroy_capturing_regions(
+            _profile(enable_codebuild=True, aws_region="us-west-2", codebuild_region=None)
+        )
+        assert regions["codebuild"] == "us-west-2"
+
+    def test_prior_codebuild_regions_are_cleaned_up(self):
+        """Orphan regression: a CodeBuild region abandoned via re-init must still be
+        torn down. destroy deletes the current region AND each prior region."""
+        calls = _run_destroy_capturing_calls(
+            _profile(
+                enable_codebuild=True,
+                aws_region="ap-southeast-1",
+                codebuild_region="us-east-1",
+                codebuild_prior_regions=["ap-southeast-2", "eu-west-1"],
+            )
+        )
+        cb_regions = sorted(region for stack, region in calls if stack == "codebuild")
+        # current region + both abandoned regions all get a delete call.
+        assert cb_regions == ["ap-southeast-2", "eu-west-1", "us-east-1"]
+
+    def test_prior_region_equal_to_current_not_deleted_twice(self):
+        """If a prior region equals the current codebuild region, don't double-delete."""
+        calls = _run_destroy_capturing_calls(
+            _profile(
+                enable_codebuild=True,
+                aws_region="ap-southeast-1",
+                codebuild_region="us-east-1",
+                codebuild_prior_regions=["us-east-1"],  # same as current
+            )
+        )
+        cb_calls = [region for stack, region in calls if stack == "codebuild"]
+        assert cb_calls == ["us-east-1"]  # exactly once
+
+    def test_prior_regions_cleaned_even_when_codebuild_disabled(self):
+        """BLOCKER regression: after init 'Skip' disables CodeBuild, a stack left in a
+        prior cross-region must STILL be torn down. The main loop skips codebuild when
+        disabled, so the prior-region cleanup must run regardless of enable_codebuild."""
+        calls = _run_destroy_capturing_calls(
+            _profile(
+                enable_codebuild=False,  # user picked "Skip" on re-init
+                aws_region="ap-southeast-1",
+                codebuild_region=None,  # current build region cleared
+                codebuild_prior_regions=["us-east-1"],  # but a stack was deployed there
+            )
+        )
+        cb_calls = [region for stack, region in calls if stack == "codebuild"]
+        # main loop skips codebuild (disabled); the orphan in us-east-1 is still cleaned.
+        assert cb_calls == ["us-east-1"]

--- a/source/tests/cli/utils/test_helpers.py
+++ b/source/tests/cli/utils/test_helpers.py
@@ -10,7 +10,9 @@ from unittest.mock import patch, MagicMock
 import pytest
 
 from claude_code_with_bedrock.cli.utils.helpers import (
+    CODEBUILD_WINDOWS_REGIONS,
     clear_cached_credentials,
+    find_nearest_codebuild_region,
     get_codebuild_region,
 )
 
@@ -85,3 +87,75 @@ class TestGetCodebuildRegion:
         profile = MagicMock(spec=[])
         profile.aws_region = "eu-west-1"
         assert get_codebuild_region(profile) == "eu-west-1"
+
+    def test_real_profile_override(self):
+        """A real Profile with codebuild_region set resolves to the override.
+
+        Uses the actual dataclass (not a mock) so the test fails if the
+        codebuild_region field is ever removed from Profile or dropped by
+        from_dict's field-filter.
+        """
+        from claude_code_with_bedrock.config import Profile
+
+        profile = Profile.from_dict(
+            {
+                "name": "t",
+                "provider_domain": "none",
+                "client_id": "x",
+                "identity_pool_name": "tp",
+                "aws_region": "ap-southeast-1",
+                "codebuild_region": "ap-southeast-2",
+                "enable_codebuild": True,
+            }
+        )
+        assert get_codebuild_region(profile) == "ap-southeast-2"
+
+    def test_real_profile_fallback(self):
+        """A real Profile without codebuild_region falls back to aws_region."""
+        from claude_code_with_bedrock.config import Profile
+
+        profile = Profile.from_dict(
+            {
+                "name": "t",
+                "provider_domain": "none",
+                "client_id": "x",
+                "identity_pool_name": "tp",
+                "aws_region": "us-west-2",
+            }
+        )
+        assert get_codebuild_region(profile) == "us-west-2"
+
+
+class TestFindNearestCodebuildRegion:
+    """Tests for find_nearest_codebuild_region (cross-region CodeBuild fallback)."""
+
+    def test_supported_region_returns_itself(self):
+        """A supported region is returned unchanged."""
+        for region in CODEBUILD_WINDOWS_REGIONS:
+            assert find_nearest_codebuild_region(region) == region
+
+    def test_ap_southeast_1_maps_to_ap_southeast_2(self):
+        """Singapore (unsupported) maps to Sydney (supported, same sub-geo)."""
+        assert find_nearest_codebuild_region("ap-southeast-1") == "ap-southeast-2"
+
+    def test_eu_unsupported_stays_in_eu(self):
+        """An unsupported EU region maps to a supported EU region."""
+        assert find_nearest_codebuild_region("eu-south-1").startswith("eu-")
+        assert find_nearest_codebuild_region("eu-west-3").startswith("eu-")
+
+    def test_ap_unsupported_stays_in_ap(self):
+        """An unsupported AP region maps to a supported AP region (not a false 'a*' match)."""
+        assert find_nearest_codebuild_region("ap-south-1").startswith("ap-")
+
+    def test_no_continent_match_falls_back_to_us_east_1(self):
+        """Regions with no supported same-continent peer fall back to us-east-1."""
+        # af-* and me-* have no supported region sharing their continent token.
+        assert find_nearest_codebuild_region("af-south-1") == "us-east-1"
+        assert find_nearest_codebuild_region("me-central-1") == "us-east-1"
+        # "af" must NOT false-match "ap-*" on the shared leading 'a'.
+        assert not find_nearest_codebuild_region("af-south-1").startswith("ap-")
+
+    def test_result_is_always_supported(self):
+        """Whatever region is returned must itself be deployable."""
+        for region in ["ap-southeast-1", "eu-south-1", "ca-central-1", "af-south-1", "me-central-1"]:
+            assert find_nearest_codebuild_region(region) in CODEBUILD_WINDOWS_REGIONS

--- a/source/tests/cli/utils/test_helpers_wiring.py
+++ b/source/tests/cli/utils/test_helpers_wiring.py
@@ -6,14 +6,72 @@
 from pathlib import Path
 
 
+COMMANDS_DIR = Path(__file__).resolve().parents[3] / "claude_code_with_bedrock" / "cli" / "commands"
+HELPER_IMPORT = "from claude_code_with_bedrock.cli.utils.helpers import get_codebuild_region"
+
+
 class TestGetCodebuildRegionWiring:
-    """Verify get_codebuild_region is used in CodeBuild commands."""
+    """Verify get_codebuild_region is used in CodeBuild commands.
+
+    All CodeBuild-region resources (the codebuild client, the codebuild stack
+    outputs, and the S3 BuildBucket) must resolve through the same region
+    helper. Mixing get_codebuild_region() for the client with raw
+    profile.aws_region for the bucket/stack would break cross-region builds:
+    the client would hit one region while the bucket lookup hit another.
+    """
 
     def test_builds_command_uses_helper(self):
-        """builds.py uses get_codebuild_region instead of raw profile.aws_region for codebuild client."""
-        source = (Path(__file__).resolve().parents[3] / "claude_code_with_bedrock" / "cli" / "commands" / "builds.py").read_text(encoding="utf-8")
-        assert "from claude_code_with_bedrock.cli.utils.helpers import get_codebuild_region" in source
+        """builds.py routes the codebuild client through the helper."""
+        source = (COMMANDS_DIR / "builds.py").read_text(encoding="utf-8")
+        assert HELPER_IMPORT in source
         assert "get_codebuild_region(profile)" in source
+
+    def test_builds_command_has_no_raw_region_for_codebuild(self):
+        """builds.py uses no raw profile.aws_region (all codebuild paths use the helper)."""
+        source = (COMMANDS_DIR / "builds.py").read_text(encoding="utf-8")
+        # Every CodeBuild resource in builds.py (client, stack outputs, bucket)
+        # must go through get_codebuild_region; nothing should reach raw aws_region.
+        assert "profile.aws_region" not in source
+
+    def test_package_cb_command_uses_helper(self):
+        """package_cb.py routes codebuild client, stack outputs, and S3 bucket through the helper."""
+        source = (COMMANDS_DIR / "package_cb.py").read_text(encoding="utf-8")
+        assert HELPER_IMPORT in source
+        # codebuild client + stack outputs + S3 upload bucket all use the helper
+        assert source.count("get_codebuild_region(profile)") >= 3
+
+    def test_package_command_uses_helper(self):
+        """package.py routes codebuild client, stack outputs, and S3 bucket through the helper."""
+        source = (COMMANDS_DIR / "package.py").read_text(encoding="utf-8")
+        assert HELPER_IMPORT in source
+        # two codebuild clients (status + start), stack outputs, S3 upload, plus the
+        # build-status client = all codebuild-region resources use the helper
+        assert source.count("get_codebuild_region(profile)") >= 4
+
+    def test_distribute_command_uses_helper(self):
+        """distribute.py routes its CodeBuild resources (windows-build clients, codebuild
+        stack outputs, BuildBucket download) through the helper. Without this, `ccwb
+        distribute` queries the main region for a cross-region build and silently bundles
+        no Windows binary."""
+        source = (COMMANDS_DIR / "distribute.py").read_text(encoding="utf-8")
+        assert HELPER_IMPORT in source
+        # 4 windows-build clients + codebuild stack outputs + BuildBucket S3 = 6 sites
+        assert source.count("get_codebuild_region(profile)") >= 6
+        # The codebuild stack outputs must NOT be read with the main region.
+        assert "get_stack_outputs(codebuild_stack_name, profile.aws_region)" not in source
+
+    def test_distribute_windows_build_client_not_main_region(self):
+        """The windows-build CodeBuild client must never use profile.aws_region."""
+        source = (COMMANDS_DIR / "distribute.py").read_text(encoding="utf-8")
+        # the windows-build project is CodeBuild; its client must resolve via the helper
+        lines = source.splitlines()
+        for i, line in enumerate(lines):
+            if "windows-build" in line and "project_name" in line:
+                # the next non-blank line creates the codebuild client — must use helper
+                nxt = lines[i + 1]
+                assert "get_codebuild_region(profile)" in nxt, (
+                    f"windows-build client at line {i + 2} must use get_codebuild_region, got: {nxt.strip()}"
+                )
 
 
 class TestClearCachedCredentialsWiring:
@@ -21,13 +79,17 @@ class TestClearCachedCredentialsWiring:
 
     def test_destroy_command_clears_credentials(self):
         """destroy.py calls clear_cached_credentials after successful stack destruction."""
-        source = (Path(__file__).resolve().parents[3] / "claude_code_with_bedrock" / "cli" / "commands" / "destroy.py").read_text(encoding="utf-8")
+        source = (
+            Path(__file__).resolve().parents[3] / "claude_code_with_bedrock" / "cli" / "commands" / "destroy.py"
+        ).read_text(encoding="utf-8")
         assert "from claude_code_with_bedrock.cli.utils.helpers import clear_cached_credentials" in source
         assert "clear_cached_credentials(profile_name)" in source
 
     def test_credential_cleanup_after_stack_destroy(self):
         """Credential cleanup happens after stacks are destroyed, not before."""
-        source = (Path(__file__).resolve().parents[3] / "claude_code_with_bedrock" / "cli" / "commands" / "destroy.py").read_text(encoding="utf-8")
+        source = (
+            Path(__file__).resolve().parents[3] / "claude_code_with_bedrock" / "cli" / "commands" / "destroy.py"
+        ).read_text(encoding="utf-8")
         idx_destroy = source.find("stack destroyed")
         idx_clear = source.find("clear_cached_credentials(profile_name)")
         assert idx_destroy < idx_clear, "Credentials should be cleared after stack destruction"

--- a/source/tests/test_config.py
+++ b/source/tests/test_config.py
@@ -118,6 +118,112 @@ class TestProfileModel:
         assert result["allowed_bedrock_regions"] == ["us-east-1", "us-east-2", "us-west-2"]
 
 
+class TestCodebuildRegionField:
+    """Tests for the codebuild_region field (cross-region CodeBuild override)."""
+
+    def test_codebuild_region_defaults_to_none(self):
+        """codebuild_region is optional and defaults to None."""
+        profile = Profile(
+            name="test",
+            provider_domain="test.okta.com",
+            client_id="test-client",
+            credential_storage="session",
+            aws_region="us-east-1",
+            identity_pool_name="test-pool",
+        )
+
+        assert profile.codebuild_region is None
+
+    def test_from_dict_keeps_codebuild_region(self):
+        """from_dict must NOT drop codebuild_region.
+
+        Regression: before this field existed on the dataclass, from_dict's
+        field-filter silently discarded the key, so the cross-region override
+        could never be loaded. This test fails against that prior behavior.
+        """
+        data = {
+            "name": "test",
+            "provider_domain": "test.okta.com",
+            "client_id": "test-client",
+            "credential_storage": "session",
+            "aws_region": "ap-southeast-1",
+            "identity_pool_name": "test-pool",
+            "enable_codebuild": True,
+            "codebuild_region": "ap-southeast-2",
+        }
+
+        profile = Profile.from_dict(data)
+
+        assert profile.codebuild_region == "ap-southeast-2"
+
+    def test_codebuild_region_round_trips(self):
+        """codebuild_region survives a to_dict -> from_dict round-trip."""
+        profile = Profile(
+            name="test",
+            provider_domain="test.okta.com",
+            client_id="test-client",
+            credential_storage="session",
+            aws_region="ap-southeast-1",
+            identity_pool_name="test-pool",
+            enable_codebuild=True,
+            codebuild_region="ap-southeast-2",
+        )
+
+        restored = Profile.from_dict(profile.to_dict())
+
+        assert "codebuild_region" in profile.to_dict()
+        assert restored.codebuild_region == "ap-southeast-2"
+
+    def test_legacy_config_without_codebuild_region_loads(self):
+        """Old configs without codebuild_region load and default to None (backward compat)."""
+        data = {
+            "name": "legacy",
+            "provider_domain": "test.okta.com",
+            "client_id": "test-client",
+            "credential_storage": "session",
+            "aws_region": "us-west-2",
+            "identity_pool_name": "test-pool",
+            "enable_codebuild": True,
+        }
+
+        profile = Profile.from_dict(data)
+
+        assert profile.codebuild_region is None
+
+    def test_codebuild_prior_regions_default_empty(self):
+        """codebuild_prior_regions defaults to an empty list (backward compat)."""
+        profile = Profile.from_dict(
+            {
+                "name": "t",
+                "provider_domain": "test.okta.com",
+                "client_id": "x",
+                "credential_storage": "session",
+                "aws_region": "us-west-2",
+                "identity_pool_name": "tp",
+            }
+        )
+        assert profile.codebuild_prior_regions == []
+
+    def test_codebuild_prior_regions_round_trip(self):
+        """codebuild_prior_regions survives from_dict -> to_dict (so destroy can read it)."""
+        profile = Profile.from_dict(
+            {
+                "name": "t",
+                "provider_domain": "test.okta.com",
+                "client_id": "x",
+                "credential_storage": "session",
+                "aws_region": "ap-southeast-1",
+                "identity_pool_name": "tp",
+                "enable_codebuild": True,
+                "codebuild_region": "us-east-1",
+                "codebuild_prior_regions": ["ap-southeast-2", "eu-west-1"],
+            }
+        )
+        assert profile.codebuild_prior_regions == ["ap-southeast-2", "eu-west-1"]
+        restored = Profile.from_dict(profile.to_dict())
+        assert restored.codebuild_prior_regions == ["ap-southeast-2", "eu-west-1"]
+
+
 class TestConfigManager:
     """Tests for the Config manager."""
 


### PR DESCRIPTION
## Description

Adds opt-in cross-region CodeBuild: when the main region lacks the Windows Server 2022 container fleet, the user picks a supported CodeBuild region in `ccwb init`, and `deploy` deploys the CodeBuild stack there while the rest of the infrastructure stays in the main region. Every CLI command that touches CodeBuild resolves the region through one helper so the client, stack outputs, and S3 bucket never split across regions.

Proposes #553 (maintainer decision requested — see issue).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

- **config**: `codebuild_region` (chosen build region) + `codebuild_prior_regions` (regions abandoned via re-init/disable, for cleanup).
- **helpers**: `CODEBUILD_WINDOWS_REGIONS` + `find_nearest_codebuild_region()` (continent-aware; us-east-1 fallback when no in-continent region).
- **init**: prompt for a supported region when the main one is unsupported; warn explicitly when the nearest crosses continents (data residency); record abandoned regions on a region change AND when CodeBuild is skipped/disabled.
- **deploy**: non-interactive; deploys the codebuild stack with its own region-bound manager; orphan detection + deletion and `--show-commands` also use the codebuild region; legacy unsupported profiles skip with a pointer to init rather than failing the whole deploy.
- **builds / package / package_cb / distribute**: route codebuild client + stack + S3 bucket through `get_codebuild_region` (distribute downloads the Windows artifact from the build region).
- **destroy**: delete the codebuild stack in its own region, plus any prior regions (ungated from `enable_codebuild`), so a cross-region/moved/disabled stack is never orphaned.

## Additional Notes

Opt-in and backward-compatible: `codebuild_region` defaults to `None` -> resolves to `aws_region`, so single-region profiles are byte-identical. >300 lines because it's one cohesive feature spanning the init->deploy->package->builds->distribute->destroy lifecycle; splitting the field from its usage would land half-wired intermediate states.

## Testing Checklist

### What was tested

**Verified live on real AWS** — full lifecycle, main infra `ap-southeast-1`, CodeBuild `ap-southeast-2` (the find_nearest_codebuild_region pick for apse1):
- [x] `ccwb init` region picker -> offered "ap-southeast-2 (nearest supported)", saved codebuild_region=ap-southeast-2
- [x] `ccwb deploy codebuild` -> CodeBuild stack CREATE_COMPLETE in ap-southeast-2
- [x] `ccwb package` -> Windows build ran to SUCCEEDED in ap-southeast-2 (client + source.zip S3 upload + in-progress check all resolved cross-region)
- [x] `ccwb distribute` -> downloaded windows-binaries.zip (57 MB) from the ap-southeast-2 BuildBucket and bundled the Windows .exe into the package
- [x] ran Claude with the resulting package -> telemetry correct in CloudWatch (real user.email/user.id, model claude-opus-4-8, cost)
- [x] `ccwb destroy` -> ap-southeast-2 CodeBuild stack DELETE_COMPLETE (+ its two S3 buckets emptied cross-region); confirmed gone via describe-stacks, no orphan

**Unit-tested + falsified against beta (not exercised live):**
- [x] cross-continent data-residency warning (would need an af-*/me-* main region; apse1->apse2 is same-continent)
- [x] prior-region destroy cleanup, incl. the skip/disable path (would need a region change/disable via re-init)
- [x] cross-region orphan detection in `ccwb deploy` (_check_orphaned_stacks)

**Suite/gates:**
- [x] `cd source && poetry run pytest tests/` — 972 passed, 22 skipped
- [x] New regression tests fail against beta, pass on this branch (falsified)
- [x] ruff format --check clean on all changed files (matches #552 style)
- [x] Verified locally: bandit (no new findings vs beta), semgrep (0)
- [x] Gates: pytest-ci + scanners apply; go-tests / cfn_nag / validate-regions N/A (no source/go/**, no CloudFormation, no region-data in this diff)
