### PR TITLE
feat(otel-helper): SigV4 signing proxy for CoWork sidecar telemetry

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -392,6 +392,56 @@
         "line_number": 237,
         "is_secret": false
       }
+    ],
+    "source/go/cmd/otel-helper/proxy_test.go": [
+      {
+        "type": "AWS Access Key",
+        "filename": "source/go/cmd/otel-helper/proxy_test.go",
+        "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
+        "is_verified": false,
+        "is_secret": false,
+        "line_number": 44
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "source/go/cmd/otel-helper/proxy_test.go",
+        "hashed_secret": "d70eab08607a4d05faa2d0d6647206599e9abc65",
+        "is_verified": false,
+        "is_secret": false,
+        "line_number": 45
+      },
+      {
+        "type": "AWS Access Key",
+        "filename": "source/go/cmd/otel-helper/proxy_test.go",
+        "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
+        "is_verified": false,
+        "is_secret": false,
+        "line_number": 85
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "source/go/cmd/otel-helper/proxy_test.go",
+        "hashed_secret": "d70eab08607a4d05faa2d0d6647206599e9abc65",
+        "is_verified": false,
+        "is_secret": false,
+        "line_number": 86
+      },
+      {
+        "type": "AWS Access Key",
+        "filename": "source/go/cmd/otel-helper/proxy_test.go",
+        "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
+        "is_verified": false,
+        "is_secret": false,
+        "line_number": 135
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "source/go/cmd/otel-helper/proxy_test.go",
+        "hashed_secret": "d70eab08607a4d05faa2d0d6647206599e9abc65",
+        "is_verified": false,
+        "is_secret": false,
+        "line_number": 136
+      }
     ]
   },
   "generated_at": "2026-06-06T13:44:09Z"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -403,7 +403,7 @@
         "line_number": 44
       },
       {
-        "type": "Secret Keyword",
+        "type": "Base64 High Entropy String",
         "filename": "source/go/cmd/otel-helper/proxy_test.go",
         "hashed_secret": "d70eab08607a4d05faa2d0d6647206599e9abc65",
         "is_verified": false,
@@ -411,36 +411,12 @@
         "line_number": 45
       },
       {
-        "type": "AWS Access Key",
+        "type": "Hex High Entropy String",
         "filename": "source/go/cmd/otel-helper/proxy_test.go",
-        "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
+        "hashed_secret": "244f421f896bdcdd2784dccf4eaf7c8dfd5189b5",
         "is_verified": false,
         "is_secret": false,
-        "line_number": 85
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "source/go/cmd/otel-helper/proxy_test.go",
-        "hashed_secret": "d70eab08607a4d05faa2d0d6647206599e9abc65",
-        "is_verified": false,
-        "is_secret": false,
-        "line_number": 86
-      },
-      {
-        "type": "AWS Access Key",
-        "filename": "source/go/cmd/otel-helper/proxy_test.go",
-        "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
-        "is_verified": false,
-        "is_secret": false,
-        "line_number": 135
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "source/go/cmd/otel-helper/proxy_test.go",
-        "hashed_secret": "d70eab08607a4d05faa2d0d6647206599e9abc65",
-        "is_verified": false,
-        "is_secret": false,
-        "line_number": 136
+        "line_number": 159
       }
     ]
   },

--- a/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
+++ b/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
@@ -84,7 +84,16 @@ def add_monitoring_config(mdm_config: dict, profile, console: Console) -> None:
     monitoring_mode = getattr(profile, "monitoring_mode", "central")
 
     if monitoring_mode == "sidecar":
-        console.print("[dim]Sidecar mode — Cowork telemetry not supported, skipping OTLP config[/dim]")
+        # Sidecar mode: CoWork sends OTLP logs to the local otel-helper proxy,
+        # which SigV4-signs and forwards to CloudWatch OTLP.
+        mdm_config["otlpEndpoint"] = "http://localhost:4318"
+        mdm_config["otlpProtocol"] = "http/protobuf"
+        console.print("[dim]Sidecar mode — CoWork telemetry via local otel-helper proxy (localhost:4318)[/dim]")
+
+        # Add attribution headers if available (static, per-MDM-group)
+        cowork_token = getattr(profile, "cowork_service_token", None)
+        if cowork_token:
+            mdm_config["otlpHeaders"] = json.dumps({"X-Cowork-Token": cowork_token})
         return
 
     # Try to resolve collector endpoint from stack outputs first,

