### PR TITLE
feat(idc): zero-binary sidecar mode for IAM Identity Center users

### DIFF
--- a/assets/docs/providers/iam-identity-center-setup.md
+++ b/assets/docs/providers/iam-identity-center-setup.md
@@ -4,7 +4,13 @@ This guide covers setting up Claude Code with Bedrock using AWS IAM Identity Cen
 
 ## How It Works
 
-IDC uses your existing AWS SSO credentials — no external IdP or JWT tokens needed. The credential-process passes through ambient AWS creds from `aws sso login`, resolves your email from the STS caller ARN session name, writes OTEL attribution headers to a local cache, and checks quota via SigV4-signed API requests.
+IDC uses your existing AWS SSO credentials — no external IdP or JWT tokens needed, and **no custom binaries required on developer machines**.
+
+- **Authentication:** Developers run `aws sso login` — Claude Code picks up ambient AWS credentials automatically via the standard credential chain. No credential-process binary needed.
+- **Monitoring:** The local OTEL sidecar collector sends metrics to CloudWatch's native OTLP endpoint using the developer's SSO session credentials (SigV4). User identity is baked as a static resource attribute in the collector config at distribution time.
+- **Attribution:** User email is resolved from the IAM Identity Center ARN session name (e.g. `user@company.com`) during `ccwb init` or `ccwb package` and embedded directly in the collector configuration.
+
+This means the IDC developer bundle contains **only the collector binary** — no credential-process, no otel-helper.
 
 ## When to Choose IAM Identity Center vs OIDC
 
@@ -118,10 +124,12 @@ Example session settings:
 
 ## Per-User Cost Attribution
 
-IDC users get per-user OTEL attribution automatically. The credential-process extracts the user email from the STS assumed-role ARN session name and writes it to the OTEL cache. Dashboard widgets (Token Usage by User, Active Users) work without additional configuration.
+IDC users get per-user OTEL attribution automatically. The user email is baked into the collector configuration at distribution time (`ccwb package` resolves it from `aws sts get-caller-identity`). Dashboard widgets (Token Usage by User, Active Users) work without additional configuration.
 
 **Requirement:** IAM Identity Center must use email as the session name (the default). The ARN format must be:
 `arn:aws:sts::ACCOUNT:assumed-role/RoleName/user@company.com`
+
+> **Note:** Unlike the OIDC path (which extracts identity dynamically from JWT tokens at runtime), the IDC path uses a static email set at distribution time. This works well for single-user machines. If a user's email changes, regenerate their package with `ccwb package`.
 
 ### Verifying Attribution
 

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -367,6 +367,41 @@ class PackageCommand(Command):
         # Show what will be packaged using shared display utility
         display_configuration_info(profile, identity_pool_id or federated_role_arn, format_type="simple")
 
+        # Determine if this is a zero-binary IDC deployment
+        # IDC users authenticate via 'aws sso login' (no credential-process) and
+        # get static identity baked into the collector config (no otel-helper).
+        is_idc_zero_binary = getattr(profile, 'effective_auth_type', profile.auth_type) == 'idc'
+        idc_user_email = None
+        if is_idc_zero_binary:
+            console.print("\n[dim]IDC auth detected — skipping credential-process and otel-helper binaries[/dim]")
+            console.print("[dim]User identity will be baked into collector config at package time[/dim]")
+
+            # Auto-detect user email from STS caller identity (IDC ARN session name = email)
+            try:
+                import boto3
+                sts = boto3.client('sts', region_name=profile.aws_region)
+                identity = sts.get_caller_identity()
+                arn = identity.get('Arn', '')
+                # IDC ARN format: arn:aws:sts::ACCOUNT:assumed-role/RoleName/user@company.com
+                session_name = arn.rsplit('/', 1)[-1] if '/' in arn else ''
+                if '@' in session_name:
+                    idc_user_email = session_name
+                    console.print(f"[dim]Detected user email from IDC: {idc_user_email}[/dim]")
+                else:
+                    # Prompt if we can't auto-detect
+                    idc_user_email = questionary.text(
+                        "User email for OTEL attribution (IDC session name):",
+                        default=session_name or "",
+                    ).ask()
+            except Exception:
+                idc_user_email = questionary.text(
+                    "User email for OTEL attribution:",
+                    default="",
+                ).ask()
+
+            if not idc_user_email:
+                console.print("[yellow]Warning: No user email — OTEL attribution will be anonymous[/yellow]")
+
         # Build package
         console.print("\n[bold]Building package...[/bold]")
 
