### PR TITLE
fix(quota): implement periodic quota re-check on cached credential path

### DIFF
--- a/source/go/cmd/credential-process/main.go
+++ b/source/go/cmd/credential-process/main.go
@@ -385,7 +385,9 @@ func (a *credentialApp) run() int {
 	if cached := a.getCachedCredentials(); cached != nil {
 		// Periodic quota re-check
 		if a.shouldRecheckQuota() {
-			a.performQuotaRecheck()
+			if !a.performQuotaRecheck() {
+				return 1
+			}
 		}
 		outputJSON(cached)
 		return 0
@@ -428,6 +430,7 @@ func (a *credentialApp) run() int {
 					printQuotaBlocked(qr)
 					return 1
 				}
+				_ = storage.SaveQuotaState(a.profile)
 			}
 		}
 		outputJSON(creds)
@@ -446,6 +449,7 @@ func (a *credentialApp) run() int {
 					printQuotaBlocked(qr)
 					return 1
 				}
+				_ = storage.SaveQuotaState(a.profile)
 			}
 		}
 		outputJSON(creds)
@@ -467,6 +471,7 @@ func (a *credentialApp) run() int {
 			printQuotaBlocked(qr)
 			return 1
 		}
+		_ = storage.SaveQuotaState(a.profile)
 	}
 
 	// Get AWS credentials
@@ -736,26 +741,34 @@ func (a *credentialApp) shouldRecheckQuota() bool {
 	if a.cfg.QuotaAPIEndpoint == "" {
 		return false
 	}
-	// Simple interval check - omitting full persistence for now
-	return false
+	// Check if enough time has passed since last quota check
+	lastCheck := storage.ReadQuotaState(a.profile)
+	if lastCheck.IsZero() {
+		// Never checked — trigger check
+		return true
+	}
+	interval := time.Duration(a.cfg.QuotaCheckInterval) * time.Minute
+	return time.Since(lastCheck) >= interval
 }
 
-func (a *credentialApp) performQuotaRecheck() {
+func (a *credentialApp) performQuotaRecheck() bool {
 	token, _ := storage.GetMonitoringToken(a.profile, a.cfg.CredentialStorage)
 	if token == "" {
-		return
-	}
-	claims, err := jwt.DecodePayload(token)
-	if err != nil {
-		return
+		return true // no token to check with — allow (fail-open for missing token)
 	}
 	qr := quota.Check(a.cfg.QuotaAPIEndpoint, token, a.cfg.QuotaCheckTimeout, a.cfg.QuotaFailMode)
-	_ = claims // suppress unused
+
+	// Persist the check timestamp regardless of outcome
+	_ = storage.SaveQuotaState(a.profile)
+
 	if !qr.Allowed {
 		printQuotaBlocked(qr)
-	} else {
-		printQuotaWarning(qr)
+		// Clear cached credentials so subsequent invocations also block
+		a.clearCache()
+		return false
 	}
+	printQuotaWarning(qr)
+	return true
 }
 
 // writeOtelCacheFromSTS resolves user identity via STS GetCallerIdentity and

--- a/source/go/internal/storage/quota_state.go
+++ b/source/go/internal/storage/quota_state.go
@@ -1,0 +1,58 @@
+package storage
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// QuotaState persists quota check timestamps so the credential-process
+// can enforce periodic re-checks even when serving cached credentials.
+type QuotaState struct {
+	LastCheckUnix int64 `json:"last_check_unix"`
+}
+
+// quotaStatePath returns the path to the quota state file for a profile.
+func quotaStatePath(profile string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, "claude-code-with-bedrock", ".quota-state-"+profile+".json")
+}
+
+// ReadQuotaState reads the last quota check timestamp for a profile.
+// Returns zero time if no state exists or on any error.
+func ReadQuotaState(profile string) time.Time {
+	path := quotaStatePath(profile)
+	if path == "" {
+		return time.Time{}
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return time.Time{}
+	}
+	var state QuotaState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return time.Time{}
+	}
+	if state.LastCheckUnix == 0 {
+		return time.Time{}
+	}
+	return time.Unix(state.LastCheckUnix, 0)
+}
+
+// SaveQuotaState persists the current time as the last quota check timestamp.
+func SaveQuotaState(profile string) error {
+	path := quotaStatePath(profile)
+	if path == "" {
+		return nil
+	}
+	state := QuotaState{LastCheckUnix: time.Now().Unix()}
+	data, err := json.Marshal(state)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0600)
+}