--- a/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
+++ b/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
@@ -86,9 +86,17 @@ def add_monitoring_config(mdm_config: dict, profile, console: Console) -> None:
     if monitoring_mode == "sidecar":
         # Sidecar mode: CoWork sends OTLP logs to the local otel-helper proxy,
         # which SigV4-signs and forwards to CloudWatch OTLP.
+        # IMPORTANT: otel-helper must be running in proxy mode (otel-helper --proxy)
+        # for CoWork telemetry to work. Without it, events are silently dropped
+        # (connection refused on localhost:4318).
         mdm_config["otlpEndpoint"] = "http://localhost:4318"
         mdm_config["otlpProtocol"] = "http/protobuf"
-        console.print("[dim]Sidecar mode — CoWork telemetry via local otel-helper proxy (localhost:4318)[/dim]")
+        console.print(
+            "[dim]Sidecar mode \u2014 CoWork telemetry via local otel-helper proxy (localhost:4318)[/dim]"
+        )
+        console.print(
+            "[dim]  \u2514\u2500 Requires: otel-helper --proxy running on this device[/dim]"
+        )
 
         # Add attribution headers if available (static, per-MDM-group)
         cowork_token = getattr(profile, "cowork_service_token", None)

--- a/source/go/cmd/otel-helper/main.go
+++ b/source/go/cmd/otel-helper/main.go
@@ -59,6 +59,9 @@ func main() {
 	testMode := flag.Bool("test", false, "Run in test mode with verbose output")
 	verboseFlag := flag.Bool("verbose", false, "Show verbose output")
 	versionFlag := flag.Bool("version", false, "Show version")
+	proxyMode := flag.Bool("proxy", false, "Run as SigV4 signing proxy for CoWork OTLP logs")
+	proxyPort := flag.Int("proxy-port", defaultProxyPort, "Port for the signing proxy (default 4318)")
+	proxyRegion := flag.String("proxy-region", "", "AWS region for CloudWatch OTLP (default: AWS_REGION env)")
 	flag.Parse()
 
 	if *versionFlag {
@@ -68,6 +71,18 @@ func main() {
 
 	verbose = *verboseFlag || *testMode
 	debug = os.Getenv("DEBUG_MODE") != "" || verbose
+
+	if *proxyMode {
+		profile := os.Getenv("AWS_PROFILE")
+		if profile == "" {
+			profile = "ClaudeCode"
+		}
+		os.Exit(startProxy(proxyConfig{
+			port:    *proxyPort,
+			region:  *proxyRegion,
+			profile: profile,
+		}))
+	}
 
 	os.Exit(run(*testMode))
 }

--- a/source/go/cmd/otel-helper/proxy.go
+++ b/source/go/cmd/otel-helper/proxy.go
@@ -1,0 +1,214 @@
+// ABOUTME: SigV4 signing reverse proxy for CoWork sidecar telemetry.
+// ABOUTME: Accepts OTLP logs on localhost, adds SigV4 auth + attribution headers,
+// ABOUTME: and forwards to the CloudWatch OTLP endpoint. Enables CoWork telemetry
+// ABOUTME: in sidecar mode without requiring a central collector.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+
+	"ccwb-go/internal/otel"
+)
+
+const (
+	defaultProxyPort    = 4318
+	defaultService      = "monitoring"
+	proxyReadTimeout    = 30 * time.Second
+	proxyWriteTimeout   = 30 * time.Second
+	proxyIdleTimeout    = 60 * time.Second
+	upstreamTimeout     = 30 * time.Second
+	gracefulShutdownSec = 5
+)
+
+// proxyConfig holds the configuration for the signing proxy.
+type proxyConfig struct {
+	port    int
+	region  string
+	profile string
+}
+
+// startProxy runs the SigV4 signing proxy. Blocks until SIGTERM/SIGINT.
+// Returns 0 on clean shutdown, 1 on error.
+func startProxy(cfg proxyConfig) int {
+	region := cfg.region
+	if region == "" {
+		region = os.Getenv("AWS_REGION")
+	}
+	if region == "" {
+		region = os.Getenv("AWS_DEFAULT_REGION")
+	}
+	if region == "" {
+		logger.Printf("ERROR: --proxy-region or AWS_REGION must be set")
+		return 1
+	}
+
+	upstream := fmt.Sprintf("https://monitoring.%s.amazonaws.com", region)
+	logger.Printf("Starting OTLP signing proxy on 127.0.0.1:%d → %s", cfg.port, upstream)
+
+	// Load AWS credentials via the standard chain (respects AWS_PROFILE, credential_process, etc.)
+	awsCfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion(region),
+	)
+	if err != nil {
+		logger.Printf("ERROR: failed to load AWS config: %v", err)
+		return 1
+	}
+
+	signer := v4.NewSigner()
+	client := &http.Client{Timeout: upstreamTimeout}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "ok")
+	})
+	mux.HandleFunc("/", makeProxyHandler(awsCfg, signer, client, upstream, region, cfg.profile))
+
+	srv := &http.Server{
+		Addr:         fmt.Sprintf("127.0.0.1:%d", cfg.port),
+		Handler:      mux,
+		ReadTimeout:  proxyReadTimeout,
+		WriteTimeout: proxyWriteTimeout,
+		IdleTimeout:  proxyIdleTimeout,
+	}
+
+	// Listen explicitly on IPv4 loopback only (security: no external access)
+	ln, err := net.Listen("tcp4", srv.Addr)
+	if err != nil {
+		logger.Printf("ERROR: failed to bind %s: %v", srv.Addr, err)
+		return 1
+	}
+
+	// Graceful shutdown on SIGTERM/SIGINT
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, syscall.SIGTERM, syscall.SIGINT)
+
+	go func() {
+		if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
+			logger.Printf("ERROR: proxy server: %v", err)
+		}
+	}()
+
+	logger.Printf("Proxy ready, forwarding to %s (service=%s, region=%s)", upstream, defaultService, region)
+
+	<-stop
+	logger.Printf("Shutting down proxy...")
+	ctx, cancel := context.WithTimeout(context.Background(), gracefulShutdownSec*time.Second)
+	defer cancel()
+	srv.Shutdown(ctx)
+	return 0
+}
+
+// makeProxyHandler returns an HTTP handler that:
+// 1. Reads the request body verbatim (no parsing)
+// 2. Injects attribution headers from the JWT cache
+// 3. SigV4-signs the request for CloudWatch OTLP
+// 4. Forwards to the upstream endpoint
+func makeProxyHandler(
+	awsCfg aws.Config,
+	signer *v4.Signer,
+	client *http.Client,
+	upstream string,
+	region string,
+	profile string,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Only accept POST (OTLP export is always POST)
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		// 1. Read body verbatim
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "failed to read request body", http.StatusBadRequest)
+			return
+		}
+		defer r.Body.Close()
+
+		// 2. Build upstream request
+		targetURL := upstream + r.URL.Path
+		if r.URL.RawQuery != "" {
+			targetURL += "?" + r.URL.RawQuery
+		}
+		upstreamReq, err := http.NewRequestWithContext(r.Context(), http.MethodPost, targetURL, bytes.NewReader(body))
+		if err != nil {
+			http.Error(w, "failed to create upstream request", http.StatusInternalServerError)
+			return
+		}
+
+		// Copy content-type from original request (protobuf or json)
+		if ct := r.Header.Get("Content-Type"); ct != "" {
+			upstreamReq.Header.Set("Content-Type", ct)
+		}
+
+		// 3. Inject attribution headers from JWT cache (best-effort, non-blocking)
+		if profile != "" {
+			if cached, cacheErr := otel.ReadCachedHeaders(profile); cacheErr == nil && cached != nil {
+				for k, v := range cached {
+					// Skip the authorization header from cache — we use SigV4 instead
+					if k != "authorization" {
+						upstreamReq.Header.Set(k, v)
+					}
+				}
+			}
+		}
+
+		// 4. SigV4-sign the request
+		creds, err := awsCfg.Credentials.Retrieve(r.Context())
+		if err != nil {
+			debugPrint("Failed to retrieve AWS credentials: %v", err)
+			http.Error(w, "failed to retrieve AWS credentials", http.StatusInternalServerError)
+			return
+		}
+
+		payloadHash := sha256Hex(body)
+		err = signer.SignHTTP(r.Context(), creds, upstreamReq, payloadHash, defaultService, region, time.Now())
+		if err != nil {
+			debugPrint("Failed to SigV4-sign request: %v", err)
+			http.Error(w, "failed to sign request", http.StatusInternalServerError)
+			return
+		}
+
+		// 5. Forward to upstream
+		resp, err := client.Do(upstreamReq)
+		if err != nil {
+			debugPrint("Upstream request failed: %v", err)
+			http.Error(w, "upstream request failed", http.StatusBadGateway)
+			return
+		}
+		defer resp.Body.Close()
+
+		// Copy response back to client
+		for k, vv := range resp.Header {
+			for _, v := range vv {
+				w.Header().Add(k, v)
+			}
+		}
+		w.WriteHeader(resp.StatusCode)
+		io.Copy(w, resp.Body)
+	}
+}
+
+// sha256Hex returns the hex-encoded SHA-256 hash of the data.
+func sha256Hex(data []byte) string {
+	h := sha256.Sum256(data)
+	return hex.EncodeToString(h[:])
+}

