### PR TITLE
feat(distribution): support generic OIDC (PingFederate, etc.) for landing page

### DIFF
--- a/deployment/infrastructure/landing-page-distribution.yaml
+++ b/deployment/infrastructure/landing-page-distribution.yaml
@@ -51,7 +51,7 @@ Parameters:
 
   IdPProvider:
     Type: String
-    AllowedValues: [okta, azure, auth0, cognito]
+    AllowedValues: [okta, azure, auth0, cognito, generic]
     Description: Identity provider type
 
   # Okta parameters
@@ -123,6 +123,39 @@ Parameters:
     Default: ''
     Description: Secrets Manager ARN for Cognito client secret
 
+  # Generic OIDC parameters (PingFederate, Keycloak, ForgeRock, etc.)
+  # ALB authenticate-oidc requires each endpoint explicitly because they cannot be
+  # derived from a single domain the way the other providers' endpoints can.
+  GenericIssuer:
+    Type: String
+    Default: ''
+    Description: Generic OIDC issuer URL (e.g., https://auth.example.com)
+
+  GenericAuthorizationEndpoint:
+    Type: String
+    Default: ''
+    Description: Generic OIDC authorization endpoint (full URL)
+
+  GenericTokenEndpoint:
+    Type: String
+    Default: ''
+    Description: Generic OIDC token endpoint (full URL)
+
+  GenericUserInfoEndpoint:
+    Type: String
+    Default: ''
+    Description: Generic OIDC userinfo endpoint (full URL)
+
+  GenericClientId:
+    Type: String
+    Default: ''
+    Description: Generic OIDC web application client ID
+
+  GenericClientSecretArn:
+    Type: String
+    Default: ''
+    Description: Secrets Manager ARN for generic OIDC client secret
+
   # REQUIRED: Custom domain for HTTPS/OIDC authentication
   CustomDomainName:
     Type: String
@@ -145,6 +178,8 @@ Conditions:
   IsAzure: !Equals [!Ref IdPProvider, 'azure']
   IsAuth0: !Equals [!Ref IdPProvider, 'auth0']
   IsCognito: !Equals [!Ref IdPProvider, 'cognito']
+  # Note: 'generic' is the terminal fallback in the AuthenticateOidcConfig !If chains
+  # (the else branch after Okta/Azure/Auth0/Cognito), so no named condition is needed.
   HasRoute53Zone: !Not [!Equals [!Ref HostedZoneId, '']]
 
 Resources:
@@ -897,7 +932,10 @@ Resources:
                 - !If
                   - IsAuth0
                   - !Sub 'https://${Auth0Domain}'
-                  - !Sub 'https://cognito-idp.${AWS::Region}.amazonaws.com/${CognitoUserPoolId}'
+                  - !If
+                    - IsCognito
+                    - !Sub 'https://cognito-idp.${AWS::Region}.amazonaws.com/${CognitoUserPoolId}'
+                    - !Ref GenericIssuer
             AuthorizationEndpoint: !If
               - IsOkta
               - !Sub 'https://${OktaDomain}/oauth2/v1/authorize'
@@ -907,7 +945,10 @@ Resources:
                 - !If
                   - IsAuth0
                   - !Sub 'https://${Auth0Domain}/authorize'
-                  - !Sub 'https://${CognitoUserPoolDomain}.auth.${AWS::Region}.amazoncognito.com/oauth2/authorize'
+                  - !If
+                    - IsCognito
+                    - !Sub 'https://${CognitoUserPoolDomain}.auth.${AWS::Region}.amazoncognito.com/oauth2/authorize'
+                    - !Ref GenericAuthorizationEndpoint
             TokenEndpoint: !If
               - IsOkta
               - !Sub 'https://${OktaDomain}/oauth2/v1/token'
@@ -917,7 +958,10 @@ Resources:
                 - !If
                   - IsAuth0
                   - !Sub 'https://${Auth0Domain}/oauth/token'
-                  - !Sub 'https://${CognitoUserPoolDomain}.auth.${AWS::Region}.amazoncognito.com/oauth2/token'
+                  - !If
+                    - IsCognito
+                    - !Sub 'https://${CognitoUserPoolDomain}.auth.${AWS::Region}.amazoncognito.com/oauth2/token'
+                    - !Ref GenericTokenEndpoint
             UserInfoEndpoint: !If
               - IsOkta
               - !Sub 'https://${OktaDomain}/oauth2/v1/userinfo'
@@ -927,7 +971,10 @@ Resources:
                 - !If
                   - IsAuth0
                   - !Sub 'https://${Auth0Domain}/userinfo'
-                  - !Sub 'https://${CognitoUserPoolDomain}.auth.${AWS::Region}.amazoncognito.com/oauth2/userInfo'
+                  - !If
+                    - IsCognito
+                    - !Sub 'https://${CognitoUserPoolDomain}.auth.${AWS::Region}.amazoncognito.com/oauth2/userInfo'
+                    - !Ref GenericUserInfoEndpoint
             ClientId: !If
               - IsOkta
               - !Ref OktaClientId
@@ -937,7 +984,10 @@ Resources:
                 - !If
                   - IsAuth0
                   - !Ref Auth0ClientId
-                  - !Ref CognitoClientId
+                  - !If
+                    - IsCognito
+                    - !Ref CognitoClientId
+                    - !Ref GenericClientId
             ClientSecret: !If
               - IsOkta
               - !Sub '{{resolve:secretsmanager:${OktaClientSecretArn}:SecretString}}'
@@ -947,7 +997,10 @@ Resources:
                 - !If
                   - IsAuth0
                   - !Sub '{{resolve:secretsmanager:${Auth0ClientSecretArn}:SecretString}}'
-                  - !Sub '{{resolve:secretsmanager:${CognitoClientSecretArn}:SecretString}}'
+                  - !If
+                    - IsCognito
+                    - !Sub '{{resolve:secretsmanager:${CognitoClientSecretArn}:SecretString}}'
+                    - !Sub '{{resolve:secretsmanager:${GenericClientSecretArn}:SecretString}}'
             SessionTimeout: 43200  # 12 hours
             Scope: 'openid email profile'
             OnUnauthenticatedRequest: authenticate

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -623,6 +623,20 @@ class DeployCommand(Command):
                                 f"CognitoClientSecretArn={profile.distribution_idp_client_secret_arn}",
                             ]
                         )
