### PR TITLE
fix(cognito): derive issuer region from User Pool ID, not deployment region

### DIFF
--- a/deployment/infrastructure/bedrock-auth-cognito-pool.yaml
+++ b/deployment/infrastructure/bedrock-auth-cognito-pool.yaml
@@ -72,7 +72,11 @@ Resources:
     Type: AWS::IAM::OIDCProvider
     Condition: UseDirectIAM
     Properties:
-      Url: !Sub 'https://cognito-idp.${AWS::Region}.amazonaws.com/${CognitoUserPoolId}'
+      # Region is derived from the User Pool ID (format: <region>_<id>), not AWS::Region,
+      # so the pool may live in a different region than this stack. See issue #596.
+      Url: !Sub
+        - 'https://cognito-idp.${PoolRegion}.amazonaws.com/${CognitoUserPoolId}'
+        - PoolRegion: !Select [0, !Split ['_', !Ref CognitoUserPoolId]]
       ClientIdList:
         - !Ref CognitoUserPoolClientId
       ThumbprintList:
@@ -192,7 +196,10 @@ Resources:
       AllowClassicFlow: false
       CognitoIdentityProviders:
         - ClientId: !Ref CognitoUserPoolClientId
-          ProviderName: !Sub 'cognito-idp.${AWS::Region}.amazonaws.com/${CognitoUserPoolId}'
+          # Region derived from the User Pool ID, not AWS::Region (see issue #596).
+          ProviderName: !Sub
+            - 'cognito-idp.${PoolRegion}.amazonaws.com/${CognitoUserPoolId}'
+            - PoolRegion: !Select [0, !Split ['_', !Ref CognitoUserPoolId]]
           ServerSideTokenCheck: true
 
   CognitoAuthenticatedRole:
@@ -306,7 +313,10 @@ Resources:
     DeletionPolicy: Delete
     Properties:
       IdentityPoolId: !Ref CognitoIdentityPool
-      IdentityProviderName: !Sub 'cognito-idp.${AWS::Region}.amazonaws.com/${CognitoUserPoolId}'
+      # Region derived from the User Pool ID, not AWS::Region (see issue #596).
+      IdentityProviderName: !Sub
+        - 'cognito-idp.${PoolRegion}.amazonaws.com/${CognitoUserPoolId}'
+        - PoolRegion: !Select [0, !Split ['_', !Ref CognitoUserPoolId]]
       UseDefaults: false
       PrincipalTags:
         UserEmail: email

--- a/deployment/infrastructure/cognito-identity-pool.yaml
+++ b/deployment/infrastructure/cognito-identity-pool.yaml
@@ -106,7 +106,10 @@ Resources:
       CognitoIdentityProviders: !If
         - UseCognitoUserPool
         - - ClientId: !Ref CognitoUserPoolClientId
-            ProviderName: !Sub 'cognito-idp.${AWS::Region}.amazonaws.com/${CognitoUserPoolId}'
+            # Region derived from the User Pool ID, not AWS::Region (see issue #596).
+            ProviderName: !Sub
+              - 'cognito-idp.${PoolRegion}.amazonaws.com/${CognitoUserPoolId}'
+              - PoolRegion: !Select [0, !Split ['_', !Ref CognitoUserPoolId]]
             ServerSideTokenCheck: true
         - !Ref 'AWS::NoValue'
 
@@ -280,7 +283,10 @@ Resources:
       IdentityProviderName: !If
         - UseExternalOIDC
         - !Ref OIDCProviderDomain
-        - !Sub 'cognito-idp.${AWS::Region}.amazonaws.com/${CognitoUserPoolId}'
+        # Region derived from the User Pool ID, not AWS::Region (see issue #596).
+        - !Sub
+          - 'cognito-idp.${PoolRegion}.amazonaws.com/${CognitoUserPoolId}'
+          - PoolRegion: !Select [0, !Split ['_', !Ref CognitoUserPoolId]]
       UseDefaults: false
       PrincipalTags:
         UserEmail: email

