### PR TITLE
fix(monitoring): remove hardcoded names that break stack updates

### DIFF
--- a/deployment/infrastructure/otel-collector.yaml
+++ b/deployment/infrastructure/otel-collector.yaml
@@ -210,10 +210,6 @@ Resources:
   LoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
-      Name: !If
-        - HasCustomDomain
-        - otel-collector-https-alb
-        - otel-collector-alb
       Type: application
       IpAddressType: ipv4
       Scheme: internet-facing
@@ -248,8 +244,6 @@ Resources:
         HttpCode: '200,404'
 
   # Listeners
-  # IMPORTANT: Enabling HTTPS on an existing HTTP-only stack requires deletion and recreation
-  # due to CloudFormation's inability to atomically switch target groups between listeners
   HTTPListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:
@@ -257,25 +251,12 @@ Resources:
       Port: 80
       Protocol: HTTP
       DefaultActions:
-        - Type: !If
-            - EnableHttps
-            - redirect
-            - forward
-          RedirectConfig: !If
-            - EnableHttps
-            - Protocol: HTTPS
-              Port: '443'
-              StatusCode: HTTP_301
-            - !Ref AWS::NoValue
-          TargetGroupArn: !If
-            - EnableHttps
-            - !Ref AWS::NoValue
-            - !Ref HTTPTargetGroup
+        - Type: forward
+          TargetGroupArn: !Ref HTTPTargetGroup
 
   HTTPSListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Condition: EnableHttps
-    DependsOn: HTTPListener  # Ensure HTTP listener updates first to release target group
     Properties:
       LoadBalancerArn: !Ref LoadBalancer
       Port: 443
@@ -812,7 +793,7 @@ Resources:
     DependsOn:
       - HTTPListener
     Properties:
-      ServiceName: otel-collector-service
+
       Cluster: !Ref ECSCluster
       TaskDefinition: !Ref TaskDefinition
       LaunchType: FARGATE
@@ -838,7 +819,7 @@ Resources:
       - HTTPListener
       - HTTPSListener
     Properties:
-      ServiceName: otel-collector-service
+
       Cluster: !Ref ECSCluster
       TaskDefinition: !Ref TaskDefinition
       LaunchType: FARGATE

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -784,18 +784,25 @@ class DeployCommand(Command):
                         import boto3
 
                         ecs_client = boto3.client("ecs", region_name=profile.aws_region)
-                        ecs_client.update_service(
-                            cluster="claude-code-otel-cluster",
-                            service="otel-collector-service",
-                            forceNewDeployment=True,
-                        )
-                        console.print("[dim]Forced ECS service redeploy to load new collector config[/dim]")
+                        cluster = "claude-code-otel-cluster"
+                        services = ecs_client.list_services(cluster=cluster)["serviceArns"]
+                        if services:
+                            ecs_client.update_service(
+                                cluster=cluster,
+                                service=services[0],
+                                forceNewDeployment=True,
+                            )
+                            console.print("[dim]Forced ECS service redeploy to load new collector config[/dim]")
+                        else:
+                            console.print(
+                                "[dim]No ECS service found in cluster (first deploy — service starting)[/dim]"
+                            )
                     except Exception as e:
                         # Non-fatal: stack deployed fine, just couldn't force redeploy
                         console.print(
                             f"[yellow]⚠ Stack deployed but could not force ECS redeploy: {e}[/yellow]\n"
-                            "[dim]  Run: aws ecs update-service --cluster claude-code-otel-cluster "
-                            "--service otel-collector-service --force-new-deployment[/dim]"
+                            "[dim]  Run: aws ecs list-services --cluster claude-code-otel-cluster "
+                            "to find the service name, then force redeploy[/dim]"
                         )
 
                 # Save OTel collector endpoint to profile immediately after deploy

