### PR TITLE
feat(settings): support managed-settings.json deployment for org enforcement

### DIFF
--- a/assets/docs/CLI_REFERENCE.md
+++ b/assets/docs/CLI_REFERENCE.md
@@ -76,6 +76,7 @@ poetry run ccwb init [options]
 **Options:**
 
 - `--profile <name>` - Configuration profile name (optional, will prompt if not specified)
+- `--managed` - Deploy settings to OS-level managed-settings.json (highest precedence, non-overridable by users)
 
 **What it does:**
 
@@ -254,7 +255,7 @@ poetry run ccwb package [options]
 
 1. Cross-compiles native Go binaries for all selected platforms (with `--go`)
 2. Creates `config.json` with federation config read from the admin profile
-3. Creates `claude-settings/settings.json` with Bedrock model and OTel endpoint
+3. Creates `claude-settings/settings.json` with Bedrock model and OTel endpoint (or `managed-settings.json` if `--managed` was used during init)
 4. Creates installer scripts (`install.sh`, `install.bat`, `ccwb-install.ps1`)
 5. Outputs to `dist/{profile}/{timestamp}/`
 

--- a/assets/docs/DEPLOYMENT.md
+++ b/assets/docs/DEPLOYMENT.md
@@ -159,6 +159,25 @@ Windows binary builds use AWS CodeBuild with Nuitka for optimal performance. Win
 - Windows builds take 20+ minutes
 - To enable Windows builds after initial setup, re-run `poetry run ccwb init`
 
+### Organization-Wide Enforcement (Optional)
+
+For large deployments (50+ users) where settings must be non-overridable, use managed settings:
+
+```bash
+poetry run ccwb init --managed
+poetry run ccwb package --go
+```
+
+This writes settings to the OS-level `managed-settings.json` path instead of user-scope `~/.claude/settings.json`. Managed settings have the **highest precedence** in Claude Code's settings hierarchy and cannot be edited or overridden by end users.
+
+| OS | Managed path | Requires |
+|---|---|---|
+| macOS | `/Library/Application Support/ClaudeCode/managed-settings.json` | `sudo` |
+| Linux/WSL | `/etc/claude-code/managed-settings.json` | `sudo` |
+| Windows | `C:\Program Files\ClaudeCode\managed-settings.json` | Administrator |
+
+The installer will detect managed settings in the package and prompt for elevated privileges. For MDM-managed fleets (Jamf, Intune, Group Policy), see Anthropic's [MDM templates](https://github.com/anthropics/claude-code/tree/main/examples/mdm) for alternative delivery.
+
 ## Phase 4: Testing Your Deployment
 
 Before distributing to users, thoroughly test the package to ensure everything works as expected. The CLI provides a comprehensive test command that simulates exactly what end users will experience:

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1321,6 +1321,34 @@ class InitCommand(Command):
                 else:
                     console.print("[dim]CoWork service token already configured[/dim]")
 
+        # Settings deployment target
+        console.print("\n[bold]Settings Deployment Target[/bold]")
+        console.print("Choose where Claude Code settings are installed on user machines:")
+        console.print("  • User scope: ~/.claude/settings.json (users can override)")
+        console.print("  • Managed (org enforcement): OS-level path (highest precedence, non-overridable)")
+
+        saved_target = config.get("settings_target", "user")
+        # --managed flag overrides the wizard default
+        if self._io and self.option("managed"):
+            saved_target = "managed"
+
+        settings_target_choices = [
+            questionary.Choice("User scope (~/.claude/settings.json)", value="user"),
+            questionary.Choice("Managed (organization-wide enforcement, requires sudo/admin)", value="managed"),
+        ]
+        settings_target = questionary.select(
+            "Settings deployment target:",
+            choices=settings_target_choices,
+            default=saved_target,
+        ).ask()
+        config["settings_target"] = settings_target or "user"
+
+        if config["settings_target"] == "managed":
+            console.print("[green]✓[/green] Settings will be deployed to OS-level managed path")
+            console.print("[dim]  Users will need sudo (Unix) or Administrator (Windows) to install[/dim]")
+        else:
+            console.print("[green]✓[/green] Settings will be deployed to user-scope path")
+
         # Package distribution support
         console.print("\n[bold]Package Distribution[/bold]")
         console.print("Choose how to distribute Claude Code packages to end users:")

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -91,7 +91,13 @@ class InitCommand(Command):
             description="Configuration profile name (optional, will prompt if not specified)",
             flag=False,
             default=None,
