### PR TITLE
fix(dashboard): support both CoWork telemetry schemas in metric filters

### DIFF
--- a/deployment/infrastructure/cowork-dashboard.yaml
+++ b/deployment/infrastructure/cowork-dashboard.yaml
@@ -16,21 +16,25 @@ Parameters:
 
 Resources:
   # CloudWatch Metric Filters — extract metrics from CoWork log events.
-  # CoWork emits lam_session_turn_completed events with token counts and cost.
-  # These filters create CloudWatch metrics in the ClaudeCoWork namespace.
+  # CoWork emits events in two schemas depending on mode:
+  #   1. Local Agent Mode: body.name="lam_session_turn_completed", body.attributes.*
+  #   2. Claude-Code-for-Desktop: body="claude_code.api_request", attributes.*
+  # We create filters for both schemas so the dashboard works regardless of mode.
   # Note: AWS limits MetricTransformations to 1 per filter, so each metric
   # requires its own filter resource.
+
+  # --- Claude-Code-for-Desktop schema (body="claude_code.api_request") ---
 
   InputTokenMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: /aws/claude-cowork/events
       FilterName: cowork-input-tokens
-      FilterPattern: '{ $.body.name = "lam_session_turn_completed" }'
+      FilterPattern: '{ $.body = "claude_code.api_request" }'
       MetricTransformations:
         - MetricNamespace: ClaudeCoWork
           MetricName: token.usage.input
-          MetricValue: $.body.attributes.input_tokens
+          MetricValue: $.attributes.input_tokens
           DefaultValue: 0
 
   OutputTokenMetricFilter:
@@ -38,11 +42,11 @@ Resources:
     Properties:
       LogGroupName: /aws/claude-cowork/events
       FilterName: cowork-output-tokens
-      FilterPattern: '{ $.body.name = "lam_session_turn_completed" }'
+      FilterPattern: '{ $.body = "claude_code.api_request" }'
       MetricTransformations:
         - MetricNamespace: ClaudeCoWork
           MetricName: token.usage.output
-          MetricValue: $.body.attributes.output_tokens
+          MetricValue: $.attributes.output_tokens
           DefaultValue: 0
 
   CacheReadTokenMetricFilter:
@@ -50,11 +54,11 @@ Resources:
     Properties:
       LogGroupName: /aws/claude-cowork/events
       FilterName: cowork-cache-read-tokens
-      FilterPattern: '{ $.body.name = "lam_session_turn_completed" }'
+      FilterPattern: '{ $.body = "claude_code.api_request" }'
       MetricTransformations:
         - MetricNamespace: ClaudeCoWork
           MetricName: token.usage.cache_read
-          MetricValue: $.body.attributes.cache_read_input_tokens
+          MetricValue: $.attributes.cache_read_tokens
           DefaultValue: 0
 
   CacheCreationTokenMetricFilter:
@@ -62,11 +66,11 @@ Resources:
     Properties:
       LogGroupName: /aws/claude-cowork/events
       FilterName: cowork-cache-creation-tokens
-      FilterPattern: '{ $.body.name = "lam_session_turn_completed" }'
+      FilterPattern: '{ $.body = "claude_code.api_request" }'
       MetricTransformations:
         - MetricNamespace: ClaudeCoWork
           MetricName: token.usage.cache_creation
-          MetricValue: $.body.attributes.cache_creation_input_tokens
+          MetricValue: $.attributes.cache_creation_tokens
           DefaultValue: 0
 
   CostMetricFilter:
@@ -74,11 +78,11 @@ Resources:
     Properties:
       LogGroupName: /aws/claude-cowork/events
       FilterName: cowork-cost
-      FilterPattern: '{ $.body.name = "lam_session_turn_completed" }'
+      FilterPattern: '{ $.body = "claude_code.api_request" }'
       MetricTransformations:
         - MetricNamespace: ClaudeCoWork
           MetricName: cost.usage
