### PR TITLE
fix(otel): validate monitoring token expiry before use

### DIFF
--- a/source/otel_helper/__main__.py
+++ b/source/otel_helper/__main__.py
@@ -106,6 +106,27 @@ def parse_args():
 # This prevents macOS keychain permission prompts for the OTEL helper
 
 
+def is_token_expired(token, buffer_seconds=60):
+    """Check if a JWT token's exp claim has passed.
+
+    Returns True if the token is expired or unparseable (fail-safe: treat
+    bad tokens as expired so they fall through to re-authentication).
+    """
+    try:
+        _, payload_b64, _ = token.split(".")
+        padding_needed = len(payload_b64) % 4
+        if padding_needed:
+            payload_b64 += "=" * (4 - padding_needed)
+        payload_b64 = payload_b64.replace("-", "+").replace("_", "/")
+        payload = json.loads(base64.b64decode(payload_b64))
+        exp = payload.get("exp")
+        if exp is None:
+            return True  # No exp claim = treat as expired
+        return time.time() > (exp - buffer_seconds)
+    except Exception:
+        return True  # Unparseable = treat as expired
+
+
 def decode_jwt_payload(token):
     """Decode the payload portion of a JWT token"""
     try:
@@ -639,7 +660,10 @@ def build_proxy_user_headers() -> dict:
     """
     token = None
     if not ANONYMOUS_MODE:
-        token = os.environ.get("CLAUDE_CODE_MONITORING_TOKEN") or get_token_via_credential_process()
+        token = os.environ.get("CLAUDE_CODE_MONITORING_TOKEN")
+        if token and is_token_expired(token):
+            token = None
+        token = token or get_token_via_credential_process()
 
     if token:
         payload = decode_jwt_payload(token)
@@ -836,7 +860,10 @@ def main():
         if cached_headers is not None:
             # Resolve Bearer fresh — the cache stores attribution headers only,
             # never the token itself. Try env var (free) then credential-process (~20ms).
-            _bearer_token = os.environ.get("CLAUDE_CODE_MONITORING_TOKEN") or get_token_via_credential_process()
+            _bearer_token = os.environ.get("CLAUDE_CODE_MONITORING_TOKEN")
+            if _bearer_token and is_token_expired(_bearer_token):
+                _bearer_token = None
+            _bearer_token = _bearer_token or get_token_via_credential_process()
             if _bearer_token:
                 _attach_bearer(cached_headers, _bearer_token)
             else:
@@ -855,6 +882,9 @@ def main():
     token = None
     if not ANONYMOUS_MODE:
         token = os.environ.get("CLAUDE_CODE_MONITORING_TOKEN")
+        if token and is_token_expired(token):
+            logger.info("Environment token CLAUDE_CODE_MONITORING_TOKEN is expired, falling through to credential-process")
+            token = None
         if token:
             logger.info("Using token from environment variable CLAUDE_CODE_MONITORING_TOKEN")
         else:

--- a/source/tests/test_env_token_expiry.py
+++ b/source/tests/test_env_token_expiry.py
@@ -1,0 +1,63 @@
+# ABOUTME: Tests for env-var token expiry validation in otel-helper
+# ABOUTME: Ensures expired CLAUDE_CODE_MONITORING_TOKEN is not used blindly
+
+"""Regression tests for monitoring token expiry check (issue #561)."""
+
+import base64
+import json
+import time
+import importlib.util
+from pathlib import Path
+
+# Load otel_helper module
+_spec = importlib.util.spec_from_file_location(
+    "otel_helper_main",
+    Path(__file__).resolve().parents[1] / "otel_helper" / "__main__.py",
+)
+_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_module)
+is_token_expired = _module.is_token_expired
+
+
+def _make_jwt(exp_offset_seconds):
+    """Create a minimal JWT with exp claim at now + offset."""
+    payload = {"sub": "test", "email": "test@co.com", "exp": int(time.time()) + exp_offset_seconds}
+    payload_b64 = base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b"=").decode()
+    return f"eyJhbGciOiJSUzI1NiJ9.{payload_b64}.fake_signature"
+
+
+class TestIsTokenExpired:
+    """Verify is_token_expired correctly identifies stale tokens."""
+
+    def test_valid_token_not_expired(self):
+        """Token with exp 1 hour in future is not expired."""
+        token = _make_jwt(3600)
+        assert is_token_expired(token) is False
+
+    def test_expired_token_detected(self):
+        """Token with exp 1 hour in past is expired."""
+        token = _make_jwt(-3600)
+        assert is_token_expired(token) is True
+
+    def test_token_within_buffer_is_expired(self):
+        """Token expiring within 60s buffer is treated as expired."""
+        token = _make_jwt(30)  # Expires in 30s, buffer is 60s
+        assert is_token_expired(token) is True
+
+    def test_token_beyond_buffer_is_valid(self):
+        """Token expiring in 120s (beyond 60s buffer) is valid."""
+        token = _make_jwt(120)
+        assert is_token_expired(token) is False
+
+    def test_no_exp_claim_treated_as_expired(self):
+        """Token without exp claim is treated as expired (fail-safe)."""
+        payload = {"sub": "test", "email": "test@co.com"}
+        payload_b64 = base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b"=").decode()
+        token = f"eyJhbGciOiJSUzI1NiJ9.{payload_b64}.fake"
+        assert is_token_expired(token) is True
+
+    def test_malformed_token_treated_as_expired(self):
+        """Unparseable token is treated as expired (fail-safe)."""
+        assert is_token_expired("not.a.valid.jwt") is True
+        assert is_token_expired("") is True
+        assert is_token_expired("garbage") is True

