### PR TITLE
fix(install): handle missing AWS CLI gracefully in install.bat

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -2623,11 +2623,13 @@ echo.
 REM Check prerequisites
 echo Checking prerequisites...
 
+set HAS_AWS_CLI=0
 where aws >nul 2>&1
 if %errorlevel% neq 0 (
-    echo INFO: AWS CLI not found -- not required. The credential process binary handles authentication directly.
+    echo INFO: AWS CLI not found -- not required. Profiles will be configured directly.
 ) else (
-    echo OK AWS CLI found [optional]
+    set HAS_AWS_CLI=1
+    echo OK AWS CLI found
 )
 
 echo OK Prerequisites found
@@ -2700,19 +2702,33 @@ for /f %%p in ('powershell -NoProfile -Command "$c=Get-Content config.json|Conve
     REM Get profile-specific region
     for /f %%r in ('powershell -NoProfile -Command "$c=Get-Content config.json|ConvertFrom-Json;$c.'"'"'%%p'"'"'.aws_region"') do set PROFILE_REGION=%%r
 
-
-    REM Set credential process with --profile flag (cross-platform, no wrapper needed)
-    aws configure set credential_process "%USERPROFILE%\\claude-code-with-bedrock\\credential-process.exe --profile %%p" --profile %%p
-
-
-    REM Set region
-    if defined PROFILE_REGION (
-        aws configure set region !PROFILE_REGION! --profile %%p
+    if "!HAS_AWS_CLI!"=="1" (
+        REM Use AWS CLI to configure profiles
+        aws configure set credential_process "%USERPROFILE%\\claude-code-with-bedrock\\credential-process.exe --profile %%p" --profile %%p
+        if !errorlevel! neq 0 (
+            echo   ERROR: Failed to configure profile '%%p' via AWS CLI
+        ) else (
+            REM Set region
+            if defined PROFILE_REGION (
+                aws configure set region !PROFILE_REGION! --profile %%p
+            ) else (
+                aws configure set region {profile.aws_region} --profile %%p
+            )
+            echo   OK Created AWS profile '%%p'
+        )
     ) else (
-        aws configure set region {profile.aws_region} --profile %%p
+        REM No AWS CLI — write directly to ~/.aws/config using PowerShell
+        powershell -NoProfile -Command ^
+            "$configDir = Join-Path $env:USERPROFILE '.aws';" ^
+            "if (-not (Test-Path $configDir)) {{ New-Item -ItemType Directory -Path $configDir -Force | Out-Null }};" ^
+            "$configFile = Join-Path $configDir 'config';" ^
+            "$profileName = '%%p';" ^
+            "$region = if ('!PROFILE_REGION!' -ne '') {{ '!PROFILE_REGION!' }} else {{ '{profile.aws_region}' }};" ^
+            "$credProc = ($env:USERPROFILE + '\claude-code-with-bedrock\credential-process.exe --profile ' + $profileName) -replace '\\', '/';" ^
+            "$section = \"`n[profile $profileName]`nregion = $region`ncredential_process = $credProc`n\";" ^
+            "$existing = if (Test-Path $configFile) {{ Get-Content $configFile -Raw }} else {{ '' }};" ^
+            "if ($existing -notmatch \"\[profile $profileName\]\") {{ Add-Content -Path $configFile -Value $section; Write-Host '  OK Created AWS profile ''$profileName''' }} else {{ Write-Host '  OK AWS profile ''$profileName'' already exists' }}"
     )
-
-    echo   OK Created AWS profile '%%p'
 )
 
 echo.

--- a/source/tests/cli/commands/test_install_bat_aws_cli.py
+++ b/source/tests/cli/commands/test_install_bat_aws_cli.py
@@ -1,0 +1,77 @@
+# ABOUTME: Tests that install.bat template handles AWS CLI presence/absence correctly
+# ABOUTME: Regression test for issue #592 (false success when aws not found)
+
+"""Tests for install.bat AWS CLI handling logic."""
+
+import pytest
+from pathlib import Path
+
+
+class TestInstallBatAwsCliHandling:
+    """Verify install.bat correctly handles AWS CLI presence/absence."""
+
+    @pytest.fixture(autouse=True)
+    def load_package_py(self):
+        self.package_path = (
+            Path(__file__).parent.parent.parent.parent
+            / "claude_code_with_bedrock"
+            / "cli"
+            / "commands"
+            / "package.py"
+        )
+        self.content = self.package_path.read_text()
+
+    def test_has_aws_cli_detection_variable(self):
+        """install.bat must set HAS_AWS_CLI variable based on 'where aws' check."""
+        assert "set HAS_AWS_CLI=0" in self.content
+        assert "set HAS_AWS_CLI=1" in self.content
+
+    def test_profile_config_checks_has_aws_cli(self):
+        """Profile configuration must be conditional on HAS_AWS_CLI."""
+        assert 'if "!HAS_AWS_CLI!"=="1"' in self.content
+
+    def test_fallback_writes_config_directly(self):
+        """When AWS CLI is absent, must write ~/.aws/config directly via PowerShell."""
+        assert ".aws" in self.content
+        assert "config" in self.content
+        assert "[profile" in self.content
+        assert "credential_process" in self.content
+
+    def test_no_unconditional_aws_calls_in_profile_setup(self):
+        """aws configure must NOT be called unconditionally in the profile section."""
+        # Find the profile configuration section
+        profile_section_start = self.content.find("REM Configure AWS profiles")
+        profile_section_end = self.content.find("Installation complete!", profile_section_start)
+        profile_section = self.content[profile_section_start:profile_section_end]
+
+        # Every 'aws configure' must be inside the HAS_AWS_CLI=1 branch
+        lines = profile_section.splitlines()
+        for i, line in enumerate(lines):
+            stripped = line.strip()
+            if stripped.startswith("aws configure"):
+                # Look backwards for the HAS_AWS_CLI check (within 15 lines)
+                context = "\n".join(lines[max(0, i - 15):i])
+                assert "HAS_AWS_CLI" in context, (
+                    f"Line {i}: 'aws configure' called without HAS_AWS_CLI guard: {stripped}"
+                )
+
+    def test_success_message_only_on_actual_success(self):
+        """'OK Created AWS profile' must not be printed unconditionally after aws calls."""
+        profile_section_start = self.content.find("REM Configure AWS profiles")
+        profile_section_end = self.content.find("Installation complete!", profile_section_start)
+        profile_section = self.content[profile_section_start:profile_section_end]
+
+        # The old bug: 'echo OK Created' appeared outside any error check
+        lines = profile_section.splitlines()
+        for i, line in enumerate(lines):
+            if "OK Created AWS profile" in line:
+                # Must be inside a conditional (errorlevel check or PowerShell Write-Host)
+                context = "\n".join(lines[max(0, i - 3):i + 1])
+                is_conditional = (
+                    "errorlevel" in context.lower()
+                    or "else" in context
+                    or "Write-Host" in line
+                )
+                assert is_conditional, (
+                    f"'OK Created AWS profile' at line {i} must be inside an error-check branch"
+                )


### PR DESCRIPTION
## Why

`install.bat` says "AWS CLI not found — not required" during prerequisite check, then unconditionally calls `aws configure` to set up profiles. When AWS CLI is absent, this produces errors followed by a misleading "OK Created AWS profile" success message.

Issue: #592

## The Flow (before this fix)

```
1. Prerequisite check: 'where aws' fails
2. Message: "AWS CLI not found — not required"  ← correct
3. Continue to profile setup...
4. Call: aws configure set credential_process ...   ← ERROR (aws not found)
5. Call: aws configure set region ...               ← ERROR (aws not found)
6. Message: "OK Created AWS profile 'xxx'"         ← WRONG (profile not created)
```

## The Flow (after this fix)

**With AWS CLI:**
```
1. 'where aws' succeeds → set HAS_AWS_CLI=1
2. Profile setup uses 'aws configure set' (existing behavior)
3. Checks errorlevel → prints success only on actual success
```

**Without AWS CLI:**
```
1. 'where aws' fails → set HAS_AWS_CLI=0
2. Profile setup writes directly to ~/.aws/config via PowerShell
3. Creates [profile xxx] section with credential_process + region
4. Prints success only after confirming the write
```

## What Changed

| File | Change |
|------|--------|
| `package.py` (install.bat template) | Track `HAS_AWS_CLI` variable; branch profile config on it; add PowerShell direct-write fallback; check errorlevel before success message |
| `tests/cli/commands/test_install_bat_aws_cli.py` | **New** — 5 tests verifying the template structure |

## Backward Compatible

✅ Users with AWS CLI: identical behavior (CLI path runs as before)
✅ Users without AWS CLI: now get working profiles instead of errors
✅ macOS/Linux install.sh unaffected
✅ The direct-write fallback produces the same `~/.aws/config` entries

## Risk: Very Low

- Only changes the Windows `install.bat` template
- CLI-present path has same behavior + added error checking
- CLI-absent path is purely additive (previously failed silently)

## Test Coverage (5 tests)

- HAS_AWS_CLI variable detection
- Profile config conditional on HAS_AWS_CLI
- Fallback writes to ~/.aws/config
- No unconditional aws calls in profile section
- Success message only on actual success

---

Credit: @emmaanuel reported the issue