@@ -464,7 +499,10 @@ class PackageCommand(Command):
 
         console.print()
 
-        if use_go:
+        if is_idc_zero_binary:
+            # IDC path: no binaries needed — skip all Go/Python builds
+            console.print("[dim]Skipping binary builds (IDC zero-binary mode)[/dim]")
+        elif use_go:
             # Go cross-compilation: build all selected platforms at once
             console.print("[cyan]Building Go binaries (cross-compilation)...[/cyan]")
             try:
@@ -550,6 +588,33 @@ class PackageCommand(Command):
         # Pass the appropriate identifier based on federation type
         federation_identifier = federated_role_arn if federation_type == "direct" else identity_pool_id
         self._create_config(output_dir, profile, federation_identifier, federation_type, profile_name, console)
+
+        # Generate IDC-specific collector config with static identity
+        if is_idc_zero_binary and profile.monitoring_enabled:
+            import shutil
+            from string import Template
+
+            idc_config_template = Path(__file__).resolve().parent.parent.parent.parent / "otel_helper" / "collector-config-idc.yaml"
+            if idc_config_template.exists():
+                template_content = idc_config_template.read_text(encoding="utf-8")
+                # Replace placeholders with actual values
+                replacements = {
+                    "${REGION}": profile.aws_region or "us-east-1",
+                    "${USER_EMAIL}": idc_user_email or "unknown@example.com",
+                    "${USER_NAME}": (idc_user_email or "unknown").split("@")[0],
+                    "${DEPARTMENT}": otel_resource_attributes.split("department=")[1].split(",")[0] if "department=" in (otel_resource_attributes or "") else "default",
+                    "${TEAM_ID}": otel_resource_attributes.split("team.id=")[1].split(",")[0] if "team.id=" in (otel_resource_attributes or "") else "default",
+                    "${COST_CENTER}": otel_resource_attributes.split("cost_center=")[1].split(",")[0] if "cost_center=" in (otel_resource_attributes or "") else "default",
+                    "${ORGANIZATION}": otel_resource_attributes.split("organization=")[1].split(",")[0] if "organization=" in (otel_resource_attributes or "") else "default",
+                }
+                for placeholder, value in replacements.items():
+                    template_content = template_content.replace(placeholder, value)
+
+                config_output = output_dir / "collector-config.yaml"
+                config_output.write_text(template_content, encoding="utf-8")
+                console.print(f"[dim]Generated IDC collector config with identity: {idc_user_email}[/dim]")
+            else:
+                console.print("[yellow]Warning: collector-config-idc.yaml template not found[/yellow]")
 
         # Create installer
         console.print("[cyan]Creating installer script...[/cyan]")
@@ -3235,8 +3300,11 @@ Available metrics include:
                     )
 
                     # Add the helper executable for generating OTEL headers with user attributes
+                    # IDC path uses static identity in collector config — no helper needed.
                     # Use a placeholder that will be replaced by the installer script based on platform
-                    settings["otelHeadersHelper"] = "__OTEL_HELPER_PATH__"
+                    _is_idc = getattr(profile, 'effective_auth_type', getattr(profile, 'auth_type', 'oidc')) == 'idc'
+                    if not _is_idc:
+                        settings["otelHeadersHelper"] = "__OTEL_HELPER_PATH__"
 
                     is_https = endpoint.startswith("https://")
                     console.print(f"[dim]Added monitoring with {'HTTPS' if is_https else 'HTTP'} endpoint[/dim]")