-          MetricValue: $.body.attributes.total_cost_usd
+          MetricValue: $.attributes.cost_usd
           DefaultValue: 0
 
   SessionCountMetricFilter:
@@ -86,6 +90,81 @@ Resources:
     Properties:
       LogGroupName: /aws/claude-cowork/events
       FilterName: cowork-sessions
+      FilterPattern: '{ $.body = "claude_code.api_request" }'
+      MetricTransformations:
+        - MetricNamespace: ClaudeCoWork
+          MetricName: session.turns
+          MetricValue: "1"
+          DefaultValue: 0
+
+  # --- Local Agent Mode schema (body.name="lam_session_turn_completed") ---
+  # These emit to the SAME metric names so both modes contribute to the dashboard.
+
+  LamInputTokenMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: /aws/claude-cowork/events
+      FilterName: cowork-lam-input-tokens
+      FilterPattern: '{ $.body.name = "lam_session_turn_completed" }'
+      MetricTransformations:
+        - MetricNamespace: ClaudeCoWork
+          MetricName: token.usage.input
+          MetricValue: $.body.attributes.input_tokens
+          DefaultValue: 0
+
+  LamOutputTokenMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: /aws/claude-cowork/events
+      FilterName: cowork-lam-output-tokens
+      FilterPattern: '{ $.body.name = "lam_session_turn_completed" }'
+      MetricTransformations:
+        - MetricNamespace: ClaudeCoWork
+          MetricName: token.usage.output
+          MetricValue: $.body.attributes.output_tokens
+          DefaultValue: 0
+
+  LamCacheReadTokenMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: /aws/claude-cowork/events
+      FilterName: cowork-lam-cache-read-tokens
+      FilterPattern: '{ $.body.name = "lam_session_turn_completed" }'
+      MetricTransformations:
+        - MetricNamespace: ClaudeCoWork
+          MetricName: token.usage.cache_read
+          MetricValue: $.body.attributes.cache_read_input_tokens
+          DefaultValue: 0
+
+  LamCacheCreationTokenMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: /aws/claude-cowork/events
+      FilterName: cowork-lam-cache-creation-tokens
+      FilterPattern: '{ $.body.name = "lam_session_turn_completed" }'
+      MetricTransformations:
+        - MetricNamespace: ClaudeCoWork
+          MetricName: token.usage.cache_creation
+          MetricValue: $.body.attributes.cache_creation_input_tokens
+          DefaultValue: 0
+
+  LamCostMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: /aws/claude-cowork/events
+      FilterName: cowork-lam-cost
+      FilterPattern: '{ $.body.name = "lam_session_turn_completed" }'
+      MetricTransformations:
+        - MetricNamespace: ClaudeCoWork
+          MetricName: cost.usage
+          MetricValue: $.body.attributes.total_cost_usd
+          DefaultValue: 0
+
+  LamSessionCountMetricFilter:
+    Type: AWS::Logs::MetricFilter
+    Properties:
+      LogGroupName: /aws/claude-cowork/events
+      FilterName: cowork-lam-sessions
       FilterPattern: '{ $.body.name = "lam_session_turn_completed" }'
       MetricTransformations:
         - MetricNamespace: ClaudeCoWork
@@ -208,7 +287,7 @@ Resources:
               "properties": {
                 "title": "Recent CoWork Events (Raw)",
                 "region": "${MetricsRegion}",
-                "query": "SOURCE '/aws/claude-cowork/events' | fields @timestamp, body.name, body.attributes.model, body.attributes.input_tokens, body.attributes.output_tokens, body.attributes.total_cost_usd | sort @timestamp desc | limit 20",
+                "query": "SOURCE '/aws/claude-cowork/events' | fields @timestamp, coalesce(body.name, body) as event_name, coalesce(body.attributes.model, attributes.model) as model, coalesce(body.attributes.input_tokens, attributes.input_tokens) as input_tokens, coalesce(body.attributes.output_tokens, attributes.output_tokens) as output_tokens, coalesce(body.attributes.total_cost_usd, attributes.cost_usd) as cost_usd | sort @timestamp desc | limit 20",
                 "view": "table"
               }
             }