-        )
+        ),
+        option(
+            "managed",
+            None,
+            description="Deploy settings to OS-level managed-settings.json (highest precedence, non-overridable)",
+            flag=True,
+        ),
     ]
 
     def handle(self) -> int:
@@ -2247,6 +2253,7 @@ class InitCommand(Command):
             "cowork_3p_enabled": config_data.get("cowork_3p", {}).get("enabled", True),
             "cowork_3p_extra_keys": config_data.get("cowork_3p", {}).get("extra_keys", {}),
             "cowork_service_token": config_data.get("cowork_3p", {}).get("service_token", ""),
+            "settings_target": "managed" if (self._io and self.option("managed")) else config_data.get("settings_target", "user"),
             "tags": config_data.get("tags", {}),
             "redirect_port": config_data.get("redirect_port"),
         }

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -578,6 +578,8 @@ class PackageCommand(Command):
             console.print("  • claude-settings/settings.json - Claude Code telemetry settings")
             for platform_name, otel_helper_path in built_otel_helpers:
                 console.print(f"  • {otel_helper_path.name} - OTEL helper executable for {platform_name}")
+        if (output_dir / "claude-settings" / "managed-settings.json").exists():
+            console.print("  • claude-settings/managed-settings.json - Organization-wide enforcement settings")
         if profile.cowork_3p_enabled:
             if (output_dir / "cowork-3p-config.json").exists():
                 console.print("  • cowork-3p-config.json - CoWork 3P MDM configuration (JSON)")
@@ -2354,7 +2356,7 @@ if [ "$HAS_ERRORS" = "true" ]; then
     exit 1
 fi
 
-if [ ! -f "claude-settings/settings.json" ]; then
+if [ ! -f "claude-settings/settings.json" ] && [ ! -f "claude-settings/managed-settings.json" ]; then
     echo "WARNING: claude-settings/settings.json not found"
     echo "         Claude Code IDE settings will not be configured automatically"
     echo ""
@@ -2433,7 +2435,42 @@ if [ -d "claude-settings" ]; then
     echo "Installing Claude Code settings..."
     mkdir -p ~/.claude
 
-    # Copy settings and replace placeholders
+    # Install managed-settings.json (OS-level enforcement) if present
+    if [ -f "claude-settings/managed-settings.json" ]; then
+        echo "Managed settings detected (organization-wide enforcement)..."
+
+        # Determine OS-appropriate managed-settings path
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            MANAGED_DIR="/Library/Application Support/ClaudeCode"
+        else
+            MANAGED_DIR="/etc/claude-code"
+        fi
+
+        # Require elevated privileges for managed-settings
+        if [ "$(id -u)" -ne 0 ]; then
+            echo "ERROR: Managed settings require root/sudo privileges."
+            echo "       Re-run the installer with: sudo ./install.sh"
+            echo "       (Managed settings are written to: $MANAGED_DIR/managed-settings.json)"
+            exit 1
+        fi
+
+        mkdir -p "$MANAGED_DIR"
+
+        # Replace placeholders and write managed settings
+        sed -e "s|__OTEL_HELPER_PATH__|$HOME/claude-code-with-bedrock/otel-helper|g" \
+            -e "s|__CREDENTIAL_PROCESS_PATH__|$HOME/claude-code-with-bedrock/credential-process|g" \
+            "claude-settings/managed-settings.json" > "$MANAGED_DIR/managed-settings.json"
+
+        # Verify placeholders were replaced
+        if grep -q '__CREDENTIAL_PROCESS_PATH__\\|__OTEL_HELPER_PATH__' "$MANAGED_DIR/managed-settings.json" 2>/dev/null; then
+            echo "WARNING: Some path placeholders were not replaced in managed-settings.json"
+        else
+            echo "OK Managed settings installed: $MANAGED_DIR/managed-settings.json"
+            echo "   These settings have highest precedence and cannot be overridden by users."
+        fi
+    fi
+
+    # Copy user-scope settings.json if present
     if [ -f "claude-settings/settings.json" ]; then
         # Check if settings file already exists
         if [ -f ~/.claude/settings.json ]; then
