### PR TITLE
fix(dashboard): remove DefaultValue from dimensioned CoWork metric filters

### DIFF
--- a/deployment/infrastructure/cowork-dashboard.yaml
+++ b/deployment/infrastructure/cowork-dashboard.yaml
@@ -35,7 +35,9 @@ Resources:
         - MetricNamespace: ClaudeCoWork
           MetricName: token.usage.input
           MetricValue: $.attributes.input_tokens
-          DefaultValue: 0
+          # NOTE: DefaultValue and Dimensions are mutually exclusive in
+          # AWS::Logs::MetricFilter (CloudWatch Logs rejects both together).
+          # Dimensions win here for per-user attribution.
           Dimensions:
             - Key: "user_email"
               Value: "$.attributes.user_email"
@@ -50,7 +52,9 @@ Resources:
         - MetricNamespace: ClaudeCoWork
           MetricName: token.usage.output
           MetricValue: $.attributes.output_tokens
-          DefaultValue: 0
+          # NOTE: DefaultValue and Dimensions are mutually exclusive in
+          # AWS::Logs::MetricFilter (CloudWatch Logs rejects both together).
+          # Dimensions win here for per-user attribution.
           Dimensions:
             - Key: "user_email"
               Value: "$.attributes.user_email"
@@ -65,7 +69,9 @@ Resources:
         - MetricNamespace: ClaudeCoWork
           MetricName: token.usage.cache_read
           MetricValue: $.attributes.cache_read_tokens
-          DefaultValue: 0
+          # NOTE: DefaultValue and Dimensions are mutually exclusive in
+          # AWS::Logs::MetricFilter (CloudWatch Logs rejects both together).
+          # Dimensions win here for per-user attribution.
           Dimensions:
             - Key: "user_email"
               Value: "$.attributes.user_email"
@@ -80,7 +86,9 @@ Resources:
         - MetricNamespace: ClaudeCoWork
           MetricName: token.usage.cache_creation
           MetricValue: $.attributes.cache_creation_tokens
-          DefaultValue: 0
+          # NOTE: DefaultValue and Dimensions are mutually exclusive in
+          # AWS::Logs::MetricFilter (CloudWatch Logs rejects both together).
+          # Dimensions win here for per-user attribution.
           Dimensions:
             - Key: "user_email"
               Value: "$.attributes.user_email"
@@ -95,7 +103,9 @@ Resources:
         - MetricNamespace: ClaudeCoWork
           MetricName: cost.usage
           MetricValue: $.attributes.cost_usd
-          DefaultValue: 0
+          # NOTE: DefaultValue and Dimensions are mutually exclusive in
+          # AWS::Logs::MetricFilter (CloudWatch Logs rejects both together).
+          # Dimensions win here for per-user attribution.
           Dimensions:
             - Key: "user_email"
               Value: "$.attributes.user_email"
@@ -110,7 +120,9 @@ Resources:
         - MetricNamespace: ClaudeCoWork
           MetricName: session.turns
           MetricValue: "1"
-          DefaultValue: 0
+          # NOTE: DefaultValue and Dimensions are mutually exclusive in
+          # AWS::Logs::MetricFilter (CloudWatch Logs rejects both together).
+          # Dimensions win here for per-user attribution.
           Dimensions:
             - Key: "user_email"
               Value: "$.attributes.user_email"

--- a/source/tests/e2e/test_cowork_dashboard_filters.py
+++ b/source/tests/e2e/test_cowork_dashboard_filters.py
@@ -109,6 +109,23 @@ class TestCoWorkDashboardMetricFilters:
                 f"{name}: expected /aws/claude-cowork/events, got {log_group}"
             )
 
+    def test_no_filter_combines_dimensions_and_default_value(self):
+        """DefaultValue and Dimensions are mutually exclusive in AWS::Logs::MetricFilter.
+
+        Regression: CloudWatch Logs rejects a MetricTransformation that sets both
+        ("dimensions and default value are mutually exclusive properties"), which
+        broke `ccwb deploy` of the cowork-dashboard stack.
+        """
+        filters = self._get_filters()
+        for name, res in filters.items():
+            for transform in res["Properties"]["MetricTransformations"]:
+                has_dimensions = "Dimensions" in transform
+                has_default = "DefaultValue" in transform
+                assert not (has_dimensions and has_default), (
+                    f"{name}: MetricTransformation sets both Dimensions and DefaultValue; "
+                    "they are mutually exclusive and CloudWatch Logs will reject the filter"
+                )
+
     def test_all_filters_use_claude_cowork_namespace(self):
         """All filters must emit to ClaudeCoWork namespace."""
         filters = self._get_filters()


### PR DESCRIPTION
## Why
\`ccwb deploy\` failed on the \`cowork-dashboard\` stack with:
\`Invalid metric transformation: dimensions and default value are mutually exclusive properties\`.

The six \`claude_code.api_request\` metric filters declared both \`DefaultValue: 0\` and a
\`Dimensions\` block in the same \`MetricTransformation\`, which AWS::Logs::MetricFilter rejects.

## What
Removed \`DefaultValue: 0\` from those filters (Dimensions retained for per-user
\`user_email\` attribution). LAM filters are unchanged. Added a regression test that
fails if any transformation sets both properties."

The error during deployment: 
<img width="829" height="130" alt="image" src="https://github.com/user-attachments/assets/d3af02a8-f4e1-405c-b316-d5f456f898df" />
