### PR TITLE
feat(monitoring): support internal ALB for private network deployments

### DIFF
--- a/deployment/infrastructure/otel-collector.yaml
+++ b/deployment/infrastructure/otel-collector.yaml
@@ -62,6 +62,17 @@ Parameters:
       CoWork cannot perform OIDC auth (no browser/helper), so this
       provides an alternative auth path for its OTLP events.
 
+  ALBScheme:
+    Type: String
+    Default: 'internet-facing'
+    AllowedValues:
+      - 'internet-facing'
+      - 'internal'
+    Description: >-
+      Load balancer scheme. Use 'internal' for private network deployments
+      where users connect via VPN, Direct Connect, or internal office networks.
+      Default: internet-facing (backwards compatible).
+
 Conditions:
   HasCustomDomain: !Not [!Equals [!Ref CustomDomainName, '']]
   NoCustomDomain: !Equals [!Ref CustomDomainName, '']
@@ -87,6 +98,7 @@ Conditions:
     - !Condition HasJwtAuth
     - !Condition HasCoWorkToken
   AnalyticsEnabled: !Equals [!Ref EnableAnalytics, 'true']
+  IsInternalALB: !Equals [!Ref ALBScheme, 'internal']
 
 # Rules section removed - validation handled by deployment script
 
@@ -153,13 +165,45 @@ Resources:
         - IpProtocol: tcp
           FromPort: 443
           ToPort: 443
-          CidrIp: 0.0.0.0/0
-          Description: HTTPS access from anywhere
+          CidrIp: !If [IsInternalALB, '10.0.0.0/8', '0.0.0.0/0']
+          Description: !If [IsInternalALB, 'HTTPS from private networks (10.x.x.x)', 'HTTPS access from anywhere']
+        - !If
+          - IsInternalALB
+          - IpProtocol: tcp
+            FromPort: 443
+            ToPort: 443
+            CidrIp: '172.16.0.0/12'
+            Description: 'HTTPS from private networks (172.16.x.x)'
+          - !Ref AWS::NoValue
+        - !If
+          - IsInternalALB
+          - IpProtocol: tcp
+            FromPort: 443
+            ToPort: 443
+            CidrIp: '192.168.0.0/16'
+            Description: 'HTTPS from private networks (192.168.x.x)'
+          - !Ref AWS::NoValue
         - IpProtocol: tcp
           FromPort: 80
           ToPort: 80
-          CidrIp: 0.0.0.0/0
-          Description: HTTP access (redirects to HTTPS)
+          CidrIp: !If [IsInternalALB, '10.0.0.0/8', '0.0.0.0/0']
+          Description: !If [IsInternalALB, 'HTTP from private networks (10.x.x.x)', 'HTTP access (redirects to HTTPS)']
+        - !If
+          - IsInternalALB
+          - IpProtocol: tcp
+            FromPort: 80
+            ToPort: 80
+            CidrIp: '172.16.0.0/12'
+            Description: 'HTTP from private networks (172.16.x.x)'
+          - !Ref AWS::NoValue
+        - !If
+          - IsInternalALB
+          - IpProtocol: tcp
+            FromPort: 80
+            ToPort: 80
+            CidrIp: '192.168.0.0/16'
+            Description: 'HTTP from private networks (192.168.x.x)'
+          - !Ref AWS::NoValue
       Tags:
         - Key: Name
           Value: otel-collector-alb-sg
@@ -212,7 +256,7 @@ Resources:
     Properties:
       Type: application
       IpAddressType: ipv4
-      Scheme: internet-facing
+      Scheme: !Ref ALBScheme
       SecurityGroups:
         - !Ref ALBSecurityGroup
       Subnets: !Ref SubnetIds

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -787,6 +787,11 @@ class DeployCommand(Command):
                 analytics_enabled = "true" if getattr(profile, "analytics_enabled", True) else "false"
                 params.append(f"EnableAnalytics={analytics_enabled}")
 