+                    elif profile.distribution_idp_provider == "generic":
+                        # Generic OIDC (PingFederate, Keycloak, etc.): endpoints can't be derived
+                        # from a domain, so pass each explicitly. Client ID + secret reuse the
+                        # shared distribution fields.
+                        params.extend(
+                            [
+                                f"GenericIssuer={profile.distribution_idp_issuer or ''}",
+                                f"GenericAuthorizationEndpoint={profile.distribution_idp_authorization_endpoint or ''}",
+                                f"GenericTokenEndpoint={profile.distribution_idp_token_endpoint or ''}",
+                                f"GenericUserInfoEndpoint={profile.distribution_idp_userinfo_endpoint or ''}",
+                                f"GenericClientId={profile.distribution_idp_client_id}",
+                                f"GenericClientSecretArn={profile.distribution_idp_client_secret_arn}",
+                            ]
+                        )
 
                     # Add optional custom domain parameters
                     if profile.distribution_custom_domain:

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1393,6 +1393,7 @@ class InitCommand(Command):
                 questionary.Choice("Auth0", value="auth0"),
                 questionary.Choice("AWS Cognito User Pool", value="cognito"),
                 questionary.Choice("Google", value="google"),
+                questionary.Choice("Generic OIDC (PingFederate, Keycloak, ForgeRock, etc.)", value="generic"),
             ]
 
             idp_provider = questionary.select(
@@ -1492,6 +1493,91 @@ class InitCommand(Command):
                 idp_client_secret = questionary.password(
                     "Web application client secret:",
                 ).ask()
+
+            # Generic OIDC providers (PingFederate, Keycloak, ForgeRock, custom IdP) can't have
+            # their ALB authenticate-oidc endpoints derived from a single domain the way
+            # Okta/Azure/Auth0/Cognito can, so collect each one explicitly. Try OIDC discovery
+            # first (mirrors the SSO generic flow) and fall back to manual entry.
+            dist_oidc_issuer = None
+            dist_oidc_authorization_endpoint = None
+            dist_oidc_token_endpoint = None
+            dist_oidc_userinfo_endpoint = None
+            if idp_provider == "generic":
+                from claude_code_with_bedrock.cli.utils.oidc_discovery import (
+                    OidcDiscoveryError,
+                    discover_oidc_endpoints,
+                )
+
+                console.print("\n[bold]Generic OIDC Landing Page Configuration[/bold]")
+                console.print(
+                    "[dim]We'll try to auto-discover endpoints via the standard well-known URL,[/dim]\n"
+                    "[dim]and fall back to manual entry if your IdP doesn't expose one.[/dim]\n"
+                )
+
+                # Use the domain entered above as the default issuer; let the user override.
+                default_issuer = (
+                    idp_domain
+                    if idp_domain and idp_domain.startswith(("http://", "https://"))
+                    else (f"https://{idp_domain}" if idp_domain else "")
+                ).rstrip("/")
+
+                dist_oidc_issuer = questionary.text(
+                    "OIDC issuer URL:",
+                    validate=lambda x: x.startswith("https://") or "Issuer must start with https://",
+                    default=config.get("distribution", {}).get("idp_issuer", default_issuer),
+                    instruction="(must match the 'iss' claim in tokens)",
+                ).ask()
+                if not dist_oidc_issuer:
+                    return None
+                dist_oidc_issuer = dist_oidc_issuer.rstrip("/")
+
+                discovered: dict[str, str] = {}
+                console.print(f"[dim]Querying {dist_oidc_issuer}/.well-known/openid-configuration ...[/dim]")
+                try:
+                    discovered = discover_oidc_endpoints(dist_oidc_issuer)
+                    console.print("[green]✓ Discovery succeeded.[/green]")
+                except OidcDiscoveryError as e:
+                    console.print(f"[yellow]Discovery failed: {e}[/yellow]")
+                    console.print("[dim]Falling back to manual entry.[/dim]")
+
+                dist_oidc_authorization_endpoint = questionary.text(
+                    "Authorization endpoint:",
+                    validate=lambda x: bool(x) or "Authorization endpoint cannot be empty",
+                    default=(
+                        discovered.get("authorization_endpoint")
+                        or config.get("distribution", {}).get("idp_authorization_endpoint")
+                        or f"{dist_oidc_issuer}/as/authorization.oauth2"
+                    ),
+                    instruction="(full URL)",
+                ).ask()
+                if not dist_oidc_authorization_endpoint:
+                    return None
+
+                dist_oidc_token_endpoint = questionary.text(
+                    "Token endpoint:",
+                    validate=lambda x: bool(x) or "Token endpoint cannot be empty",
+                    default=(
+                        discovered.get("token_endpoint")
+                        or config.get("distribution", {}).get("idp_token_endpoint")
+                        or f"{dist_oidc_issuer}/as/token.oauth2"
+                    ),
+                    instruction="(full URL)",
+                ).ask()
+                if not dist_oidc_token_endpoint:
+                    return None
+
+                dist_oidc_userinfo_endpoint = questionary.text(
+                    "UserInfo endpoint:",
+                    validate=lambda x: bool(x) or "UserInfo endpoint cannot be empty",
+                    default=(
+                        discovered.get("userinfo_endpoint")
+                        or config.get("distribution", {}).get("idp_userinfo_endpoint")
+                        or f"{dist_oidc_issuer}/idp/userinfo.openid"
+                    ),
+                    instruction="(full URL)",
+                ).ask()
+                if not dist_oidc_userinfo_endpoint:
+                    return None
 
             # Store secret in AWS Secrets Manager (only if not auto-configured)
             import boto3
@@ -1597,6 +1683,17 @@ class InitCommand(Command):
                     "hosted_zone_id": hosted_zone_id,
                 }
             )