--- a/source/tests/e2e/test_cowork_dashboard_filters.py
+++ b/source/tests/e2e/test_cowork_dashboard_filters.py
@@ -1,0 +1,122 @@
+# ABOUTME: Tests that cowork-dashboard.yaml metric filters match both CoWork schemas
+# ABOUTME: Regression test for issue #541 gap 4 (metric filters don't match real events)
+
+"""Tests for CoWork dashboard metric filter schema coverage."""
+
+import yaml
+import pytest
+from pathlib import Path
+
+
+DASHBOARD_PATH = Path(__file__).parent.parent.parent.parent / "deployment" / "infrastructure" / "cowork-dashboard.yaml"
+
+
+class TestCoWorkDashboardMetricFilters:
+    """Verify metric filters cover both CoWork telemetry schemas."""
+
+    @pytest.fixture(autouse=True)
+    def load_template(self):
+        # Add CloudFormation intrinsic function constructors
+        loader = yaml.SafeLoader
+        for tag in ["!Sub", "!Ref", "!GetAtt", "!If", "!Not", "!Equals", "!Select", "!Join", "!Split"]:
+            loader.add_constructor(tag, lambda l, n: l.construct_scalar(n) if n.id == "scalar" else l.construct_sequence(n))
+        loader.add_multi_constructor("!", lambda l, suffix, n: l.construct_scalar(n) if n.id == "scalar" else l.construct_sequence(n))
+        with open(DASHBOARD_PATH) as f:
+            self.template = yaml.load(f, Loader=loader)
+        self.resources = self.template.get("Resources", {})
+
+    def _get_filters(self):
+        """Extract all MetricFilter resources."""
+        return {
+            name: res for name, res in self.resources.items()
+            if res.get("Type") == "AWS::Logs::MetricFilter"
+        }
+
+    def test_has_api_request_schema_filters(self):
+        """Dashboard should have filters for claude_code.api_request schema."""
+        filters = self._get_filters()
+        api_request_filters = [
+            name for name, res in filters.items()
+            if 'claude_code.api_request' in res["Properties"]["FilterPattern"]
+        ]
+        # Should have input, output, cache_read, cache_creation, cost, sessions
+        assert len(api_request_filters) >= 6, (
+            f"Expected at least 6 api_request filters, got {len(api_request_filters)}: {api_request_filters}"
+        )
+
+    def test_has_lam_schema_filters(self):
+        """Dashboard should have filters for lam_session_turn_completed schema."""
+        filters = self._get_filters()
+        lam_filters = [
+            name for name, res in filters.items()
+            if 'lam_session_turn_completed' in res["Properties"]["FilterPattern"]
+        ]
+        assert len(lam_filters) >= 6, (
+            f"Expected at least 6 lam filters, got {len(lam_filters)}: {lam_filters}"
+        )
+
+    def test_api_request_uses_top_level_attributes(self):
+        """api_request schema uses $.attributes.* (not $.body.attributes.*)."""
+        filters = self._get_filters()
+        for name, res in filters.items():
+            props = res["Properties"]
+            if 'claude_code.api_request' in props["FilterPattern"]:
+                for transform in props["MetricTransformations"]:
+                    value = transform["MetricValue"]
+                    if value == "1":
+                        continue  # session count uses literal
+                    assert value.startswith("$.attributes."), (
+                        f"{name}: api_request filter should use $.attributes.*, got {value}"
+                    )
+                    assert "body.attributes" not in value, (
+                        f"{name}: api_request filter must NOT use $.body.attributes.*, got {value}"
+                    )
+
+    def test_lam_uses_body_attributes(self):
+        """lam schema uses $.body.attributes.* (nested under body)."""
+        filters = self._get_filters()
+        for name, res in filters.items():
+            props = res["Properties"]
+            if 'lam_session_turn_completed' in props["FilterPattern"]:
+                for transform in props["MetricTransformations"]:
+                    value = transform["MetricValue"]
+                    if value == "1":
+                        continue  # session count uses literal
+                    assert value.startswith("$.body.attributes."), (
+                        f"{name}: lam filter should use $.body.attributes.*, got {value}"
+                    )
+
+    def test_both_schemas_emit_same_metric_names(self):
+        """Both schema filters should emit to the same CloudWatch metric names."""
+        filters = self._get_filters()
+        api_metrics = set()
+        lam_metrics = set()
+        for name, res in filters.items():
+            props = res["Properties"]
+            for transform in props["MetricTransformations"]:
+                metric_name = transform["MetricName"]
+                if 'claude_code.api_request' in props["FilterPattern"]:
+                    api_metrics.add(metric_name)
+                elif 'lam_session_turn_completed' in props["FilterPattern"]:
+                    lam_metrics.add(metric_name)
+        assert api_metrics == lam_metrics, (
+            f"Schema metric name mismatch:\n  api_request: {sorted(api_metrics)}\n  lam: {sorted(lam_metrics)}"
+        )
+
+    def test_all_filters_target_cowork_log_group(self):
+        """All filters must target /aws/claude-cowork/events."""
+        filters = self._get_filters()
+        for name, res in filters.items():
+            log_group = res["Properties"]["LogGroupName"]
+            assert log_group == "/aws/claude-cowork/events", (
+                f"{name}: expected /aws/claude-cowork/events, got {log_group}"
+            )
+
+    def test_all_filters_use_claude_cowork_namespace(self):
+        """All filters must emit to ClaudeCoWork namespace."""
+        filters = self._get_filters()
+        for name, res in filters.items():
+            for transform in res["Properties"]["MetricTransformations"]:
+                assert transform["MetricNamespace"] == "ClaudeCoWork", (
+                    f"{name}: expected ClaudeCoWork namespace, got {transform['MetricNamespace']}"
+                )


