### PR TITLE
fix(otel): validate monitoring token expiry in Go otel-helper (env-var path)

### DIFF
--- a/source/go/cmd/otel-helper/main.go
+++ b/source/go/cmd/otel-helper/main.go
@@ -104,7 +104,9 @@ func run(testMode bool) int {
 			debugPrint("Using cached OTEL headers (token still valid)")
 			// Resolve Bearer fresh — the cache stores attribution headers only,
 			// never the token itself. Try env var (free) then credential-process (~20ms).
-			if t := os.Getenv("CLAUDE_CODE_MONITORING_TOKEN"); t != "" {
+			// An expired env-var token is skipped so we fall through to
+			// credential-process refresh instead of attaching a stale Bearer.
+			if t := os.Getenv("CLAUDE_CODE_MONITORING_TOKEN"); t != "" && !jwt.IsTokenExpired(t) {
 				attachBearer(headers, t)
 			} else if t, err := getTokenViaCredentialProcess(profile); err == nil && t != "" {
 				attachBearer(headers, t)
@@ -120,8 +122,14 @@ func run(testMode bool) int {
 		}
 	}
 
-	// Layer 2: Check environment variable
+	// Layer 2: Check environment variable. An expired env-var token is treated
+	// as absent so we fall through to credential-process (which handles refresh)
+	// instead of attaching a stale token that would yield a silent 401.
 	token := os.Getenv("CLAUDE_CODE_MONITORING_TOKEN")
+	if token != "" && jwt.IsTokenExpired(token) {
+		debugPrint("Environment token CLAUDE_CODE_MONITORING_TOKEN is expired, falling through to credential-process")
+		token = ""
+	}
 	if token != "" {
 		debugPrint("Using token from environment variable CLAUDE_CODE_MONITORING_TOKEN")
 	} else {

--- a/source/go/internal/jwt/decode.go
+++ b/source/go/internal/jwt/decode.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 )
 
 // Claims is a map of JWT payload claims.
@@ -64,4 +65,26 @@ func DecodePayload(token string) (Claims, error) {
 	}
 
 	return claims, nil
+}
+
+// expiryBufferSeconds is the freshness margin applied when checking a token's
+// exp claim. It mirrors the Python otel-helper's is_token_expired buffer so the
+// Go and Python variants treat the same token identically (parity).
+const expiryBufferSeconds = 60
+
+// IsTokenExpired reports whether a JWT's exp claim has passed (within a 60s
+// buffer). It is fail-safe: a token that is unparseable or has no exp claim is
+// treated as expired, so callers fall through to re-authentication rather than
+// attaching a stale or malformed token. The signature is NOT verified — exp is
+// read for freshness/display only, never for trust decisions.
+func IsTokenExpired(token string) bool {
+	claims, err := DecodePayload(token)
+	if err != nil {
+		return true // unparseable = treat as expired
+	}
+	exp, ok := claims["exp"].(float64)
+	if !ok {
+		return true // missing/non-numeric exp = treat as expired
+	}
+	return time.Now().Unix() > int64(exp)-expiryBufferSeconds
 }

--- a/source/go/internal/jwt/decode_test.go
+++ b/source/go/internal/jwt/decode_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"testing"
+	"time"
 )
 
 func makeTestJWT(claims map[string]interface{}) string {
@@ -95,5 +96,58 @@ func TestGetFloat_WrongType(t *testing.T) {
 	claims := Claims{"str": "hello"}
 	if claims.GetFloat("str") != 0 {
 		t.Error("expected 0 for non-float value")
+	}
+}
+
+// IsTokenExpired mirrors the Python otel-helper's is_token_expired (60s buffer,
+// fail-safe). These cases match the Python regression suite for #561 so the Go
+// and Python variants treat the same token identically.
+
+func TestIsTokenExpired_Valid(t *testing.T) {
+	token := makeTestJWT(map[string]interface{}{
+		"exp": float64(time.Now().Unix() + 3600),
+	})
+	if IsTokenExpired(token) {
+		t.Error("token expiring in 1h should not be expired")
+	}
+}
+
+func TestIsTokenExpired_Expired(t *testing.T) {
+	token := makeTestJWT(map[string]interface{}{
+		"exp": float64(time.Now().Unix() - 3600),
+	})
+	if !IsTokenExpired(token) {
+		t.Error("token that expired 1h ago should be expired")
+	}
+}
+
+func TestIsTokenExpired_WithinBuffer(t *testing.T) {
+	// Expires in 30s — inside the 60s buffer, so treated as expired.
+	token := makeTestJWT(map[string]interface{}{
+		"exp": float64(time.Now().Unix() + 30),
+	})
+	if !IsTokenExpired(token) {
+		t.Error("token expiring within the 60s buffer should be treated as expired")
+	}
+}
+
+func TestIsTokenExpired_NoExpClaim(t *testing.T) {
+	token := makeTestJWT(map[string]interface{}{
+		"sub": "user123",
+	})
+	if !IsTokenExpired(token) {
+		t.Error("token without exp claim should be treated as expired (fail-safe)")
+	}
+}
+
+func TestIsTokenExpired_Malformed(t *testing.T) {
+	if !IsTokenExpired("not-a-jwt") {
+		t.Error("unparseable token should be treated as expired (fail-safe)")
+	}
+}
+
+func TestIsTokenExpired_Empty(t *testing.T) {
+	if !IsTokenExpired("") {
+		t.Error("empty token should be treated as expired (fail-safe)")
 	}
 }

--- a/source/go/internal/storage/monitoring.go
+++ b/source/go/internal/storage/monitoring.go
@@ -5,13 +5,20 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"ccwb-go/internal/jwt"
 )
 
 // GetMonitoringToken retrieves a valid monitoring token from the configured storage.
 func GetMonitoringToken(profile, storageType string) (string, error) {
-	// Check environment first
+	// Check environment first. Drop an expired env-var token (mirrors the
+	// file/keyring expiry check below and the Python otel-helper) so callers
+	// fall through to credential-process refresh instead of attaching a stale
+	// token that the collector/ALB would reject with a silent 401.
 	if token := os.Getenv("CLAUDE_CODE_MONITORING_TOKEN"); token != "" {
-		return token, nil
+		if !jwt.IsTokenExpired(token) {
+			return token, nil
+		}
 	}
 
 	var data *MonitoringTokenData

--- a/source/go/internal/storage/monitoring_test.go
+++ b/source/go/internal/storage/monitoring_test.go
@@ -1,0 +1,52 @@
+package storage
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func makeMonitoringJWT(claims map[string]interface{}) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	payload, _ := json.Marshal(claims)
+	payloadB64 := base64.RawURLEncoding.EncodeToString(payload)
+	return header + "." + payloadB64 + ".signature"
+}
+
+// TestGetMonitoringToken_EnvExpired is the regression guard for #561: an
+// expired token in CLAUDE_CODE_MONITORING_TOKEN must NOT be returned. On the
+// unfixed code the env branch returned the token on truthiness alone, so this
+// fails there and passes once the expiry check is applied.
+func TestGetMonitoringToken_EnvExpired(t *testing.T) {
+	expired := makeMonitoringJWT(map[string]interface{}{
+		"exp": float64(time.Now().Unix() - 3600),
+	})
+	t.Setenv("CLAUDE_CODE_MONITORING_TOKEN", expired)
+
+	// "file" storage with no cache file on disk: a valid env token would be
+	// returned; an expired one must be dropped. After dropping it, the call
+	// falls through to a (missing) file read, so an error here is expected —
+	// the contract under test is that NO token is returned.
+	token, _ := GetMonitoringToken("nonexistent-profile-561", "file")
+	if token != "" {
+		t.Errorf("expected expired env token to be dropped, got non-empty token")
+	}
+}
+
+// TestGetMonitoringToken_EnvValid confirms the normal path is unchanged: a
+// fresh env token is still returned directly.
+func TestGetMonitoringToken_EnvValid(t *testing.T) {
+	valid := makeMonitoringJWT(map[string]interface{}{
+		"exp": float64(time.Now().Unix() + 3600),
+	})
+	t.Setenv("CLAUDE_CODE_MONITORING_TOKEN", valid)
+
+	token, err := GetMonitoringToken("nonexistent-profile-561", "file")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token != valid {
+		t.Errorf("expected valid env token to be returned unchanged")
+	}
+}


