### PR TITLE
feat(quota): count CoWork 3P token usage toward per-user quota

### DIFF
--- a/assets/docs/COWORK_3P.md
+++ b/assets/docs/COWORK_3P.md
@@ -319,6 +319,48 @@ Per-device dashboard dimensions are planned — see [#585](https://github.com/aw
 
 ![Claude CoWork Dashboard](../../assets/images/ClaudeCoworkDashboard.png)
 
+## Quota Enforcement
+
+CoWork 3P usage is subject to the same per-user quota enforcement as Claude Code. Here's how it works:
+
+### How enforcement applies
+
+CoWork uses `credential-process` for credential refresh (via the `inferenceBedrockProfile` AWS named profile). The credential-process binary checks the quota API on every refresh cycle:
+
+1. CoWork's AWS session token expires (~1 hour)
+2. AWS SDK calls `credential-process --profile <name>` for fresh credentials
+3. `credential-process` calls the quota-check API (`GET /check`)
+4. If the user is over quota → credentials are denied → CoWork loses Bedrock access
+5. If under quota → fresh credentials issued → CoWork continues
+
+**Enforcement granularity:** Per credential refresh (~1 hour). A user can exceed their quota within a session but will be blocked on the next refresh.
+
+### How CoWork usage is counted
+
+CoWork sends OTLP **log events** (not metrics) to the collector. The monitoring pipeline processes them:
+
+1. CoWork sends `claude_code.api_request` log events to the OTEL collector
+2. Collector injects `user_email` from HTTP attribution headers
+3. Events are written to `/aws/claude-cowork/events` CloudWatch Logs
+4. MetricFilters extract per-user token counts into the `ClaudeCoWork` namespace (with `user_email` dimension)
+5. `quota_monitor` Lambda queries both `ClaudeCode` and `ClaudeCoWork` PromQL metrics
+6. Combined usage is aggregated into a single DynamoDB record per user
+
+**Result:** A user's total quota includes both Claude Code CLI and CoWork Desktop usage.
+
+### Requirements for per-user CoWork quota
+
+- Monitoring stack deployed with custom domain + HTTPS (central mode)
+- CoWork service token configured (`ccwb init` generates it)
+- Attribution headers flowing (credential-process provides `x-user-email`)
+- CoWork dashboard stack deployed (`ccwb deploy --stack cowork-dashboard`)
+
+### Limitations
+
+- **No inline blocking:** CoWork calls Bedrock directly via AWS credentials. There is no per-request interception — enforcement happens at credential refresh boundaries only.
+- **Attribution required:** If `x-user-email` header is not configured, CoWork usage is aggregate-only and cannot be attributed to individual users for quota purposes.
+- **CoWork-native `user.id`:** The opaque hash in raw CoWork events cannot be mapped back to an email without a separate device registry.
+
 ## Additional Resources
 
 - [AWS Blog: From Developer Desks to the Whole Organization — Running Claude Cowork in Amazon Bedrock](https://aws.amazon.com/blogs/machine-learning/from-developer-desks-to-the-whole-organization-running-claude-cowork-in-amazon-bedrock/)

--- a/assets/docs/MONITORING.md
+++ b/assets/docs/MONITORING.md
@@ -113,6 +113,8 @@ Quota monitoring uses the CloudWatch Prometheus-compatible API (`monitoring.<reg
 
 The quota check Lambda provides real-time allow/block decisions by reading the DynamoDB table (fast reads, at most 15 minutes stale).
 
+Both Claude Code and CoWork 3P (Claude Desktop) usage are counted toward the same per-user quota when the CoWork dashboard stack is deployed. See [CoWork 3P Quota Enforcement](COWORK_3P.md#quota-enforcement) for details.
+
 > **Detailed Information**: See the [Quota Monitoring Guide](QUOTA_MONITORING.md).
 
 ## Analytics Pipeline (Optional)

--- a/assets/docs/QUOTA_MONITORING.md
+++ b/assets/docs/QUOTA_MONITORING.md
@@ -715,6 +715,28 @@ ccwb deploy quota --parameters EnableBypassDetection=true
 - Group membership requires JWT group claims from identity provider (not available for IDC users — user-level policies only)
 - Enforcement only at credential issuance (see [Enforcement Timing](#enforcement-timing) for mitigation)
 
+## CoWork 3P Usage Counting
+
+When the CoWork dashboard stack is deployed, CoWork (Claude Desktop) token usage is automatically counted toward the same per-user quota as Claude Code:
+
+| Source | Namespace | Metric | Dimension |
+|--------|-----------|--------|-----------|
+| Claude Code | `ClaudeCode` | `claude_code.token.usage` | `user.email` |
+| CoWork 3P | `ClaudeCoWork` | `token.usage.input` / `token.usage.output` | `user_email` |
+
+The `quota_monitor` Lambda queries both namespaces and merges the results into a single DynamoDB record per user. This means:
+
+- `ccwb quota usage <email>` shows combined Claude Code + CoWork usage
+- Quota limits apply to the combined total
+- A user hitting their limit on CoWork will be blocked on the next Claude Code credential refresh (and vice versa)
+
+**Requirements:**
+- CoWork monitoring stack deployed (`ccwb deploy --stack cowork-dashboard`)
+- Attribution headers configured (collector injects `user_email` from `x-user-email` HTTP header)
+- Central monitoring mode (sidecar mode does not support CoWork telemetry counting)
+
+**Without attribution headers:** CoWork usage is aggregate-only and cannot be counted toward individual user quotas. The `quota_monitor` CoWork query gracefully returns empty results.
+
 ## Data Latency
 
 Different data paths have different latency characteristics:

--- a/deployment/infrastructure/cowork-dashboard.yaml
+++ b/deployment/infrastructure/cowork-dashboard.yaml
@@ -36,6 +36,9 @@ Resources:
           MetricName: token.usage.input
           MetricValue: $.attributes.input_tokens
           DefaultValue: 0
+          Dimensions:
+            - Key: "user_email"
+              Value: "$.attributes.user_email"
 
   OutputTokenMetricFilter:
     Type: AWS::Logs::MetricFilter
@@ -48,6 +51,9 @@ Resources:
           MetricName: token.usage.output
           MetricValue: $.attributes.output_tokens
           DefaultValue: 0
+          Dimensions:
+            - Key: "user_email"
+              Value: "$.attributes.user_email"
 
   CacheReadTokenMetricFilter:
     Type: AWS::Logs::MetricFilter
@@ -60,6 +66,9 @@ Resources:
           MetricName: token.usage.cache_read
           MetricValue: $.attributes.cache_read_tokens
           DefaultValue: 0
+          Dimensions:
+            - Key: "user_email"
+              Value: "$.attributes.user_email"
 
   CacheCreationTokenMetricFilter:
     Type: AWS::Logs::MetricFilter
@@ -72,6 +81,9 @@ Resources:
           MetricName: token.usage.cache_creation
           MetricValue: $.attributes.cache_creation_tokens
           DefaultValue: 0
+          Dimensions:
+            - Key: "user_email"
+              Value: "$.attributes.user_email"
 
   CostMetricFilter:
     Type: AWS::Logs::MetricFilter
@@ -84,6 +96,9 @@ Resources:
           MetricName: cost.usage
           MetricValue: $.attributes.cost_usd
           DefaultValue: 0
+          Dimensions:
+            - Key: "user_email"
+              Value: "$.attributes.user_email"
 
   SessionCountMetricFilter:
     Type: AWS::Logs::MetricFilter
@@ -96,6 +111,9 @@ Resources:
           MetricName: session.turns
           MetricValue: "1"
           DefaultValue: 0
+          Dimensions:
+            - Key: "user_email"
+              Value: "$.attributes.user_email"
 
   # --- Local Agent Mode schema (body.name="lam_session_turn_completed") ---
   # These emit to the SAME metric names so both modes contribute to the dashboard.

--- a/deployment/infrastructure/lambda-functions/quota_monitor/index.py
+++ b/deployment/infrastructure/lambda-functions/quota_monitor/index.py
@@ -103,6 +103,32 @@ def fetch_usage_from_promql():
                 u["cache_tokens"] = val
 
     print(f"Fetched delta usage for {len(users)} users from PromQL ({window}s window)")
+
+    # Also fetch CoWork 3P token usage (separate namespace, MetricFilter-derived).
+    # CoWork events are logged to /aws/claude-cowork/events and MetricFilters extract
+    # per-user metrics into the ClaudeCoWork namespace with user_email dimension.
+    # This ensures CoWork token consumption counts toward the same quota as Claude Code.
+    try:
+        cowork_input = _promql_query(
+            f'sum by ("user_email")(increase({{"ClaudeCoWork","token.usage.input"}}[{window}s]))'
+        )
+        cowork_output = _promql_query(
+            f'sum by ("user_email")(increase({{"ClaudeCoWork","token.usage.output"}}[{window}s]))'
+        )
+        cowork_count = 0
+        for r in cowork_input + cowork_output:
+            email = r["metric"].get("user_email", "")
+            val = float(r["value"][1])
+            if email and val > 0:
+                u = users.setdefault(email, {"total_tokens": 0})
+                u["total_tokens"] = u.get("total_tokens", 0) + val
+                cowork_count += 1
+        if cowork_count > 0:
+            print(f"Added CoWork 3P usage for {cowork_count} user-metric pairs")
+    except Exception as e:
+        # CoWork metrics are optional — don't fail quota monitoring if unavailable
+        print(f"CoWork PromQL query skipped (non-fatal): {e}")
+
     return users
 
 

--- a/source/tests/e2e/test_cowork_quota_counting.py
+++ b/source/tests/e2e/test_cowork_quota_counting.py
@@ -1,0 +1,90 @@
+# ABOUTME: Tests that quota_monitor aggregates CoWork 3P usage alongside Claude Code
+# ABOUTME: Regression test for CoWork tokens not counting toward per-user quota
+
+"""Tests for CoWork 3P quota counting in quota_monitor Lambda."""
+
+import json
+import pytest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+
+class TestCoWorkQuotaCounting:
+    """Verify quota_monitor queries ClaudeCoWork namespace and merges usage."""
+
+    def test_quota_monitor_has_cowork_promql_query(self):
+        """The quota_monitor Lambda must query ClaudeCoWork namespace metrics."""
+        lambda_path = (
+            Path(__file__).parent.parent.parent.parent
+            / "deployment"
+            / "infrastructure"
+            / "lambda-functions"
+            / "quota_monitor"
+            / "index.py"
+        )
+        content = lambda_path.read_text()
+        assert "ClaudeCoWork" in content, "quota_monitor must query ClaudeCoWork namespace"
+        assert "token.usage.input" in content, "quota_monitor must query CoWork input tokens"
+        assert "token.usage.output" in content, "quota_monitor must query CoWork output tokens"
+        assert "user_email" in content, "quota_monitor must group CoWork metrics by user_email"
+
+    def test_cowork_query_is_non_fatal(self):
+        """CoWork PromQL failure must not crash quota monitoring."""
+        lambda_path = (
+            Path(__file__).parent.parent.parent.parent
+            / "deployment"
+            / "infrastructure"
+            / "lambda-functions"
+            / "quota_monitor"
+            / "index.py"
+        )
+        content = lambda_path.read_text()
+        # The CoWork query must be wrapped in try/except
+        assert "non-fatal" in content.lower() or "non_fatal" in content.lower() or "optional" in content.lower(), (
+            "CoWork PromQL query must be wrapped in try/except with non-fatal handling"
+        )
+
+    def test_cowork_dashboard_has_user_email_dimension(self):
+        """CoWork metric filters must include user_email dimension for per-user attribution."""
+        import yaml
+        dashboard_path = (
+            Path(__file__).parent.parent.parent.parent
+            / "deployment"
+            / "infrastructure"
+            / "cowork-dashboard.yaml"
+        )
+        loader = yaml.SafeLoader
+        loader.add_multi_constructor("!", lambda l, suffix, n: l.construct_scalar(n) if n.id == "scalar" else l.construct_sequence(n))
+        with open(dashboard_path) as f:
+            template = yaml.load(f, Loader=loader)
+
+        resources = template.get("Resources", {})
+        api_request_filters = [
+            (name, res) for name, res in resources.items()
+            if res.get("Type") == "AWS::Logs::MetricFilter"
+            and "claude_code.api_request" in res.get("Properties", {}).get("FilterPattern", "")
+        ]
+
+        assert len(api_request_filters) >= 6, "Expected at least 6 api_request metric filters"
+
+        for name, res in api_request_filters:
+            transforms = res["Properties"]["MetricTransformations"]
+            for t in transforms:
+                dims = t.get("Dimensions", [])
+                dim_keys = [d.get("Key", "") for d in dims]
+                assert "user_email" in dim_keys, (
+                    f"{name}: MetricFilter must have user_email dimension for quota counting"
+                )
+
+    def test_cowork_docs_mention_quota_enforcement(self):
+        """COWORK_3P.md must document quota enforcement behavior."""
+        docs_path = (
+            Path(__file__).parent.parent.parent.parent
+            / "assets"
+            / "docs"
+            / "COWORK_3P.md"
+        )
+        content = docs_path.read_text()
+        assert "## Quota Enforcement" in content
+        assert "credential-process" in content
+        assert "credential refresh" in content.lower() or "refresh cycle" in content.lower()


### PR DESCRIPTION
## Why

CoWork 3P telemetry is tracked in a separate CloudWatch namespace (`ClaudeCoWork`) but never aggregated into the quota system. A user's CoWork Desktop usage is invisible to quota enforcement — they could burn through tokens on Claude Desktop without it counting toward their limit.

## How CoWork Quota Enforcement Works (after this PR)

```
┌─────────────────────────────────────────────────────────────────────────┐
│ COUNTING (post-hoc)                                                      │
│                                                                          │
│ CoWork Desktop → OTLP logs → Collector (injects user_email)              │
│   → CloudWatch Logs (/aws/claude-cowork/events)                          │
│     → MetricFilters (with user_email dimension) → ClaudeCoWork namespace │
│       → quota_monitor PromQL query → merges into UserQuotaMetrics DDB    │
│                                                                          │
├─────────────────────────────────────────────────────────────────────────┤
│ ENFORCEMENT (per credential refresh, ~1 hour)                            │
│                                                                          │
│ CoWork needs fresh creds → credential-process → quota_check API          │
│   → reads UserQuotaMetrics (combined Claude Code + CoWork usage)         │
│     → allowed? → issue/deny credentials                                  │
└─────────────────────────────────────────────────────────────────────────┘
```

## What Changed

| File | Change |
|------|--------|
| `deployment/infrastructure/cowork-dashboard.yaml` | Add `user_email` dimension to 6 api_request MetricFilters |
| `deployment/infrastructure/lambda-functions/quota_monitor/index.py` | Add PromQL query for `ClaudeCoWork` namespace, merge into per-user usage |
| `assets/docs/COWORK_3P.md` | New "Quota Enforcement" section documenting the full flow |
| `source/tests/e2e/test_cowork_quota_counting.py` | 4 new tests |

## Key Design Decisions

1. **Non-fatal CoWork query**: Wrapped in try/except — if ClaudeCoWork namespace doesn't exist (no CoWork deployed), quota monitoring continues for Claude Code only
2. **Additive merging**: CoWork tokens are added to the same DynamoDB user record as Claude Code tokens — single unified quota view
3. **`user_email` dimension (underscore)**: The collector's `attributes/logs` processor already creates this underscore variant specifically for MetricFilter compatibility (dots not allowed in JSON filter paths)
4. **Enforcement via credential refresh**: No inline blocking possible — CoWork calls Bedrock directly. Enforcement happens when session tokens expire (~1 hour)

## Backward Compatible

✅ Deployments without CoWork: PromQL returns empty, zero impact
✅ Deployments without attribution headers: `user_email` dimension absent, metrics are aggregate-only
✅ `quota_check` Lambda: zero changes (reads same DynamoDB table)
✅ Requires `ccwb deploy --stack cowork-dashboard` for MetricFilter dimension update

## Risk: Low

- MetricFilter dimension addition is non-breaking (existing metrics continue; dimension adds a new metric series)
- PromQL query failure is caught and logged (non-fatal)
- quota_monitor Lambda has existing tests for the aggregation logic

## Test Coverage (4 tests)

- PromQL query references ClaudeCoWork namespace
- CoWork query has non-fatal error handling
- MetricFilters have user_email dimension
- COWORK_3P.md documents quota enforcement