--- a/source/tests/test_cognito_cross_region.py
+++ b/source/tests/test_cognito_cross_region.py
@@ -1,0 +1,64 @@
+# ABOUTME: Static analysis tests ensuring Cognito issuer/provider URLs derive their region from
+# ABOUTME: the User Pool ID, not the deployment region (AWS::Region). Prevents regression of issue #596.
+
+"""Cognito cross-region deployment tests.
+
+Bug this prevents:
+- #596: When the Cognito User Pool lives in a different region than the stack
+  (e.g. pool in eu-west-1, infra in eu-west-3), the OIDC provider / identity-pool
+  provider name was built from ${AWS::Region}, pointing at the wrong region and
+  failing deployment. The pool's region is encoded in its ID (<region>_<id>), so
+  the templates must derive it from CognitoUserPoolId via !Split, mirroring the
+  Python logic in deploy.py (pool_id.split("_")[0]).
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+INFRA_DIR = Path(__file__).parent.parent.parent / "deployment" / "infrastructure"
+
+# Templates that build a cognito-idp issuer/provider URL from CognitoUserPoolId.
+COGNITO_TEMPLATES = [
+    "bedrock-auth-cognito-pool.yaml",
+    "cognito-identity-pool.yaml",
+]
+
+# The bug: a cognito-idp host built from the deployment region instead of the pool's region.
+_BAD_PATTERN = re.compile(r"cognito-idp\.\$\{AWS::Region\}\.amazonaws\.com/\$\{CognitoUserPoolId\}")
+
+# The fix: the host's region is a ${PoolRegion} substitution derived from the pool ID.
+_GOOD_PATTERN = re.compile(r"cognito-idp\.\$\{PoolRegion\}\.amazonaws\.com/\$\{CognitoUserPoolId\}")
+
+
+def _read(template: str) -> str:
+    path = INFRA_DIR / template
+    if not path.exists():
+        pytest.skip(f"{path} not found")
+    return path.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("template", COGNITO_TEMPLATES)
+def test_no_cognito_issuer_uses_deployment_region(template):
+    """No cognito-idp issuer/provider URL may be built from ${AWS::Region} (issue #596)."""
+    content = _read(template)
+    bad = _BAD_PATTERN.findall(content)
+    assert not bad, (
+        f"{template} builds a Cognito issuer URL from ${{AWS::Region}} ({len(bad)} site(s)). "
+        "Derive the region from the User Pool ID instead (see issue #596)."
+    )
+
+
+@pytest.mark.parametrize("template", COGNITO_TEMPLATES)
+def test_cognito_issuer_derives_region_from_pool_id(template):
+    """Every cognito-idp issuer URL must derive its region from the pool ID via ${PoolRegion}."""
+    content = _read(template)
+    assert _GOOD_PATTERN.search(content), (
+        f"{template} should build the Cognito issuer URL with a ${{PoolRegion}} substitution "
+        "derived from CognitoUserPoolId (!Select [0, !Split ['_', !Ref CognitoUserPoolId]])."
+    )
+    # The PoolRegion mapping must actually split the pool ID on '_'.
+    assert "!Split ['_', !Ref CognitoUserPoolId]" in content, (
+        f"{template} must derive PoolRegion from !Split ['_', !Ref CognitoUserPoolId]."
+    )


### PR DESCRIPTION
## Why

When the Cognito User Pool lives in a **different region** than the stack (e.g. pool in `eu-west-1`, infra in `eu-west-3`), the Cognito OIDC issuer / Identity-Pool provider names are built from `${AWS::Region}` — the *deployment* region — so they point at the wrong region.

Fixes #596.

This is subtler than a deploy failure. The direct-IAM path **deploys successfully** because `AWS::IAM::OIDCProvider` does not validate that the pool exists — it just creates a provider with the wrong-region URL. The breakage shows up at **runtime**: the issuer's discovery endpoint 404s, so federation / JWT validation fails. The Identity-Pool `ProviderName` path *does* validate against Cognito and fails louder at deploy (the symptom the reporter hit). This fix covers both.

## What

Derive the pool's region from its ID (`<region>_<id>`) via `!Select [0, !Split ['_', !Ref CognitoUserPoolId]]`, mirroring the logic already shipping in `deploy.py` (`pool_id.split("_")[0]`). No new parameter, no Python change.

Applied at all 5 issuer/provider-name sites:
- `bedrock-auth-cognito-pool.yaml` — OIDCProvider `Url`, IdentityPool `ProviderName`, `IdentityPoolPrincipalTag`
- `cognito-identity-pool.yaml` — IdentityProviders `ProviderName`, `IdentityPoolPrincipalTag`

The deployment-region `aws_region` in the config-JSON outputs and the GovCloud conditions are intentionally left unchanged (those correctly reference where Bedrock/STS run, not the pool).

> The issue suggested an optional `CognitoRegion` parameter with an `AWS::Region` fallback. Deriving from the pool ID was preferred: the ID already encodes its region, so it's a single source of truth with no fallback ambiguity and nothing new to thread through the wizard/config. Happy to switch approaches if maintainers prefer the explicit parameter.

## How

`!Select [0, !Split ['_', !Ref CognitoUserPoolId]]` — a pure intrinsic, evaluated at deploy time, no custom resource. The same `!Select [..., !Split [...]]` idiom is already used in `bedrock-auth-generic.yaml`. Works across partitions (GovCloud IDs split correctly). Same-region deployments are unaffected (split yields the same region).

## Testing Evidence

**Regression test** (`source/tests/test_cognito_cross_region.py`, 4 cases) — asserts no issuer URL uses `${AWS::Region}` and each derives region from the pool ID. Falsified against `beta`:

```
$ poetry run pytest tests/test_cognito_cross_region.py -q   # on the fix
4 passed in 0.02s

# against origin/beta's templates (falsification):
4 failed   # both "no AWS::Region" and "derives from pool ID" assertions fail
```

**Live cross-region deploy** (pool in `eu-west-1`, stack to `eu-west-3`, `FederationType=direct`):

| Template | OIDC provider `Url` created | discovery endpoint |
|----------|-----------------------------|--------------------|
| beta (unfixed) | `cognito-idp.`**`eu-west-3`**`...` | **404 — broken** |
| this fix | `cognito-idp.`**`eu-west-1`**`...` | **200 — valid issuer** |

Test resources torn down afterward.

**CI gates verified locally:** `poetry run pytest tests/` (new test green, no regressions), `ruff check`/`ruff format` clean, `cfn-lint` clean on both templates (no E-level findings; warning count unchanged vs beta), `detect-secrets` 0, `bandit` only the expected `B101` assert-in-test (matches existing test baseline). Also exercised via `ccwb test`-equivalent CFN deploy above.

Credit: reported by @emmaanuel.