### PR TITLE
fix(idc): fix OTEL attribution for IDC users (credential recursion + non-email usernames)

### DIFF
--- a/source/go/cmd/credential-process/idc.go
+++ b/source/go/cmd/credential-process/idc.go
@@ -23,11 +23,14 @@ import (
 	"os"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials/ssocreds"
 	"github.com/aws/aws-sdk-go-v2/service/sso"
 	"github.com/aws/aws-sdk-go-v2/service/ssooidc"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 
+	"ccwb-go/internal/otel"
 	"ccwb-go/internal/quota"
 )
 
@@ -130,8 +133,10 @@ func (a *credentialApp) runIDC() int {
 		printQuotaWarning(qr)
 	}
 
-	// Write OTEL attribution cache (email from STS ARN session name).
-	a.writeOtelCacheFromSTS()
+	// Write OTEL attribution cache using the just-obtained IDC credentials.
+	// We pass creds explicitly to avoid LoadDefaultConfig resolving via
+	// credential_process (which would recurse back into this binary).
+	a.writeOtelCacheFromIDC(creds, region)
 
 	// Output credential_process JSON.
 	out := passthroughOutput{
@@ -151,4 +156,49 @@ func (a *credentialApp) runIDC() int {
 	}
 	fmt.Println(string(data))
 	return 0
+}
+
+// writeOtelCacheFromIDC resolves user identity via STS GetCallerIdentity
+// using the just-obtained IDC credentials (passed explicitly to avoid
+// LoadDefaultConfig resolving via credential_process recursion).
+func (a *credentialApp) writeOtelCacheFromIDC(creds aws.Credentials, region string) {
+	ctx := context.Background()
+	cfg, err := awsconfig.LoadDefaultConfig(ctx,
+		awsconfig.WithRegion(region),
+		awsconfig.WithCredentialsProvider(
+			aws.CredentialsProviderFunc(func(ctx context.Context) (aws.Credentials, error) {
+				return creds, nil
+			}),
+		),
+	)
+	if err != nil {
+		debugPrint("writeOtelCacheFromIDC: failed to load AWS config: %v", err)
+		return
+	}
+
+	stsClient := sts.NewFromConfig(cfg)
+	identity, err := stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
+		debugPrint("writeOtelCacheFromIDC: GetCallerIdentity failed: %v", err)
+		return
+	}
+
+	arn := ""
+	if identity.Arn != nil {
+		arn = *identity.Arn
+	}
+	email := extractEmailFromARN(arn)
+	if email == "" {
+		debugPrint("writeOtelCacheFromIDC: could not extract identity from ARN: %s", arn)
+		return
+	}
+
+	debugPrint("writeOtelCacheFromIDC: resolved identity: %s", email)
+
+	userInfo := otel.UserInfo{Email: email}
+	headers := otel.FormatHeaders(userInfo)
+	expiry := time.Now().Add(1 * time.Hour).Unix()
+	if err := otel.WriteCachedHeaders(a.profile, headers, expiry); err != nil {
+		debugPrint("writeOtelCacheFromIDC: cache write failed: %v", err)
+	}
 }

