### PR TITLE
feat(collector): enable per-team and per-device attribution on CoWork logs pipeline

### DIFF
--- a/deployment/infrastructure/otel-collector.yaml
+++ b/deployment/infrastructure/otel-collector.yaml
@@ -458,7 +458,7 @@ Resources:
               # Logs-specific processor: extracts the same attribution from HTTP
               # headers as the metrics 'attributes' processor, PLUS creates
               # underscore-renamed copies of dotted keys (user.id → user_id,
-              # session.id → session_id) so CloudWatch MetricFilter Dimensions
+              # team.id → team_id) so CloudWatch MetricFilter Dimensions
               # can reference them (MetricFilter JSON patterns cannot handle dots
               # in key names).
               attributes/logs:
@@ -494,9 +494,8 @@ Resources:
                   - key: team_id
                     from_context: metadata.x-team-id
                     action: upsert
-                  - key: session_id
-                    from_context: metadata.x-session-id
-                    action: upsert
+                  # Note: session.id is native in CoWork events (not from headers).
+                  # Use Logs Insights backtick escaping for session queries.
               resource:
                 attributes:
                   - key: aws.account_id
@@ -653,9 +652,8 @@ Resources:
                   - key: team_id
                     from_context: metadata.x-team-id
                     action: upsert
-                  - key: session_id
-                    from_context: metadata.x-session-id
-                    action: upsert
+                  # Note: session.id is native in CoWork events (not from headers).
+                  # Use Logs Insights backtick escaping for session queries.
               resource:
                 attributes:
                   - key: aws.account_id

--- a/deployment/infrastructure/otel-collector.yaml
+++ b/deployment/infrastructure/otel-collector.yaml
@@ -455,6 +455,48 @@ Resources:
                   - key: manager
                     from_context: metadata.x-manager
                     action: upsert
+              # Logs-specific processor: extracts the same attribution from HTTP
+              # headers as the metrics 'attributes' processor, PLUS creates
+              # underscore-renamed copies of dotted keys (user.id → user_id,
+              # session.id → session_id) so CloudWatch MetricFilter Dimensions
+              # can reference them (MetricFilter JSON patterns cannot handle dots
+              # in key names).
+              attributes/logs:
+                actions:
+                  - key: user.email
+                    from_context: metadata.x-user-email
+                    action: upsert
+                  - key: user.id
+                    from_context: metadata.x-user-id
+                    action: upsert
+                  - key: user.name
+                    from_context: metadata.x-user-name
+                    action: upsert
+                  - key: department
+                    from_context: metadata.x-department
+                    action: upsert
+                  - key: team.id
+                    from_context: metadata.x-team-id
+                    action: upsert
+                  - key: cost_center
+                    from_context: metadata.x-cost-center
+                    action: upsert
+                  - key: organization
+                    from_context: metadata.x-organization
+                    action: upsert
+                  # Underscore-renamed copies for CloudWatch MetricFilter compat
+                  - key: user_id
+                    from_context: metadata.x-user-id
+                    action: upsert
+                  - key: user_email
+                    from_context: metadata.x-user-email
+                    action: upsert
+                  - key: team_id
+                    from_context: metadata.x-team-id
+                    action: upsert
+                  - key: session_id
+                    from_context: metadata.x-session-id
+                    action: upsert
               resource:
                 attributes:
                   - key: aws.account_id
@@ -523,7 +565,7 @@ Resources:
                   exporters: [otlphttp, awsemf]
                 logs:
                   receivers: [otlp]
-                  processors: [resource]
+                  processors: [attributes/logs, resource]
                   exporters: [awscloudwatchlogs/cowork]
         - !Sub |
             extensions:
@@ -579,6 +621,41 @@ Resources:
                   - key: manager
                     from_context: metadata.x-manager
                     action: upsert
+              attributes/logs:
+                actions:
+                  - key: user.email
+                    from_context: metadata.x-user-email
+                    action: upsert
+                  - key: user.id
+                    from_context: metadata.x-user-id
+                    action: upsert
+                  - key: user.name
+                    from_context: metadata.x-user-name
+                    action: upsert
+                  - key: department
+                    from_context: metadata.x-department
+                    action: upsert
+                  - key: team.id
+                    from_context: metadata.x-team-id
+                    action: upsert
+                  - key: cost_center
+                    from_context: metadata.x-cost-center
+                    action: upsert
+                  - key: organization
+                    from_context: metadata.x-organization
+                    action: upsert
+                  - key: user_id
+                    from_context: metadata.x-user-id
+                    action: upsert
+                  - key: user_email
+                    from_context: metadata.x-user-email
+                    action: upsert
+                  - key: team_id
+                    from_context: metadata.x-team-id
+                    action: upsert
+                  - key: session_id
+                    from_context: metadata.x-session-id
+                    action: upsert
               resource:
                 attributes:
                   - key: aws.account_id
