### PR TITLE
fix(quota): resolve IDC usernames without @ as valid identity

### DIFF
--- a/deployment/infrastructure/lambda-functions/quota_check/index.py
+++ b/deployment/infrastructure/lambda-functions/quota_check/index.py
@@ -66,16 +66,23 @@ def lambda_handler(event, context):
             email = jwt_claims.get("email")
             groups = extract_groups_from_claims(jwt_claims)
 
-        # Path 2: IAM identity (IDC users) — extract email from caller ARN
+        # Path 2: IAM identity (IDC users) — extract identity from caller ARN
         # ARN format: arn:aws:sts::ACCOUNT:assumed-role/AWSReservedSSO_.../user@company.com
+        # OR:         arn:aws:sts::ACCOUNT:assumed-role/AWSReservedSSO_.../username (non-email IDC usernames)
         if not email:
             identity = event.get("requestContext", {}).get("identity", {})
             caller_arn = identity.get("caller", "") or identity.get("userArn", "")
             if "/" in caller_arn:
                 session_name = caller_arn.split("/")[-1]
                 if "@" in session_name:
+                    # Standard case: IDC username is an email address
                     email = session_name
-                    print(f"Identity resolved from IAM ARN: {email}")
+                    print(f"Identity resolved from IAM ARN (email): {email}")
+                elif session_name and "AWSReservedSSO" in caller_arn:
+                    # IDC username without @ (e.g. "akshaya.claude" instead of "user@company.com")
+                    # Use the raw username as the identity — policies can be set by username
+                    email = session_name
+                    print(f"Identity resolved from IAM ARN (IDC username): {email}")
 
         if not email:
             # Neither JWT nor IAM identity resolved

--- a/source/tests/test_quota_check_lambda.py
+++ b/source/tests/test_quota_check_lambda.py
@@ -515,3 +515,67 @@ class TestInputValidationContract:
 
         body = _parse(mod.lambda_handler(event, None))
         assert body["allowed"] is False
+
+
+class TestIdcUsernameIdentity:
+    """Tests for IAM Identity Center username-based identity resolution (#592 feedback)."""
+
+    @pytest.fixture
+    def base_env(self):
+        return {
+            "AWS_DEFAULT_REGION": "us-east-1",
+            "QUOTA_TABLE_NAME": "test-table",
+            "ENABLE_FINEGRAINED_QUOTAS": "false",
+            "MONTHLY_TOKEN_LIMIT": "1000000",
+            "DAILY_TOKEN_LIMIT": "100000",
+            "MONTHLY_ENFORCEMENT_MODE": "warn",
+            "DAILY_ENFORCEMENT_MODE": "warn",
+            "MISSING_EMAIL_ENFORCEMENT": "allow",
+        }
+
+    def test_email_session_name_resolves(self, base_env):
+        """Standard case: IDC username is an email address."""
+        mod = _load_quota_check(base_env)
+        event = {
+            "requestContext": {
+                "authorizer": {"jwt": {"claims": {}}},
+                "identity": {
+                    "caller": "arn:aws:sts::123456789012:assumed-role/AWSReservedSSO_BedrockDeveloper_abc123/user@company.com"
+                }
+            }
+        }
+        body = _parse(mod.lambda_handler(event, None))
+        # Should resolve identity and not return missing_identity
+        assert body.get("reason") != "missing_identity"
+
+    def test_non_email_idc_username_resolves(self, base_env):
+        """IDC username without @ (e.g. 'akshaya.claude') should still resolve."""
+        mod = _load_quota_check(base_env)
+        event = {
+            "requestContext": {
+                "authorizer": {"jwt": {"claims": {}}},
+                "identity": {
+                    "caller": "arn:aws:sts::123456789012:assumed-role/AWSReservedSSO_BedrockDeveloper_abc123/akshaya.claude"
+                }
+            }
+        }
+        body = _parse(mod.lambda_handler(event, None))
+        # Should resolve identity (not missing_identity)
+        assert body.get("reason") != "missing_identity"
+
+    def test_non_sso_role_without_email_does_not_resolve(self, base_env):
+        """Non-SSO role without @ should NOT be treated as identity."""
+        env = {**base_env, "MISSING_EMAIL_ENFORCEMENT": "block"}
+        mod = _load_quota_check(env)
+        event = {
+            "requestContext": {
+                "authorizer": {"jwt": {"claims": {}}},
+                "identity": {
+                    "caller": "arn:aws:sts::123456789012:assumed-role/CustomRole/session123"
+                }
+            }
+        }
+        body = _parse(mod.lambda_handler(event, None))
+        # Non-SSO role without email should be blocked
+        assert body.get("reason") == "missing_identity"
+        assert body["allowed"] is False


### PR DESCRIPTION
## Why

The quota Lambda requires the IAM session name to contain `@` to extract user identity. For IDC users whose username isn't an email (e.g. `akshaya.claude` instead of `user@company.com`), the Lambda returns `missing_identity` and quota enforcement fails silently.

**ARN example:** `arn:aws:sts::ACCOUNT:assumed-role/AWSReservedSSO_BedrockDeveloper_.../akshaya.claude`

The current code:
```python
session_name = arn.split("/")[-1]
if "@" in session_name: return session_name  # ← fails for non-email usernames
```

## Fix

When the session name doesn't contain `@` but the caller ARN includes `AWSReservedSSO` (confirming it's an IDC-assumed role), use the raw username as the identity:

```python
if "@" in session_name:
    email = session_name  # Standard: email-as-username
elif session_name and "AWSReservedSSO" in caller_arn:
    email = session_name  # Fallback: non-email IDC username
```

**Why the `AWSReservedSSO` guard?** Prevents non-SSO roles (Lambda execution roles, service roles, custom roles) from accidentally being treated as user identities. Only IDC permission sets create roles with `AWSReservedSSO` in the name.

## Quota policy implications

Admins can now set policies using the IDC username directly:
```bash
ccwb quota set akshaya.claude --limit-monthly 5000000
```

## Backward Compatible

✅ Email-based IDC usernames: identical behavior (`@` check succeeds first)
✅ Non-email IDC usernames: now resolve instead of silently failing
✅ Non-SSO roles: still correctly return `missing_identity`
✅ OIDC (JWT) path: unaffected (Path 1 resolves before Path 2)

## Risk: Very Low

- Single `elif` branch added to existing identity resolution
- Guarded by `AWSReservedSSO` check (can't false-positive on non-IDC roles)
- Existing tests unaffected (they use JWT path or email-format session names)

## Test Coverage (3 new tests)

- Email session name resolves (existing behavior preserved)
- Non-email IDC username resolves (`akshaya.claude` → identity found)
- Non-SSO role without email does NOT resolve (security guard works)

## Verification

```bash
cd source && poetry run pytest tests/test_quota_check_lambda.py::TestIdcUsernameIdentity -v
```