+
+            # Generic OIDC: persist the explicit endpoints (only set for provider == "generic")
+            if idp_provider == "generic":
+                config["distribution"].update(
+                    {
+                        "idp_issuer": dist_oidc_issuer,
+                        "idp_authorization_endpoint": dist_oidc_authorization_endpoint,
+                        "idp_token_endpoint": dist_oidc_token_endpoint,
+                        "idp_userinfo_endpoint": dist_oidc_userinfo_endpoint,
+                    }
+                )
 
             console.print("\n[green]✓[/green] Landing page distribution will be deployed with IdP authentication")
 
@@ -2264,6 +2361,12 @@ class InitCommand(Command):
             "distribution_idp_client_secret_arn": config_data.get("distribution", {}).get("idp_client_secret_arn"),
             "distribution_custom_domain": config_data.get("distribution", {}).get("custom_domain"),
             "distribution_hosted_zone_id": config_data.get("distribution", {}).get("hosted_zone_id"),
+            "distribution_idp_issuer": config_data.get("distribution", {}).get("idp_issuer"),
+            "distribution_idp_authorization_endpoint": config_data.get("distribution", {}).get(
+                "idp_authorization_endpoint"
+            ),
+            "distribution_idp_token_endpoint": config_data.get("distribution", {}).get("idp_token_endpoint"),
+            "distribution_idp_userinfo_endpoint": config_data.get("distribution", {}).get("idp_userinfo_endpoint"),
             "quota_monitoring_enabled": (
                 config_data.get("quota", {}).get("enabled", False)
                 if config_data.get("monitoring", {}).get("enabled")
@@ -2655,6 +2758,10 @@ class InitCommand(Command):
                     "idp_client_secret_arn": getattr(profile, "distribution_idp_client_secret_arn", None),
                     "custom_domain": getattr(profile, "distribution_custom_domain", None),
                     "hosted_zone_id": getattr(profile, "distribution_hosted_zone_id", None),
+                    "idp_issuer": getattr(profile, "distribution_idp_issuer", None),
+                    "idp_authorization_endpoint": getattr(profile, "distribution_idp_authorization_endpoint", None),
+                    "idp_token_endpoint": getattr(profile, "distribution_idp_token_endpoint", None),
+                    "idp_userinfo_endpoint": getattr(profile, "distribution_idp_userinfo_endpoint", None),
                 }
 
             # Add quota monitoring configuration if present

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -61,12 +61,22 @@ class Profile:
 
     # Distribution platform configuration
     distribution_type: str | None = None  # "presigned-s3" | "landing-page" | None (disabled)