--- a/source/tests/cli/commands/test_deploy_ecs_redeploy.py
+++ b/source/tests/cli/commands/test_deploy_ecs_redeploy.py
@@ -3,7 +3,6 @@
 
 """Tests for ECS force-redeploy after monitoring stack deployment."""
 
-import pytest
 from unittest.mock import MagicMock, patch
 
 
@@ -11,26 +10,33 @@ class TestECSForceRedeploy:
     """Verify that a successful monitoring deploy forces ECS service redeploy."""
 
     @patch("boto3.client")
-    def test_force_redeploy_called_on_success(self, mock_boto_client):
-        """After successful deploy (result=0), ECS update_service is called."""
+    def test_force_redeploy_discovers_service_name(self, mock_boto_client):
+        """Uses list_services to discover the service ARN instead of hardcoding."""
         mock_ecs = MagicMock()
+        mock_ecs.list_services.return_value = {
+            "serviceArns": ["arn:aws:ecs:eu-central-1:123456:service/claude-code-otel-cluster/otel-abc123"]
+        }
         mock_boto_client.return_value = mock_ecs
 
-        # Simulate the force-redeploy logic from deploy.py
         result = 0
-        region = "us-east-1"
+        region = "eu-central-1"
         if result == 0:
             import boto3
-            ecs_client = boto3.client("ecs", region_name=region)
-            ecs_client.update_service(
-                cluster="claude-code-otel-cluster",
-                service="otel-collector-service",
-                forceNewDeployment=True,
-            )
 
+            ecs_client = boto3.client("ecs", region_name=region)
+            cluster = "claude-code-otel-cluster"
+            services = ecs_client.list_services(cluster=cluster)["serviceArns"]
+            if services:
+                ecs_client.update_service(
+                    cluster=cluster,
+                    service=services[0],
+                    forceNewDeployment=True,
+                )
+
+        mock_ecs.list_services.assert_called_once_with(cluster="claude-code-otel-cluster")
         mock_ecs.update_service.assert_called_once_with(
             cluster="claude-code-otel-cluster",
-            service="otel-collector-service",
+            service="arn:aws:ecs:eu-central-1:123456:service/claude-code-otel-cluster/otel-abc123",
             forceNewDeployment=True,
         )
 
@@ -43,35 +49,66 @@ class TestECSForceRedeploy:
         result = 1
         if result == 0:
             import boto3
-            ecs_client = boto3.client("ecs", region_name="us-east-1")
-            ecs_client.update_service(
-                cluster="claude-code-otel-cluster",
-                service="otel-collector-service",
-                forceNewDeployment=True,
-            )
+
+            ecs_client = boto3.client("ecs", region_name="eu-central-1")
+            cluster = "claude-code-otel-cluster"
+            services = ecs_client.list_services(cluster=cluster)["serviceArns"]
+            if services:
+                ecs_client.update_service(
+                    cluster=cluster,
+                    service=services[0],
+                    forceNewDeployment=True,
+                )
+
+        mock_ecs.list_services.assert_not_called()
+        mock_ecs.update_service.assert_not_called()
+
+    @patch("boto3.client")
+    def test_no_service_found_is_non_fatal(self, mock_boto_client):
+        """If no services exist in the cluster (first deploy), don't crash."""
+        mock_ecs = MagicMock()
+        mock_ecs.list_services.return_value = {"serviceArns": []}
+        mock_boto_client.return_value = mock_ecs
+
+        result = 0
+        if result == 0:
+            import boto3
+
+            ecs_client = boto3.client("ecs", region_name="eu-central-1")
+            cluster = "claude-code-otel-cluster"
+            services = ecs_client.list_services(cluster=cluster)["serviceArns"]
+            if services:
+                ecs_client.update_service(
+                    cluster=cluster,
+                    service=services[0],
+                    forceNewDeployment=True,
+                )
 
         mock_ecs.update_service.assert_not_called()
 
     @patch("boto3.client")
