### PR TITLE
docs: fix stale IDC and sidecar claims in COST_ATTRIBUTION and QUOTA_MONITORING

### DIFF
--- a/assets/docs/COST_ATTRIBUTION.md
+++ b/assets/docs/COST_ATTRIBUTION.md
@@ -188,4 +188,4 @@ Once configured, the CloudWatch dashboard shows usage grouped by project in the 
 
 ### IDC limitation
 
-IAM Identity Center (SSO) users do not have JWT claims, so project attribution via OTEL is not available for IDC deployments. Use CUR 2.0 with IAM principal tags (section 2) as an alternative.
+IAM Identity Center (SSO) users do not have JWT claims, so project/team/department attribution via OTEL is not available for IDC deployments (per-user email attribution still works). For per-user cost visibility in CUR 2.0, configure [ABAC attributes](https://docs.aws.amazon.com/singlesignon/latest/userguide/abac.html) in IAM Identity Center so session tags flow automatically.

--- a/assets/docs/QUOTA_MONITORING.md
+++ b/assets/docs/QUOTA_MONITORING.md
@@ -733,7 +733,7 @@ The `quota_monitor` Lambda queries both namespaces and merges the results into a
 **Requirements:**
 - CoWork monitoring stack deployed (`ccwb deploy --stack cowork-dashboard`)
 - Attribution headers configured (collector injects `user_email` from `x-user-email` HTTP header)
-- Central monitoring mode (sidecar mode does not support CoWork telemetry counting)
+- Central or sidecar monitoring mode (both support CoWork telemetry counting)
 
 **Without attribution headers:** CoWork usage is aggregate-only and cannot be counted toward individual user quotas. The `quota_monitor` CoWork query gracefully returns empty results.
 


### PR DESCRIPTION
## Why

Two docs have stale statements that contradict the README and recent PRs:

1. **COST_ATTRIBUTION.md** — said IDC can't do OTEL attribution at all. IDC actually gets per-user email attribution; only project/team/dept claims are unavailable. Updated to reference ABAC for CUR 2.0 (aligned with README table).

2. **QUOTA_MONITORING.md** — said sidecar mode doesn't support CoWork telemetry counting. Both central and sidecar now work (per #587/#608).

No code changes — docs-only alignment.