### PR TITLE
fix(monitoring): create the CoWork events log group so cowork-dashboard deploys

### DIFF
--- a/deployment/infrastructure/otel-collector.yaml
+++ b/deployment/infrastructure/otel-collector.yaml
@@ -106,6 +106,24 @@ Resources:
         - Key: Stack
           Value: !Ref AWS::StackName
 
+  # CoWork telemetry log group. The collector's awscloudwatchlogs/cowork exporter
+  # writes here, and the cowork-dashboard stack attaches MetricFilters to it. A
+  # MetricFilter requires its target log group to already exist at deploy time,
+  # so this group must be a managed resource (not left to runtime auto-creation by
+  # the exporter) — otherwise the cowork-dashboard deploy fails on a fresh stack
+  # with "The specified log group does not exist". RetentionInDays matches the
+  # exporter's log_retention (30).
+  CoWorkEventsLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: /aws/claude-cowork/events
+      RetentionInDays: 30
+      Tags:
+        - Key: Purpose
+          Value: Claude CoWork Telemetry
+        - Key: Stack
+          Value: !Ref AWS::StackName
+
   # Security Groups
   ALBSecurityGroup:
     Type: AWS::EC2::SecurityGroup

--- a/source/tests/e2e/test_cfn_contracts.py
+++ b/source/tests/e2e/test_cfn_contracts.py
@@ -255,3 +255,58 @@ class TestDeployCommandStackNames:
             assert "Resources" in content or "AWSTemplateFormatVersion" in content, (
                 f"Template {template_path.name} doesn't look like a valid CloudFormation template"
             )
+
+
+class TestCoWorkLogGroupContract:
+    """Contract: cowork-dashboard MetricFilters target a log group that the
+    monitoring stack actually creates.
+
+    Regression for the fresh-deploy failure "AWS::Logs::MetricFilter
+    (CostMetricFilter): The specified log group does not exist." A MetricFilter
+    requires its target log group to exist at deploy time; the cowork log group
+    must therefore be a managed AWS::Logs::LogGroup resource (in otel-collector),
+    not left to runtime auto-creation by the collector's exporter.
+    """
+
+    COWORK_LOG_GROUP = "/aws/claude-cowork/events"
+
+    def _log_group_names(self, template: dict) -> set:
+        names = set()
+        for resource in template.get("Resources", {}).values():
+            if resource.get("Type") == "AWS::Logs::LogGroup":
+                lg = resource.get("Properties", {}).get("LogGroupName")
+                if isinstance(lg, str):
+                    names.add(lg)
+        return names
+
+    def _metric_filter_log_groups(self, template: dict) -> set:
+        groups = set()
+        for resource in template.get("Resources", {}).values():
+            if resource.get("Type") == "AWS::Logs::MetricFilter":
+                lg = resource.get("Properties", {}).get("LogGroupName")
+                if isinstance(lg, str):
+                    groups.add(lg)
+        return groups
+
+    def test_cowork_dashboard_filters_target_cowork_log_group(self):
+        """Sanity: the cowork-dashboard filters do reference the cowork log group."""
+        dash = _load_template("cowork-dashboard.yaml")
+        assert self.COWORK_LOG_GROUP in self._metric_filter_log_groups(dash)
+
+    def test_cowork_log_group_is_created_by_monitoring_stack(self):
+        """otel-collector must create the cowork log group as a managed resource,
+        so it exists before cowork-dashboard's MetricFilters attach to it."""
+        otel = _load_template("otel-collector.yaml")
+        assert self.COWORK_LOG_GROUP in self._log_group_names(otel), (
+            f"{self.COWORK_LOG_GROUP} is referenced by cowork-dashboard MetricFilters but "
+            f"not created as an AWS::Logs::LogGroup in otel-collector.yaml — a fresh deploy "
+            f"will fail with 'The specified log group does not exist'."
+        )
+
+    def test_every_cowork_filter_group_has_a_creator(self):
+        """Every log group a cowork-dashboard MetricFilter targets must be created
+        somewhere in the monitoring stack (no assume-exists log groups)."""
+        dash_groups = self._metric_filter_log_groups(_load_template("cowork-dashboard.yaml"))
+        created = self._log_group_names(_load_template("otel-collector.yaml"))
+        missing = dash_groups - created
+        assert not missing, f"cowork-dashboard filters target log groups nobody creates: {missing}"


### PR DESCRIPTION
## Description

Create `/aws/claude-cowork/events` as a managed `AWS::Logs::LogGroup` in the monitoring stack (`otel-collector.yaml`), so it exists before the cowork-dashboard stack attaches MetricFilters to it.

## Why is this change needed

A fresh `ccwb deploy` (central mode + CoWork dashboard) fails on the cowork-dashboard stack:

```
AWS::Logs::MetricFilter (CostMetricFilter): The specified log group does not exist.
(CloudWatchLogs, 400, HandlerErrorCode: NotFound)
```

cowork-dashboard.yaml attaches six MetricFilters to `/aws/claude-cowork/events`, but no template creates that log group — it was left to runtime auto-creation by the collector's `awscloudwatchlogs/cowork` exporter, which only happens after the collector emits its first CoWork log, long after the dashboard stack deploys. A MetricFilter requires its target log group to exist at deploy time.

Fixes #555

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Infrastructure/deployment change

## Changes Made

- Add `CoWorkEventsLogGroup` (`AWS::Logs::LogGroup`, `/aws/claude-cowork/events`, 30-day retention) to `otel-collector.yaml`, mirroring the existing `/aws/claude-code/metrics` group. The monitoring stack deploys before cowork-dashboard, so the group exists when the MetricFilters attach.
- Add a CFN contract test asserting every log group a cowork-dashboard MetricFilter targets is created by the monitoring stack.

## Additional Notes

Retention (30) matches the collector exporter's `log_retention`. The collector writes to the group and the dashboard filters attach to it — single owner, no runtime race.

Pre-existing note (not introduced here): `tests/e2e/test_cfn_contracts.py` has some lines that `ruff format` would rewrap (the `VALID_ACTION_PREFIXES` set, untouched by this change). Left as-is to keep this fix minimal; can be folded into a separate format pass.

## Testing Checklist

### What was tested

- [x] **Verified live on real AWS**: re-deployed monitoring → `CoWorkEventsLogGroup` CREATE_COMPLETE, log group `/aws/claude-cowork/events` exists (retention 30); then `ccwb deploy cowork-dashboard` → CREATE_COMPLETE with all 6 MetricFilters attached (previously `ROLLBACK_COMPLETE`).
- [x] `cfn-lint deployment/infrastructure/otel-collector.yaml` (workflow ignore-list) — PASS.
- [x] New `TestCoWorkLogGroupContract` fails against the prior templates (2/3) and passes on this change (falsified).
- [x] `cd source && poetry run pytest tests/e2e/test_cfn_contracts.py` — green.
- [x] Gates: cfn_nag/cfn-lint + pytest-ci + scanners apply; go-tests / validate-regions N/A (no `source/go/**`, no region data).
