### PR TITLE
fix(quota): add execute-api:Invoke managed policy for IAM-auth callers

### DIFF
--- a/deployment/infrastructure/quota-monitoring.yaml
+++ b/deployment/infrastructure/quota-monitoring.yaml
@@ -450,7 +450,6 @@ Resources:
   QuotaCheckAuthorizer:
     Condition: HasJwtAuth
     Type: AWS::ApiGatewayV2::Authorizer
-    Condition: HasJwtAuth
     Properties:
       ApiId: !Ref QuotaCheckApi
       AuthorizerType: JWT
@@ -512,6 +511,25 @@ Resources:
   # End Quota Check API
   # ============================================
 
+  # IAM Managed Policy granting execute-api:Invoke on the quota API.
+  # Required for IAM-auth callers (IDC permission sets, federated roles).
+  # The credential-process signs requests with SigV4, and API Gateway
+  # requires the caller to have this permission in their identity policy.
+  # Admins should attach this policy to their IDC permission set or IAM role.
+  QuotaApiInvokePolicy:
+    Condition: NoJwtAuth
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: !Sub '${AWS::StackName}-QuotaApiInvoke'
+      Description: 'Allows invoke on the quota check API Gateway (required for IAM-auth callers)'
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: AllowQuotaApiInvoke
+            Effect: Allow
+            Action: 'execute-api:Invoke'
+            Resource: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${QuotaCheckApi}/*'
+
 Outputs:
   QuotaTableName:
     Description: Name of the UserQuotaMetrics DynamoDB table
@@ -567,3 +585,12 @@ Outputs:
     Value: !GetAtt SidecarMonitorFunction.Arn
     Export:
       Name: !Sub '${AWS::StackName}-SidecarMonitorFunctionArn'
+
+  QuotaApiInvokePolicyArn:
+    Condition: NoJwtAuth
+    Description: >-
+      IAM Managed Policy ARN granting execute-api:Invoke on the quota API.
+      Attach this to your IDC permission set or IAM role used by Claude Code users.
+    Value: !Ref QuotaApiInvokePolicy
+    Export:
+      Name: !Sub '${AWS::StackName}-QuotaApiInvokePolicyArn'

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -933,6 +933,19 @@ class DeployCommand(Command):
                     if result == 0:
                         self._create_default_quota_policy(profile, stack_name, console)
 
+                        # If using IAM auth (IDC/non-OIDC), remind about execute-api:Invoke permission
+                        if profile.effective_auth_type == "idc":
+                            quota_outputs = get_stack_outputs(stack_name, profile.aws_region)
+                            policy_arn = (quota_outputs or {}).get("QuotaApiInvokePolicyArn", "")
+                            if policy_arn:
+                                console.print(
+                                    f"\n[yellow]\u26a0 IAM Auth Mode: Attach this policy to your IDC permission set "
+                                    f"(or the IAM role used by Claude Code users):[/yellow]\n"
+                                    f"[bold]{policy_arn}[/bold]\n"
+                                    f"[dim]This grants execute-api:Invoke on the quota API. "
+                                    f"Without it, quota checks will return 403.[/dim]"
+                                )
+
                     return result
 
                 finally:

--- a/source/tests/e2e/test_quota_api_invoke_policy.py
+++ b/source/tests/e2e/test_quota_api_invoke_policy.py
@@ -1,0 +1,67 @@
+# ABOUTME: Tests that quota-monitoring.yaml includes execute-api:Invoke policy for IAM auth
+# ABOUTME: Regression test for 403 error when IDC users call the quota API
+
+"""Tests for quota API invoke policy in CloudFormation template."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+TEMPLATE_PATH = Path(__file__).parent.parent.parent.parent / "deployment" / "infrastructure" / "quota-monitoring.yaml"
+
+
+class TestQuotaApiInvokePolicy:
+    """Verify quota-monitoring.yaml includes IAM policy for API Gateway access."""
+
+    @pytest.fixture(autouse=True)
+    def load_template(self):
+        # Add CloudFormation intrinsic function constructors
+        loader = yaml.SafeLoader
+        loader.add_multi_constructor(
+            "!",
+            lambda loader, suffix, node: (
+                loader.construct_scalar(node) if node.id == "scalar" else loader.construct_sequence(node)
+            ),
+        )
+        with open(TEMPLATE_PATH) as f:
+            self.template = yaml.load(f, Loader=loader)
+        self.resources = self.template.get("Resources", {})
+        self.outputs = self.template.get("Outputs", {})
+
+    def test_invoke_policy_resource_exists(self):
+        """Template must include a QuotaApiInvokePolicy managed policy."""
+        assert "QuotaApiInvokePolicy" in self.resources
+        policy = self.resources["QuotaApiInvokePolicy"]
+        assert policy["Type"] == "AWS::IAM::ManagedPolicy"
+
+    def test_invoke_policy_grants_execute_api(self):
+        """Policy must grant execute-api:Invoke action."""
+        policy = self.resources["QuotaApiInvokePolicy"]
+        doc = policy["Properties"]["PolicyDocument"]
+        actions = []
+        for stmt in doc["Statement"]:
+            action = stmt.get("Action", "")
+            if isinstance(action, list):
+                actions.extend(action)
+            else:
+                actions.append(action)
+        assert "execute-api:Invoke" in actions
+
+    def test_invoke_policy_is_conditional_on_iam_auth(self):
+        """Policy should only be created when using IAM auth (NoJwtAuth condition)."""
+        policy = self.resources["QuotaApiInvokePolicy"]
+        assert policy.get("Condition") == "NoJwtAuth"
+
+    def test_invoke_policy_arn_output_exists(self):
+        """Template must output the policy ARN for admins to attach."""
+        assert "QuotaApiInvokePolicyArn" in self.outputs
+
+    def test_invoke_policy_scoped_to_quota_api(self):
+        """Policy resource must be scoped to the quota API (not wildcard)."""
+        policy = self.resources["QuotaApiInvokePolicy"]
+        doc = policy["Properties"]["PolicyDocument"]
+        for stmt in doc["Statement"]:
+            resource = stmt.get("Resource", "")
+            # Should reference the specific API, not arn:aws:execute-api:*:*:*
+            assert "QuotaCheckApi" in str(resource) or "${" in str(resource)

--- a/source/tests/test_cloudformation.py
+++ b/source/tests/test_cloudformation.py
@@ -32,8 +32,10 @@ def getatt_constructor(loader, node):
 
 
 def sub_constructor(loader, node):
-    """Handle !Sub function."""
-    return {"Fn::Sub": loader.construct_scalar(node)}
+    """Handle !Sub function (scalar or sequence form)."""
+    if node.id == "scalar":
+        return {"Fn::Sub": loader.construct_scalar(node)}
+    return {"Fn::Sub": loader.construct_sequence(node)}
 
 
 def if_constructor(loader, node):


### PR DESCRIPTION
## Why

When the quota API uses `AWS_IAM` authorization (IDC/non-OIDC mode), API Gateway requires callers to have `execute-api:Invoke` permission in their identity policy. IDC permission sets (e.g. `BedrockDeveloper`) typically don't include this, causing a **403 error** on quota check requests.

Users currently have to manually add:
```json
{
  "Effect": "Allow",
  "Action": "execute-api:Invoke",
  "Resource": "arn:aws:execute-api:<region>:<account>:<api-id>/*"
}
```

This should be handled by the deployment tooling.

## Step-by-Step Flow (before this fix)

```
1. Admin runs: ccwb deploy --stack quota
2. CFN creates HTTP API with AuthorizationType: AWS_IAM
3. User runs: credential-process --profile ClaudeCode
4. credential-process signs GET /check with SigV4 using IDC credentials
5. API Gateway checks: does caller have execute-api:Invoke? → NO (not in permission set)
6. API Gateway returns 403 ❌
7. Quota enforcement silently fails
```

## Step-by-Step Flow (after this fix)

```
1. Admin runs: ccwb deploy --stack quota
2. CFN creates:
   - HTTP API with AuthorizationType: AWS_IAM (same as before)
   - QuotaApiInvokePolicy (NEW): managed policy granting execute-api:Invoke on THIS API only
3. deploy.py prints: "⚠ Attach this policy ARN to your IDC permission set: arn:aws:iam::...:policy/..."
4. Admin attaches the policy to their IDC permission set (one-time)
5. User runs: credential-process --profile ClaudeCode
6. credential-process signs GET /check with SigV4
7. API Gateway checks: does caller have execute-api:Invoke? → YES (from attached policy) ✅
8. Quota enforcement works
```

## Why not a resource policy?

**HTTP APIs (ApiGatewayV2) do NOT support resource policies** — only REST APIs (ApiGateway) do. For HTTP APIs with `AWS_IAM` auth, the caller's identity-based policy MUST include `execute-api:Invoke`. There is no server-side override.

## What Changed

| File | Change |
|------|--------|
| `deployment/infrastructure/quota-monitoring.yaml` | Add `QuotaApiInvokePolicy` (managed policy, conditional on `NoJwtAuth`) + output its ARN |
| `source/claude_code_with_bedrock/cli/commands/deploy.py` | Print policy ARN with attachment instructions after successful quota deploy (IAM-auth mode only) |
| `source/tests/e2e/test_quota_api_invoke_policy.py` | **New** — 5 tests |

## Backward Compatible

✅ **OIDC mode:** Policy has `Condition: NoJwtAuth` → never created (JWT path doesn't need it)
✅ **Existing IAM-auth deploys:** Policy is created on next `ccwb deploy --stack quota`. Admin attaches it once. Users stop getting 403.
✅ **Already-working deployments** (where admin manually added the permission): No behavioral change — having the permission in both places is harmless
✅ **Policy is scoped** to the specific API (not `arn:aws:execute-api:*:*:*`)

## Risk: Very Low

- Purely additive: creates a managed policy resource + output
- Conditional: only in IAM-auth mode (OIDC unaffected)
- Non-breaking: existing deployments get the policy on next update but don't require it
- The admin still has to manually attach it (no automatic IAM changes to permission sets)

## Test Coverage (5 tests)

- Policy resource exists in template
- Policy grants `execute-api:Invoke` action
- Policy is conditional on NoJwtAuth
- Policy ARN is output
- Policy is scoped to the quota API (not wildcard)

## Verification

```bash
cd source && poetry run pytest tests/e2e/test_quota_api_invoke_policy.py -v
cfn-lint deployment/infrastructure/quota-monitoring.yaml
```