--- a/source/go/cmd/credential-process/main.go
+++ b/source/go/cmd/credential-process/main.go
@@ -825,6 +825,11 @@ func (a *credentialApp) writeOtelCacheFromSTS() bool {
 
 // extractEmailFromARN extracts the session name (typically email) from an
 // assumed-role ARN. Format: arn:aws:sts::ACCOUNT:assumed-role/ROLE/SESSION
+//
+// For IAM Identity Center, the session name is the IDC username — which may
+// be an email (user@company.com) or a plain username (akshaya.claude).
+// Non-email usernames are accepted when the role name contains "AWSReservedSSO"
+// (confirming it's an IDC-assumed role, not a Lambda/service role).
 func extractEmailFromARN(arn string) string {
 	// Split on "/" — assumed-role ARNs have: assumed-role/RoleName/SessionName
 	parts := strings.Split(arn, "/")
@@ -832,8 +837,15 @@ func extractEmailFromARN(arn string) string {
 		return ""
 	}
 	sessionName := parts[len(parts)-1]
-	// Only return if it looks like an email (contains @)
+	if sessionName == "" {
+		return ""
+	}
+	// Standard case: session name is an email address
 	if strings.Contains(sessionName, "@") {
+		return sessionName
+	}
+	// Non-email IDC username (e.g. "akshaya.claude") — accept if AWSReservedSSO role
+	if strings.Contains(arn, "AWSReservedSSO") {
 		return sessionName
 	}
 	return ""

--- a/source/go/cmd/credential-process/otel_idc_test.go
+++ b/source/go/cmd/credential-process/otel_idc_test.go
@@ -54,3 +54,41 @@ func TestExtractEmailFromARN(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractEmailFromARN_NonEmailIDC(t *testing.T) {
+	tests := []struct {
+		name     string
+		arn      string
+		expected string
+	}{
+		{
+			name:     "non-email IDC username with AWSReservedSSO role",
+			arn:      "arn:aws:sts::123456789012:assumed-role/AWSReservedSSO_BedrockDeveloper_abc123/akshaya.claude",
+			expected: "akshaya.claude",
+		},
+		{
+			name:     "non-email with generic role (NOT IDC) must NOT resolve",
+			arn:      "arn:aws:sts::123456789012:assumed-role/LambdaExecutionRole/session123",
+			expected: "",
+		},
+		{
+			name:     "email IDC username still works",
+			arn:      "arn:aws:sts::123456789012:assumed-role/AWSReservedSSO_BedrockDev_xyz/user@company.com",
+			expected: "user@company.com",
+		},
+		{
+			name:     "email with non-SSO role still works",
+			arn:      "arn:aws:sts::123456789012:assumed-role/CustomRole/admin@corp.com",
+			expected: "admin@corp.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractEmailFromARN(tt.arn)
+			if result != tt.expected {
+				t.Errorf("extractEmailFromARN(%q) = %q, want %q", tt.arn, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why

IDC users may get no OTEL attribution (empty user identity in dashboards) due to two bugs in the credential-process binary's IDC path.

## Bug 1: Credential recursion in `writeOtelCacheFromSTS`

**Location:** `idc.go:134` → `main.go:writeOtelCacheFromSTS()`

The function calls `awsconfig.LoadDefaultConfig(ctx)` to create an STS client. But in an IDC deployment, the active profile in `~/.aws/config` has `credential_process = .../credential-process --profile X`. This means:

1. `LoadDefaultConfig` resolves credentials via `credential_process`
2. SDK spawns a NEW credential-process → which calls `runIDC()` → which calls `writeOtelCacheFromSTS()` → recursion
3. The 120s timeout kills the recursive chain → STS call fails silently → no OTEL cache written

**Fix:** New `writeOtelCacheFromIDC(creds, region)` passes the just-obtained IDC credentials explicitly via `CredentialsProviderFunc` — bypasses the default chain entirely.

## Bug 2: Non-email IDC usernames get no attribution

**Location:** `main.go:extractEmailFromARN()`

The function requires `@` in the session name. IDC users with non-email usernames (e.g. `akshaya.claude`) return empty → OTEL cache is never written.

This was fixed in the quota Lambda (#597) but not in the Go binary.

**Fix:** Accept non-email session names when the ARN contains `AWSReservedSSO` (same guard as #597).

## What Changed

| File | Change |
|------|--------|
| `idc.go` | Replace `writeOtelCacheFromSTS()` with `writeOtelCacheFromIDC(creds, region)` |
| `idc.go` | New `writeOtelCacheFromIDC` function (explicit creds + region) |
| `main.go` | Update `extractEmailFromARN` with `AWSReservedSSO` guard for non-email usernames |
| `otel_idc_test.go` | 4 new test cases |

## OIDC Path Impact: NONE

- `writeOtelCacheFromIDC` is only called from `idc.go` (new function)
- `extractEmailFromARN` existing `@` behavior unchanged (new branch is after the @ check)
- OIDC uses `saveMonitoringTokenAndHeaders()` for attribution (JWT path, never calls `extractEmailFromARN`)
- Passthrough fallback path still uses `writeOtelCacheFromSTS` (unchanged)

## Backward Compatible

✅ Email IDC users: identical behavior (`@` check succeeds first)
✅ Non-email IDC users: now get attribution (previously silent failure)  
✅ Non-SSO roles: still return empty (`AWSReservedSSO` guard)
✅ OIDC: untouched
✅ Passthrough: untouched

## Risk: Low

- Go changes in credential-process (Tier 1 file)
- But: only IDC-specific code paths modified
- Existing tests continue to pass (email extraction unchanged)
- New tests cover the new branches
- CI Go tests run on all platforms

## Test Coverage

4 new test cases:
- Non-email IDC username with `AWSReservedSSO` role → resolves
- Non-email with generic role → does NOT resolve (guard works)
- Email with IDC role → still works
- Email with non-SSO role → still works