### PR DESCRIPTION
## Why

PR #581 fixed expired-`CLAUDE_CODE_MONITORING_TOKEN` handling in the **Python** otel-helper, but the **Go** otel-helper (the shipped default) still attaches an expired env-var token on truthiness alone. The result is a silent failure:

- **Central/proxy mode:** ALB rejects with 401 → telemetry dropped, no diagnostic.
- **Sidecar mode:** stale token used for attribution → user shows as anonymous.

`main` and `beta` carry the same `monitoring.go`, so both are affected. This closes a Go↔Python parity gap (`.claude/rules/credential-helper-parity.md`).

Fixes #561 (Go side; Python side fixed in #581).

## What

Add a fail-safe `jwt.IsTokenExpired` helper (60s buffer, matching the Python `is_token_expired`) and apply it at the three Go env-var read sites so an expired token falls through to credential-process refresh instead of being attached.

## How

- `internal/jwt/decode.go`: new `IsTokenExpired` beside `DecodePayload` — exp read only, signature not verified; unparseable / missing-exp tokens treated as expired (fail-safe).
- `internal/storage/monitoring.go`: env branch returns the token only if not expired (mirrors its own file/keyring guard).
- `cmd/otel-helper/main.go`: Layer-1 bearer resolution and Layer-2 env path skip an expired token. `attachBearer` stays exp-agnostic by design (its doc-comment forbids an exp check there — validation lives at the token source).

## Testing Evidence

**Unit + regression** (`source/go`):
```
$ go test ./...
ok  ccwb-go/internal/jwt
ok  ccwb-go/internal/storage
ok  ccwb-go/cmd/otel-helper
... (all packages green)
$ go test -race ./internal/jwt/ ./internal/storage/ ./cmd/otel-helper/   # clean
```
- 6 `IsTokenExpired_*` cases mirror the Python regression suite (valid / expired / within-60s-buffer / no-exp / malformed / empty).
- `TestGetMonitoringToken_EnvExpired` / `_EnvValid` guard the bug site.

**Falsification:** restored `beta`'s `monitoring.go` (kept the tests) → `TestGetMonitoringToken_EnvExpired` **FAILS** (`expected expired env token to be dropped, got non-empty token`); passes on the fix.

**Real-binary test:** built the actual `otel-helper` and ran real JWTs:
- Fixed + expired token → `Environment token … is expired, falling through to credential-process` → no stale Bearer attached.
- Fixed + valid token → `authorization: Bearer …` + full attribution headers (unchanged).
- Unfixed `beta` binary + expired token → wrongly attaches `authorization: Bearer <expired>` (the bug, reproduced live).

CI gates verified locally: `go build` / `go vet` / `go test` / `gofmt`. N/A for this Go-only change: pytest (no Python touched), cfn-lint/cfn_nag (no templates), validate-regions (no region data).

## Checklist

- [x] Regression test that fails on the unfixed code (falsified against `beta`)
- [x] Go↔Python parity verified (same 60s buffer + fail-safe semantics)
- [x] Tier-1 paths (otel-helper, storage) covered with tests
- [x] No unrelated changes