+                # Pass ALB scheme (internet-facing or internal) for private network deployments
+                alb_scheme = monitoring_config.get("alb_scheme", "internet-facing")
+                if alb_scheme == "internal":
+                    params.append("ALBScheme=internal")
+
                 console.print(f"[dim]Using parameters: {params}[/dim]")
                 result = deploy_with_cf(
                     template, stack_name, params, task_description="Deploying monitoring collector..."

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -938,6 +938,24 @@ class InitCommand(Command):
                         return None
                     config["monitoring"]["vpc_config"] = vpc_config
 
+                    # ALB scheme: internet-facing (default) or internal (private network)
+                    existing_alb_scheme = config["monitoring"].get("alb_scheme", "internet-facing")
+                    alb_scheme = questionary.select(
+                        "Load balancer network exposure:",
+                        choices=[
+                            questionary.Choice(
+                                "Internet-facing (default — accessible from public internet)",
+                                value="internet-facing",
+                            ),
+                            questionary.Choice(
+                                "Internal (private — only accessible via VPN/Direct Connect/internal network)",
+                                value="internal",
+                            ),
+                        ],
+                        default=existing_alb_scheme,
+                    ).ask()
+                    config["monitoring"]["alb_scheme"] = alb_scheme
+
                     # Optional: Configure HTTPS with custom domain
                     console.print("\n[yellow]Optional: Configure HTTPS for secure telemetry[/yellow]")
 


### PR DESCRIPTION
## Summary

Adds support for deploying the OTEL collector ALB as **internal** (private network only), addressing #190.

Enterprise customers using VPN, Direct Connect, or internal office networks can now deploy without exposing a public endpoint.

## Changes

| File | Change |
|------|--------|
| `deployment/infrastructure/otel-collector.yaml` | New `ALBScheme` parameter, `IsInternalALB` condition, SG rules covering all RFC 1918 ranges for internal mode |
| `source/.../deploy.py` | Pass `ALBScheme=internal` when configured |
| `source/.../init.py` | New "Load balancer network exposure" prompt in central monitoring mode |

## Security Group Behaviour

| Mode | CIDR Blocks (ports 80 + 443) |
|------|------------------------------|
| `internet-facing` (default) | `0.0.0.0/0` — unchanged from today |
| `internal` | `10.0.0.0/8` + `172.16.0.0/12` + `192.168.0.0/16` — all RFC 1918 private ranges |

This ensures coverage regardless of which private address range the enterprise VPN or peered VPC uses.

## How clients connect with internal ALB

Claude Code and Claude Desktop (CoWork) connect to the OTEL endpoint via:

1. **Corporate VPN** — route to VPC private subnets, ALB DNS resolves to private IPs
2. **Direct Connect / Transit Gateway** — on-premises networks peered to VPC
3. **VPC peering** — clients in another VPC (Cloud9, WorkSpaces)
4. **AWS Client VPN** — managed VPN endpoint in the same VPC

**No client-side config changes** — OTEL_EXPORTER_OTLP_ENDPOINT uses the same ALB DNS name. Only requirement is network reachability.

## Backwards compatible

- Default remains `internet-facing` — no change for existing deployments
- New deployments with `internal` pick up the scheme cleanly

**Note for existing stacks switching modes:** Changing an ALB from internet-facing to internal (or vice versa) requires CloudFormation resource replacement (ALB is recreated with a new DNS name). This is an AWS limitation. Users switching modes should plan for brief monitoring interruption and update their OTEL endpoint config.

## Testing

```bash
ccwb init  # select Internal for load balancer exposure
ccwb deploy --stack monitoring
aws elbv2 describe-load-balancers --names otel-collector-alb --query "LoadBalancers[0].Scheme"
# Expected: "internal"
```

## Acknowledgements

Thank you to @scouturier for opening #190, and @adiospeds and @aravind-jl for providing feedback on the need for private ALB support in enterprise environments. Your input directly shaped this implementation.

**We would love your help validating this PR:**

1. Pull the `feat/internal-alb-support` branch
2. Run `ccwb init` → select central monitoring → choose "Internal" for load balancer exposure
3. Deploy with `ccwb deploy --stack monitoring`
4. Verify the ALB is internal: `aws elbv2 describe-load-balancers --names otel-collector-alb --query "LoadBalancers[0].Scheme"`
5. Confirm telemetry flows from Claude Code/CoWork clients on your VPN/internal network
6. Verify the SG has all three RFC 1918 ranges: `aws ec2 describe-security-groups --group-ids <sg-id> --query "SecurityGroups[0].IpPermissions[*].IpRanges[*].CidrIp"`

Please let us know if everything works as expected, or if your environment needs any adjustments (e.g., custom CIDR ranges beyond RFC 1918).

Closes #190