@@ -2442,30 +2479,68 @@ if [ -d "claude-settings" ]; then
             BACKUP_NAME="settings.json.backup-$(date +%Y%m%d-%H%M%S)"
             cp ~/.claude/settings.json ~/.claude/$BACKUP_NAME
             echo "  Backed up to: ~/.claude/$BACKUP_NAME"
-            read -p "Overwrite with new settings? (Y/n): " -n 1 -r
-            echo
-            # Default to Yes if user just presses enter (empty REPLY)
-            if [[ -z "$REPLY" ]]; then
-                REPLY="y"
-            fi
-            if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-                echo "Skipping Claude Code settings..."
-                SKIP_SETTINGS=true
+
+            # Merge new settings into existing (preserves user customizations)
+            $PYTHON -c "
+import json, sys
+try:
+    with open('$HOME/.claude/$BACKUP_NAME') as f:
+        existing = json.load(f)
+except (json.JSONDecodeError, FileNotFoundError):
+    existing = {{}}
+
+with open('claude-settings/settings.json') as f:
+    incoming = json.load(f)
+
+# Deep merge: incoming overwrites existing keys, but existing keys not in incoming are preserved
+def deep_merge(base, override):
+    result = base.copy()
+    for key, value in override.items():
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = deep_merge(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+merged = deep_merge(existing, incoming)
+with open('$HOME/.claude/settings.json', 'w') as f:
+    json.dump(merged, f, indent=2)
+" 2>/dev/null
+
+            if [ $? -eq 0 ]; then
+                echo "OK Claude Code settings merged: ~/.claude/settings.json"
+                echo "   (existing user settings preserved, new Bedrock config added)"
+            else
+                # Fallback: overwrite if merge fails
+                read -p "Merge failed. Overwrite with new settings? (Y/n): " -n 1 -r
+                echo
+                if [[ -z "$REPLY" ]]; then REPLY="y"; fi
+                if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+                    echo "Skipping Claude Code settings..."
+                    SKIP_SETTINGS=true
+                fi
             fi
         fi
 
-        if [ "$SKIP_SETTINGS" != "true" ]; then
-            # Replace placeholders and write settings
+        if [ "$SKIP_SETTINGS" != "true" ] && [ ! -f ~/.claude/settings.json ]; then
+            # No existing settings — just write directly
             sed -e "s|__OTEL_HELPER_PATH__|$HOME/claude-code-with-bedrock/otel-helper|g" \
                 -e "s|__CREDENTIAL_PROCESS_PATH__|$HOME/claude-code-with-bedrock/credential-process|g" \
                 "claude-settings/settings.json" > ~/.claude/settings.json
+            echo "OK Claude Code settings configured: ~/.claude/settings.json"
+        fi
+
+        # Replace placeholders in the final settings file
+        if [ -f ~/.claude/settings.json ] && [ "$SKIP_SETTINGS" != "true" ]; then
+            sed -i.tmp -e "s|__OTEL_HELPER_PATH__|$HOME/claude-code-with-bedrock/otel-helper|g" \
+                       -e "s|__CREDENTIAL_PROCESS_PATH__|$HOME/claude-code-with-bedrock/credential-process|g" \
+                       ~/.claude/settings.json
+            rm -f ~/.claude/settings.json.tmp
 
             # Verify placeholders were replaced
             if grep -q '__CREDENTIAL_PROCESS_PATH__\\|__OTEL_HELPER_PATH__' ~/.claude/settings.json 2>/dev/null; then
                 echo "WARNING: Some path placeholders were not replaced in settings.json"
                 echo "         You may need to edit the file manually: ~/.claude/settings.json"
-            else
-                echo "OK Claude Code settings configured: ~/.claude/settings.json"
             fi
         fi
     fi
@@ -2509,6 +2584,11 @@ if [ -f "claude-settings/settings.json" ]; then
     DEFAULT_REGION=$($PYTHON -c "
 import json
 print(json.load(open('claude-settings/settings.json'))['env']['AWS_REGION'])
+" 2>/dev/null || echo "{profile.aws_region}")
+elif [ -f "claude-settings/managed-settings.json" ]; then
+    DEFAULT_REGION=$($PYTHON -c "
+import json
+print(json.load(open('claude-settings/managed-settings.json'))['env']['AWS_REGION'])
 " 2>/dev/null || echo "{profile.aws_region}")
 else
     DEFAULT_REGION="{profile.aws_region}"
@@ -2648,23 +2728,53 @@ copy /Y "config.json" "%USERPROFILE%\\claude-code-with-bedrock\\" >nul
 REM Copy Claude Code settings if they exist
 if exist "claude-settings" (
     echo Copying Claude Code telemetry settings...
-    if not exist "%USERPROFILE%\\.claude" mkdir "%USERPROFILE%\\.claude"
+    if not exist "%USERPROFILE%\.claude" mkdir "%USERPROFILE%\.claude"
 
-    REM Copy settings and replace placeholders
-    if exist "claude-settings\\settings.json" (
+    REM Install managed-settings.json (organization-wide enforcement) if present
+    if exist "claude-settings\managed-settings.json" (
+        echo Managed settings detected [organization-wide enforcement]...
+
+        REM Check for Administrator privileges
+        net session >nul 2>&1
+        if %errorlevel% neq 0 (
+            echo ERROR: Managed settings require Administrator privileges.
+            echo        Right-click install.bat and select "Run as administrator"
+            echo        [Target: C:\Program Files\ClaudeCode\managed-settings.json]
+            pause
+            exit /b 1
+        )
+
+        REM Create managed-settings directory
+        if not exist "C:\Program Files\ClaudeCode" mkdir "C:\Program Files\ClaudeCode"
+
+        REM Replace placeholders and write managed settings
+        powershell -Command "$otelPath = $env:USERPROFILE + '\claude-code-with-bedrock\otel-helper.cmd' -replace '\\\\', '/'; $credPath = $env:USERPROFILE + '\claude-code-with-bedrock\credential-process.exe' -replace '\\\\', '/'; (Get-Content 'claude-settings\managed-settings.json') -replace '__OTEL_HELPER_PATH__', $otelPath -replace '__CREDENTIAL_PROCESS_PATH__', $credPath | Set-Content 'C:\Program Files\ClaudeCode\managed-settings.json'"
+        echo OK Managed settings installed: C:\Program Files\ClaudeCode\managed-settings.json
+        echo    These settings have highest precedence and cannot be overridden by users.
+    )
+
+    REM Copy user-scope settings.json if present (with merge support)
+    if exist "claude-settings\settings.json" (
         set SKIP_SETTINGS=false
-        if exist "%USERPROFILE%\\.claude\\settings.json" (
-            echo Existing Claude Code settings found
-            set /p OVERWRITE="Overwrite with new settings? (y/n): "
-            if /i not "%OVERWRITE%"=="y" (
-                echo Skipping Claude Code settings...
-                set SKIP_SETTINGS=true
+        if exist "%USERPROFILE%\.claude\settings.json" (
+            echo Existing Claude Code settings found - merging...
+
+            REM Merge new settings into existing (preserves user customizations)
+            powershell -NoProfile -Command "$otelPath = $env:USERPROFILE + '\claude-code-with-bedrock\otel-helper.cmd' -replace '\\\\', '/'; $credPath = $env:USERPROFILE + '\claude-code-with-bedrock\credential-process.exe' -replace '\\\\', '/'; $existing = Get-Content (Join-Path $env:USERPROFILE '.claude\settings.json') | ConvertFrom-Json; $incoming = (Get-Content 'claude-settings\settings.json') -replace '__OTEL_HELPER_PATH__', $otelPath -replace '__CREDENTIAL_PROCESS_PATH__', $credPath | ConvertFrom-Json; foreach ($prop in $incoming.PSObject.Properties) {{{{ $existing | Add-Member -MemberType NoteProperty -Name $prop.Name -Value $prop.Value -Force }}}}; $existing | ConvertTo-Json -Depth 10 | Set-Content (Join-Path $env:USERPROFILE '.claude\settings.json')"
+            if %errorlevel% equ 0 (
+                echo OK Claude Code settings merged [user settings preserved]
+            ) else (
+                set /p OVERWRITE="Merge failed. Overwrite with new settings? (y/n): "
+                if /i not "%OVERWRITE%"=="y" (
+                    echo Skipping Claude Code settings...
+                    set SKIP_SETTINGS=true
+                )
             )
         )
 
-        if not "%SKIP_SETTINGS%"=="true" (
-            REM Use PowerShell to replace placeholders
-            powershell -Command "$otelPath = $env:USERPROFILE + '\\claude-code-with-bedrock\\otel-helper.cmd' -replace '\\\\', '/'; $credPath = $env:USERPROFILE + '\\claude-code-with-bedrock\\credential-process.exe' -replace '\\\\', '/'; (Get-Content 'claude-settings\\settings.json') -replace '__OTEL_HELPER_PATH__', $otelPath -replace '__CREDENTIAL_PROCESS_PATH__', $credPath | Set-Content (Join-Path $env:USERPROFILE '.claude\\settings.json')"
+        if not "%SKIP_SETTINGS%"=="true" if not exist "%USERPROFILE%\.claude\settings.json" (
+            REM No existing settings - write directly
+            powershell -Command "$otelPath = $env:USERPROFILE + '\claude-code-with-bedrock\otel-helper.cmd' -replace '\\\\', '/'; $credPath = $env:USERPROFILE + '\claude-code-with-bedrock\credential-process.exe' -replace '\\\\', '/'; (Get-Content 'claude-settings\settings.json') -replace '__OTEL_HELPER_PATH__', $otelPath -replace '__CREDENTIAL_PROCESS_PATH__', $credPath | Set-Content (Join-Path $env:USERPROFILE '.claude\settings.json')"
             echo OK Claude Code settings configured
         )
     )
@@ -3092,8 +3202,15 @@ Available metrics include:
                     console.print("[red]ERROR: Monitoring enabled but no OTel endpoint configured.[/red]")
                     console.print("[red]Run 'ccwb deploy' first or set otel_collector_endpoint in the profile.[/red]")
 
-            # Save settings.json
-            settings_path = claude_dir / "settings.json"
+            # Determine output filename based on settings_target
+            settings_target = getattr(profile, "settings_target", "user")
+            if settings_target == "managed":
+                settings_filename = "managed-settings.json"
+                console.print("[dim]Writing to managed-settings.json (OS-level enforcement)[/dim]")
+            else:
+                settings_filename = "settings.json"
+
+            settings_path = claude_dir / settings_filename
             with open(settings_path, "w", encoding="utf-8") as f:
                 json.dump(settings, f, indent=2)
 

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -117,6 +117,11 @@ class Profile:
     # Claude Code settings configuration
     include_coauthored_by: bool = True  # Whether to include "co-authored-by Claude" in git commits
 
+    # Settings deployment target
+    # "user" = ~/.claude/settings.json (default, lowest precedence)
+    # "managed" = OS-level managed-settings.json (highest precedence, non-overridable)
+    settings_target: str = "user"
+
     # Claude Cowork 3P MDM configuration
     cowork_3p_enabled: bool = True  # Generate CoWork 3P MDM configs during packaging
     cowork_3p_extra_keys: dict[str, str] = field(default_factory=dict)  # Custom MDM keys merged into CoWork 3P output

--- a/source/tests/cli/commands/test_package_managed_settings.py
+++ b/source/tests/cli/commands/test_package_managed_settings.py
@@ -1,0 +1,286 @@
+# ABOUTME: Unit tests for managed-settings.json deployment feature (#538)
+# ABOUTME: Tests Profile backward compat, filename selection, and installer script logic
+
+"""Tests for managed-settings deployment in the package command."""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from claude_code_with_bedrock.cli.commands.package import PackageCommand
+from claude_code_with_bedrock.config import Profile
+
+
+class TestProfileSettingsTarget:
+    """Tests for Profile settings_target field and backward compatibility."""
+
+    def test_profile_defaults_to_user_target(self):
+        """New profiles default to settings_target='user'."""
+        profile = Profile(
+            name="test",
+            provider_domain="test.okta.com",
+            client_id="test-client",
+            credential_storage="keyring",
+            aws_region="us-east-1",
+            identity_pool_name="test-pool",
+        )
+        assert profile.settings_target == "user"
+
+    def test_profile_accepts_managed_target(self):
+        """Profiles can be created with settings_target='managed'."""
+        profile = Profile(
+            name="test",
+            provider_domain="test.okta.com",
+            client_id="test-client",
+            credential_storage="keyring",
+            aws_region="us-east-1",
+            identity_pool_name="test-pool",
+            settings_target="managed",
+        )
+        assert profile.settings_target == "managed"
+
+    def test_profile_without_settings_target_field_is_backward_compatible(self):
+        """Profiles loaded from old configs without settings_target work correctly."""
+        # Simulate loading an old profile dict that lacks the field
+        old_profile_data = {
+            "name": "legacy",
+            "provider_domain": "legacy.okta.com",
+            "client_id": "old-client",
+            "credential_storage": "keyring",
+            "aws_region": "eu-west-1",
+            "identity_pool_name": "legacy-pool",
+        }
+        profile = Profile(**old_profile_data)
+        # Should default to "user" — no KeyError or crash
+        assert profile.settings_target == "user"
+
+    def test_getattr_settings_target_fallback(self):
+        """getattr with default works for settings_target on any profile."""
+        profile = Profile(
+            name="test",
+            provider_domain="test.okta.com",
+            client_id="test-client",
+            credential_storage="keyring",
+            aws_region="us-east-1",
+            identity_pool_name="test-pool",
+        )
+        # This is how the package command reads it
+        target = getattr(profile, "settings_target", "user")
+        assert target == "user"
+
+
+class TestGenerateClaudeSettings:
+    """Tests for _create_claude_settings filename selection."""
+
+    def _make_profile(self, settings_target="user", monitoring_enabled=False):
+        """Helper to create a test profile."""
+        return Profile(
+            name="test",
+            provider_domain="test.okta.com",
+            client_id="test-client",
+            credential_storage="keyring",
+            aws_region="us-east-1",
+            identity_pool_name="test-pool",
+            monitoring_enabled=monitoring_enabled,
+            settings_target=settings_target,
+        )
+
+    def test_user_target_creates_settings_json(self):
+        """settings_target='user' writes to claude-settings/settings.json."""
+        command = PackageCommand()
+        profile = self._make_profile(settings_target="user")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            command._create_claude_settings(output_dir, profile)
+
+            assert (output_dir / "claude-settings" / "settings.json").exists()
+            assert not (output_dir / "claude-settings" / "managed-settings.json").exists()
+
+    def test_managed_target_creates_managed_settings_json(self):
+        """settings_target='managed' writes to claude-settings/managed-settings.json."""
+        command = PackageCommand()
+        profile = self._make_profile(settings_target="managed")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            command._create_claude_settings(output_dir, profile)
+
+            assert (output_dir / "claude-settings" / "managed-settings.json").exists()
+            assert not (output_dir / "claude-settings" / "settings.json").exists()
+
+    def test_managed_settings_contains_correct_content(self):
+        """managed-settings.json has the same Bedrock config as settings.json would."""
+        command = PackageCommand()
+        profile = self._make_profile(settings_target="managed")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            command._create_claude_settings(output_dir, profile)
+
+            settings_path = output_dir / "claude-settings" / "managed-settings.json"
+            with open(settings_path) as f:
+                settings = json.load(f)
+
+            # Must contain Bedrock env vars
+            assert settings["env"]["CLAUDE_CODE_USE_BEDROCK"] == "1"
+            assert settings["env"]["AWS_REGION"] == "us-east-1"
+            assert "__CREDENTIAL_PROCESS_PATH__" in settings["env"]["AWS_CREDENTIAL_PROCESS"]
+
+    def test_user_target_settings_content_unchanged(self):
+        """Default user target still produces correct settings.json content."""
+        command = PackageCommand()
+        profile = self._make_profile(settings_target="user")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            command._create_claude_settings(output_dir, profile)
+
+            settings_path = output_dir / "claude-settings" / "settings.json"
+            with open(settings_path) as f:
+                settings = json.load(f)
+
+            assert settings["env"]["CLAUDE_CODE_USE_BEDROCK"] == "1"
+            assert settings["env"]["AWS_REGION"] == "us-east-1"
+
+
+class TestInstallerScriptManagedSettings:
+    """Tests for install.sh template handling of managed-settings.json."""
+
+    def _get_installer_content(self, profile):
+        """Generate installer and return its content."""
+        command = PackageCommand()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+
+            # Create minimal required structure
+            (output_dir / "claude-settings").mkdir()
+            (output_dir / "config.json").write_text("{}")
+
+            # Generate settings based on profile target
+            command._create_claude_settings(output_dir, profile)
+
+            # Build a mock executables list
+            built_executables = [("darwin-arm64", output_dir / "credential-process")]
+            (output_dir / "credential-process").touch()
+
+            # Generate installer
+            installer_path = command._create_installer(
+                output_dir, profile, built_executables, built_otel_helpers=[]
+            )
+
+            return installer_path.read_text()
+
+    def test_managed_installer_contains_elevation_check(self):
+        """Installer checks for root when managed-settings.json is present."""
+        profile = Profile(
+            name="test",
+            provider_domain="test.okta.com",
+            client_id="test-client",
+            credential_storage="keyring",
+            aws_region="us-east-1",
+            identity_pool_name="test-pool",
+            settings_target="managed",
+            monitoring_enabled=False,
+        )
+
+        content = self._get_installer_content(profile)
+
+        # Should contain managed-settings handling
+        assert "managed-settings.json" in content
+        assert "id -u" in content or "sudo" in content
+
+    def test_user_installer_has_merge_logic(self):
+        """User-mode installer merges into existing settings rather than overwriting."""
+        profile = Profile(
+            name="test",
+            provider_domain="test.okta.com",
+            client_id="test-client",
+            credential_storage="keyring",
+            aws_region="us-east-1",
+            identity_pool_name="test-pool",
+            settings_target="user",
+            monitoring_enabled=False,
+        )
+
+        content = self._get_installer_content(profile)
+
+        # Should contain merge logic
+        assert "deep_merge" in content or "Merge" in content.lower()
+
+    def test_user_installer_creates_backup(self):
+        """User-mode installer backs up existing settings before merge."""
+        profile = Profile(
+            name="test",
+            provider_domain="test.okta.com",
+            client_id="test-client",
+            credential_storage="keyring",
+            aws_region="us-east-1",
+            identity_pool_name="test-pool",
+            settings_target="user",
+            monitoring_enabled=False,
+        )
+
+        content = self._get_installer_content(profile)
+
+        assert "backup" in content.lower()
+
+
+class TestInstallerMergeLogic:
+    """Tests for the deep merge logic in the installer."""
+
+    def test_deep_merge_preserves_user_keys(self):
+        """The merge function preserves keys that only exist in the user's config."""
+
+        def deep_merge(base, override):
+            result = base.copy()
+            for key, value in override.items():
+                if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+                    result[key] = deep_merge(result[key], value)
+                else:
+                    result[key] = value
+            return result
+
+        existing = {
+            "env": {"MY_CUSTOM_VAR": "keep_me", "AWS_REGION": "old-region"},
+            "myCustomSetting": True,
+        }
+        incoming = {
+            "env": {"CLAUDE_CODE_USE_BEDROCK": "1", "AWS_REGION": "us-east-1"},
+        }
+
+        merged = deep_merge(existing, incoming)
+
+        # User's custom key preserved
+        assert merged["myCustomSetting"] is True
+        # User's env var preserved
+        assert merged["env"]["MY_CUSTOM_VAR"] == "keep_me"
+        # Incoming values applied
+        assert merged["env"]["CLAUDE_CODE_USE_BEDROCK"] == "1"
+        # Conflicting key overridden by incoming
+        assert merged["env"]["AWS_REGION"] == "us-east-1"
+
+    def test_deep_merge_handles_nested_dicts(self):
+        """Deep merge recurses into nested dictionaries."""
+
+        def deep_merge(base, override):
+            result = base.copy()
+            for key, value in override.items():
+                if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+                    result[key] = deep_merge(result[key], value)
+                else:
+                    result[key] = value
+            return result
+
+        existing = {"env": {"A": "1", "B": "2"}, "permissions": {"deny": ["rm"]}}
+        incoming = {"env": {"C": "3"}, "permissions": {"deny": ["rm", "sudo"]}}
+
+        merged = deep_merge(existing, incoming)
+
+        assert merged["env"] == {"A": "1", "B": "2", "C": "3"}
+        # Non-dict values are overwritten (not merged)
+        assert merged["permissions"]["deny"] == ["rm", "sudo"]

--- a/source/tests/cli/commands/test_package_managed_settings.py
+++ b/source/tests/cli/commands/test_package_managed_settings.py
@@ -173,7 +173,7 @@ class TestInstallerScriptManagedSettings:
                 output_dir, profile, built_executables, built_otel_helpers=[]
             )
 
-            return installer_path.read_text()
+            return installer_path.read_text(encoding="utf-8")
 
     def test_managed_installer_contains_elevation_check(self):
         """Installer checks for root when managed-settings.json is present."""


### PR DESCRIPTION
## Why

Users deploying to ~100+ seats need enforcement settings (Bedrock routing, permissions deny-rules, `forceLoginMethod`) to be **non-overridable**. The current installer writes everything to `~/.claude/settings.json` (user-scope, lowest precedence), which users can trivially edit or delete.

Additionally, `install.sh` currently **overwrites** existing `settings.json` entirely — clobbering users' custom preferences (reported by @jorgevazquezsanchez in #538).

## What

Add opt-in support for deploying settings to the OS-level **managed-settings.json** location, which has the highest precedence in Claude Code's settings hierarchy.

### Changes

1. **New `settings_target` profile field** — `'user'` (default) or `'managed'`
2. **Filename selection** — `_create_claude_settings` outputs to `managed-settings.json` when target is managed
3. **install.sh** — detects `managed-settings.json`, requires sudo, writes to OS path:
   - macOS: `/Library/Application Support/ClaudeCode/managed-settings.json`
   - Linux/WSL: `/etc/claude-code/managed-settings.json`
4. **install.bat** — detects `managed-settings.json`, requires Administrator, writes to:
   - Windows: `C:\Program Files\ClaudeCode\managed-settings.json`
5. **Merge logic** for user-scope settings — deep-merges incoming config into existing `settings.json` instead of overwriting (preserves user customizations)
6. **`--managed` flag on `ccwb init`** — opt-in to managed deployment mode
7. **13 new tests** covering backward compat, filename selection, installer scripts, and merge behavior

### Backward Compatibility

- Default is `settings_target='user'` — zero behavior change for existing users
- Profiles without the field work correctly (dataclass default)
- Managed mode is strictly opt-in via `ccwb init --managed`

### Simplification Notes

- Same settings dict generated regardless of target — only the output filename and installer path differ
- Deep merge replaces the old overwrite-with-prompt flow, solving @jorgevazquezsanchez's complaint even for non-managed users

## Testing

```
993 passed, 22 skipped, 1 xfailed, 1 xpassed (full suite)
13 new tests in test_package_managed_settings.py
```

Closes #538

Credit: @adiospeds for the detailed issue write-up and implementation notes.