### PR TITLE
fix(destroy): exit non-zero when a stack delete failed

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/destroy.py
+++ b/source/claude_code_with_bedrock/cli/commands/destroy.py
@@ -212,7 +212,10 @@ class DestroyCommand(Command):
         # Show cleanup summary at the end
         self._show_cleanup_summary(all_failed_resources, all_retained_resources, stacks_with_failures, profile, console)
 
-        return 0
+        # Exit non-zero when any stack didn't delete cleanly so scripts/CI can
+        # fail fast on a broken teardown. Matches deploy/package, which already
+        # return 1 on failure. The summary above still surfaces what to clean up.
+        return 1 if stacks_with_failures else 0
 
     def _delete_stack(self, stack_name: str, region: str, console: Console) -> int:
         """Delete a CloudFormation stack using boto3.

--- a/source/tests/cli/commands/test_destroy_skip_logic.py
+++ b/source/tests/cli/commands/test_destroy_skip_logic.py
@@ -153,6 +153,49 @@ class TestSkipGuards:
         assert {"distribution", "codebuild"} <= deleted
 
 
+def _run_destroy_with_delete(profile, delete_return, stack_arg=None):
+    """Run `destroy --force` with `_delete_stack` stubbed to a fixed return code.
+
+    `delete_return` is the int every `_delete_stack` call returns (0 = clean,
+    non-zero = the stack didn't delete cleanly). Returns the command exit code.
+    """
+    with (
+        patch("claude_code_with_bedrock.cli.commands.destroy.Config") as MockConfig,
+        patch.object(DestroyCommand, "_delete_stack", return_value=delete_return),
+        patch.object(DestroyCommand, "_get_failed_resources", return_value=[]),
+        patch.object(DestroyCommand, "_get_retained_resources", return_value=[]),
+        patch.object(DestroyCommand, "_show_cleanup_summary"),
+    ):
+        MockConfig.load.return_value.get_profile.return_value = profile
+        MockConfig.load.return_value.active_profile = "test"
+
+        tester = CommandTester(DestroyCommand())
+        args = f"{stack_arg} --force" if stack_arg else "--force"
+        return tester.execute(args)
+
+
+class TestExitCodeReflectsFailure:
+    """`ccwb destroy` must exit non-zero when a stack didn't delete cleanly, so
+    scripts/CI can fail fast on a broken teardown (parity with deploy/package)."""
+
+    def test_failed_delete_exits_nonzero(self):
+        # DELETE_FAILED (1): some resources need manual cleanup -> non-zero exit.
+        exit_code = _run_destroy_with_delete(
+            _profile(enable_distribution=True), delete_return=1, stack_arg="distribution"
+        )
+        assert exit_code != 0
+
+    def test_delete_error_exits_nonzero(self):
+        # A real delete error (2: permissions/network/timeout) -> non-zero exit.
+        exit_code = _run_destroy_with_delete(_profile(enable_codebuild=True), delete_return=2, stack_arg="codebuild")
+        assert exit_code != 0
+
+    def test_clean_run_exits_zero(self):
+        # The all-clean path must still exit 0.
+        exit_code = _run_destroy_with_delete(_profile(), delete_return=0)
+        assert exit_code == 0
+
+
 class TestSingleStackArg:
     def test_distribution_arg_accepted(self):
         exit_code, deleted = _run_destroy(_profile(enable_distribution=True), stack_arg="distribution")


### PR DESCRIPTION
## Description

`ccwb destroy` now returns exit code 1 when any stack fails to delete, instead of always returning 0. Reporting and deletion behavior are unchanged — only the exit code now reflects reality.

## Why is this change needed

`destroy` collected every stack that didn't delete cleanly into `stacks_with_failures` and printed them in the summary, but `handle()` always returned 0. Scripts and CI running `ccwb destroy --force && ...` saw success after a failed teardown, leaving orphaned resources behind silently. `deploy` and `package` already return 1 on failure; destroy was the odd one out.

Fixes #564

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

> Note: this changes the exit-code contract for `destroy` (0 → 1 on failure). It is non-breaking for the success path but worth a maintainer's eyes if destroy was intentionally non-failing.

## Changes Made

- `destroy.py`: replace the final unconditional `return 0` with `return 1 if stacks_with_failures else 0`.
- `test_destroy_skip_logic.py`: add `TestExitCodeReflectsFailure` (failed delete → exit ≠ 0; clean run → exit 0), plus a `_run_destroy_with_delete` helper that stubs `_delete_stack` to a fixed return code.

## Additional Notes

Builds on #559 (merged), which broadened `stacks_with_failures` to capture the no-enumerable-resources / client-timeout failure case. The exit code now covers the same set of failures the reporting surfaces.

---

## Testing Checklist

### What was tested

- [x] Unit/integration tests pass (`ccwb test` / `poetry run pytest tests/`)

## Testing Evidence

**Test Environment:** ap-southeast-1, Python 3.12.13, macOS 26.5.1

**Test Results:**

```text
$ poetry run pytest tests/ -q
983 passed, 22 skipped, 1 xfailed, 1 xpassed in 144.74s

$ poetry run pytest tests/cli/commands/test_destroy_skip_logic.py -q
17 passed

# Falsification — new test run against beta's UNFIXED destroy.py:
FAILED test_destroy_skip_logic.py::TestExitCodeReflectsFailure::test_failed_delete_exits_nonzero
FAILED test_destroy_skip_logic.py::TestExitCodeReflectsFailure::test_delete_error_exits_nonzero
2 failed, 1 passed
# With the fix restored: 3 passed. The regression test catches the bug.
```

CI gates verified locally: `bandit` on destroy.py (0 findings), `semgrep --config auto` on both changed files (0 findings), `detect-secrets` (no new secrets), `ruff` on added code (clean). N/A: cfn_nag (no CFN), validate-regions (no region data), go-tests (no `source/go/**`).