--- a/source/otel_helper/collector-config-idc.yaml
+++ b/source/otel_helper/collector-config-idc.yaml
@@ -1,0 +1,80 @@
+# ABOUTME: Local OTEL Collector sidecar config for IAM Identity Center (IDC) users
+# ABOUTME: Same as collector-config.yaml but uses STATIC identity attributes instead of
+# ABOUTME: extracting from HTTP headers (no otel-helper binary needed)
+#
+# Placeholders replaced by installer:
+#   ${REGION}     - AWS region (e.g. us-east-1)
+#   ${USER_EMAIL} - User's email (resolved from IDC ARN at package time)
+#   ${USER_NAME}  - User's display name (optional, defaults to email prefix)
+#   ${DEPARTMENT} - Department (optional)
+#   ${TEAM_ID}    - Team identifier (optional)
+#   ${COST_CENTER} - Cost center (optional)
+#   ${ORGANIZATION} - Organization (optional)
+#
+# Why no otel-helper? IDC users authenticate via 'aws sso login' which provides
+# SigV4 credentials directly. User identity is known at distribution time (from
+# the IDC session name = email), so we bake it statically rather than extracting
+# from JWT at runtime.
+
+extensions:
+  sigv4auth:
+    service: "monitoring"
+    region: "${REGION}"
+
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: localhost:4318
+        include_metadata: true
+
+processors:
+  batch/metrics:
+    timeout: 60s
+  # Static identity: baked at distribution time from IDC user's email.
+  # Unlike the OIDC path (collector-config.yaml) which extracts identity from
+  # HTTP headers injected by otel-helper, the IDC path sets them as fixed
+  # resource attributes — no helper binary needed.
+  resource/identity:
+    attributes:
+      - key: user.email
+        value: "${USER_EMAIL}"
+        action: upsert
+      - key: user.name
+        value: "${USER_NAME}"
+        action: upsert
+      - key: department
+        value: "${DEPARTMENT}"
+        action: upsert
+      - key: team.id
+        value: "${TEAM_ID}"
+        action: upsert
+      - key: cost_center
+        value: "${COST_CENTER}"
+        action: upsert
+      - key: organization
+        value: "${ORGANIZATION}"
+        action: upsert
+      - key: deployment.environment
+        value: "production"
+        action: insert
+
+exporters:
+  otlphttp:
+    tls:
+      insecure: false
+    endpoint: "https://monitoring.${REGION}.amazonaws.com"
+    auth:
+      authenticator: sigv4auth
+
+service:
+  extensions: [sigv4auth]
+  telemetry:
+    logs:
+      level: info
+      output_paths: [stderr]
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [resource/identity, batch/metrics]
+      exporters: [otlphttp]


### PR DESCRIPTION
## Problem

IDC (IAM Identity Center) users currently receive the same package as OIDC users: credential-process binary + otel-helper binary + collector. But IDC users don't need either custom binary:

- **Auth:** `aws sso login` handles authentication natively — no credential-process needed
- **Identity:** User email is known at distribution time (from IDC ARN session name) — no runtime JWT extraction needed

Shipping unnecessary binaries adds distribution friction, AV false positives (Windows), and support burden for a path that doesn't need them.

## Solution

A complete end-to-end zero-binary IDC path — from email detection through config generation to updated documentation.

### 1. Binary skip logic (`package.py`)

When `auth_type=idc`, the package command:
- Skips credential-process binary build
- Skips otel-helper binary build
- Omits `otelHeadersHelper` from Claude Code settings.json

### 2. Email auto-detection (`package.py`)

Automatically resolves the user's email from `aws sts get-caller-identity`:
- IDC ARN format: `arn:aws:sts::ACCOUNT:assumed-role/RoleName/user@company.com`
- Falls back to interactive prompt if detection fails (e.g. no active SSO session)
- Warns if no email available (attribution will be anonymous)

### 3. IDC collector config generation (`collector-config-idc.yaml`)

New config template uses `resource/identity` processor with static attributes:
```yaml
processors:
  resource/identity:
    attributes:
      - key: user.email
        value: "alice@company.com"  # baked at package time
        action: upsert
```

Generated with real values at `ccwb package` time and written as `collector-config.yaml` in the output directory — the installer picks it up unchanged.

### 4. Documentation update (`iam-identity-center-setup.md`)

Updated to reflect:
- Zero-binary deployment model (only collector shipped)
- How attribution works (static vs dynamic identity)
- Limitation: email baked at distribution time (re-run `ccwb package` if it changes)

## Developer bundle comparison

| Component | OIDC path | IDC path (before) | IDC path (after) |
|---|---|---|---|
| credential-process | ✅ | ✅ | ❌ Skipped |
| otel-helper | ✅ | ✅ | ❌ Skipped |
| otelcol (collector) | ✅ | ✅ | ✅ |
| collector-config | Dynamic (header extraction) | Dynamic (header extraction) | Static (baked identity) |
| settings.json `otelHeadersHelper` | ✅ Set | ✅ Set | ❌ Omitted |

## Why this should be one PR (not split)

These changes form a single atomic feature. Shipping any piece alone creates a broken state:
- Binary skip without config generation → no monitoring at all
- Config generation without email detection → hardcoded placeholder email
- Either without docs → users don't know the new behavior exists

All four pieces together deliver the complete zero-binary IDC experience.

## Backwards compatible

- OIDC path completely unchanged (still builds and uses all binaries)
- Existing IDC deployments continue to work (otel-helper still functions if already installed)
- No changes to central monitoring mode
- `auth_type=none` path unchanged
- Only activates when `profile.effective_auth_type == 'idc'`
