### PR TITLE
docs: add plugin distribution guide for Claude Code and Cowork 3P

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -1,0 +1,21 @@
+# Claude Code Plugin Marketplace Manifest
+
+This directory contains the `marketplace.json` file that registers available plugins for discovery via Claude Code's plugin system.
+
+## Usage
+
+```bash
+/plugin marketplace add aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock
+```
+
+## What this is
+
+The `marketplace.json` file is an index of all plugins in this repository. It tells Claude Code where to find each plugin's source directory and metadata. Individual plugins live under [`assets/claude-code-plugins/plugins/`](assets/claude-code-plugins/plugins/).
+
+## Important
+
+These are **example plugins** — reference implementations demonstrating enterprise development patterns. Fork and customize for your organization before production deployment.
+
+For distribution guidance (Claude Code vs Cowork 3P), see [Plugin Distribution Guide](assets/docs/PLUGINS.md).
+
+For the companion hands-on workshop, see [Claude Code on Amazon Bedrock Workshop](https://catalog.workshops.aws/claude-code-on-amazon-bedrock/en-US).

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ See [QUICK_START.md](QUICK_START.md#platform-builds) for build configuration.
 
 - [Quick Start Guide](QUICK_START.md) - Step-by-step deployment walkthrough
 - [CLI Reference](assets/docs/CLI_REFERENCE.md) - Complete command reference for the `ccwb` tool
+- [Workshop: Claude Code on Amazon Bedrock](https://catalog.workshops.aws/claude-code-on-amazon-bedrock/en-US) - Hands-on guided workshop with example plugins
 - [Claude Code deployment patterns and best practices with Amazon Bedrock](https://aws.amazon.com/blogs/machine-learning/claude-code-deployment-patterns-and-best-practices-with-amazon-bedrock/) - Blog post covering deployment patterns and best practices
 
 ### Architecture & Deployment
@@ -177,6 +178,11 @@ See [QUICK_START.md](QUICK_START.md#platform-builds) for build configuration.
 
 - [Cost Estimates](assets/docs/COST_ESTIMATES.md) - High-level monthly cost estimates by deployment tier and team size
 - [Cost Attribution](assets/docs/COST_ATTRIBUTION.md) - Per-user and per-team cost tracking via CUR 2.0 and Cost Explorer
+
+### Plugins & Extensions
+
+- [Plugin Distribution Guide](assets/docs/PLUGINS.md) - How to distribute plugins for Claude Code and Cowork 3P
+- [Example Plugins](assets/claude-code-plugins/) - Enterprise plugin examples (security, architecture, testing, etc.)
 
 ### Claude Cowork (Desktop)
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ See [QUICK_START.md](QUICK_START.md#platform-builds) for build configuration.
 
 - [Quick Start Guide](QUICK_START.md) - Step-by-step deployment walkthrough
 - [CLI Reference](assets/docs/CLI_REFERENCE.md) - Complete command reference for the `ccwb` tool
-- [Workshop: Claude Code on Amazon Bedrock](https://catalog.workshops.aws/claude-code-on-amazon-bedrock/en-US) - Hands-on guided workshop with example plugins
+- [Workshop: Claude Code on Amazon Bedrock](https://catalog.workshops.aws/claude-code-on-amazon-bedrock/en-US) - Companion hands-on workshop
 - [Claude Code deployment patterns and best practices with Amazon Bedrock](https://aws.amazon.com/blogs/machine-learning/claude-code-deployment-patterns-and-best-practices-with-amazon-bedrock/) - Blog post covering deployment patterns and best practices
 
 ### Architecture & Deployment
@@ -179,10 +179,9 @@ See [QUICK_START.md](QUICK_START.md#platform-builds) for build configuration.
 - [Cost Estimates](assets/docs/COST_ESTIMATES.md) - High-level monthly cost estimates by deployment tier and team size
 - [Cost Attribution](assets/docs/COST_ATTRIBUTION.md) - Per-user and per-team cost tracking via CUR 2.0 and Cost Explorer
 
-### Plugins & Extensions
+### Plugins
 
-- [Plugin Distribution Guide](assets/docs/PLUGINS.md) - How to distribute plugins for Claude Code and Cowork 3P
-- [Example Plugins](assets/claude-code-plugins/) - Enterprise plugin examples (security, architecture, testing, etc.)
+- [Example Plugins](assets/claude-code-plugins/) - Example plugins for Claude Code and Cowork 3P ([distribution guide](assets/docs/PLUGINS.md))
 
 ### Claude Cowork (Desktop)
 

--- a/assets/claude-code-plugins/README.md
+++ b/assets/claude-code-plugins/README.md
@@ -1,9 +1,9 @@
 > **Part of**: [Guidance for Claude Code with Amazon Bedrock](https://github.com/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock)
-> **Purpose**: This subdirectory contains production-ready Claude Code plugins - completely independent of the authentication setup
+> **Purpose**: This subdirectory contains example Claude Code plugins - completely independent of the authentication setup
 
 # Claude Code Plugins Marketplace
 
-Production-ready agents, hooks, and workflows for Claude Code - a comprehensive plugin marketplace providing specialized tools for systematic development, documentation, architecture, security, and more.
+Example agents, hooks, and workflows for Claude Code - a comprehensive plugin marketplace providing specialized tools for systematic development, documentation, architecture, security, and more.
 
 ## 🚀 Quick Start
 
@@ -336,12 +336,12 @@ This project is licensed under MIT-0 - see the [LICENSE](LICENSE) file for detai
 
 ## ⭐ Highlights
 
-- **11 Production-Ready Plugins** - Comprehensive tooling for modern development
+- **11 Example Plugins** - Reference implementations for modern development patterns
 - **Advanced Metadata** - Rich discoverability with keywords, tags, and categories
 - **Modular Design** - Install only what you need
 - **Team-Friendly** - Enforce standards with required plugins
 - **Well-Documented** - Complete guides and examples
-- **Battle-Tested** - Based on proven patterns and workflows
+- **Fork & Customize** - Designed as starting points for your organization's specific needs
 
 ---
 

--- a/assets/docs/PLUGINS.md
+++ b/assets/docs/PLUGINS.md
@@ -1,0 +1,79 @@
+# Plugin Distribution Guide
+
+This guidance ships example Claude Code plugins demonstrating enterprise development patterns. These plugins work with both **Claude Code** (CLI) and **Claude Cowork** (Desktop) but are distributed differently depending on your deployment model.
+
+> **⚠️ Important:** These are example starting points — fork and customize for your organization before production use. Adapt security policies, tooling integrations, and workflows to match your environment.
+
+## Distribution Models
+
+### Claude Code (developer-initiated)
+
+Developers install plugins directly from this repository's marketplace using the Claude Code CLI:
+
+```bash
+# Add this repo as a marketplace source
+/plugin marketplace add aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock
+
+# Install a specific plugin
+/plugin install security@aws-claude-code-plugins
+
+# Update all marketplace plugins
+/plugin marketplace update
+```
+
+Plugins are stored in the user's local `.claude/plugins/` directory. Users choose which plugins to install and can remove them at any time.
+
+**Official documentation:** [Discover and install plugins](https://code.claude.com/docs/en/discover-plugins) | [Create a plugin marketplace](https://code.claude.com/docs/en/plugin-marketplaces)
+
+### Claude Cowork on 3P (admin-managed)
+
+For Cowork on third-party platforms (e.g., Amazon Bedrock), administrators provision plugins through the filesystem rather than the marketplace CLI. There are three extension layers, in order of precedence:
+
+| Layer | Provisioned by | Delivered via |
+|-------|---------------|---------------|
+| Managed MCP servers | Admin | `managedMcpServers` configuration key |
+| Organization plugins | Admin | System-wide directory on each device |
+| User extensions | End user | In-app Connectors and Plugins UI |
+
+**Organization plugins** are distributed by placing plugin directories on each device via MDM (Jamf, Intune, Group Policy) or your standard software distribution channel. Users cannot remove admin-provisioned plugins.
+
+**Recommended workflow for Cowork 3P:**
+
+1. **Fork** this repository
+2. **Customize** plugins for your organization (connectors, terminology, workflows, security policies)
+3. **Push** the customized plugin directories to devices via MDM alongside the managed-settings configuration
+4. Optionally disable the user extension layer if you want admin-only control
+
+**Official documentation:** [MCP, plugins, skills, and hooks for Cowork 3P](https://claude.com/docs/cowork/3p/extensions)
+
+### Comparison
+
+| Aspect | Claude Code | Cowork 3P (admin) |
+|--------|------------|-------------------|
+| Install mechanism | `/plugin marketplace add` (git-backed) | MDM push to filesystem |
+| Who decides | Individual developer | IT administrator |
+| Removable by user | Yes | No (org plugins) |
+| Update mechanism | `/plugin marketplace update` | Re-push via MDM |
+| MCP servers | Bundled in plugin `.mcp.json` | Separate `managedMcpServers` config key |
+| Team enforcement | `.claude/settings.json` `requiredPlugins` | MDM policy |
+
+## Customization Before Deployment
+
+These plugins are designed as **templates**, not turnkey solutions. Before deploying to your organization:
+
+- **Security plugin:** Review PII patterns for your jurisdiction, adjust regex rules, configure audit log destinations
+- **Architecture plugin:** Update architecture decision record (ADR) templates to match your standards
+- **EPCC workflow:** Customize commit message formats, branch naming, and review processes
+- **All plugins:** Update `.mcp.json` connector configurations to point at your internal tools
+
+## Workshop
+
+For a guided walkthrough of these plugins, see the companion workshop:
+[Claude Code on Amazon Bedrock Workshop](https://catalog.workshops.aws/claude-code-on-amazon-bedrock/en-US)
+
+## Related Resources
+
+- [Anthropic's knowledge-work-plugins](https://github.com/anthropics/knowledge-work-plugins) — Official role-based plugin examples for Cowork
+- [Claude Code Plugin Reference](https://code.claude.com/docs/en/plugins) — Full plugin authoring guide
+- [Cowork 3P Configuration Reference](https://claude.com/docs/cowork/3p/configuration) — Managed settings schema
+- [COWORK_3P.md](COWORK_3P.md) — This guidance's Cowork 3P deployment guide

--- a/assets/docs/PLUGINS.md
+++ b/assets/docs/PLUGINS.md
@@ -46,7 +46,7 @@ For Cowork on third-party platforms (e.g., Amazon Bedrock), administrators provi
 
 **Official documentation:** [MCP, plugins, skills, and hooks for Cowork 3P](https://claude.com/docs/cowork/3p/extensions)
 
-### Comparison
+### Distribution Comparison
 
 | Aspect | Claude Code | Cowork 3P (admin) |
 |--------|------------|-------------------|
@@ -54,8 +54,35 @@ For Cowork on third-party platforms (e.g., Amazon Bedrock), administrators provi
 | Who decides | Individual developer | IT administrator |
 | Removable by user | Yes | No (org plugins) |
 | Update mechanism | `/plugin marketplace update` | Re-push via MDM |
-| MCP servers | Bundled in plugin `.mcp.json` | Separate `managedMcpServers` config key |
+| MCP servers | Bundled in plugin `.mcp.json` | Bundled `.mcp.json` + separate `managedMcpServers` config key |
 | Team enforcement | `.claude/settings.json` `requiredPlugins` | MDM policy |
+
+## Plugin Component Differences
+
+The plugin directory format is largely shared between Claude Code and Cowork, but each product supports different component types:
+
+| Component | Claude Code | Cowork | Notes |
+|-----------|:-----------:|:------:|-------|
+| Skills (`skills/`) | ✅ | ✅ | Same format on both |
+| Commands (`commands/`) | ✅ | ✅ | Slash commands |
+| Agents/Sub-agents (`agents/`) | ✅ | ✅ | Same format on both |
+| Hooks (`hooks/hooks.json`) | ✅ | ✅ | Same lifecycle events |
+| MCP servers (`.mcp.json`) | ✅ | ✅ | Called "connectors" in Cowork UI |
+| LSP servers | ✅ | ❌ | Code intelligence (editor-only) |
+| Monitors | ✅ | ❌ | Claude Code-specific |
+| Themes | ✅ | ❌ | Terminal UI theming |
+| Tool policy locks | ❌ | ✅ | Admin can set `allow`/`ask`/`blocked` per tool |
+
+**Key behavioral differences:**
+
+- **MCP server approval:** In Claude Code, users approve MCP server access at runtime. In Cowork org plugins, MCP servers are pre-approved by the administrator — users cannot block them.
+- **Connectors vs MCP servers:** Cowork uses the term "connectors" in the UI for MCP servers. The underlying protocol (MCP) is the same.
+- **Standalone MCP provisioning:** Cowork admins can deploy MCP servers *without* a plugin via the `managedMcpServers` configuration key. Claude Code requires MCP servers to be either in a plugin's `.mcp.json` or in the user's `.claude/settings.json`.
+- **LSP/Monitors/Themes:** These are Claude Code-specific (terminal editor features). Plugins containing only these components won't provide any value when deployed to Cowork.
+
+**Official documentation:**
+- Claude Code plugin components: [Plugins reference](https://code.claude.com/docs/en/plugins-reference)
+- Cowork 3P extensions: [MCP, plugins, skills, and hooks](https://claude.com/docs/cowork/3p/extensions)
 
 ## Customization Before Deployment
 


### PR DESCRIPTION
## Why

This repository ships example Claude Code plugins but lacks clear documentation on:
- How to distribute them (Claude Code marketplace vs Cowork 3P MDM push)
- Which plugin components work on which product
- That they are examples to fork, not production-ready solutions
- The connection to the [companion workshop](https://catalog.workshops.aws/claude-code-on-amazon-bedrock/en-US) — the workshop depends on these plugins for its hands-on labs, so they cannot be removed from the repository without breaking the workshop content. Previous proposals to remove them didn't account for this dependency.

## Changes

### New: `assets/docs/PLUGINS.md`
- Documents both distribution models (marketplace vs MDM) with comparison table
- Component comparison table: skills, agents, hooks, MCP, LSP, monitors, themes, tool policies
- Key behavioral differences (approval model, connectors terminology, standalone MCP)
- Official Anthropic documentation links
- Recommended customization steps before deployment
- Links to companion workshop and Anthropic's knowledge-work-plugins repo

### New: `.claude-plugin/README.md`
- Explains what the marketplace manifest directory is
- Links to distribution guide and workshop

### Updated: `README.md`
- Added workshop link under "Getting Started" in Additional Resources
- Added new "Plugins" section linking to the distribution guide

### Updated: `assets/claude-code-plugins/README.md`
- Replaced "production-ready" with "example" throughout
- Replaced "Battle-Tested" with "Fork & Customize" guidance
- Positions plugins as reference implementations, not turnkey solutions