--- a/source/go/internal/storage/quota_state_test.go
+++ b/source/go/internal/storage/quota_state_test.go
@@ -1,0 +1,81 @@
+package storage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestQuotaState_ReadWriteCycle(t *testing.T) {
+	// Use a temp dir as home
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir) // Windows compat
+
+	// Ensure the target directory exists
+	os.MkdirAll(filepath.Join(tmpDir, "claude-code-with-bedrock"), 0755)
+
+	profile := "test-profile"
+
+	// Initially should return zero time
+	ts := ReadQuotaState(profile)
+	if !ts.IsZero() {
+		t.Errorf("expected zero time for fresh state, got %v", ts)
+	}
+
+	// Save state
+	err := SaveQuotaState(profile)
+	if err != nil {
+		t.Fatalf("SaveQuotaState failed: %v", err)
+	}
+
+	// Read back — should be within last 2 seconds
+	ts = ReadQuotaState(profile)
+	if ts.IsZero() {
+		t.Fatal("expected non-zero time after save")
+	}
+	if time.Since(ts) > 2*time.Second {
+		t.Errorf("timestamp too old: %v (now: %v)", ts, time.Now())
+	}
+}
+
+func TestQuotaState_IntervalCheck(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+	os.MkdirAll(filepath.Join(tmpDir, "claude-code-with-bedrock"), 0755)
+
+	profile := "interval-test"
+
+	// No state = zero time (should trigger re-check)
+	ts := ReadQuotaState(profile)
+	if !ts.IsZero() {
+		t.Fatal("expected zero time initially")
+	}
+
+	// Save, then immediately read — should be recent (within interval)
+	_ = SaveQuotaState(profile)
+	ts = ReadQuotaState(profile)
+	interval := 30 * time.Minute
+	if time.Since(ts) >= interval {
+		t.Errorf("freshly saved state should be within interval")
+	}
+}
+
+func TestQuotaState_CorruptFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+
+	dir := filepath.Join(tmpDir, "claude-code-with-bedrock")
+	os.MkdirAll(dir, 0755)
+
+	// Write garbage
+	os.WriteFile(filepath.Join(dir, ".quota-state-corrupt.json"), []byte("not json"), 0600)
+
+	ts := ReadQuotaState("corrupt")
+	if !ts.IsZero() {
+		t.Errorf("expected zero time for corrupt file, got %v", ts)
+	}
+}


### PR DESCRIPTION
## Why

Quota enforcement mode `block` does not actually deny access when quota is exceeded (#606). Users are only checked on first login — once credentials are cached, `shouldRecheckQuota()` always returned `false`, so cached credentials are served indefinitely without re-checking quota.

This makes the entire quota blocking feature non-functional for any user past their first auth.

## Root Cause

`shouldRecheckQuota()` in `main.go:735` was hardcoded to `return false` with a TODO comment: *"Simple interval check - omitting full persistence for now"*.

## What

1. **New `quota_state.go`** — persists last-check timestamp to `~/claude-code-with-bedrock/.quota-state-<profile>.json`
2. **`shouldRecheckQuota()`** — compares `time.Since(lastCheck)` against `quota_check_interval` config (default 30 min)
3. **`performQuotaRecheck()`** — returns bool; when blocked, **clears the credential cache** so subsequent invocations also fail
4. **All successful quota paths** now call `SaveQuotaState()` to reset the interval timer

## Auth Flow Impact

| Flow | Change | Risk |
|------|--------|------|
| OIDC (cached creds) | **Fixed** — now enforces quota periodically | This is the fix |
| OIDC (fresh auth) | Adds `SaveQuotaState()` call after successful check | None — additive |
| OIDC (silent refresh) | Adds `SaveQuotaState()` call after successful check | None — additive |
| OIDC (refresh_token) | Adds `SaveQuotaState()` call after successful check | None — additive |
| IDC (`runIDC`) | **No change** — already checks every invocation (no caching) | None |
| Passthrough | **No change** — already checks every invocation (no caching) | None |

## Backward Compatibility

- Missing quota state file → triggers immediate check (safe first-run behavior)
- `quota_check_interval=0` → checks every invocation (existing semantic preserved)
- No config schema changes — uses the existing `quota_check_interval` field
- Users without quota enabled: `QuotaAPIEndpoint == ""` → early return, no file written

## Testing

- `gofmt` passes on both files
- Python test suite: 1116 passed, 0 failures
- Go compile: requires Go 1.24 (CI will validate)

Closes #606
@xenity — would appreciate your testing on this once it's on beta.