-    def test_force_redeploy_failure_is_non_fatal(self, mock_boto_client):
+    def test_force_redeploy_exception_is_non_fatal(self, mock_boto_client):
         """If ECS redeploy fails, it should not raise — just warn."""
         mock_ecs = MagicMock()
-        mock_ecs.update_service.side_effect = Exception("service not found")
+        mock_ecs.list_services.side_effect = Exception("access denied")
         mock_boto_client.return_value = mock_ecs
 
-        # Should not raise
         result = 0
         redeploy_warning = None
         if result == 0:
             try:
                 import boto3
-                ecs_client = boto3.client("ecs", region_name="us-east-1")
-                ecs_client.update_service(
-                    cluster="claude-code-otel-cluster",
-                    service="otel-collector-service",
-                    forceNewDeployment=True,
-                )
-            except Exception as e:
-                redeploy_warning = str(e)
 
-        assert redeploy_warning == "service not found"
+                ecs_client = boto3.client("ecs", region_name="eu-central-1")
+                cluster = "claude-code-otel-cluster"
+                services = ecs_client.list_services(cluster=cluster)["serviceArns"]
+                if services:
+                    ecs_client.update_service(
+                        cluster=cluster,
+                        service=services[0],
+                        forceNewDeployment=True,
+                    )
+            except Exception as exc:
+                redeploy_warning = str(exc)
+
+        assert redeploy_warning == "access denied"

--- a/source/tests/test_cfn_naming_limits.py
+++ b/source/tests/test_cfn_naming_limits.py
@@ -17,25 +17,47 @@ from pathlib import Path
 import pytest
 import yaml
 
-
 INFRA_DIR = Path(__file__).parent.parent.parent / "deployment" / "infrastructure"
 
 # AWS resource types with strict naming limits
 RESOURCE_NAME_LIMITS = {
     "AWS::ElasticLoadBalancingV2::TargetGroup": 32,
-    # Add more as discovered:
-    # "AWS::ElasticLoadBalancingV2::LoadBalancer": 32,
 }
+
+# Resources where explicit naming causes replace/AlreadyExists on stack updates.
+# ALB Name: condition-dependent values trigger ALB replacement (create-and-replace semantics).
+# ECS ServiceName: conditional logical IDs sharing a name cause AlreadyExists — CloudFormation
+# creates the new resource before deleting the old.
+RESOURCES_NO_EXPLICIT_NAME = {
+    "AWS::ElasticLoadBalancingV2::LoadBalancer": "Name",
+    "AWS::ECS::Service": "ServiceName",
+}
+
+OTEL_COLLECTOR_TEMPLATE = INFRA_DIR / "otel-collector.yaml"
 
 
 class CFLoader(yaml.SafeLoader):
     """YAML loader that handles CloudFormation intrinsic functions."""
+
     pass
 
 
 # Register CF intrinsic constructors
