### PR TITLE
fix: enable Cognito Hosted UI password reset via email

### DIFF
--- a/deployment/infrastructure/cognito-user-pool-setup.yaml
+++ b/deployment/infrastructure/cognito-user-pool-setup.yaml
@@ -94,10 +94,17 @@ Resources:
           AttributeDataType: String
           Required: false
           Mutable: true
-      # Message configuration - don't automatically send messages
-      AutoVerifiedAttributes: []
+      # Message configuration - enable email for password reset
+      AutoVerifiedAttributes:
+        - email
       EmailConfiguration:
         EmailSendingAccount: COGNITO_DEFAULT
+      AccountRecoverySetting:
+        RecoveryMechanisms:
+          - Name: verified_email
+            Priority: 1
+      AdminCreateUserConfig:
+        AllowAdminCreateUserOnly: true
       # Disable self-registration as required
       Policies:
         PasswordPolicy:


### PR DESCRIPTION
Cherry-pick of #144 (by @takakuni-classmethod) rebased onto `beta`.

## Changes

- Set `AutoVerifiedAttributes: [email]` to allow Cognito to send password reset codes
- Add `AccountRecoverySetting` with `verified_email` as recovery mechanism
- Explicitly set `AdminCreateUserConfig.AllowAdminCreateUserOnly: true`

## Background

The "Forgot your password?" link in Cognito Hosted UI was not functional because `AutoVerifiedAttributes` was set to an empty list, preventing Cognito from sending reset emails.

## Impact on Existing Deployments

This is a **CloudFormation in-place update** (no resource replacement). When applied to existing stacks:

| Change | Impact |
|--------|--------|
| `AutoVerifiedAttributes: [email]` | Cognito will now auto-verify email addresses when users confirm them. Previously, emails were never auto-verified, which broke password reset. Existing users with already-verified emails are unaffected. |
| `AccountRecoverySetting: verified_email` | Makes recovery mechanism explicit. Cognito's default was already email-based recovery, so this codifies existing behaviour — no functional change for users. |
| `AllowAdminCreateUserOnly: true` | Explicitly disables self-registration. See side effects below. |

## Potential Side Effects

1. **`AllowAdminCreateUserOnly: true`** — If any existing deployment had Cognito self-registration implicitly enabled (Cognito default is `false`), this would disable direct sign-up after the stack update. However, CCWB is designed for enterprise SSO (Okta/Azure/Google/Cognito federation) — direct Cognito sign-up was never a supported or intended flow. This change codifies the existing design intent.

2. **Email auto-verification** — After update, if a user changes their email address and confirms it, Cognito will automatically mark it as verified. This is standard Cognito behaviour and is required for password reset to work. No negative impact expected.

3. **No MFA interaction** — The template already has `MfaConfiguration: OPTIONAL`. Password reset via email bypasses MFA (standard Cognito behaviour). Users who have MFA enabled will still need their MFA device after resetting their password.

## Verdict

Safe for all intended CCWB deployment patterns (enterprise SSO). The only theoretical regression is for deployments that relied on Cognito self-registration, which was never a supported configuration.

---

Thank you @takakuni-classmethod for the original fix and testing.

Closes #143
Supersedes #144