### PR TITLE
feat(rules): guard against hand-built AWS ARNs (rule + static test)

### DIFF
--- a/.claude/rules/aws-identifiers.md
+++ b/.claude/rules/aws-identifiers.md
@@ -1,0 +1,33 @@
+# AWS Identifiers
+
+## Rule
+Never hand-build an ARN or resource ID that an API response or CloudFormation
+output already returns. Read it from the source of truth.
+
+## Why
+AWS adds parts you can't predict - Secrets Manager appends a random 6-char
+suffix to secret ARNs (`...-FhLi4n`); many IDs are server-assigned. A
+formatted `f"arn:...:{name}"` silently omits them, and downstream consumers
+(e.g. `{{resolve:secretsmanager:<arn>}}` in an ALB listener) fail with
+ResourceNotFoundException at deploy time.
+
+## Examples
+```python
+# ❌ Wrong - omits the random suffix
+secret_arn = f"arn:aws:secretsmanager:{region}:{account_id}:secret:{name}"
+
+# ✅ Correct - use the API response
+resp = client.create_secret(Name=name, SecretString=val)   # or update_secret
+secret_arn = resp["ARN"]
+# ...or recover it when you have no response:
+secret_arn = client.describe_secret(SecretId=name)["ARN"]
+```
+
+The escape hatch for a genuine last-resort fallback is a plain
+`# allow-handbuilt-arn` comment on the line (not a `# noqa:` code, which ruff
+would reject and `ruff --fix` could strip).
+
+## Related
+- Sibling of .claude/rules/iam-actions.md (bedrock-runtime: prefix). Same class:
+  AWS strings written from memory instead of from the source of truth.
+- Issue: distribution HTTPSListener ResourceNotFoundException (init secret ARN).

--- a/.claude/rules/iam-actions.md
+++ b/.claude/rules/iam-actions.md
@@ -19,3 +19,6 @@ The `bedrock-runtime:` prefix doesn't exist in IAM. It's been a persistent sourc
 
 ## Related Issues
 #375, #63
+
+## See Also
+.claude/rules/aws-identifiers.md

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1488,7 +1488,7 @@ class InitCommand(Command):
                     try:
                         secret_arn = secrets_client.describe_secret(SecretId=secret_name)["ARN"]
                     except Exception:
-                        secret_arn = f"arn:aws:secretsmanager:{region}:{account_id}:secret:{secret_name}"
+                        secret_arn = f"arn:aws:secretsmanager:{region}:{account_id}:secret:{secret_name}"  # allow-handbuilt-arn
 
             # Custom domain (REQUIRED for authenticated landing page)
             console.print("\n[bold]Custom Domain Configuration (REQUIRED)[/bold]")

--- a/source/tests/test_no_handbuilt_arns.py
+++ b/source/tests/test_no_handbuilt_arns.py
@@ -1,0 +1,39 @@
+# ABOUTME: Static analysis preventing hand-built AWS ARNs that omit server-assigned parts
+# ABOUTME: Enforces .claude/rules/aws-identifiers.md (Secrets Manager suffix bug class)
+
+import re
+from pathlib import Path
+
+SRC = Path(__file__).parent.parent / "claude_code_with_bedrock"
+
+# f-string ARNs for services whose ARNs carry an unpredictable server-assigned
+# part (e.g. Secrets Manager's random suffix). Reading these from the API is the
+# only correct option; constructing them is the bug. Scoped to f-strings because
+# that is the only interpolation style the codebase uses for ARNs; .format()/%
+# are intentionally out of scope to keep the check high-signal.
+DANGEROUS = re.compile(
+    r'f["\'][^"\']*arn:aws:(secretsmanager)[^"\']*\{[^"\']*\}[^"\']*["\']'
+)
+
+# Lines explicitly accepted (e.g. documented last-resort fallback after
+# describe_secret fails) carry this marker. Deliberately NOT a `# noqa:` code —
+# ruff parses `# noqa:` and would reject a non-standard code (and `ruff --fix`
+# could strip it), so this uses a plain project-specific comment instead.
+ALLOW = "# allow-handbuilt-arn"
+
+
+def _py_files():
+    return list(SRC.rglob("*.py"))
+
+
+def test_no_handbuilt_secretsmanager_arns():
+    offenders = []
+    for f in _py_files():
+        for i, line in enumerate(f.read_text(encoding="utf-8").splitlines(), 1):
+            if DANGEROUS.search(line) and ALLOW not in line:
+                offenders.append(f"{f.relative_to(SRC.parent)}:{i}: {line.strip()}")
+    assert not offenders, (
+        "Hand-built Secrets Manager ARN(s) found - read the ARN from the API "
+        "response (see .claude/rules/aws-identifiers.md). If a documented "
+        f"last-resort fallback, append `{ALLOW}`:\n" + "\n".join(offenders)
+    )