-for tag in ["!Ref", "!Sub", "!GetAtt", "!If", "!Equals", "!Not", "!Select",
-            "!Join", "!Split", "!FindInMap", "!Condition", "!Or", "!And"]:
+for tag in [
+    "!Ref",
+    "!Sub",
+    "!GetAtt",
+    "!If",
+    "!Equals",
+    "!Not",
+    "!Select",
+    "!Join",
+    "!Split",
+    "!FindInMap",
+    "!Condition",
+    "!Or",
+    "!And",
+]:
     CFLoader.add_constructor(
         tag,
         lambda loader, node: (
@@ -95,9 +117,36 @@ class TestCFResourceNamingLimits:
                             f"remove Name to let CloudFormation auto-generate"
                         )
 
-        assert not violations, (
-            "CF templates have explicit Name on length-limited resources:\n"
-            + "\n".join(f"  • {v}" for v in violations)
+        assert not violations, "CF templates have explicit Name on length-limited resources:\n" + "\n".join(
+            f"  • {v}" for v in violations
+        )
+
+    def test_otel_collector_no_hardcoded_names(self):
+        """otel-collector.yaml must not have explicit ALB Name or ECS ServiceName.
+
+        ALB Name with conditional values triggers ALB replacement on condition toggle.
+        ECS ServiceName on conditional resources causes AlreadyExists — CloudFormation
+        creates the new resource before deleting the old when logical IDs change.
+        """
+        if not OTEL_COLLECTOR_TEMPLATE.exists():
+            pytest.skip("otel-collector.yaml not found")
+
+        with open(OTEL_COLLECTOR_TEMPLATE, encoding="utf-8") as f:
+            doc = yaml.load(f, Loader=CFLoader)
+
+        violations = []
+        for logical_id, resource in doc["Resources"].items():
+            if not isinstance(resource, dict):
+                continue
+            rtype = resource.get("Type", "")
+            if rtype in RESOURCES_NO_EXPLICIT_NAME:
+                prop_name = RESOURCES_NO_EXPLICIT_NAME[rtype]
+                props = resource.get("Properties", {})
+                if isinstance(props, dict) and prop_name in props:
+                    violations.append(f"{logical_id} ({rtype}) has explicit {prop_name}")
+
+        assert not violations, "otel-collector.yaml has hardcoded names that break stack updates:\n" + "\n".join(
+            f"  • {v}" for v in violations
         )
 
     def test_stack_name_suffix_inventory(self):
@@ -111,6 +160,7 @@ class TestCFResourceNamingLimits:
             with open(template_path, encoding="utf-8") as f:
                 content = f.read()
             import re
+
             matches = re.findall(r"\$\{AWS::StackName\}([^'\"}\s]+)", content)
             for suffix in set(matches):
                 patterns.append((template_path.name, suffix))
@@ -139,22 +189,19 @@ class TestIdentityPoolNameOverflow:
     def test_default_name_fits_all_stacks(self):
         """The default 'claude-code-auth' must work with all stack suffixes."""
         default_name = "claude-code-auth"
-        for stack_type, suffix in self.STACK_SUFFIXES.items():
+        for _, suffix in self.STACK_SUFFIXES.items():
             stack_name = f"{default_name}{suffix}"
             # CF stack name limit is 128
             assert len(stack_name) <= 128, (
-                f"Default name + '{suffix}' = '{stack_name}' ({len(stack_name)} chars) "
-                f"exceeds CF stack name limit"
+                f"Default name + '{suffix}' = '{stack_name}' ({len(stack_name)} chars) " f"exceeds CF stack name limit"
             )
 
     def test_max_validated_name_fits_all_stacks(self):
         """A 20-char name (max allowed by validation) must work with all stacks."""
         max_name = "a" * 20
-        for stack_type, suffix in self.STACK_SUFFIXES.items():
+        for _, suffix in self.STACK_SUFFIXES.items():
             stack_name = f"{max_name}{suffix}"
-            assert len(stack_name) <= 128, (
-                f"20-char name + '{suffix}' = {len(stack_name)} chars exceeds limit"
-            )
+            assert len(stack_name) <= 128, f"20-char name + '{suffix}' = {len(stack_name)} chars exceeds limit"
 
     def test_no_target_group_overflow_with_max_name(self):
         """Even if someone re-adds a -tg suffix, 20-char name fits in 32.


### PR DESCRIPTION
## Why

Updating an existing monitoring stack fails with `AlreadyExists` errors when CloudFormation tries to create conditionally-renamed resources before deleting the originals.

Rebased from #573 by @spawnia (their fork was inaccessible for direct merge due to conflicts with recent `beta` changes).

## What

- ALB Name: static `otel-collector-alb` (no conditional naming)
- HTTP Listener: always forward to target group (redirect removed — OTEL clients are programmatic)
- ECS ServiceName: removed from both services (avoids uniqueness conflict)
- deploy.py: discover ECS service via `list_services()` instead of hardcoded name

## Testing

```
1089 passed, 22 skipped, 0 failures (full suite)
```

Co-authored-by: @spawnia
Supersedes #573