--- a/source/tests/test_otel_latency_fixes.py
+++ b/source/tests/test_otel_latency_fixes.py
@@ -448,6 +448,8 @@ class TestMainErrorPathEmitsValidJson:
         monkeypatch.setattr(mod, "parse_args", lambda: _ns(proxy=None, proxy_port=4318))
         monkeypatch.setattr(mod, "ensure_collector_running", lambda: None)
         monkeypatch.setattr(mod, "read_cached_headers", lambda: None)
+        # Bypass expiry check so the dummy token reaches decode_jwt_payload
+        monkeypatch.setattr(mod, "is_token_expired", lambda *a, **kw: False)
         # Raise after the token is obtained, before any stdout is printed.
         monkeypatch.setattr(
             mod, "decode_jwt_payload", lambda _t: (_ for _ in ()).throw(ValueError("boom"))


### PR DESCRIPTION
## Why

When `CLAUDE_CODE_MONITORING_TOKEN` env var contains an expired token, otel-helper blindly attaches it to telemetry requests. The result depends on the deployment mode:

| Mode | What happens with expired token | User impact |
|---|---|---|
| **Central/proxy** (ECS) | ALB rejects with 401 | Telemetry **silently dropped** — no metrics, no diagnostic |
| **Sidecar** (local) | Token used for attribution headers | User shows as **anonymous** instead of real identity |

Both are silent failures — the user sees no error, just missing or incorrect data.

Fixes #561. Credit: @peepeepopapapeepeepo (issue report + design proposal).

## Who is affected

- **Central mode users** where the ECS task has `CLAUDE_CODE_MONITORING_TOKEN` injected via environment (e.g., Secrets Manager) and it expired without rotation → silent telemetry loss
- **Sidecar mode users** with long-running terminal sessions where the env var was set by credential-process and the token expired while the shell stayed open → anonymous attribution
- **Normal users** (credential-process refreshes tokens automatically) → **not affected** — this is an edge case for stale env vars

## Change

Added `is_token_expired(token, buffer_seconds=60)` and applied at all 3 env-var read sites:

1. **Line 663** (sidecar/headers mode) — expired → skip env var, try credential-process
2. **Line 860** (proxy mode Bearer attachment) — expired → skip env var, try credential-process
3. **Line 878** (main entry) — expired → skip env var, fall through to credential-process

In all cases: expired token is discarded and the code falls through to `get_token_via_credential_process()` which handles refresh. If that also fails, the existing anonymous/no-token paths handle it gracefully.

## Risk & Backwards Compatibility

| Concern | Assessment |
|---|---|
| **Valid token (normal flow)** | Unchanged — `is_token_expired` returns False, token used as before |
| **Expired token (bug case)** | Improved — falls through to refresh instead of silent 401 |
| **No token at all** | Unchanged — same anonymous/fallback path |
| **Performance** | Negligible (~0.1ms: base64 decode + JSON parse + time comparison) |
| **Fail-safe** | Unparseable tokens treated as expired → triggers fallback, never crash |

**Regression risk: Very low.** The only behavior change is for expired tokens, which previously failed silently anyway. Valid tokens are completely unaffected.

## Testing (6 regression tests + 1 existing test fix)

New tests (`test_env_token_expiry.py`):
- `test_valid_token_not_expired` — 1h future token passes
- `test_expired_token_detected` — 1h past token caught
- `test_token_within_buffer_is_expired` — 30s remaining (within 60s buffer) → expired
- `test_token_beyond_buffer_is_valid` — 120s remaining → valid
- `test_no_exp_claim_treated_as_expired` — fail-safe
- `test_malformed_token_treated_as_expired` — fail-safe

Existing test fix (`test_otel_latency_fixes.py`):
- `test_exception_emits_empty_json_and_exit_zero` — patched to bypass expiry check on dummy token (test targets decode error path, not expiry path)

## Files

- `source/otel_helper/__main__.py` — `is_token_expired()` + 3 call sites modified
- `source/tests/test_env_token_expiry.py` — 6 new tests
- `source/tests/test_otel_latency_fixes.py` — 1 line added (monkeypatch for new function)
