### PR TITLE
Fix invalid YAML in Windows CodeBuild buildspec

### DIFF
--- a/deployment/infrastructure/codebuild-windows.yaml
+++ b/deployment/infrastructure/codebuild-windows.yaml
@@ -180,8 +180,8 @@ Resources:
               commands:
                 - echo Build completed
                 - echo Validating all required binaries exist...
-                - if (-not (Test-Path credential-process-windows.exe)) { Write-Error "FATAL: credential-process-windows.exe was not built. Nuitka compilation failed."; exit 1 }
-                - if (-not (Test-Path otel-helper-windows.exe)) { Write-Error "FATAL: otel-helper-windows.exe was not built. Nuitka compilation failed. Consider using 'ccwb package --go' for reliable Go-based builds."; exit 1 }
+                - 'if (-not (Test-Path credential-process-windows.exe)) { Write-Error "FATAL: credential-process-windows.exe was not built. Nuitka compilation failed."; exit 1 }'
+                - 'if (-not (Test-Path otel-helper-windows.exe)) { Write-Error "FATAL: otel-helper-windows.exe was not built. Nuitka compilation failed. Consider using ''ccwb package --go'' for reliable Go-based builds."; exit 1 }'
                 - Get-ChildItem *.exe | ForEach-Object { Write-Host "$($_.Name) - $([math]::Round($_.Length/1MB, 1)) MB" }
 
           artifacts:


### PR DESCRIPTION
## Problem

Every Windows binary build via AWS CodeBuild fails in the `DOWNLOAD_SOURCE` phase (before Nuitka runs) with:

```
Phase context status code: YAML_FILE_ERROR
Message: Expected Commands[2] to be of string type: found subkeys instead
at line 40, value of the key 'tag' on line 39 might be empty
```

This blocks the CodeBuild Windows build path entirely. The Linux x64 / ARM64 CodeBuild builds are unaffected.

## Root cause

In `deployment/infrastructure/codebuild-windows.yaml`, the Windows project's inline buildspec `post_build.commands` has two **unquoted** commands containing `"FATAL: ` — a colon followed by a space:

```yaml
- if (-not (Test-Path credential-process-windows.exe)) { Write-Error "FATAL: credential-process-windows.exe was not built. Nuitka compilation failed."; exit 1 }
- if (-not (Test-Path otel-helper-windows.exe)) { Write-Error "FATAL: otel-helper-windows.exe was not built. Nuitka compilation failed. Consider using 'ccwb package --go' for reliable Go-based builds."; exit 1 }
```

In YAML, `key: value` (colon + space) denotes a mapping. Because these list items are unquoted plain scalars, the parser interprets the `: ` as a mapping separator and reads the command as a nested mapping instead of a string — which is exactly the "found subkeys instead" error CodeBuild reports.

## Fix

Wrap each command in single quotes so the whole string (including `FATAL: `) is a literal scalar. The second command's inner `'ccwb package --go'` single quotes are doubled (`''ccwb package --go''`) per YAML single-quote escaping rules. This is a **quoting-only** change — command behavior is unchanged.

## Verification

Extracted the corrected buildspec block and parsed it with a YAML loader: the `phases` (install / pre_build / build / post_build) parse correctly and all five `post_build` commands are now string scalars (previously the parse aborted).

## When this bites

Reproducible whenever the CodeBuild + Nuitka path is the only route to a Windows binary — e.g. the `ccwb package --go` (Go cross-compile) alternative isn't available because Go can't be installed on the build host. Encountered while deploying with infrastructure in `eu-central-1`.