@@ -617,7 +694,7 @@ Resources:
                   exporters: [otlphttp]
                 logs:
                   receivers: [otlp]
-                  processors: [resource]
+                  processors: [attributes/logs, resource]
                   exporters: [awscloudwatchlogs/cowork]
 
   # ECS Task Definition


### PR DESCRIPTION
## Why

CoWork telemetry events flow through the central collector but **lack team/department and per-device attribution** because the logs pipeline skips the `attributes` processor (it was only applied to the metrics pipeline). This means:

1. **Team attribution from `otlpHeaders` is lost** — Administrators can inject `x-department`, `x-team-id`, `x-cost-center` via CoWork MDM config, but these headers are never written into log events
2. **Per-device MetricFilter dimensions are blocked** — CloudWatch MetricFilter JSON patterns cannot handle dots in key names (`user.id` is interpreted as nested path), so per-device billing dimensions are impossible without underscore-renamed copies
3. **Cost chargeback by team is impossible** — even though the infrastructure accepts the headers, the data never reaches CloudWatch Logs

After this PR, administrators can achieve per-team and per-device billing on CoWork by:
- Setting `otlpHeaders` with team/department values per MDM group
- Using CloudWatch MetricFilter dimensions on `$.attributes.user_id`, `$.attributes.department`, `$.attributes.team_id`

## What this PR does

Adds an `attributes/logs` processor to both collector config variants (analytics-enabled + OTLP-only) that:

### 1. Team/department attribution (from HTTP headers)
Extracts the same attribution headers the metrics pipeline already uses:
- `x-user-email` → `user.email`
- `x-department` → `department`
- `x-team-id` → `team.id`
- `x-cost-center` → `cost_center`
- `x-organization` → `organization`
- `x-user-id` → `user.id`

### 2. MetricFilter-compatible copies (underscore-renamed)
Creates flat-key aliases that CloudWatch MetricFilter Dimensions can reference:
- `user_id` (from `x-user-id` header)
- `user_email` (from `x-user-email` header)
- `team_id` (from `x-team-id` header)
- `session_id` (from `x-session-id` header)

### Pipeline change
```yaml
# Before
logs:
  processors: [resource]

# After  
logs:
  processors: [attributes/logs, resource]
```

## How per-team attribution works after this PR

1. Administrator deploys different `otlpHeaders` per team MDM group:
```json
{
  "X-Cowork-Token": "<auth-uuid>",
  "x-department": "Engineering",
  "x-team-id": "platform",
  "x-cost-center": "CC-1234"
}
```

2. Claude Desktop sends events with these static headers to the ALB

3. Collector's new `attributes/logs` processor reads headers → writes into event body

4. CloudWatch Logs receives events with `department`, `team_id`, `cost_center` attributes

5. MetricFilter Dimensions can now group by team/department for billing dashboards

## Backward compatibility

| Aspect | Impact |
|---|---|
| Metrics pipeline | ✅ Completely unchanged |
| Existing log events | ✅ Gain additional attributes (additive only) |
| Original dotted keys | ✅ Preserved (copies added alongside, not renamed) |
| Events without headers | ✅ No attributes injected (upsert with empty = no-op) |
| IAM / VPC / infra | ✅ No changes |
| Both config variants | ✅ Both updated identically |

## What this unblocks

- **Dashboard PR** (next): Per-device + per-team MetricFilter dimensions using `$.attributes.user_id`, `$.attributes.department`
- **Per-team billing**: otlpHeaders → event body → MetricFilter dimension (full chain works)
- **Logs Insights queries**: `| stats sum(cost_usd) by department` or `by user_id`

## Testing

```bash
cfn-lint deployment/infrastructure/otel-collector.yaml
```

The processor is purely additive — if no `x-user-*` / `x-department` headers are present on a request, no attributes are added (no null/empty values injected).

## Related

- #585 — CoWork per-user/device/team attribution (parent issue)
- PR #586 — Docs fix (removes incorrect "no identity" claim)
- PR #587 — otel-helper SigV4 proxy for sidecar mode