### PR TITLE
fix(destroy): don't report success when a stack delete errored

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/destroy.py
+++ b/source/claude_code_with_bedrock/cli/commands/destroy.py
@@ -154,11 +154,15 @@ class DestroyCommand(Command):
 
             result = self._delete_stack(stack_name, stack_region, console)
             if result != 0:
-                # Don't break - collect failed resources and continue
+                # Don't break - record the failure and continue with remaining stacks.
+                # Always track the stack: a non-zero result means it did not delete cleanly.
+                # Enumerable DELETE_FAILED resources may be empty (e.g. a real delete error,
+                # or a client-side timeout while resources are still DELETE_IN_PROGRESS), and
+                # the summary must not report overall success in that case.
+                stacks_with_failures.append(stack_name)
                 failed = self._get_failed_resources(stack_name, stack_region)
                 if failed:
                     all_failed_resources.extend(failed)
-                    stacks_with_failures.append(stack_name)
                     console.print(f"[yellow]⚠ {stack.capitalize()} stack — failed resources:[/yellow]")
                     for r in failed:
                         console.print(f"    • {r['logical_id']} ({r['resource_type']}): {r['physical_id']}")
@@ -297,6 +301,22 @@ class DestroyCommand(Command):
             console.print()
 
         if not failed_resources:
+            # Stacks failed to delete but no DELETE_FAILED resources are enumerable
+            # (real delete error, or a client-side timeout mid-delete). Don't claim
+            # success. Point the user at the affected stacks to re-run / verify.
+            if stacks:
+                region = profile.aws_region
+                console.print("\n[yellow]⚠ The following stacks did not delete cleanly:[/yellow]")
+                for stack in stacks:
+                    console.print(f"  • {stack}")
+                    console.print(
+                        f"    [cyan]aws cloudformation delete-stack "
+                        f"--stack-name {stack} --region {region}[/cyan]"
+                    )
+                console.print(
+                    "\n[dim]A delete may still be in progress - re-run "
+                    "[cyan]ccwb destroy[/cyan] or check the CloudFormation console to confirm.[/dim]"
+                )
             return
 
         console.print("\n[yellow]⚠ Manual cleanup required for the following resources:[/yellow]\n")

--- a/source/tests/cli/commands/test_destroy_reporting.py
+++ b/source/tests/cli/commands/test_destroy_reporting.py
@@ -1,0 +1,110 @@
+# ABOUTME: Regression tests for destroy summary reporting correctness
+# ABOUTME: A stack that errors with no enumerable DELETE_FAILED resources must not report success
+
+"""Regression coverage for the false "All stacks destroyed successfully!" report.
+
+When `_delete_stack` returns non-zero (e.g. a real error, or a client-side timeout while
+resources are still DELETE_IN_PROGRESS) and `_get_failed_resources` returns an empty list,
+the stack must still be tracked as failed and the summary must not claim success.
+"""
+
+from unittest.mock import Mock, patch
+
+from cleo.testers.command_tester import CommandTester
+from rich.console import Console
+
+from claude_code_with_bedrock.cli.commands.destroy import DestroyCommand
+
+
+def _profile(**overrides):
+    p = Mock()
+    p.identity_pool_name = "test-pool"
+    p.stack_names = {}
+    p.monitoring_enabled = True
+    p.monitoring_mode = "central"
+    p.quota_monitoring_enabled = False
+    p.enable_distribution = False
+    p.enable_codebuild = False
+    p.aws_region = "us-east-1"
+    p.codebuild_region = None  # explicit: Mock would otherwise auto-create a truthy attr
+    p.codebuild_prior_regions = []  # explicit: Mock would otherwise be a non-iterable truthy attr
+    for k, v in overrides.items():
+        setattr(p, k, v)
+    return p
+
+
+def test_errored_stack_with_no_failed_resources_is_tracked():
+    """A non-zero delete result with empty failed-resources must reach the summary as a failure."""
+    captured = {}
+
+    def _spy_summary(self, failed_resources, retained_resources, stacks, profile, console):
+        captured["stacks"] = list(stacks)
+
+    # auth (the always-deleted stack) errors with code 2; everything else "succeeds".
+    def _delete(self, stack_name, region, console):
+        return 2 if stack_name.endswith("-auth") else 0
+
+    with (
+        patch("claude_code_with_bedrock.cli.commands.destroy.Config") as MockConfig,
+        patch.object(DestroyCommand, "_delete_stack", _delete),
+        patch.object(DestroyCommand, "_get_failed_resources", return_value=[]),
+        patch.object(DestroyCommand, "_get_retained_resources", return_value=[]),
+        patch.object(DestroyCommand, "_show_cleanup_summary", _spy_summary),
+    ):
+        MockConfig.load.return_value.get_profile.return_value = _profile()
+        MockConfig.load.return_value.active_profile = "test"
+        CommandTester(DestroyCommand()).execute("--force")
+
+    assert captured["stacks"], "errored stack must be recorded in stacks_with_failures"
+    assert any(s.endswith("-auth") for s in captured["stacks"])
+
+
+def test_summary_does_not_claim_success_for_errored_stack():
+    """_show_cleanup_summary with a failed stack but no per-resource rows must not print success."""
+    console = Console(record=True, width=120)
+    DestroyCommand()._show_cleanup_summary(
+        failed_resources=[],
+        retained_resources=[],
+        stacks=["test-pool-monitoring"],
+        profile=_profile(),
+        console=console,
+    )
+    out = console.export_text()
+    assert "All stacks destroyed successfully" not in out
+    assert "did not delete cleanly" in out
+    assert "test-pool-monitoring" in out
+    assert "delete-stack" in out
+
+
+def test_summary_with_both_failed_resources_and_stacks():
+    """A stack with enumerable DELETE_FAILED resources AND tracked failure shows both sections."""
+    console = Console(record=True, width=120)
+    DestroyCommand()._show_cleanup_summary(
+        failed_resources=[
+            {
+                "logical_id": "DNSRecord",
+                "resource_type": "AWS::Route53::RecordSet",
+                "physical_id": "app.example.com",
+                "status_reason": "client timeout",
+            }
+        ],
+        retained_resources=[],
+        stacks=["test-pool-monitoring"],
+        profile=_profile(),
+        console=console,
+    )
+    out = console.export_text()
+    # Per-resource cleanup section is shown...
+    assert "Manual cleanup required" in out
+    assert "DNSRecord" in out
+    # ...and the per-stack delete-stack guidance is still reached (not short-circuited).
+    assert "delete-stack" in out
+    assert "test-pool-monitoring" in out
+    assert "All stacks destroyed successfully" not in out
+
+
+def test_clean_run_still_reports_success():
+    """No failures, no retained, no stacks -> success message preserved (no false negative)."""
+    console = Console(record=True, width=120)
+    DestroyCommand()._show_cleanup_summary([], [], [], _profile(), console)
+    assert "All stacks destroyed successfully" in console.export_text()


