### PR TITLE
fix(monitoring): add user.email as awsemf dimension for quota PromQL queries

### DIFF
--- a/deployment/infrastructure/otel-collector.yaml
+++ b/deployment/infrastructure/otel-collector.yaml
@@ -491,6 +491,8 @@ Resources:
                     metric_name_selectors: [".*"]
                   - dimensions: [[model, OTelLib]]
                     metric_name_selectors: [".*"]
+                  - dimensions: [[user.email, OTelLib]]
+                    metric_name_selectors: ["claude_code.token.usage", "claude_code.cost.usage"]
                   - dimensions: [[cost_center, OTelLib]]
                     metric_name_selectors: ["claude_code.cost.usage", "claude_code.token.usage"]
                   - dimensions: [[type, OTelLib]]


### PR DESCRIPTION
## Problem

Users running **central monitoring mode + fine-grained quotas** report that `UserQuotaMetrics` (DynamoDB) stays permanently empty — `ccwb quota usage <email>` always returns 0 and quota blocking never fires. This happens even when:

- Telemetry flows correctly (Claude Code usage + `user.email` visible in CloudWatch Logs)
- Fine-grained quotas are enabled and policies are configured correctly
- The #499/#501 IAM permission fix is deployed (which fixed `dynamodb:UpdateItem` + `ENABLE_FINEGRAINED_QUOTAS` env var)

The quota monitor Lambda runs clean (no errors) but consistently reports `Fetched delta usage for 0 users` — meaning the upstream PromQL query returns nothing.

## Hypothesis

The quota monitor Lambda queries PromQL for per-user token usage:

```promql
sum by ("user.email")(increase({"claude_code.token.usage"}[900s]))
```

But `user.email` is not declared as a dimension in the `awsemf` exporter's `metric_declarations`. Without an explicit dimension declaration, CloudWatch cannot group EMF-generated metrics by `user.email`. The PromQL-compatible API queries across CloudWatch metrics — if the dimension doesn't exist, the `sum by ("user.email")` aggregation returns empty results.

The #499/#501 fix was necessary (Lambda couldn't write even with data) but not sufficient — this is the remaining upstream gap that prevents data from reaching the Lambda in the first place.

## Change

Adds `user.email` as an explicit `awsemf` dimension, scoped to `claude_code.token.usage` and `claude_code.cost.usage` only (avoids unnecessary cardinality on other metrics).

## Status: Needs Validation

This is positioned as a **hypothesis** based on code analysis of the telemetry pipeline. The alternative explanation is that the `otlphttp` exporter (which sends to `monitoring.{region}.amazonaws.com`) independently preserves `user.email` as a PromQL label — in which case the gap lies elsewhere (e.g. the OTLP endpoint dropping high-cardinality attributes).

**Data points that would confirm or refute:**

1. After deploying this change, does `UserQuotaMetrics` start populating?
2. Run this PromQL query before/after and check if `user.email` labels appear:
   ```
   sum by ("user.email")({"claude_code.token.usage"})
   ```
3. Check the quota monitor Lambda logs (`/aws/lambda/claude-code-quota-monitor`) — does `Fetched delta usage for N users` show N > 0 after redeployment?

If you're running central mode + fine-grained quotas and seeing the empty-table symptom, testing this fix would be very helpful.

## Refs

- #499 (original fine-grained quota bug — IAM fix merged via #501)
- #541 (CoWork telemetry gap in central mode — related pipeline analysis)
- #583 (CoWork dashboard metrics stuck at 0)
