### PR TITLE
ci: add ruff lint + format CI workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,42 @@
+name: Lint
+
+on:
+  push:
+    branches: ["main", "beta"]
+    paths:
+      - 'source/**'
+      - '.github/workflows/lint.yml'
+  pull_request:
+    branches: ["main", "beta"]
+    paths:
+      - 'source/**'
+      - '.github/workflows/lint.yml'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  ruff:
+    name: Ruff (lint + format)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install ruff
+        run: pip install ruff
+
+      - name: Ruff check (lint)
+        working-directory: source
+        run: ruff check .
+
+      - name: Ruff format (formatting)
+        working-directory: source
+        run: ruff format --check .


### PR DESCRIPTION
## Why

No CI enforcement existed for Python code style — lint violations accumulated silently across PRs.

## What

Adds `.github/workflows/lint.yml` that runs on PRs/pushes targeting main/beta:
- `ruff check .` (lint violations)
- `ruff format --check .` (formatting consistency)

Path-filtered to `source/**` so non-Python changes don't trigger it.

## Why this PR instead of #591

#591 combined the CI workflow with 187 lint fixes across 71 files (+1027/-829). That would create rebase conflicts for all in-flight feature PRs. This PR extracts just the CI workflow (1 file, +42 lines, zero conflict risk) so we get enforcement immediately.

The lint fixes from #591 can land after the current feature batch merges.

---

Credit: @spawnia authored the workflow in #591. Extracted here for faster merge.