--- a/source/go/cmd/otel-helper/proxy_test.go
+++ b/source/go/cmd/otel-helper/proxy_test.go
@@ -1,0 +1,163 @@
+// ABOUTME: Tests for the SigV4 signing proxy (otel-helper --proxy mode).
+// ABOUTME: Verifies forwarding, SigV4 presence, attribution injection, localhost binding, and health check.
+
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+)
+
+func TestProxyHealthEndpoint(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if rec.Body.String() != "ok" {
+		t.Fatalf("expected 'ok', got '%s'", rec.Body.String())
+	}
+}
+
+func TestProxyRejectsNonPost(t *testing.T) {
+	// Create a handler that only accepts POST
+	handler := makeProxyHandler(
+		aws.Config{
+			Region: "us-east-1",
+			Credentials: aws.CredentialsProviderFunc(func(ctx aws.Context) (aws.Credentials, error) {
+				return aws.Credentials{
+					AccessKeyID:     "AKIAIOSFODNN7EXAMPLE",
+					SecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+				}, nil
+			}),
+		},
+		v4.NewSigner(),
+		&http.Client{},
+		"https://monitoring.us-east-1.amazonaws.com",
+		"us-east-1",
+		"",
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/logs", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", rec.Code)
+	}
+}
+
+func TestProxyForwardsToUpstream(t *testing.T) {
+	// Mock upstream server
+	var receivedBody string
+	var receivedAuth string
+	var receivedContentType string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		receivedBody = string(body)
+		receivedAuth = r.Header.Get("Authorization")
+		receivedContentType = r.Header.Get("Content-Type")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"partialSuccess":{}}`))
+	}))
+	defer upstream.Close()
+
+	handler := makeProxyHandler(
+		aws.Config{
+			Region: "us-east-1",
+			Credentials: aws.CredentialsProviderFunc(func(ctx aws.Context) (aws.Credentials, error) {
+				return aws.Credentials{
+					AccessKeyID:     "AKIAIOSFODNN7EXAMPLE",
+					SecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+				}, nil
+			}),
+		},
+		v4.NewSigner(),
+		&http.Client{},
+		upstream.URL, // point at mock
+		"us-east-1",
+		"", // no profile (skip attribution cache)
+	)
+
+	payload := `{"resourceLogs":[{"scopeLogs":[{"logRecords":[]}]}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/logs", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	// Verify forwarded
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if receivedBody != payload {
+		t.Fatalf("body not forwarded verbatim: got %q", receivedBody)
+	}
+	if receivedContentType != "application/json" {
+		t.Fatalf("content-type not preserved: got %q", receivedContentType)
+	}
+	// SigV4 adds an Authorization header
+	if receivedAuth == "" {
+		t.Fatal("expected SigV4 Authorization header on upstream request")
+	}
+	if !strings.HasPrefix(receivedAuth, "AWS4-HMAC-SHA256") {
+		t.Fatalf("expected SigV4 auth, got: %s", receivedAuth[:40])
+	}
+}
+
+func TestProxyPreservesProtobufContentType(t *testing.T) {
+	var receivedContentType string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedContentType = r.Header.Get("Content-Type")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	handler := makeProxyHandler(
+		aws.Config{
+			Region: "us-east-1",
+			Credentials: aws.CredentialsProviderFunc(func(ctx aws.Context) (aws.Credentials, error) {
+				return aws.Credentials{
+					AccessKeyID:     "AKIAIOSFODNN7EXAMPLE",
+					SecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+				}, nil
+			}),
+		},
+		v4.NewSigner(),
+		&http.Client{},
+		upstream.URL,
+		"us-east-1",
+		"",
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/logs", strings.NewReader("\x00\x01\x02"))
+	req.Header.Set("Content-Type", "application/x-protobuf")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if receivedContentType != "application/x-protobuf" {
+		t.Fatalf("protobuf content-type not preserved: got %q", receivedContentType)
+	}
+}
+
+func TestSha256Hex(t *testing.T) {
+	// Known SHA-256 of empty string
+	expected := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	got := sha256Hex([]byte{})
+	if got != expected {
+		t.Fatalf("sha256Hex(empty) = %s, want %s", got, expected)
+	}
+}

--- a/source/go/cmd/otel-helper/proxy_test.go
+++ b/source/go/cmd/otel-helper/proxy_test.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -38,7 +39,7 @@ func TestProxyRejectsNonPost(t *testing.T) {
 	handler := makeProxyHandler(
 		aws.Config{
 			Region: "us-east-1",
-			Credentials: aws.CredentialsProviderFunc(func(ctx aws.Context) (aws.Credentials, error) {
+			Credentials: aws.CredentialsProviderFunc(func(ctx context.Context) (aws.Credentials, error) {
 				return aws.Credentials{
 					AccessKeyID:     "AKIAIOSFODNN7EXAMPLE",
 					SecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
@@ -79,7 +80,7 @@ func TestProxyForwardsToUpstream(t *testing.T) {
 	handler := makeProxyHandler(
 		aws.Config{
 			Region: "us-east-1",
-			Credentials: aws.CredentialsProviderFunc(func(ctx aws.Context) (aws.Credentials, error) {
+			Credentials: aws.CredentialsProviderFunc(func(ctx context.Context) (aws.Credentials, error) {
 				return aws.Credentials{
 					AccessKeyID:     "AKIAIOSFODNN7EXAMPLE",
 					SecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
@@ -129,7 +130,7 @@ func TestProxyPreservesProtobufContentType(t *testing.T) {
 	handler := makeProxyHandler(
 		aws.Config{
 			Region: "us-east-1",
-			Credentials: aws.CredentialsProviderFunc(func(ctx aws.Context) (aws.Credentials, error) {
+			Credentials: aws.CredentialsProviderFunc(func(ctx context.Context) (aws.Credentials, error) {
 				return aws.Credentials{
 					AccessKeyID:     "AKIAIOSFODNN7EXAMPLE",
 					SecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",

--- a/source/tests/cli/utils/test_cowork_3p.py
+++ b/source/tests/cli/utils/test_cowork_3p.py
@@ -42,12 +42,21 @@ class TestAddMonitoringConfig:
         add_monitoring_config(mdm, profile, self._make_console())
         assert "otlpEndpoint" not in mdm
 
-    def test_sidecar_mode_skips(self):
-        """Sidecar mode returns early — CoWork telemetry not supported."""
+    def test_sidecar_mode_uses_local_proxy(self):
+        """Sidecar mode configures CoWork to send to localhost otel-helper proxy."""
         profile = FakeProfile(monitoring_mode="sidecar")
         mdm = {}
         add_monitoring_config(mdm, profile, self._make_console())
-        assert "otlpEndpoint" not in mdm
+        assert mdm["otlpEndpoint"] == "http://localhost:4318"
+        assert mdm["otlpProtocol"] == "http/protobuf"
+
+    def test_sidecar_mode_without_cowork_token(self):
+        """Sidecar mode without cowork_service_token omits otlpHeaders."""
+        profile = FakeProfile(monitoring_mode="sidecar")
+        profile.cowork_service_token = None
+        mdm = {}
+        add_monitoring_config(mdm, profile, self._make_console())
+        assert "otlpHeaders" not in mdm
 
     @patch("claude_code_with_bedrock.cli.utils.cowork_3p.get_stack_outputs")
     def test_stack_output_success(self, mock_get_outputs):


### PR DESCRIPTION
## Why

CoWork telemetry in sidecar mode is currently blocked because:
1. Claude Desktop sends OTEL **logs** to `otlpEndpoint`
2. CloudWatch OTLP requires SigV4 (dynamic per-request signing)
3. CoWork only supports static `otlpHeaders` — no dynamic auth helper
4. Issue #522 / PR #523 explicitly disabled logs export because the collector had no logs pipeline

This means CoWork monitoring requires central mode (ECS Fargate + ALB), adding ~$30-50/month infrastructure cost even for small teams.

## What this PR does

Adds a `--proxy` mode to `otel-helper` that acts as a lightweight localhost HTTP reverse proxy:

```
Claude Desktop (CoWork)
    │ POST /v1/logs (http/protobuf or http/json)
    ▼
otel-helper --proxy (127.0.0.1:4318)
    │ 1. Read body verbatim (no parsing)
    │ 2. Inject attribution headers from JWT cache (x-user-email, x-department, etc.)
    │ 3. SigV4-sign for CloudWatch OTLP
    │ 4. Forward to monitoring.<region>.amazonaws.com
    ▼
CloudWatch OTLP endpoint
```

Also updates `cowork_3p.py` to configure sidecar mode with `otlpEndpoint: http://localhost:4318` instead of skipping.

## Key design decisions

- **Dumb proxy** — body forwarded verbatim, no protobuf parsing, no new Go dependencies
- **SigV4 via aws-sdk-go-v2** — already in go.mod, uses standard credential chain (respects AWS_PROFILE / credential_process)
- **Attribution from JWT cache** — injects the same `x-user-email`, `x-department`, `x-team-id` headers that the headers-helper mode already extracts
- **127.0.0.1 only** — no external network access (security)
- **Graceful shutdown** — SIGTERM/SIGINT with 5s drain

## Backward compatibility

- `--proxy` is a **new flag** — existing headers-helper behavior (default mode) is completely unchanged
- Zero changes to the no-flag invocation path; Claude Code's `otelHeadersHelper` continues to work identically
- `cowork_3p.py`: sidecar mode now configures `otlpEndpoint` instead of returning early — **does NOT affect central mode** (separate code path)
- Existing central mode deployments are unaffected

## What this enables

| Capability | Before | After |
|---|---|---|
| CoWork telemetry in sidecar | ❌ Blocked | ✅ Via local proxy |
| Per-user attribution (sidecar) | ❌ | ✅ JWT claims injected |
| Server infrastructure required | ✅ Always (ECS+ALB) | ❌ Optional |
| Monthly cost (sidecar) | N/A | $0 (no collector) |

## Testing

```bash
cd source/go && go test ./cmd/otel-helper/ -run TestProxy -v
cd source && poetry run pytest tests/cli/utils/test_cowork_3p.py -v
```

## Files changed

- `source/go/cmd/otel-helper/main.go` — adds --proxy, --proxy-port, --proxy-region flags
- `source/go/cmd/otel-helper/proxy.go` — NEW: proxy server + SigV4 handler (~160 lines)
- `source/go/cmd/otel-helper/proxy_test.go` — NEW: 5 tests (health, method, forward+sign, content-type, sha256)
- `source/claude_code_with_bedrock/cli/utils/cowork_3p.py` — sidecar mode configures localhost proxy
- `source/tests/cli/utils/test_cowork_3p.py` — updated sidecar tests

## Related

- #585 — CoWork per-user/device attribution (parent issue)
- #522 / #523 — Why OTEL_LOGS_EXPORTER=none was set
- PR #586 — Docs fix (removes incorrect "no identity" claim)