### PR DESCRIPTION
## Description

`ccwb destroy` could print "✓ All stacks destroyed successfully!" in the same run where a stack returned a delete error. The fix records a stack as failed whenever its delete returns non-zero, instead of only when CloudFormation has already surfaced `DELETE_FAILED` resources, and makes the cleanup summary call those stacks out (with a `delete-stack` command and a note to verify) even when there are no resource-level rows to show.

This is purely a reporting change. It doesn't touch what gets deleted, the skip rules, or the order stacks are torn down in.

## Why is this change needed

For a destroy command, falsely reporting a clean teardown is genuinely risky - you can be left with a live, still-billing stack while believing the account is empty. The success line could land immediately after an "Error deleting stack" line in the very same run, which is what prompted this.

Fixes #557

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- In `handle()` (`destroy.py`), a stack is now added to `stacks_with_failures` as soon as its delete returns non-zero, rather than only inside the branch that handles enumerable `DELETE_FAILED` resources. A comment explains why a failure with no listable resources still has to be tracked.
- `_show_cleanup_summary()` no longer returns early when there are failed stacks but no per-resource rows. It lists the affected stacks, prints the `aws cloudformation delete-stack` command for each, and adds a note that the delete may still be finishing in the background and is worth verifying.
- New test file `source/tests/cli/commands/test_destroy_reporting.py` with four regression tests: the errored stack is tracked, the summary never claims success after an error, the case where a stack has both listable failed resources and a tracked failure still reaches the per-stack guidance, and a fully clean run still reports success.

## Additional Notes

- The success line only fires when `failed_resources`, `retained_resources`, and `stacks` are all empty, so tracking the errored stack unconditionally is enough to close the hole.
- The wording is intentionally cautious ("a delete may still be in progress, verify") because a client timeout really is ambiguous - CloudFormation sometimes finishes the job afterward.
- One thing I deliberately left out of this PR: `handle()` still returns exit code 0 even when stacks failed, so a script doing `ccwb destroy && ...` can't detect the failure from the exit code. That's a pre-existing behavior change on its own and I'd rather keep this PR to just the reporting fix; happy to follow up separately.

## Testing Checklist

### What was tested

- [x] Unit/integration tests pass (`ccwb test` / `poetry run pytest tests/`)

## Testing Evidence

**Test Environment:** ap-southeast-2, Python 3.12, macOS (Apple silicon)

**Test Results:**

```text
# Full suite (rebased on beta f2afa73)
$ cd source && poetry run pytest tests/ -q
979 passed, 22 skipped, 1 xfailed, 1 xpassed

# The new regression tests
$ poetry run pytest tests/cli/commands/test_destroy_reporting.py -q
4 passed

# Falsification: same tests, run against beta's destroy.py (source reverted, tests kept)
#   test_errored_stack_with_no_failed_resources_is_tracked   -> FAILED  (stacks list came back empty)
#   test_summary_does_not_claim_success_for_errored_stack    -> FAILED  ("did not delete cleanly" missing)
#   test_summary_with_both_failed_resources_and_stacks       -> PASSED  (guards behavior we didn't change)
#   test_clean_run_still_reports_success                     -> PASSED  (so we don't over-correct)
#   => 2 failed / 2 passed on beta, 4 passed on the fix. Source restored afterward.

# Sibling destroy tests still green
$ poetry run pytest tests/cli/commands/test_destroy_skip_logic.py tests/cli/commands/test_destroy_stacks.py -q
(all pass)
```

I also ran the local gate checks on the changed files: bandit is clean on `destroy.py` (the test file only trips the usual B101 assert baseline), semgrep finds nothing, detect-secrets finds nothing, and the changed test file is ruff-clean. (The pre-existing `I001` import-sort note on `destroy.py` is already on beta and untouched by this diff.)
