### PR TITLE
fix(go): respect $BROWSER env var for WSL compatibility

### DIFF
--- a/source/go/internal/browser/open.go
+++ b/source/go/internal/browser/open.go
@@ -1,10 +1,18 @@
 package browser
 
 import (
+	"os"
+	"os/exec"
+
 	"github.com/pkg/browser"
 )
 
 // OpenURL opens a URL in the user's default browser.
+// Respects $BROWSER env var, which is critical for WSL environments where
+// xdg-open opens a Linux browser instead of the Windows host browser.
 func OpenURL(url string) error {
+	if b := os.Getenv("BROWSER"); b != "" {
+		return exec.Command(b, url).Start()
+	}
 	return browser.OpenURL(url)
 }

--- a/source/go/internal/oidc/flow.go
+++ b/source/go/internal/oidc/flow.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"time"
 
+	"ccwb-go/internal/browser"
 	"ccwb-go/internal/jwt"
 	"ccwb-go/internal/provider"
-	"github.com/pkg/browser"
 )
 
 // AuthResult holds the result of a successful OIDC authentication.


### PR DESCRIPTION
## Why

In WSL (Windows Subsystem for Linux), `xdg-open` opens a Linux browser instead of the Windows host browser. This breaks the OIDC callback flow because the callback server listens on `localhost` inside WSL — a browser running in Linux can't reach it if WSL networking isn't forwarded, and even when it can, the user's Azure AD session lives in the Windows browser.

The `$BROWSER` env var is the standard Unix mechanism for overriding the default browser. WSL users set it to a wrapper script that invokes the Windows browser binary (e.g. `msedge.exe` via `/mnt/c/...`).

## What

Route browser opens through `internal/browser.OpenURL` which checks `$BROWSER` first, falling back to `pkg/browser` (xdg-open) when unset. No behavior change for non-WSL users who don't set `$BROWSER`.

## Verified

- [x] WSL with `$BROWSER` set to Windows Edge wrapper — opens correct browser, auth callback succeeds
- [x] Go tests pass
- [x] No behavior change when `$BROWSER` is unset (falls back to pkg/browser → xdg-open)

🤖 Generated with Claude Code