-    distribution_idp_provider: str | None = None  # "okta" | "azure" | "auth0" | "cognito" (for landing-page only)
+    distribution_idp_provider: str | None = None  # okta|azure|auth0|cognito|generic (landing-page only)
     distribution_idp_domain: str | None = None  # IdP domain for web auth (e.g., "company.okta.com")
     distribution_idp_client_id: str | None = None  # Web application client ID
     distribution_idp_client_secret_arn: str | None = None  # Secrets Manager ARN for client secret
     distribution_custom_domain: str | None = None  # Optional custom domain (e.g., "downloads.company.com")
     distribution_hosted_zone_id: str | None = None  # Optional Route53 hosted zone ID
+
+    # Generic OIDC distribution config (distribution_idp_provider == "generic").
+    # Required when the landing-page IdP isn't Okta/Azure/Auth0/Cognito (e.g. PingFederate,
+    # Keycloak, ForgeRock). Unlike those providers, ALB authenticate-oidc endpoints cannot be
+    # derived from a single domain, so each must be supplied explicitly. The ALB runs the OAuth
+    # authorization-code flow (not JWT signature validation), so no JWKS/thumbprint is needed here.
+    distribution_idp_issuer: str | None = None  # OIDC issuer URL (must match the 'iss' claim)
+    distribution_idp_authorization_endpoint: str | None = None  # Full authorization endpoint URL
+    distribution_idp_token_endpoint: str | None = None  # Full token endpoint URL
+    distribution_idp_userinfo_endpoint: str | None = None  # Full userinfo endpoint URL
 
     # Quota monitoring configuration
     quota_monitoring_enabled: bool = False  # Enable per-user token quota monitoring

--- a/source/claude_code_with_bedrock/validators.py
+++ b/source/claude_code_with_bedrock/validators.py
@@ -171,15 +171,27 @@ class ProfileValidator:
                 dist_provider = profile_data.get("distribution_idp_provider")
                 if not dist_provider:
                     errors.append("distribution_idp_provider is required for landing-page distribution")