### PR DESCRIPTION
> 🟡 **Maintainer decision requested.** This adds a project convention (a `.claude/rules/` entry plus an enforcing test) rather than fixing a bug. It generalizes the #547 Secrets Manager ARN issue the same way `iam-actions.md` covers the `bedrock-runtime:` one. Scoped narrow on purpose. Please close freely if it's not a convention you want to adopt.

## Description

This adds a guardrail for the "hand-built AWS identifier" class of bug: a short rule doc, plus a static test that fails CI if the Python source builds a Secrets Manager ARN with an f-string (which silently drops the random suffix AWS appends). There's a documented `# allow-handbuilt-arn` escape hatch for the single genuine last-resort fallback that already exists in `init.py`.

## Why is this change needed

The distribution deploy broke because a hand-built Secrets Manager ARN left off the server-assigned suffix, so the ALB listener's `{{resolve:secretsmanager:<arn>}}` couldn't resolve it. That was fixed in #547. It's the same class as the recurring `bedrock-runtime:` IAM prefix bug, which we already guard with a rule and a test. This adds the matching guard so the ARN version can't quietly come back.

Fixes #558

## Type of Change

- [x] New feature (non-breaking change which adds functionality) — a convention guardrail, no product behavior change

## Changes Made

- New `.claude/rules/aws-identifiers.md`: the rule, why it matters, ✅/❌ examples (fenced, matching `iam-actions.md`), and the escape-hatch convention.
- New `source/tests/test_no_handbuilt_arns.py`: scans the Python source under `claude_code_with_bedrock/` and fails on an f-string Secrets Manager ARN that doesn't carry `# allow-handbuilt-arn`. It's scoped to Secrets Manager so it won't flag legitimate constructed ARNs (Bedrock `foundation-model/*` patterns, IAM resource wildcards, and so on), and the f-string-only scope is documented in the test.
- `init.py`: a one-line, comment-only `# allow-handbuilt-arn` on the documented last-resort fallback at the end of the secret-store exception path. No behavior change.
- `iam-actions.md`: a one-line "See Also" pointer to the new rule.

## Additional Notes

A couple of things worth knowing for review:

- The escape-hatch marker is intentionally not a `# noqa:` code. ruff parses `# noqa:` and rejects a non-standard code there, and `ruff --fix` (which runs in pre-commit) could strip it, so the marker is a plain project-specific `# allow-handbuilt-arn` comment instead. I confirmed ruff no longer reports an "Invalid # noqa directive" with this wording.
- The one marked line in `init.py` only runs when both the create/update call and the follow-up `describe_secret` raise. At that point any ARN is best-effort and the config isn't deployable anyway. It also doubles as a live check that the escape hatch actually works.
- Scope is narrow on purpose (Option A from the issue): Secrets Manager f-strings only. `.format()`/`%` and other services are left for later, since nothing in the codebase uses those today (confirmed by grep).

## Testing Checklist

### What was tested

- [x] Unit/integration tests pass (`ccwb test` / `poetry run pytest tests/`)

## Testing Evidence

**Test Environment:** ap-southeast-2, Python 3.12, macOS (Apple silicon)

**Test Results:**

```text
# Full suite (rebased on beta f2afa73)
$ cd source && poetry run pytest tests/ -q
976 passed, 22 skipped, 1 xfailed, 1 xpassed

# The new static test, on the marked tree
$ poetry run pytest tests/test_no_handbuilt_arns.py -q
1 passed

# Falsification: drop the marker (restore beta's init.py) and the test must fail
#   test_no_handbuilt_secretsmanager_arns -> FAILED, pointing at:
#     claude_code_with_bedrock/cli/commands/init.py:1491: secret_arn = f"arn:aws:secretsmanager:..."
#   put the marked version back -> 1 passed.
#   So the guard catches the real thing, and the escape hatch works.

# No false positives: the regex is scoped to secretsmanager, so Bedrock / IAM / S3 constructed ARNs
# are left alone.

# Lint: the new test file is ruff-clean, and init.py no longer shows an "Invalid # noqa directive"
# with the # allow-handbuilt-arn marker. (That line is over 120 chars, matching the 7 E501s already
# on beta's init.py; ruff isn't a CI gate here.)
```

Local gate checks on the changed files: bandit on `init.py` shows the same baseline as beta with no new findings (the test file only trips B101), semgrep finds nothing, and detect-secrets finds nothing.

## Note for the eventual beta→main promotion

`main` doesn't have #547 yet, and it still carries two unmarked hand-built Secrets Manager ARNs in `init.py` (around lines 1359 and 1366). This test would fail on `main` until #547 and those two lines are sorted out, so the guardrail shouldn't be promoted ahead of its dependency.