### PR DESCRIPTION
## Why

The CoWork dashboard stays empty even when events flow to `/aws/claude-cowork/events`. The metric filters target only the **Local Agent Mode** schema (`lam_session_turn_completed`), but real interactive CoWork usage emits the **Claude-Code-for-Desktop** schema (`claude_code.api_request`) with a fundamentally different structure:

- `body` is a flat string (`"claude_code.api_request"`), not an object
- Token/cost fields are under a top-level `attributes` object (sibling of `body`), not `body.attributes`
- Field names differ (`cache_read_tokens` vs `cache_read_input_tokens`, `cost_usd` vs `total_cost_usd`)

## What

- Add 6 metric filters for `claude_code.api_request` schema (pattern: `{ $.body = "claude_code.api_request" }`, values: `$.attributes.*`)
- Retain 6 `lam_session_turn_completed` filters (renamed with `Lam` prefix)
- Both schema filters emit to the **same** CloudWatch metric names (dashboard works regardless of mode)
- Fix Logs Insights query to use `coalesce()` for both schemas
- **Tests**: 7 new tests validating filter patterns, value paths, namespace, and cross-schema metric name parity

## Backward Compatible

Existing deployments with lam-mode events continue to work. The additional filters for the api_request schema are purely additive — CloudWatch Metric Filters with new names don't conflict. Template is idempotent on redeploy.

## Verification

```bash
cd source && poetry run pytest tests/e2e/test_cowork_dashboard_filters.py -v
cfn-lint deployment/infrastructure/cowork-dashboard.yaml
```

---

Credit: @adiospeds captured the wire format and identified the schema mismatch (#541). Their corrected YAML was used as reference.