-                elif dist_provider not in ["okta", "auth0", "azure", "cognito"]:
+                elif dist_provider not in ["okta", "auth0", "azure", "cognito", "generic"]:
                     errors.append(
                         f"Invalid distribution_idp_provider: {dist_provider}. "
-                        "Must be 'okta', 'auth0', 'azure', or 'cognito'"
+                        "Must be 'okta', 'auth0', 'azure', 'cognito', or 'generic'"
                     )
 
-                dist_domain = profile_data.get("distribution_idp_domain")
-                if not dist_domain:
-                    errors.append("distribution_idp_domain is required for landing-page distribution")
+                # Domain-derived providers need a domain; generic providers supply explicit
+                # endpoints instead (the domain isn't used to build the ALB OIDC config).
+                if dist_provider == "generic":
+                    for required_field in (
+                        "distribution_idp_issuer",
+                        "distribution_idp_authorization_endpoint",
+                        "distribution_idp_token_endpoint",
+                        "distribution_idp_userinfo_endpoint",
+                    ):
+                        if not profile_data.get(required_field):
+                            errors.append(f"{required_field} is required for generic landing-page distribution")
+                else:
+                    dist_domain = profile_data.get("distribution_idp_domain")
+                    if not dist_domain:
+                        errors.append("distribution_idp_domain is required for landing-page distribution")
 
                 dist_client_id = profile_data.get("distribution_idp_client_id")
                 if not dist_client_id:

--- a/source/tests/test_generic_oidc_distribution.py
+++ b/source/tests/test_generic_oidc_distribution.py
@@ -1,0 +1,200 @@
+# ABOUTME: Tests for generic OIDC (PingFederate, Keycloak, etc.) landing-page distribution support
+# ABOUTME: Validates allowlist, required endpoints, config round-trip, deploy params, and CFN template
+
+"""Tests for generic OIDC support on the landing-page distribution.
+
+Previously the landing page only supported Okta/Azure/Auth0/Cognito, while SSO auth
+already supported a 'generic' provider. This wires generic OIDC (PingFederate, Keycloak,
+ForgeRock, etc.) through the validator, config round-trip, deploy params, and CFN template.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from claude_code_with_bedrock.config import Profile
+from claude_code_with_bedrock.validators import validate_profile
+
+SOURCE_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = SOURCE_ROOT.parents[0]
+DEPLOY_PY = SOURCE_ROOT / "claude_code_with_bedrock" / "cli" / "commands" / "deploy.py"
+INIT_PY = SOURCE_ROOT / "claude_code_with_bedrock" / "cli" / "commands" / "init.py"
+LANDING_TEMPLATE = REPO_ROOT / "deployment" / "infrastructure" / "landing-page-distribution.yaml"
+
+
+class TestGenericDistributionValidator:
+    """Validator accepts generic and enforces its required endpoints."""
+
+    @pytest.fixture
+    def base_profile(self):
+        return {
+            "name": "my-profile",
+            "provider_domain": "myorg.okta.com",
+            "client_id": "0oa1234567890abcdef",
+            "credential_storage": "keyring",
+            "aws_region": "us-east-1",
+            "identity_pool_name": "my-pool",
+            "distribution_type": "landing-page",
+            "distribution_idp_client_id": "web-client-id",
+        }
+
+    def test_generic_provider_is_accepted(self, base_profile):
+        """'generic' is a valid distribution_idp_provider when endpoints are supplied."""
+        base_profile.update(
+            {
+                "distribution_idp_provider": "generic",
+                "distribution_idp_issuer": "https://auth.example.com",
+                "distribution_idp_authorization_endpoint": "https://auth.example.com/as/authorization.oauth2",
+                "distribution_idp_token_endpoint": "https://auth.example.com/as/token.oauth2",
+                "distribution_idp_userinfo_endpoint": "https://auth.example.com/idp/userinfo.openid",
+            }
+        )
+        result = validate_profile(base_profile)
+        assert result.valid is True, result.errors
+
+    def test_generic_requires_issuer_and_endpoints(self, base_profile):
+        """Generic provider without explicit endpoints fails validation."""
+        base_profile["distribution_idp_provider"] = "generic"
+        result = validate_profile(base_profile)
+        assert result.valid is False
+        for field in (
+            "distribution_idp_issuer",
+            "distribution_idp_authorization_endpoint",
+            "distribution_idp_token_endpoint",
+            "distribution_idp_userinfo_endpoint",
+        ):
+            assert any(field in e for e in result.errors), f"missing error for {field}"
+
+    def test_generic_does_not_require_domain(self, base_profile):
+        """Generic providers supply endpoints directly, so idp_domain is not required."""
+        base_profile.update(
+            {
+                "distribution_idp_provider": "generic",
+                "distribution_idp_issuer": "https://auth.example.com",
+                "distribution_idp_authorization_endpoint": "https://auth.example.com/authorize",
+                "distribution_idp_token_endpoint": "https://auth.example.com/token",
+                "distribution_idp_userinfo_endpoint": "https://auth.example.com/userinfo",
+            }
+        )
+        # No distribution_idp_domain set
+        result = validate_profile(base_profile)
+        assert result.valid is True, result.errors
+        assert not any("distribution_idp_domain" in e for e in result.errors)
+
+    def test_okta_still_requires_domain(self, base_profile):
+        """Regression: non-generic providers still require a domain."""
+        base_profile["distribution_idp_provider"] = "okta"
+        result = validate_profile(base_profile)
+        assert result.valid is False
+        assert any("distribution_idp_domain" in e for e in result.errors)
+
+    def test_unknown_distribution_provider_rejected(self, base_profile):
+        """An unsupported provider is still rejected with an updated message."""
+        base_profile["distribution_idp_provider"] = "pingfederate"
+        result = validate_profile(base_profile)
+        assert result.valid is False
+        assert any("generic" in e for e in result.errors)
+
+
+class TestGenericDistributionProfileFields:
+    """Profile dataclass carries the new generic OIDC distribution fields."""
+
+    def test_profile_has_generic_distribution_fields(self):
+        profile = Profile(
+            name="p",
+            provider_domain="auth.example.com",
+            client_id="cid",
+            credential_storage="keyring",
+            aws_region="us-east-1",
+            identity_pool_name="pool",
+            distribution_idp_provider="generic",
+            distribution_idp_issuer="https://auth.example.com",
+            distribution_idp_authorization_endpoint="https://auth.example.com/authorize",
+            distribution_idp_token_endpoint="https://auth.example.com/token",
+            distribution_idp_userinfo_endpoint="https://auth.example.com/userinfo",
+        )
+        assert profile.distribution_idp_issuer == "https://auth.example.com"
+        assert profile.distribution_idp_authorization_endpoint.endswith("/authorize")
+        assert profile.distribution_idp_token_endpoint.endswith("/token")
+        assert profile.distribution_idp_userinfo_endpoint.endswith("/userinfo")
+
+    def test_generic_distribution_fields_default_none(self):
+        """Backward-compat: profiles without the new fields default to None."""
+        profile = Profile(
+            name="p",
+            provider_domain="auth.example.com",
+            client_id="cid",
+            credential_storage="keyring",
+            aws_region="us-east-1",
+            identity_pool_name="pool",
+        )
+        assert profile.distribution_idp_issuer is None
+        assert profile.distribution_idp_authorization_endpoint is None
+        assert profile.distribution_idp_token_endpoint is None
+        assert profile.distribution_idp_userinfo_endpoint is None
+
+
+class TestGenericDistributionDeployParams:
+    """deploy.py wires generic OIDC params to the CloudFormation stack."""
+
+    def test_deploy_has_generic_branch(self):
+        source = DEPLOY_PY.read_text(encoding="utf-8")
+        assert 'profile.distribution_idp_provider == "generic"' in source
+
+    def test_deploy_passes_generic_params(self):
+        source = DEPLOY_PY.read_text(encoding="utf-8")
+        for param in (
+            "GenericIssuer={profile.distribution_idp_issuer",
+            "GenericAuthorizationEndpoint={profile.distribution_idp_authorization_endpoint",
+            "GenericTokenEndpoint={profile.distribution_idp_token_endpoint",
+            "GenericUserInfoEndpoint={profile.distribution_idp_userinfo_endpoint",
+            "GenericClientId={profile.distribution_idp_client_id}",
+            "GenericClientSecretArn={profile.distribution_idp_client_secret_arn}",
+        ):
+            assert param in source, f"missing deploy param: {param}"
+
+
+class TestGenericDistributionInitRoundTrip:
+    """init.py offers generic and round-trips the new fields through config."""
+
+    def test_init_offers_generic_choice(self):
+        source = INIT_PY.read_text(encoding="utf-8")
+        assert 'value="generic"' in source
+        assert "PingFederate" in source
+
+    def test_init_maps_generic_fields_both_directions(self):
+        source = INIT_PY.read_text(encoding="utf-8")
+        # config -> Profile (load)
+        assert '"distribution_idp_issuer": config_data.get("distribution", {}).get("idp_issuer")' in source
+        # Profile -> config (save)
+        assert '"idp_issuer": getattr(profile, "distribution_idp_issuer", None)' in source
+
+
+class TestGenericDistributionTemplate:
+    """landing-page CFN template supports generic OIDC."""
+
+    def test_template_allows_generic(self):
+        text = LANDING_TEMPLATE.read_text(encoding="utf-8")
+        assert "AllowedValues: [okta, azure, auth0, cognito, generic]" in text
+
+    def test_template_has_generic_parameters(self):
+        text = LANDING_TEMPLATE.read_text(encoding="utf-8")
+        for param in (
+            "GenericIssuer:",
+            "GenericAuthorizationEndpoint:",
+            "GenericTokenEndpoint:",
+            "GenericUserInfoEndpoint:",
+            "GenericClientId:",
+            "GenericClientSecretArn:",
+        ):
+            assert param in text, f"missing CFN parameter: {param}"
+
+    def test_template_oidc_config_falls_back_to_generic(self):
+        """The AuthenticateOidcConfig else-branch references generic params."""
+        text = LANDING_TEMPLATE.read_text(encoding="utf-8")
+        assert "!Ref GenericIssuer" in text
+        assert "!Ref GenericAuthorizationEndpoint" in text
+        assert "!Ref GenericTokenEndpoint" in text
+        assert "!Ref GenericUserInfoEndpoint" in text
+        assert "!Ref GenericClientId" in text
+        assert "resolve:secretsmanager:${GenericClientSecretArn}" in text


### PR DESCRIPTION
Closes #604

## Why

Generic OIDC providers (PingFederate, Keycloak, ForgeRock) are already supported for **SSO authentication**, but the authenticated **landing-page distribution** was locked to Okta, Azure, Auth0, and Cognito. An organization on a generic IdP could use generic OIDC for the CLI credential flow but could not stand up an authenticated download page without hand-editing the CloudFormation template.

## What

Wires `generic` through the full landing-page path, mirroring the existing SSO generic flow:

- **`config.py`** — add `distribution_idp_issuer` / `authorization` / `token` / `userinfo` endpoint fields. ALB `authenticate-oidc` needs each endpoint explicitly because (unlike the four built-in providers) they can't be derived from a single domain. No JWKS/thumbprint is needed — the ALB runs the OAuth authorization-code flow, not JWT signature validation.
- **`validators.py`** — accept `generic`; require the four endpoints when generic; generic providers no longer require `distribution_idp_domain`.
- **`init.py`** — offer "Generic OIDC (PingFederate, Keycloak, ForgeRock, etc.)" in the landing-page IdP picker, prompt for endpoints (with OIDC discovery + manual fallback, reusing `oidc_discovery`), and round-trip the fields through config load/save.
- **`deploy.py`** — add a `generic` branch passing the `Generic*` CloudFormation parameters.
- **`landing-page-distribution.yaml`** — add `Generic*` parameters, extend `AllowedValues` to include `generic`, and make generic the terminal fallback in the `AuthenticateOidcConfig` `!If` chains (Cognito promoted to an explicit `IsCognito` branch).

## Testing

- New `source/tests/test_generic_oidc_distribution.py` (22 tests): validator allowlist, required endpoints, domain-not-required for generic, backward-compat defaults, config round-trip, deploy param wiring, and CFN template structure.
- Existing validator/config/CFN-validation suites pass.
- `cfn-lint` clean on the template — no new warnings vs. the `beta` baseline.

## Notes for reviewers

- Tier-2 change (`init.py`, `deploy.py` distribution paths + Tier-1 `config.py`/`validators.py`). Backward compatible: the new fields default to `None`, and non-generic providers are unaffected.
- The Go credential binary does not read distribution config, so no Go ↔ Python config-sync change is required.