### PR TITLE
feat(auth): support multiple profiles in one AWS account/region (#528)

### DIFF
--- a/deployment/infrastructure/bedrock-auth-auth0.yaml
+++ b/deployment/infrastructure/bedrock-auth-auth0.yaml
@@ -57,10 +57,25 @@ Parameters:
       - 'false'
     Description: Enable CloudWatch monitoring for Bedrock usage
 
+  ExistingOIDCProviderArn:
+    Type: String
+    Default: ''
+    Description: >-
+      ARN of a pre-existing IAM OIDC provider for this issuer URL. Leave empty
+      (default) to create a new provider. Provide an existing provider's ARN to
+      reuse it instead of creating a duplicate - useful when deploying multiple
+      profiles that share the same identity provider in one AWS account/region
+      (IAM allows only one OIDC provider per issuer URL per account). The
+      existing provider's ClientIdList must already include this profile's
+      client ID.
+    AllowedPattern: '^(arn:aws[a-zA-Z-]*:iam::[0-9]{12}:oidc-provider/.+)?$'
+    ConstraintDescription: Must be empty or a valid IAM OIDC provider ARN
+
 Conditions:
   UseDirectIAM: !Equals [!Ref FederationType, direct]
   UseCognitoIdentity: !Equals [!Ref FederationType, cognito]
   MonitoringEnabled: !Equals [!Ref EnableMonitoring, 'true']
+  CreateOIDCProvider: !Equals [!Ref ExistingOIDCProviderArn, '']
   # Partition-aware conditions for Cognito Identity service principals
   IsGovCloudWest: !Equals [!Ref 'AWS::Region', 'us-gov-west-1']
   IsGovCloudEast: !Equals [!Ref 'AWS::Region', 'us-gov-east-1']
@@ -72,6 +87,7 @@ Resources:
 
   Auth0OIDCProvider:
     Type: AWS::IAM::OIDCProvider
+    Condition: CreateOIDCProvider
     Properties:
       Url: !Sub 'https://${Auth0Domain}/'
       ClientIdList:
@@ -167,7 +183,10 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Federated: !GetAtt Auth0OIDCProvider.Arn
+              Federated: !If
+                - CreateOIDCProvider
+                - !GetAtt Auth0OIDCProvider.Arn
+                - !Ref ExistingOIDCProviderArn
             Action:
               - 'sts:AssumeRoleWithWebIdentity'
               - 'sts:TagSession'
@@ -193,7 +212,10 @@ Resources:
       AllowUnauthenticatedIdentities: false
       AllowClassicFlow: false
       OpenIdConnectProviderARNs:
-        - !GetAtt Auth0OIDCProvider.Arn
+        - !If
+          - CreateOIDCProvider
+          - !GetAtt Auth0OIDCProvider.Arn
+          - !Ref ExistingOIDCProviderArn
 
   CognitoAuthenticatedRole:
     Type: AWS::IAM::Role
@@ -332,7 +354,10 @@ Outputs:
 
   OIDCProviderArn:
     Description: ARN of the Auth0 OIDC Provider
-    Value: !GetAtt Auth0OIDCProvider.Arn
+    Value: !If
+      - CreateOIDCProvider
+      - !GetAtt Auth0OIDCProvider.Arn
+      - !Ref ExistingOIDCProviderArn
     Export:
       Name: !Sub '${AWS::StackName}-OIDCProviderArn'
 

--- a/deployment/infrastructure/bedrock-auth-azure.yaml
+++ b/deployment/infrastructure/bedrock-auth-azure.yaml
@@ -49,7 +49,22 @@ Parameters:
       - 'false'
     Description: Enable CloudWatch monitoring for Bedrock usage
 
+  ExistingOIDCProviderArn:
+    Type: String
+    Default: ''
+    Description: >-
+      ARN of a pre-existing IAM OIDC provider for this issuer URL. Leave empty
+      (default) to create a new provider. Provide an existing provider's ARN to
+      reuse it instead of creating a duplicate - useful when deploying multiple
+      profiles that share the same identity provider in one AWS account/region
+      (IAM allows only one OIDC provider per issuer URL per account). The
+      existing provider's ClientIdList must already include this profile's
+      client ID.
+    AllowedPattern: '^(arn:aws[a-zA-Z-]*:iam::[0-9]{12}:oidc-provider/.+)?$'
+    ConstraintDescription: Must be empty or a valid IAM OIDC provider ARN
+
 Conditions:
+  CreateOIDCProvider: !Equals [!Ref ExistingOIDCProviderArn, '']
   UseDirectIAM: !Equals [!Ref FederationType, direct]
   UseCognitoIdentity: !Equals [!Ref FederationType, cognito]
   MonitoringEnabled: !Equals [!Ref EnableMonitoring, 'true']
@@ -64,6 +79,7 @@ Resources:
 
   AzureOIDCProvider:
     Type: AWS::IAM::OIDCProvider
+    Condition: CreateOIDCProvider
     Properties:
       Url: !Sub 'https://login.microsoftonline.com/${AzureTenantId}/v2.0'
       ClientIdList:
@@ -159,7 +175,10 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Federated: !GetAtt AzureOIDCProvider.Arn
+              Federated: !If
+                - CreateOIDCProvider
+                - !GetAtt AzureOIDCProvider.Arn
+                - !Ref ExistingOIDCProviderArn
             Action:
               - 'sts:AssumeRoleWithWebIdentity'
               - 'sts:TagSession'
@@ -185,7 +204,10 @@ Resources:
       AllowUnauthenticatedIdentities: false
       AllowClassicFlow: false
       OpenIdConnectProviderARNs:
-        - !GetAtt AzureOIDCProvider.Arn
+        - !If
+          - CreateOIDCProvider
+          - !GetAtt AzureOIDCProvider.Arn
+          - !Ref ExistingOIDCProviderArn
 
   CognitoAuthenticatedRole:
     Type: AWS::IAM::Role
@@ -324,7 +346,10 @@ Outputs:
 
   OIDCProviderArn:
     Description: ARN of the Azure AD OIDC Provider
-    Value: !GetAtt AzureOIDCProvider.Arn
+    Value: !If
+      - CreateOIDCProvider
+      - !GetAtt AzureOIDCProvider.Arn
+      - !Ref ExistingOIDCProviderArn
     Export:
       Name: !Sub '${AWS::StackName}-OIDCProviderArn'
 

--- a/deployment/infrastructure/bedrock-auth-cognito-pool.yaml
+++ b/deployment/infrastructure/bedrock-auth-cognito-pool.yaml
@@ -55,10 +55,27 @@ Parameters:
       - 'false'
     Description: Enable CloudWatch monitoring for Bedrock usage
 
+  ExistingOIDCProviderArn:
+    Type: String
+    Default: ''
+    Description: >-
+      ARN of a pre-existing IAM OIDC provider for this issuer URL. Leave empty
+      (default) to create a new provider. Provide an existing provider's ARN to
+      reuse it instead of creating a duplicate - useful when deploying multiple
+      profiles that share the same identity provider in one AWS account/region
+      (IAM allows only one OIDC provider per issuer URL per account). The
+      existing provider's ClientIdList must already include this profile's
+      client ID.
+    AllowedPattern: '^(arn:aws[a-zA-Z-]*:iam::[0-9]{12}:oidc-provider/.+)?$'
+    ConstraintDescription: Must be empty or a valid IAM OIDC provider ARN
+
 Conditions:
   UseDirectIAM: !Equals [!Ref FederationType, direct]
   UseCognitoIdentity: !Equals [!Ref FederationType, cognito]
   MonitoringEnabled: !Equals [!Ref EnableMonitoring, 'true']
+  CreateOIDCProvider: !And
+    - !Condition UseDirectIAM
+    - !Equals [!Ref ExistingOIDCProviderArn, '']
   # Partition-aware conditions for Cognito Identity service principals
   IsGovCloudWest: !Equals [!Ref 'AWS::Region', 'us-gov-west-1']
   IsGovCloudEast: !Equals [!Ref 'AWS::Region', 'us-gov-east-1']
@@ -70,7 +87,7 @@ Resources:
 
   CognitoUserPoolOIDCProvider:
     Type: AWS::IAM::OIDCProvider
-    Condition: UseDirectIAM
+    Condition: CreateOIDCProvider
     Properties:
       # Region is derived from the User Pool ID (format: <region>_<id>), not AWS::Region,
       # so the pool may live in a different region than this stack. See issue #596.
@@ -169,7 +186,10 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Federated: !GetAtt CognitoUserPoolOIDCProvider.Arn
+              Federated: !If
+                - CreateOIDCProvider
+                - !GetAtt CognitoUserPoolOIDCProvider.Arn
+                - !Ref ExistingOIDCProviderArn
             Action:
               - 'sts:AssumeRoleWithWebIdentity'
               - 'sts:TagSession'
@@ -343,7 +363,10 @@ Outputs:
   OIDCProviderArn:
     Description: ARN of the Cognito User Pool OIDC Provider
     Condition: UseDirectIAM
-    Value: !GetAtt CognitoUserPoolOIDCProvider.Arn
+    Value: !If
+      - CreateOIDCProvider
+      - !GetAtt CognitoUserPoolOIDCProvider.Arn
+      - !Ref ExistingOIDCProviderArn
     Export:
       Name: !Sub '${AWS::StackName}-OIDCProviderArn'
 

--- a/deployment/infrastructure/bedrock-auth-generic.yaml
+++ b/deployment/infrastructure/bedrock-auth-generic.yaml
@@ -53,10 +53,25 @@ Parameters:
       - 'false'
     Description: Enable CloudWatch monitoring for Bedrock usage
 
+  ExistingOIDCProviderArn:
+    Type: String
+    Default: ''
+    Description: >-
+      ARN of a pre-existing IAM OIDC provider for this issuer URL. Leave empty
+      (default) to create a new provider. Provide an existing provider's ARN to
+      reuse it instead of creating a duplicate - useful when deploying multiple
+      profiles that share the same identity provider in one AWS account/region
+      (IAM allows only one OIDC provider per issuer URL per account). The
+      existing provider's ClientIdList must already include this profile's
+      client ID.
+    AllowedPattern: '^(arn:aws[a-zA-Z-]*:iam::[0-9]{12}:oidc-provider/.+)?$'
+    ConstraintDescription: Must be empty or a valid IAM OIDC provider ARN
+
 Conditions:
   UseDirectIAM: !Equals [!Ref FederationType, direct]
   UseCognitoIdentity: !Equals [!Ref FederationType, cognito]
   MonitoringEnabled: !Equals [!Ref EnableMonitoring, 'true']
+  CreateOIDCProvider: !Equals [!Ref ExistingOIDCProviderArn, '']
   # Partition-aware conditions for Cognito Identity service principals
   IsGovCloudWest: !Equals [!Ref 'AWS::Region', 'us-gov-west-1']
   IsGovCloudEast: !Equals [!Ref 'AWS::Region', 'us-gov-east-1']
@@ -68,6 +83,7 @@ Resources:
 
   OidcProvider:
     Type: AWS::IAM::OIDCProvider
+    Condition: CreateOIDCProvider
     Properties:
       Url: !Ref OidcIssuerUrl
       ClientIdList:
@@ -166,7 +182,10 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Federated: !GetAtt OidcProvider.Arn
+              Federated: !If
+                - CreateOIDCProvider
+                - !GetAtt OidcProvider.Arn
+                - !Ref ExistingOIDCProviderArn
             Action:
               - 'sts:AssumeRoleWithWebIdentity'
               - 'sts:TagSession'
@@ -192,7 +211,10 @@ Resources:
       AllowUnauthenticatedIdentities: false
       AllowClassicFlow: false
       OpenIdConnectProviderARNs:
-        - !GetAtt OidcProvider.Arn
+        - !If
+          - CreateOIDCProvider
+          - !GetAtt OidcProvider.Arn
+          - !Ref ExistingOIDCProviderArn
 
   CognitoAuthenticatedRole:
     Type: AWS::IAM::Role
@@ -332,7 +354,10 @@ Outputs:
 
   OIDCProviderArn:
     Description: ARN of the OIDC Provider
-    Value: !GetAtt OidcProvider.Arn
+    Value: !If
+      - CreateOIDCProvider
+      - !GetAtt OidcProvider.Arn
+      - !Ref ExistingOIDCProviderArn
     Export:
       Name: !Sub '${AWS::StackName}-OIDCProviderArn'
 

--- a/deployment/infrastructure/bedrock-auth-google.yaml
+++ b/deployment/infrastructure/bedrock-auth-google.yaml
@@ -50,10 +50,25 @@ Parameters:
       - 'false'
     Description: Enable CloudWatch monitoring for Bedrock usage
 
+  ExistingOIDCProviderArn:
+    Type: String
+    Default: ''
+    Description: >-
+      ARN of a pre-existing IAM OIDC provider for this issuer URL. Leave empty
+      (default) to create a new provider. Provide an existing provider's ARN to
+      reuse it instead of creating a duplicate - useful when deploying multiple
+      profiles that share the same identity provider in one AWS account/region
+      (IAM allows only one OIDC provider per issuer URL per account). The
+      existing provider's ClientIdList must already include this profile's
+      client ID.
+    AllowedPattern: '^(arn:aws[a-zA-Z-]*:iam::[0-9]{12}:oidc-provider/.+)?$'
+    ConstraintDescription: Must be empty or a valid IAM OIDC provider ARN
+
 Conditions:
   UseDirectIAM: !Equals [!Ref FederationType, direct]
   UseCognitoIdentity: !Equals [!Ref FederationType, cognito]
   MonitoringEnabled: !Equals [!Ref EnableMonitoring, 'true']
+  CreateOIDCProvider: !Equals [!Ref ExistingOIDCProviderArn, '']
   # Partition-aware conditions for Cognito Identity service principals
   IsGovCloudWest: !Equals [!Ref 'AWS::Region', 'us-gov-west-1']
   IsGovCloudEast: !Equals [!Ref 'AWS::Region', 'us-gov-east-1']
@@ -65,6 +80,7 @@ Resources:
 
   GoogleOIDCProvider:
     Type: AWS::IAM::OIDCProvider
+    Condition: CreateOIDCProvider
     Properties:
       Url: !Sub 'https://${GoogleDomain}'
       ClientIdList:
@@ -169,7 +185,10 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Federated: !GetAtt GoogleOIDCProvider.Arn
+              Federated: !If
+                - CreateOIDCProvider
+                - !GetAtt GoogleOIDCProvider.Arn
+                - !Ref ExistingOIDCProviderArn
             Action:
               - 'sts:AssumeRoleWithWebIdentity'
               - 'sts:TagSession'
@@ -198,7 +217,10 @@ Resources:
       AllowUnauthenticatedIdentities: false
       AllowClassicFlow: false
       OpenIdConnectProviderARNs:
-        - !GetAtt GoogleOIDCProvider.Arn
+        - !If
+          - CreateOIDCProvider
+          - !GetAtt GoogleOIDCProvider.Arn
+          - !Ref ExistingOIDCProviderArn
 
   CognitoAuthenticatedRole:
     Type: AWS::IAM::Role
@@ -342,7 +364,10 @@ Outputs:
 
   OIDCProviderArn:
     Description: ARN of the Google OIDC Provider
-    Value: !GetAtt GoogleOIDCProvider.Arn
+    Value: !If
+      - CreateOIDCProvider
+      - !GetAtt GoogleOIDCProvider.Arn
+      - !Ref ExistingOIDCProviderArn
     Export:
       Name: !Sub '${AWS::StackName}-OIDCProviderArn'
 

--- a/deployment/infrastructure/bedrock-auth-okta.yaml
+++ b/deployment/infrastructure/bedrock-auth-okta.yaml
@@ -49,10 +49,25 @@ Parameters:
       - 'false'
     Description: Enable CloudWatch monitoring for Bedrock usage
 
+  ExistingOIDCProviderArn:
+    Type: String
+    Default: ''
+    Description: >-
+      ARN of a pre-existing IAM OIDC provider for this issuer URL. Leave empty
+      (default) to create a new provider. Provide an existing provider's ARN to
+      reuse it instead of creating a duplicate - useful when deploying multiple
+      profiles that share the same identity provider in one AWS account/region
+      (IAM allows only one OIDC provider per issuer URL per account). The
+      existing provider's ClientIdList must already include this profile's
+      client ID.
+    AllowedPattern: '^(arn:aws[a-zA-Z-]*:iam::[0-9]{12}:oidc-provider/.+)?$'
+    ConstraintDescription: Must be empty or a valid IAM OIDC provider ARN
+
 Conditions:
   UseDirectIAM: !Equals [!Ref FederationType, direct]
   UseCognitoIdentity: !Equals [!Ref FederationType, cognito]
   MonitoringEnabled: !Equals [!Ref EnableMonitoring, 'true']
+  CreateOIDCProvider: !Equals [!Ref ExistingOIDCProviderArn, '']
   # Partition-aware conditions for Cognito Identity service principals
   IsGovCloudWest: !Equals [!Ref 'AWS::Region', 'us-gov-west-1']
   IsGovCloudEast: !Equals [!Ref 'AWS::Region', 'us-gov-east-1']
@@ -64,6 +79,7 @@ Resources:
 
   OktaOIDCProvider:
     Type: AWS::IAM::OIDCProvider
+    Condition: CreateOIDCProvider
     Properties:
       Url: !Sub 'https://${OktaDomain}'
       ClientIdList:
@@ -158,7 +174,10 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Federated: !GetAtt OktaOIDCProvider.Arn
+              Federated: !If
+                - CreateOIDCProvider
+                - !GetAtt OktaOIDCProvider.Arn
+                - !Ref ExistingOIDCProviderArn
             Action:
               - 'sts:AssumeRoleWithWebIdentity'
               - 'sts:TagSession'
@@ -184,7 +203,10 @@ Resources:
       AllowUnauthenticatedIdentities: false
       AllowClassicFlow: false
       OpenIdConnectProviderARNs:
-        - !GetAtt OktaOIDCProvider.Arn
+        - !If
+          - CreateOIDCProvider
+          - !GetAtt OktaOIDCProvider.Arn
+          - !Ref ExistingOIDCProviderArn
 
   CognitoAuthenticatedRole:
     Type: AWS::IAM::Role
@@ -323,7 +345,10 @@ Outputs:
 
   OIDCProviderArn:
     Description: ARN of the Okta OIDC Provider
-    Value: !GetAtt OktaOIDCProvider.Arn
+    Value: !If
+      - CreateOIDCProvider
+      - !GetAtt OktaOIDCProvider.Arn
+      - !Ref ExistingOIDCProviderArn
     Export:
       Name: !Sub '${AWS::StackName}-OIDCProviderArn'
 

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -522,6 +522,17 @@ class DeployCommand(Command):
                         ]
                     )
 
+                # Issue #528: reuse an existing IAM OIDC provider instead of creating a
+                # duplicate when multiple profiles share an issuer in one account.
+                if getattr(profile, "existing_oidc_provider_arn", None):
+                    params.append(f"ExistingOIDCProviderArn={profile.existing_oidc_provider_arn}")
+
+                # Issue #528: per-profile IAM role name so multiple profiles in one
+                # account don't collide on the federation role. Passed only when set;
+                # unset -> template default (preserves existing single-profile deploys).
+                if getattr(profile, "federated_role_name", None):
+                    params.append(f"FederatedRoleName={profile.federated_role_name}")
+
                 # Use profile regions, or fall back to all known Bedrock regions
                 bedrock_regions = profile.allowed_bedrock_regions
                 if not bedrock_regions:
@@ -1101,6 +1112,13 @@ class DeployCommand(Command):
                             f"CognitoUserPoolDomain={cognito_domain}",
                         ]
                     )
+                # Issue #528: reuse an existing IAM OIDC provider instead of creating a
+                # duplicate when multiple profiles share an issuer in one account.
+                if getattr(profile, "existing_oidc_provider_arn", None):
+                    params.append(f"ExistingOIDCProviderArn={profile.existing_oidc_provider_arn}")
+                # Issue #528: per-profile IAM role name (passed only when set).
+                if getattr(profile, "federated_role_name", None):
+                    params.append(f"FederatedRoleName={profile.federated_role_name}")
                 params.extend(
                     [
                         f"IdentityPoolName={profile.identity_pool_name}",

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -2892,6 +2892,13 @@ class InitCommand(Command):
                 "oidc_token_endpoint",
                 "oidc_jwks_uri",
                 "oidc_thumbprint",
+                # Issue #528: restore the reused-provider ARN so a re-run of init
+                # pre-fills the prompt with the saved value instead of blank. Without
+                # this, the prompt defaults to "" -> user presses Enter -> the field is
+                # wiped -> the next deploy recreates the shared provider and fails with
+                # EntityAlreadyExists (the exact bug this feature prevents). Must mirror
+                # _save_configuration, which persists existing_oidc_provider_arn.
+                "existing_oidc_provider_arn",
             ):
                 if getattr(profile, oidc_field, None):
                     existing_config[oidc_field] = getattr(profile, oidc_field)

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -810,6 +810,32 @@ class InitCommand(Command):
             config["federation_type"] = federation_type
             config["max_session_duration"] = 43200 if federation_type == "direct" else 28800
 
+            # Existing OIDC Provider (optional)
+            console.print("\n[bold]Existing OIDC Provider (optional)[/bold]")
+            console.print(
+                "[dim]If you've already deployed a profile in this AWS account that uses the same\n"
+                "identity provider, IAM already has an OIDC provider for it. Paste that provider's\n"
+                "ARN here to reuse it (avoids an EntityAlreadyExists error on the second deploy).\n"
+                "Leave blank to create a new one. The existing provider's allowed client IDs must\n"
+                "already include this profile's client ID.[/dim]"
+            )
+            existing_oidc_provider_arn = questionary.text(
+                "Existing IAM OIDC provider ARN (leave blank to create one):",
+                default=config.get("existing_oidc_provider_arn") or "",
+                validate=lambda x: (
+                    # Mirror the CFN AllowedPattern so the wizard fails fast instead
+                    # of deferring to a CloudFormation ConstraintDescription at deploy.
+                    x == ""
+                    or bool(re.match(r"^arn:aws[a-zA-Z-]*:iam::[0-9]{12}:oidc-provider/.+$", x))
+                    or "Must be empty or a valid IAM OIDC provider ARN (arn:aws:iam::<acct>:oidc-provider/...)"
+                ),
+                instruction="(only needed for multiple profiles sharing one provider in the same account)",
+            ).ask()
+            if existing_oidc_provider_arn is None:
+                return None
+
+            config["existing_oidc_provider_arn"] = existing_oidc_provider_arn or None
+
             # Save progress
             progress.save_step("oidc_complete", config)
 
@@ -2391,6 +2417,34 @@ class InitCommand(Command):
 
         return 0
 
+    @staticmethod
+    def _derive_role_name(identity_pool_name: str, provider_type: str | None = None) -> str:
+        """Derive a per-profile federation IAM role name.
+
+        Keeps the template's provider-branded default and appends the identity pool
+        name as a per-profile suffix: ``Bedrock<Provider>FederatedRole-<pool>`` (e.g.
+        ``BedrockAzureFederatedRole-wmgccwb2``). The ``Bedrock`` prefix guarantees the
+        result starts with a letter, so it satisfies the template's FederatedRoleName
+        AllowedPattern ('^[a-zA-Z][a-zA-Z0-9-_]*$') regardless of the pool name (which
+        may start with a digit). Truncated to MaxLength 64, suffix preserved.
+        """
+        # Mirror the per-template FederatedRoleName defaults.
+        defaults = {
+            "okta": "BedrockOktaFederatedRole",
+            "auth0": "BedrockAuth0FederatedRole",
+            "azure": "BedrockAzureFederatedRole",
+            "cognito": "BedrockCognitoFederatedRole",
+            "google": "BedrockGoogleFederatedRole",
+            "generic": "BedrockOidcFederatedRole",
+        }
+        prefix = defaults.get(provider_type or "", "BedrockFederatedRole")
+        pool = re.sub(r"[^a-zA-Z0-9_-]", "-", identity_pool_name or "")
+        if not pool:
+            return prefix
+        # Truncate the whole name to MaxLength 64, preserving the leading prefix
+        # (which guarantees a letter start). A very long pool name is cut at the end.
+        return f"{prefix}-{pool}"[:64]
+
     def _save_configuration(self, config_data: dict[str, Any], profile_name: str) -> None:
         """Save configuration to file.
 
@@ -2456,6 +2510,8 @@ class InitCommand(Command):
             "oidc_token_endpoint": config_data.get("oidc_token_endpoint"),
             "oidc_jwks_uri": config_data.get("oidc_jwks_uri"),
             "oidc_thumbprint": config_data.get("oidc_thumbprint"),
+            "existing_oidc_provider_arn": config_data.get("existing_oidc_provider_arn"),
+            "federated_role_name": config_data.get("federated_role_name"),
             "federation_type": config_data.get("federation_type", "cognito"),
             "max_session_duration": config_data.get("max_session_duration", 28800),
             "sso_enabled": config_data.get("sso_enabled", True),
@@ -2502,6 +2558,18 @@ class InitCommand(Command):
             "tags": config_data.get("tags", {}),
             "redirect_port": config_data.get("redirect_port"),
         }
+
+        # Issue #528: give NEW profiles a per-profile IAM role name derived from the
+        # identity pool name so multiple profiles in one account don't collide on the
+        # federation role. Existing profiles keep their current value (None -> template
+        # default) so a re-run of init never renames a deployed role (which would change
+        # its ARN and break the packaged config.json).
+        if existing_profile:
+            wizard_fields["federated_role_name"] = getattr(existing_profile, "federated_role_name", None)
+        elif wizard_fields.get("federation_type") == "direct":
+            wizard_fields["federated_role_name"] = self._derive_role_name(
+                wizard_fields["identity_pool_name"], wizard_fields.get("provider_type")
+            )
 
         if existing_profile:
             # Update existing profile — preserves fields not managed by the wizard

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -101,6 +101,13 @@ class Profile:
     # Federation configuration
     federation_type: str = "cognito"  # "cognito" or "direct"
     federated_role_arn: str | None = None  # ARN for Direct STS federation
+    # ARN of a pre-existing IAM OIDC provider to reuse instead of creating one
+    # (multi-profile same-account deployments). See issue #528.
+    existing_oidc_provider_arn: str | None = None
+    # Name for the federation IAM role. None -> template default (e.g.
+    # BedrockAzureFederatedRole). Set to a per-profile name so multiple profiles
+    # in one account don't collide on the role name. See issue #528.
+    federated_role_name: str | None = None
     max_session_duration: int = 28800  # 8 hours default, 43200 (12 hours) for Direct STS
     sso_enabled: bool = True  # Enable SSO authentication (Okta, Auth0, Azure, Cognito)
 

--- a/source/tests/cli/commands/test_deploy_existing_oidc.py
+++ b/source/tests/cli/commands/test_deploy_existing_oidc.py
@@ -1,0 +1,199 @@
+# ABOUTME: Regression tests for issue #528 — ExistingOIDCProviderArn parameter passing
+# ABOUTME: Verifies the auth stack receives ExistingOIDCProviderArn when profile.existing_oidc_provider_arn is set
+
+"""Deploy existing OIDC provider ARN parameter tests.
+
+Issue #528: When multiple profiles share the same OIDC issuer in one AWS
+account, the second profile's auth stack deploy fails with:
+
+    "EntityAlreadyExists: Provider with url ... already exists."
+
+The fix lets the user set profile.existing_oidc_provider_arn to the first
+profile's IAM OIDC provider ARN, and passes "ExistingOIDCProviderArn=<arn>"
+to the CloudFormation auth stack so it reuses the existing provider instead of
+trying to create a duplicate.
+
+These tests verify that _deploy_stack("auth", ...) correctly appends the
+ExistingOIDCProviderArn parameter when the profile has it set, and omits it
+when not set.
+"""
+
+from dataclasses import fields
+from unittest.mock import MagicMock
+
+from rich.console import Console
+
+from claude_code_with_bedrock.cli.commands.deploy import DeployCommand
+from claude_code_with_bedrock.config import Profile
+
+
+def _base_profile(**overrides):
+    """Create a minimal valid profile with overrides.
+
+    Filters overrides to only valid Profile fields to avoid TypeError.
+    """
+    field_names = {f.name for f in fields(Profile)}
+    defaults = {
+        "name": "TestProfile",
+        "provider_domain": "company.okta.com",
+        "client_id": "test-client-id",
+        "credential_storage": "session",
+        "aws_region": "us-east-1",
+        "identity_pool_name": "claude-code-test",
+        "sso_enabled": True,
+        "provider_type": "okta",
+        "monitoring_enabled": True,
+        "monitoring_mode": "central",
+        "federation_type": "direct",
+        "federated_role_arn": "arn:aws:iam::123456789012:role/BedrockRole",
+    }
+    defaults.update(overrides)
+    return Profile(**{k: v for k, v in defaults.items() if k in field_names})
+
+
+class TestExistingOIDCProviderArn:
+    """Tests for ExistingOIDCProviderArn parameter passing in auth stack deploys."""
+
+    def test_existing_oidc_arn_passed_when_set(self):
+        """When profile.existing_oidc_provider_arn is set, parameter is passed to CF stack."""
+        # Arrange
+        provider_arn = "arn:aws:iam::123456789012:oidc-provider/company.okta.com"
+        profile = _base_profile(
+            provider_type="okta",
+            existing_oidc_provider_arn=provider_arn,
+        )
+        command = DeployCommand()
+        console = Console()
+
+        # Mock CloudFormationManager.deploy_stack to capture params
+        mock_cf_manager = MagicMock()
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.error = None
+        mock_cf_manager.deploy_stack.return_value = mock_result
+
+        # Act — invoke _deploy_stack which builds params and calls cf_manager.deploy_stack
+        result = command._deploy_stack("auth", profile, console, mock_cf_manager)
+
+        # Assert
+        assert result == 0, "Deploy should succeed"
+        assert mock_cf_manager.deploy_stack.called, "CF manager deploy_stack should be called"
+
+        # Extract the parameters kwarg passed to deploy_stack
+        call_kwargs = mock_cf_manager.deploy_stack.call_args.kwargs
+        params = call_kwargs.get("parameters", [])
+
+        # params is a list of {"ParameterKey": ..., "ParameterValue": ...} dicts
+        # (after _convert_params_to_boto3 conversion)
+        param_dict = {p["ParameterKey"]: p["ParameterValue"] for p in params}
+
+        assert "ExistingOIDCProviderArn" in param_dict, (
+            f"ExistingOIDCProviderArn parameter missing. Got params: {list(param_dict.keys())}"
+        )
+        assert param_dict["ExistingOIDCProviderArn"] == provider_arn, (
+            f"ExistingOIDCProviderArn value mismatch. "
+            f"Expected {provider_arn}, got {param_dict['ExistingOIDCProviderArn']}"
+        )
+
+    def test_existing_oidc_arn_absent_when_none(self):
+        """When profile.existing_oidc_provider_arn is None, parameter is NOT passed."""
+        # Arrange
+        profile = _base_profile(
+            provider_type="okta",
+            existing_oidc_provider_arn=None,  # Explicitly None (default)
+        )
+        command = DeployCommand()
+        console = Console()
+
+        mock_cf_manager = MagicMock()
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.error = None
+        mock_cf_manager.deploy_stack.return_value = mock_result
+
+        # Act
+        result = command._deploy_stack("auth", profile, console, mock_cf_manager)
+
+        # Assert
+        assert result == 0, "Deploy should succeed"
+        assert mock_cf_manager.deploy_stack.called, "CF manager deploy_stack should be called"
+
+        call_kwargs = mock_cf_manager.deploy_stack.call_args.kwargs
+        params = call_kwargs.get("parameters", [])
+        param_dict = {p["ParameterKey"]: p["ParameterValue"] for p in params}
+
+        assert "ExistingOIDCProviderArn" not in param_dict, (
+            f"ExistingOIDCProviderArn should NOT be in params when None. Got params: {list(param_dict.keys())}"
+        )
+
+    def test_existing_oidc_arn_passed_for_cognito_provider(self):
+        """ExistingOIDCProviderArn works for cognito provider type too."""
+        # Arrange — Cognito pool ARN format (Cognito User Pool uses cognito-idp issuer)
+        provider_arn = (
+            "arn:aws:iam::123456789012:oidc-provider/cognito-idp.us-east-1.amazonaws.com/us-east-1_TestPool123"
+        )
+        profile = _base_profile(
+            provider_type="cognito",
+            cognito_user_pool_id="us-east-1_TestPool123",
+            existing_oidc_provider_arn=provider_arn,
+        )
+        command = DeployCommand()
+        console = Console()
+
+        mock_cf_manager = MagicMock()
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.error = None
+        mock_cf_manager.deploy_stack.return_value = mock_result
+
+        # Act
+        result = command._deploy_stack("auth", profile, console, mock_cf_manager)
+
+        # Assert
+        assert result == 0, "Deploy should succeed"
+        assert mock_cf_manager.deploy_stack.called, "CF manager deploy_stack should be called"
+
+        call_kwargs = mock_cf_manager.deploy_stack.call_args.kwargs
+        params = call_kwargs.get("parameters", [])
+        param_dict = {p["ParameterKey"]: p["ParameterValue"] for p in params}
+
+        assert "ExistingOIDCProviderArn" in param_dict, (
+            f"ExistingOIDCProviderArn parameter missing for Cognito. Got params: {list(param_dict.keys())}"
+        )
+        assert param_dict["ExistingOIDCProviderArn"] == provider_arn, (
+            f"ExistingOIDCProviderArn value mismatch for Cognito. "
+            f"Expected {provider_arn}, got {param_dict['ExistingOIDCProviderArn']}"
+        )
+
+
+class TestFederatedRoleNameParam:
+    """FederatedRoleName threaded to the auth stack only when profile sets it (issue #528).
+
+    Per-profile role name avoids the same-account IAM role collision. Unset ->
+    template default (preserves existing single-profile deploys).
+    """
+
+    def _params(self, profile):
+        command = DeployCommand()
+        console = Console()
+        mock_cf = MagicMock()
+        mock_cf.deploy_stack.return_value = MagicMock(success=True, error=None)
+        assert command._deploy_stack("auth", profile, console, mock_cf) == 0
+        params = mock_cf.deploy_stack.call_args.kwargs.get("parameters", [])
+        return {p["ParameterKey"]: p["ParameterValue"] for p in params}
+
+    def test_role_name_passed_when_set(self):
+        """When federated_role_name is set, FederatedRoleName param is passed."""
+        profile = _base_profile(provider_type="okta", federated_role_name="BedrockOktaFederatedRole-wmgccwb2")
+        param_dict = self._params(profile)
+        assert param_dict.get("FederatedRoleName") == "BedrockOktaFederatedRole-wmgccwb2", (
+            f"FederatedRoleName missing/wrong. Got: {list(param_dict.keys())}"
+        )
+
+    def test_role_name_absent_when_none(self):
+        """When federated_role_name is None, FederatedRoleName is NOT passed (template default)."""
+        profile = _base_profile(provider_type="okta", federated_role_name=None)
+        param_dict = self._params(profile)
+        assert "FederatedRoleName" not in param_dict, (
+            f"FederatedRoleName should be absent when None. Got: {list(param_dict.keys())}"
+        )

--- a/source/tests/cli/commands/test_init.py
+++ b/source/tests/cli/commands/test_init.py
@@ -769,6 +769,143 @@ class TestStoreIdpSecret:
         client.update_secret.assert_called_once()
 
 
+class TestFederatedRoleNameDerivation:
+    """init derives a per-profile FederatedRoleName for NEW direct profiles and
+    never renames the role of an existing profile (issue #528)."""
+
+    @pytest.fixture
+    def cmd(self):
+        from claude_code_with_bedrock.cli.commands.init import InitCommand
+
+        return InitCommand()
+
+    def _config_data(self, pool_name):
+        return {
+            "sso_enabled": True,
+            "okta": {"domain": "company.okta.com", "client_id": "0oa123abc456def789gh"},
+            "provider_type": "okta",
+            "federation_type": "direct",
+            "credential_storage": "session",
+            "aws": {
+                "region": "us-east-1",
+                "identity_pool_name": pool_name,
+                "allowed_bedrock_regions": ["us-east-1"],
+                "stacks": {},
+                "cross_region_profile": "us",
+                "selected_model": None,
+            },
+            "monitoring": {"enabled": False},
+        }
+
+    def _save_in_tmp(self, cmd, config_data, profile_name, tmp_path):
+        import json
+        from unittest.mock import patch
+
+        from claude_code_with_bedrock.config import Config
+
+        config_dir = tmp_path / ".ccwb"
+        config_dir.mkdir(exist_ok=True)
+        profiles_dir = config_dir / "profiles"
+        profiles_dir.mkdir(exist_ok=True)
+        config_file = config_dir / "config.json"
+        if not config_file.exists():
+            config_file.write_text(json.dumps({"schema_version": "2.0", "active_profile": None}))
+
+        with patch.object(Config, "CONFIG_DIR", config_dir), \
+             patch.object(Config, "CONFIG_FILE", config_file), \
+             patch.object(Config, "PROFILES_DIR", profiles_dir):
+            cmd._save_configuration(config_data, profile_name)
+            return Config.load().get_profile(profile_name)
+
+    def test_derive_role_name_satisfies_template_pattern(self):
+        """Derived name must match the FederatedRoleName AllowedPattern + MaxLength 64,
+        across provider types and edge-case pool names (incl. digit-leading)."""
+        from claude_code_with_bedrock.cli.commands.init import InitCommand
+
+        pat = re.compile(r"^[a-zA-Z][a-zA-Z0-9-_]*$")
+        for provider in ("okta", "azure", "auth0", "cognito", "google", "generic", None):
+            for pool in ("wmgccwb2", "123pool", "a" * 80, "my_pool-x", ""):
+                name = InitCommand._derive_role_name(pool, provider)
+                assert pat.match(name), f"{name!r} ({provider}/{pool!r}) fails pattern"
+                assert len(name) <= 64
+                assert name.startswith("Bedrock"), f"{name!r} lost provider-branded prefix"
+
+    def test_derive_role_name_format_keeps_provider_brand_and_pool_suffix(self):
+        """Format is Bedrock<Provider>FederatedRole-<pool>."""
+        from claude_code_with_bedrock.cli.commands.init import InitCommand
+
+        assert InitCommand._derive_role_name("wmgccwb2", "azure") == "BedrockAzureFederatedRole-wmgccwb2"
+        assert InitCommand._derive_role_name("rnd-pool", "okta") == "BedrockOktaFederatedRole-rnd-pool"
+
+    def test_new_direct_profile_gets_derived_role_name(self, cmd, tmp_path):
+        """A brand-new direct profile gets a per-profile (non-default) role name."""
+        # _config_data uses provider_type="okta", pool "wmgccwb2"
+        profile = self._save_in_tmp(cmd, self._config_data("wmgccwb2"), "new-b", tmp_path)
+        assert profile.federated_role_name == "BedrockOktaFederatedRole-wmgccwb2"
+
+    def test_existing_profile_role_name_not_renamed_on_reinit(self, cmd, tmp_path):
+        """Re-running init on an existing profile must NOT change its role name.
+
+        Renaming a deployed role changes its ARN and breaks the packaged config.json.
+        """
+        # First save (new) -> gets derived name
+        self._save_in_tmp(cmd, self._config_data("wmgccwb2"), "edit-b", tmp_path)
+        # Pin an existing role name (simulates a previously deployed profile)
+        import json
+        from unittest.mock import patch
+
+        from claude_code_with_bedrock.config import Config
+
+        config_dir = tmp_path / ".ccwb"
+        profiles_dir = config_dir / "profiles"
+        config_file = config_dir / "config.json"
+        pinned = "LegacyAzureFederatedRole"
+        pf = profiles_dir / "edit-b.json"
+        data = json.loads(pf.read_text())
+        data["federated_role_name"] = pinned
+        pf.write_text(json.dumps(data))
+
+        # Re-run init (edit path)
+        with patch.object(Config, "CONFIG_DIR", config_dir), \
+             patch.object(Config, "CONFIG_FILE", config_file), \
+             patch.object(Config, "PROFILES_DIR", profiles_dir):
+            cmd._save_configuration(self._config_data("wmgccwb2"), "edit-b")
+            reloaded = Config.load().get_profile("edit-b")
+
+        assert reloaded.federated_role_name == pinned, "init must not rename an existing profile's role"
+
+
+class TestExistingOidcArnPromptDefault:
+    """Regression: the OIDC-provider-ARN wizard prompt must tolerate a resumed config
+    where existing_oidc_provider_arn is present but None (issue #528).
+
+    On resume, init persists config["existing_oidc_provider_arn"] = <val> or None.
+    A prior `config.get(key, "")` then returned None, and questionary.text(default=None)
+    raises `TypeError: object of type 'NoneType' has no len()` at construction.
+    The fix resolves the default with `or ""`.
+    """
+
+    def test_default_resolves_to_empty_string_when_config_value_is_none(self):
+        """config.get(key) or "" must yield '' (not None) so questionary.text accepts it."""
+        import questionary
+
+        config = {"existing_oidc_provider_arn": None}  # resumed-session shape
+
+        # The expression used in init.py for the prompt default
+        default = config.get("existing_oidc_provider_arn") or ""
+
+        assert default == ""
+        # Construction with the resolved default must NOT raise (the bug raised here)
+        questionary.text("Existing IAM OIDC provider ARN:", default=default)
+
+    def test_questionary_text_rejects_none_default(self):
+        """Guards the assumption behind the fix: default=None is what crashed."""
+        import questionary
+
+        with pytest.raises(TypeError):
+            questionary.text("x", default=None)
+
+
 if __name__ == "__main__":
     # Run the tests
     pytest.main([__file__, "-v"])

--- a/source/tests/cli/commands/test_init_existing_oidc_roundtrip.py
+++ b/source/tests/cli/commands/test_init_existing_oidc_roundtrip.py
@@ -1,0 +1,92 @@
+# ABOUTME: Regression test ensuring re-running init preserves a saved existing_oidc_provider_arn
+# ABOUTME: Guards _check_existing_deployment against round-trip drift with _save_configuration (issue #528)
+
+"""Regression test: re-running `ccwb init` must preserve the reused OIDC provider ARN.
+
+Issue #528: when a second profile shares an OIDC issuer in one AWS account, the
+user sets `existing_oidc_provider_arn` so the auth stack reuses the existing IAM
+OIDC provider instead of failing with EntityAlreadyExists.
+
+`_check_existing_deployment` rebuilds the in-memory config dict from the saved
+Profile on a re-run of init. If it does not restore `existing_oidc_provider_arn`,
+the prompt default resolves to "" (init.py: `config.get(...) or ""`), the user
+presses Enter, the field is wiped, deploy stops passing ExistingOIDCProviderArn,
+the template recreates the shared provider, and the deploy fails with
+EntityAlreadyExists — the exact failure this feature prevents.
+
+This test fails without the reload-path restore and passes with it.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+# ruff: noqa: E402
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+from claude_code_with_bedrock.cli.commands.init import InitCommand
+from claude_code_with_bedrock.config import Config, Profile
+
+_ARN = "arn:aws:iam::123456789012:oidc-provider/company.okta.com"
+
+
+def _make_profile(existing_oidc_provider_arn=_ARN) -> Profile:
+    """A direct-federation profile that reuses an existing OIDC provider, as if previously saved."""
+    return Profile(
+        name="test",
+        provider_domain="company.okta.com",
+        client_id="0oa1234567890",
+        identity_pool_name="claude-code-auth",
+        credential_storage="session",
+        aws_region="us-east-1",
+        provider_type="okta",
+        federation_type="direct",
+        existing_oidc_provider_arn=existing_oidc_provider_arn,
+    )
+
+
+def _rebuild_config(profile: Profile) -> dict:
+    """Run _check_existing_deployment with AWS interaction stubbed out."""
+    command = InitCommand()
+    fake_config = Config()
+    with (
+        patch.object(Config, "load", return_value=fake_config),
+        patch.object(fake_config, "get_profile", return_value=profile),
+        # Avoid any AWS calls; pretend the stack check could not run.
+        patch.object(InitCommand, "_stack_exists", side_effect=Exception("no creds")),
+    ):
+        return command._check_existing_deployment("test")
+
+
+def test_rerun_preserves_existing_oidc_provider_arn():
+    """existing_oidc_provider_arn must survive the profile -> config rebuild."""
+    rebuilt = _rebuild_config(_make_profile())
+
+    assert rebuilt.get("existing_oidc_provider_arn") == _ARN, (
+        "existing_oidc_provider_arn dropped on init re-run; the next deploy would "
+        "recreate the shared provider and fail EntityAlreadyExists (issue #528)"
+    )
+
+
+def test_rebuilt_arn_prefills_prompt_default():
+    """The rebuilt config must drive a non-empty prompt default on re-run.
+
+    Mirrors the expression init.py uses for the questionary default
+    (`config.get("existing_oidc_provider_arn") or ""`).
+    """
+    rebuilt = _rebuild_config(_make_profile())
+
+    prompt_default = rebuilt.get("existing_oidc_provider_arn") or ""
+    assert prompt_default == _ARN
+
+
+def test_rerun_omits_arn_when_not_set():
+    """A profile that never reused a provider must not gain a spurious key.
+
+    The reload uses a truthy guard (like the other OIDC fields), so None/empty is
+    simply absent — the prompt default then correctly resolves to "".
+    """
+    rebuilt = _rebuild_config(_make_profile(existing_oidc_provider_arn=None))
+
+    assert "existing_oidc_provider_arn" not in rebuilt
+    assert (rebuilt.get("existing_oidc_provider_arn") or "") == ""

--- a/source/tests/test_cloudformation.py
+++ b/source/tests/test_cloudformation.py
@@ -425,3 +425,408 @@ class TestBedrockAuthGenericTemplate:
                         partition_found = True
                         break
         assert partition_found, "Bedrock ARNs must use ${AWS::Partition} for GovCloud support"
+
+
+class TestExistingOIDCProviderReuse:
+    """Tests for ExistingOIDCProviderArn parameter across all bedrock-auth-* templates.
+
+    Issue #528: All 6 bedrock-auth templates now support an optional ExistingOIDCProviderArn
+    parameter so a second profile sharing an IdP issuer in one AWS account can reuse an
+    existing IAM OIDC provider instead of failing with EntityAlreadyExists.
+
+    Verifies:
+    1. Parameter exists with proper Type, Default, and AllowedPattern
+    2. CreateOIDCProvider condition exists and is properly structured
+    3. OIDC provider resource is conditionally created (Condition: CreateOIDCProvider)
+    4. All references to the provider ARN use !If [CreateOIDCProvider, !GetAtt, !Ref ExistingOIDCProviderArn]
+    5. No bare !GetAtt references remain outside the !If wrapper
+    """
+
+    TEMPLATES = [
+        ("bedrock-auth-okta.yaml", "OktaOIDCProvider"),
+        ("bedrock-auth-azure.yaml", "AzureOIDCProvider"),
+        ("bedrock-auth-auth0.yaml", "Auth0OIDCProvider"),
+        ("bedrock-auth-generic.yaml", "OidcProvider"),
+        ("bedrock-auth-google.yaml", "GoogleOIDCProvider"),
+        ("bedrock-auth-cognito-pool.yaml", "CognitoUserPoolOIDCProvider"),
+    ]
+
+    def _load_template(self, template_file):
+        """Load a CloudFormation template using the CloudFormationLoader."""
+        template_path = Path(__file__).parent.parent.parent / "deployment" / "infrastructure" / template_file
+        with open(template_path, encoding="utf-8") as f:
+            return yaml.load(f, Loader=CloudFormationLoader)
+
+    def _find_bare_getatt_arn(self, node, provider_id):
+        """Recursively search for bare !GetAtt [provider_id, Arn] references.
+
+        Returns True if a bare reference is found (NOT wrapped in proper !If structure).
+        A proper wrapper is: !If [CreateOIDCProvider, !GetAtt [provider_id, Arn], !Ref ExistingOIDCProviderArn]
+        """
+        if isinstance(node, dict):
+            # Check if this is a !GetAtt that references our provider's Arn
+            if "Fn::GetAtt" in node:
+                getatt_args = node["Fn::GetAtt"]
+                if isinstance(getatt_args, list) and len(getatt_args) == 2:
+                    if getatt_args[0] == provider_id and getatt_args[1] == "Arn":
+                        # Found a !GetAtt reference - is it wrapped?
+                        return True  # Caller needs to verify it's inside proper !If
+
+            # Check if this is a proper !If wrapper
+            if "Fn::If" in node:
+                if_args = node["Fn::If"]
+                if isinstance(if_args, list) and len(if_args) == 3:
+                    condition_name = if_args[0]
+                    true_branch = if_args[1]
+                    false_branch = if_args[2]
+
+                    # If this is the correct !If structure, don't recurse into the true branch
+                    # (it's allowed to have !GetAtt there)
+                    if condition_name == "CreateOIDCProvider":
+                        # Verify false branch is !Ref ExistingOIDCProviderArn
+                        if isinstance(false_branch, dict) and false_branch.get("Ref") == "ExistingOIDCProviderArn":
+                            # This is a proper wrapper - verify true branch has the !GetAtt
+                            if isinstance(true_branch, dict) and "Fn::GetAtt" in true_branch:
+                                getatt_args = true_branch["Fn::GetAtt"]
+                                if (
+                                    isinstance(getatt_args, list)
+                                    and len(getatt_args) == 2
+                                    and getatt_args[0] == provider_id
+                                    and getatt_args[1] == "Arn"
+                                ):
+                                    # This is wrapped correctly, skip recursing into this subtree
+                                    return False
+                        # For other !If structures, continue recursing
+                        for branch in if_args[1:]:
+                            if self._find_bare_getatt_arn(branch, provider_id):
+                                return True
+                        return False
+
+            # Recurse into dict values
+            for value in node.values():
+                if self._find_bare_getatt_arn(value, provider_id):
+                    return True
+
+        elif isinstance(node, list):
+            for item in node:
+                if self._find_bare_getatt_arn(item, provider_id):
+                    return True
+
+        return False
+
+    def test_existing_oidc_provider_parameter_exists(self):
+        """Verify ExistingOIDCProviderArn parameter exists in all templates with correct properties."""
+        for template_file, _ in self.TEMPLATES:
+            template = self._load_template(template_file)
+            params = template.get("Parameters", {})
+
+            assert "ExistingOIDCProviderArn" in params, f"{template_file}: Missing ExistingOIDCProviderArn parameter"
+
+            param = params["ExistingOIDCProviderArn"]
+            assert param["Type"] == "String", f"{template_file}: ExistingOIDCProviderArn must be Type: String"
+            assert param["Default"] == "", f"{template_file}: ExistingOIDCProviderArn Default must be empty string"
+            assert "AllowedPattern" in param, f"{template_file}: ExistingOIDCProviderArn must have AllowedPattern"
+
+            # Verify pattern allows empty or valid IAM OIDC provider ARN
+            pattern = param["AllowedPattern"]
+            assert "arn:aws" in pattern, f"{template_file}: AllowedPattern must accept ARN format"
+            assert "iam" in pattern, f"{template_file}: AllowedPattern must include iam service"
+            assert "oidc-provider" in pattern, f"{template_file}: AllowedPattern must include oidc-provider"
+
+    def test_create_oidc_provider_condition_exists(self):
+        """Verify CreateOIDCProvider condition exists and has correct structure."""
+        for template_file, _ in self.TEMPLATES:
+            template = self._load_template(template_file)
+            conditions = template.get("Conditions", {})
+
+            assert (
+                "CreateOIDCProvider" in conditions
+            ), f"{template_file}: Missing CreateOIDCProvider condition"
+
+            condition = conditions["CreateOIDCProvider"]
+
+            # For cognito-pool, condition must be !And [UseDirectIAM, !Equals [ExistingOIDCProviderArn, '']]
+            if template_file == "bedrock-auth-cognito-pool.yaml":
+                assert "Fn::And" in condition, (
+                    f"{template_file}: CreateOIDCProvider must use !And for cognito-pool"
+                )
+                and_args = condition["Fn::And"]
+                assert len(and_args) == 2, f"{template_file}: !And must have 2 conditions"
+
+                # First condition should be !Condition UseDirectIAM
+                assert and_args[0] == {"Condition": "UseDirectIAM"}, (
+                    f"{template_file}: First condition must be UseDirectIAM"
+                )
+
+                # Second condition should be !Equals [!Ref ExistingOIDCProviderArn, '']
+                assert "Fn::Equals" in and_args[1], (
+                    f"{template_file}: Second condition must be !Equals"
+                )
+                equals_args = and_args[1]["Fn::Equals"]
+                assert equals_args == [{"Ref": "ExistingOIDCProviderArn"}, ""], (
+                    f"{template_file}: !Equals must check ExistingOIDCProviderArn == ''"
+                )
+            else:
+                # For all other templates, condition must be !Equals [!Ref ExistingOIDCProviderArn, '']
+                assert "Fn::Equals" in condition, f"{template_file}: CreateOIDCProvider must use !Equals"
+                equals_args = condition["Fn::Equals"]
+                assert equals_args == [{"Ref": "ExistingOIDCProviderArn"}, ""], (
+                    f"{template_file}: Condition must check ExistingOIDCProviderArn == ''"
+                )
+
+    def test_oidc_provider_resource_has_condition(self):
+        """Verify OIDC provider resource has Condition: CreateOIDCProvider."""
+        for template_file, provider_id in self.TEMPLATES:
+            template = self._load_template(template_file)
+            resources = template.get("Resources", {})
+
+            assert provider_id in resources, f"{template_file}: Missing OIDC provider resource {provider_id}"
+
+            resource = resources[provider_id]
+            assert resource["Type"] == "AWS::IAM::OIDCProvider", (
+                f"{template_file}: {provider_id} must be AWS::IAM::OIDCProvider"
+            )
+            assert "Condition" in resource, f"{template_file}: {provider_id} must have Condition"
+            assert resource["Condition"] == "CreateOIDCProvider", (
+                f"{template_file}: {provider_id} Condition must be CreateOIDCProvider"
+            )
+
+    def test_direct_iam_role_trust_policy_uses_conditional_arn(self):
+        """Verify DirectIAMRole trust policy Principal.Federated uses !If structure."""
+        for template_file, provider_id in self.TEMPLATES:
+            template = self._load_template(template_file)
+            resources = template.get("Resources", {})
+
+            # cognito-pool template only creates OIDC provider in direct mode, so this is especially important
+            if "DirectIAMRole" not in resources:
+                continue
+
+            role = resources["DirectIAMRole"]
+            assume_policy = role["Properties"]["AssumeRolePolicyDocument"]
+            statements = assume_policy["Statement"]
+
+            # Find the statement with Federated principal
+            federated_stmt = None
+            for stmt in statements:
+                if "Principal" in stmt and "Federated" in stmt["Principal"]:
+                    federated_stmt = stmt
+                    break
+
+            assert federated_stmt is not None, f"{template_file}: DirectIAMRole must have Federated principal"
+
+            federated = federated_stmt["Principal"]["Federated"]
+
+            # Must be !If [CreateOIDCProvider, !GetAtt provider.Arn, !Ref ExistingOIDCProviderArn]
+            assert isinstance(federated, dict), f"{template_file}: Federated must be a dict (intrinsic function)"
+            assert "Fn::If" in federated, f"{template_file}: Federated must use !If"
+
+            if_args = federated["Fn::If"]
+            assert len(if_args) == 3, f"{template_file}: !If must have [condition, true, false]"
+            assert if_args[0] == "CreateOIDCProvider", (
+                f"{template_file}: !If condition must be CreateOIDCProvider"
+            )
+
+            # True branch: !GetAtt provider.Arn
+            true_branch = if_args[1]
+            assert "Fn::GetAtt" in true_branch, f"{template_file}: True branch must be !GetAtt"
+            assert true_branch["Fn::GetAtt"] == [provider_id, "Arn"], (
+                f"{template_file}: True branch must be !GetAtt {provider_id}.Arn"
+            )
+
+            # False branch: !Ref ExistingOIDCProviderArn
+            false_branch = if_args[2]
+            assert "Ref" in false_branch, f"{template_file}: False branch must be !Ref"
+            assert false_branch["Ref"] == "ExistingOIDCProviderArn", (
+                f"{template_file}: False branch must be !Ref ExistingOIDCProviderArn"
+            )
+
+    def test_cognito_identity_pool_uses_conditional_arn(self):
+        """Verify CognitoIdentityPool OpenIdConnectProviderARNs uses !If structure.
+
+        Note: cognito-pool template does NOT have a CognitoIdentityPool resource that references
+        the OIDC provider ARN (it uses the User Pool directly), so we skip it.
+        """
+        for template_file, provider_id in self.TEMPLATES:
+            # Skip cognito-pool - it doesn't have CognitoIdentityPool with OpenIdConnectProviderARNs
+            if template_file == "bedrock-auth-cognito-pool.yaml":
+                continue
+
+            template = self._load_template(template_file)
+            resources = template.get("Resources", {})
+
+            if "CognitoIdentityPool" not in resources:
+                continue
+
+            pool = resources["CognitoIdentityPool"]
+            props = pool["Properties"]
+
+            assert "OpenIdConnectProviderARNs" in props, (
+                f"{template_file}: CognitoIdentityPool must have OpenIdConnectProviderARNs"
+            )
+
+            arns = props["OpenIdConnectProviderARNs"]
+            assert isinstance(arns, list), f"{template_file}: OpenIdConnectProviderARNs must be a list"
+            assert len(arns) >= 1, f"{template_file}: OpenIdConnectProviderARNs must have at least one entry"
+
+            # First entry should be the !If structure
+            arn_entry = arns[0]
+            assert isinstance(arn_entry, dict), f"{template_file}: ARN entry must be a dict (intrinsic function)"
+            assert "Fn::If" in arn_entry, f"{template_file}: ARN entry must use !If"
+
+            if_args = arn_entry["Fn::If"]
+            assert len(if_args) == 3, f"{template_file}: !If must have [condition, true, false]"
+            assert if_args[0] == "CreateOIDCProvider", (
+                f"{template_file}: !If condition must be CreateOIDCProvider"
+            )
+
+            # True branch: !GetAtt provider.Arn
+            true_branch = if_args[1]
+            assert "Fn::GetAtt" in true_branch, f"{template_file}: True branch must be !GetAtt"
+            assert true_branch["Fn::GetAtt"] == [provider_id, "Arn"], (
+                f"{template_file}: True branch must be !GetAtt {provider_id}.Arn"
+            )
+
+            # False branch: !Ref ExistingOIDCProviderArn
+            false_branch = if_args[2]
+            assert "Ref" in false_branch, f"{template_file}: False branch must be !Ref"
+            assert false_branch["Ref"] == "ExistingOIDCProviderArn", (
+                f"{template_file}: False branch must be !Ref ExistingOIDCProviderArn"
+            )
+
+    def test_output_oidc_provider_arn_uses_conditional(self):
+        """Verify Outputs.OIDCProviderArn.Value uses !If structure."""
+        for template_file, provider_id in self.TEMPLATES:
+            template = self._load_template(template_file)
+            outputs = template.get("Outputs", {})
+
+            assert "OIDCProviderArn" in outputs, f"{template_file}: Missing OIDCProviderArn output"
+
+            output = outputs["OIDCProviderArn"]
+            value = output["Value"]
+
+            # Must be !If [CreateOIDCProvider, !GetAtt provider.Arn, !Ref ExistingOIDCProviderArn]
+            assert isinstance(value, dict), f"{template_file}: Output Value must be a dict (intrinsic function)"
+            assert "Fn::If" in value, f"{template_file}: Output Value must use !If"
+
+            if_args = value["Fn::If"]
+            assert len(if_args) == 3, f"{template_file}: !If must have [condition, true, false]"
+            assert if_args[0] == "CreateOIDCProvider", (
+                f"{template_file}: !If condition must be CreateOIDCProvider"
+            )
+
+            # True branch: !GetAtt provider.Arn
+            true_branch = if_args[1]
+            assert "Fn::GetAtt" in true_branch, f"{template_file}: True branch must be !GetAtt"
+            assert true_branch["Fn::GetAtt"] == [provider_id, "Arn"], (
+                f"{template_file}: True branch must be !GetAtt {provider_id}.Arn"
+            )
+
+            # False branch: !Ref ExistingOIDCProviderArn
+            false_branch = if_args[2]
+            assert "Ref" in false_branch, f"{template_file}: False branch must be !Ref"
+            assert false_branch["Ref"] == "ExistingOIDCProviderArn", (
+                f"{template_file}: False branch must be !Ref ExistingOIDCProviderArn"
+            )
+
+    def test_no_bare_getatt_arn_references(self):
+        """Verify no bare !GetAtt [provider, Arn] references exist outside proper !If wrappers.
+
+        This is the key falsifiable assertion - ensures ALL references to the provider ARN
+        are wrapped in !If [CreateOIDCProvider, !GetAtt, !Ref ExistingOIDCProviderArn].
+        """
+        for template_file, provider_id in self.TEMPLATES:
+            template = self._load_template(template_file)
+
+            # Check specific known locations where provider ARN should be referenced
+            resources = template.get("Resources", {})
+            outputs = template.get("Outputs", {})
+
+            # Locations to check (these are the critical ones):
+            # 1. DirectIAMRole trust policy - already tested above, but verify no bare reference
+            # 2. CognitoIdentityPool OpenIdConnectProviderARNs - already tested above
+            # 3. Outputs.OIDCProviderArn - already tested above
+
+            # Do a comprehensive scan to ensure no bare references anywhere
+            # Start with Resources (excluding the provider resource itself)
+            for resource_name, resource in resources.items():
+                if resource_name == provider_id:
+                    continue  # Skip the provider resource itself
+
+                # Check if this resource has bare GetAtt references
+                has_bare = self._find_bare_getatt_arn(resource, provider_id)
+
+                # If we found a GetAtt, verify it's properly wrapped
+                if has_bare:
+                    # This means we found a !GetAtt reference - need to verify it's wrapped
+                    # Re-check with proper wrapping verification
+                    import json
+
+                    resource_json = json.dumps(resource, default=str)
+                    if (
+                        f'"Fn::GetAtt": ["{provider_id}", "Arn"]' in resource_json
+                        or f'"Fn::GetAtt": [\\"{provider_id}\\", \\"Arn\\"]' in resource_json
+                    ):
+                        # Found a GetAtt reference - ensure it's inside a proper If
+                        # Check if the full pattern exists
+                        if (
+                            '"Fn::If": ["CreateOIDCProvider"' not in resource_json
+                            or '"Ref": "ExistingOIDCProviderArn"' not in resource_json
+                        ):
+                            raise AssertionError(
+                                f"{template_file}: Found bare !GetAtt {provider_id}.Arn in {resource_name} "
+                                f"without proper !If wrapper"
+                            )
+
+            # Check Outputs
+            for output_name, output in outputs.items():
+                has_bare = self._find_bare_getatt_arn(output, provider_id)
+
+                if has_bare:
+                    import json
+
+                    output_json = json.dumps(output, default=str)
+                    if f'"Fn::GetAtt": ["{provider_id}", "Arn"]' in output_json:
+                        if (
+                            '"Fn::If": ["CreateOIDCProvider"' not in output_json
+                            or '"Ref": "ExistingOIDCProviderArn"' not in output_json
+                        ):
+                            raise AssertionError(
+                                f"{template_file}: Found bare !GetAtt {provider_id}.Arn in output {output_name} "
+                                f"without proper !If wrapper"
+                            )
+
+    def test_cognito_pool_condition_is_combined(self):
+        """Verify bedrock-auth-cognito-pool.yaml has combined condition while others have simple condition.
+
+        cognito-pool: CreateOIDCProvider = !And [UseDirectIAM, !Equals [ExistingOIDCProviderArn, '']]
+        others: CreateOIDCProvider = !Equals [ExistingOIDCProviderArn, '']
+        """
+        for template_file, _ in self.TEMPLATES:
+            template = self._load_template(template_file)
+            conditions = template.get("Conditions", {})
+            condition = conditions["CreateOIDCProvider"]
+
+            if template_file == "bedrock-auth-cognito-pool.yaml":
+                # Must be !And with two conditions
+                assert "Fn::And" in condition, "cognito-pool CreateOIDCProvider must use !And"
+                and_args = condition["Fn::And"]
+                assert len(and_args) == 2, "cognito-pool !And must have exactly 2 conditions"
+
+                # Verify first condition is !Condition UseDirectIAM
+                assert and_args[0] == {"Condition": "UseDirectIAM"}, (
+                    "cognito-pool first condition must be !Condition UseDirectIAM"
+                )
+
+                # Verify second condition is !Equals [!Ref ExistingOIDCProviderArn, '']
+                assert "Fn::Equals" in and_args[1], (
+                    "cognito-pool second condition must be !Equals"
+                )
+                assert and_args[1]["Fn::Equals"] == [{"Ref": "ExistingOIDCProviderArn"}, ""], (
+                    "cognito-pool !Equals must check ExistingOIDCProviderArn == ''"
+                )
+            else:
+                # Must be simple !Equals [!Ref ExistingOIDCProviderArn, '']
+                assert "Fn::Equals" in condition, f"{template_file} CreateOIDCProvider must use !Equals"
+                assert condition["Fn::Equals"] == [{"Ref": "ExistingOIDCProviderArn"}, ""], (
+                    f"{template_file} Condition must check ExistingOIDCProviderArn == ''"
+                )

--- a/source/tests/test_existing_oidc_provider_arn.py
+++ b/source/tests/test_existing_oidc_provider_arn.py
@@ -1,0 +1,156 @@
+# ABOUTME: Regression tests for existing_oidc_provider_arn field (issue #528)
+# ABOUTME: Tests field defaults, round-trip serialization, and backward compatibility
+
+"""Tests for the existing_oidc_provider_arn field in Profile dataclass.
+
+Issue #528: Allow reusing a pre-existing IAM OIDC provider ARN instead of
+creating a new one, for multi-profile same-account deployments.
+"""
+
+from claude_code_with_bedrock.config import Profile
+
+
+class TestExistingOidcProviderArn:
+    """Tests for the existing_oidc_provider_arn federation field."""
+
+    def test_field_defaults_to_none(self):
+        """existing_oidc_provider_arn is optional and defaults to None."""
+        profile = Profile(
+            name="test",
+            provider_domain="company.okta.com",
+            client_id="test-client-id",
+            credential_storage="session",
+            aws_region="us-east-1",
+            identity_pool_name="test-pool",
+        )
+
+        assert profile.existing_oidc_provider_arn is None
+
+    def test_field_round_trips_through_to_dict_from_dict(self):
+        """existing_oidc_provider_arn survives to_dict() → from_dict() round-trip."""
+        arn = "arn:aws:iam::123456789012:oidc-provider/company.okta.com"
+        profile = Profile(
+            name="test",
+            provider_domain="company.okta.com",
+            client_id="test-client-id",
+            credential_storage="session",
+            aws_region="us-east-1",
+            identity_pool_name="test-pool",
+            existing_oidc_provider_arn=arn,
+        )
+
+        serialized = profile.to_dict()
+        restored = Profile.from_dict(serialized)
+
+        assert restored.existing_oidc_provider_arn == arn
+
+    def test_old_config_without_field_still_loads(self):
+        """OLD saved config without existing_oidc_provider_arn must load (backward compat).
+
+        This is a Tier 1 requirement per .claude/rules/review-tiers.md:
+        changes to config.py must not break old configs.
+        """
+        # Realistic minimal profile dict representing an OLD saved config
+        # (pre-issue-528) with NO existing_oidc_provider_arn key
+        data = {
+            "name": "legacy",
+            "provider_domain": "dev-12345.okta.com",
+            "client_id": "0oa123abc456",
+            "credential_storage": "session",
+            "aws_region": "us-west-2",
+            "identity_pool_name": "ccwb-identity-pool",
+            "federation_type": "direct",
+            "federated_role_arn": "arn:aws:iam::123456789012:role/ClaudeCodeRole",
+            # existing_oidc_provider_arn intentionally absent (old config)
+        }
+
+        profile = Profile.from_dict(data)
+
+        assert profile.existing_oidc_provider_arn is None
+
+    def test_to_dict_includes_field(self):
+        """to_dict() must include existing_oidc_provider_arn in output."""
+        profile = Profile(
+            name="test",
+            provider_domain="company.okta.com",
+            client_id="test-client-id",
+            credential_storage="session",
+            aws_region="us-east-1",
+            identity_pool_name="test-pool",
+            existing_oidc_provider_arn="arn:aws:iam::123456789012:oidc-provider/company.okta.com",
+        )
+
+        result = profile.to_dict()
+
+        assert "existing_oidc_provider_arn" in result
+        assert result["existing_oidc_provider_arn"] == "arn:aws:iam::123456789012:oidc-provider/company.okta.com"
+
+    def test_to_dict_includes_field_when_none(self):
+        """to_dict() must include existing_oidc_provider_arn even when None (for schema completeness)."""
+        profile = Profile(
+            name="test",
+            provider_domain="company.okta.com",
+            client_id="test-client-id",
+            credential_storage="session",
+            aws_region="us-east-1",
+            identity_pool_name="test-pool",
+        )
+
+        result = profile.to_dict()
+
+        assert "existing_oidc_provider_arn" in result
+        assert result["existing_oidc_provider_arn"] is None
+
+
+class TestFederatedRoleName:
+    """Tests for the federated_role_name field (issue #528 follow-up).
+
+    A per-profile IAM role name so multiple profiles in one account don't collide
+    on the federation role. None -> template default (backward compatible).
+    """
+
+    def test_field_defaults_to_none(self):
+        """federated_role_name is optional and defaults to None (template default)."""
+        profile = Profile(
+            name="test",
+            provider_domain="company.okta.com",
+            client_id="test-client-id",
+            credential_storage="session",
+            aws_region="us-east-1",
+            identity_pool_name="test-pool",
+        )
+
+        assert profile.federated_role_name is None
+
+    def test_field_round_trips(self):
+        """federated_role_name survives to_dict() → from_dict() round-trip."""
+        profile = Profile(
+            name="test",
+            provider_domain="company.okta.com",
+            client_id="test-client-id",
+            credential_storage="session",
+            aws_region="us-east-1",
+            identity_pool_name="test-pool",
+            federated_role_name="BedrockOktaFederatedRole-test-pool",
+        )
+
+        restored = Profile.from_dict(profile.to_dict())
+
+        assert restored.federated_role_name == "BedrockOktaFederatedRole-test-pool"
+
+    def test_old_config_without_field_still_loads(self):
+        """OLD saved config without federated_role_name must load (backward compat)."""
+        data = {
+            "name": "legacy",
+            "provider_domain": "dev-12345.okta.com",
+            "client_id": "0oa123abc456",
+            "credential_storage": "session",
+            "aws_region": "us-west-2",
+            "identity_pool_name": "ccwb-identity-pool",
+            "federation_type": "direct",
+            # federated_role_name intentionally absent (old config)
+        }
+
+        profile = Profile.from_dict(data)
+
+        assert profile.federated_role_name is None


### PR DESCRIPTION
## Why

Deploying a second profile that shares an OIDC issuer in the same AWS account fails the auth stack with `EntityAlreadyExists: Provider with url ... already exists` — IAM allows only one OIDC provider per issuer URL per account. Google always hits this (the issuer is always `accounts.google.com`); okta/azure/auth0/generic hit it whenever two profiles share an issuer; cognito-pool hits it when two direct-mode stacks point at the same user pool.

This is the exact scenario in #528: two profiles (e.g. R&D vs non-R&D) with different quotas, same IdP, same account/region (to preserve regional Bedrock prompt-cache locality and unified quota/billing).

Once the provider collision is resolved, a second profile of the **same provider type** then collides on the IAM **role name** (the federation role name is a template default, e.g. `BedrockAzureFederatedRole`, and `deploy.py` never overrode it on the standard auth path). Both same-account collisions are fixed here so the multi-profile case actually works end to end.

Fixes #528

## What

Implements the maintainer-recommended **Option 1** from the issue thread: an optional `ExistingOIDCProviderArn` parameter on the auth templates. When supplied, the stack reuses the existing provider instead of creating a duplicate; when empty (the default), behavior is byte-for-byte unchanged.

- **CFN (all 6 `bedrock-auth-*.yaml`):** new `ExistingOIDCProviderArn` parameter (`Default: ''`, partition-aware ARN `AllowedPattern`) + `CreateOIDCProvider` condition gating the provider resource. Every provider-ARN reference (trust policy, Cognito identity pool, output) is wrapped in `!If [CreateOIDCProvider, !GetAtt …, !Ref ExistingOIDCProviderArn]`. cognito-pool uses a combined `!And [UseDirectIAM, !Equals [arn, '']]` since its provider only exists in direct mode.
- **Role name:** per-profile `FederatedRoleName`, derived for **new direct** profiles (`Bedrock<Provider>FederatedRole-<identity_pool_name>`, ≤64 chars), mirroring the existing IDC path. Existing profiles keep their value (unset → template default), so a re-run never renames a deployed role.
- **Python:** optional `existing_oidc_provider_arn` and `federated_role_name` Profile fields (both default `None`, backward-compatible); `deploy.py` passes each param only when set; `init.py` adds an optional OIDC-provider-ARN wizard prompt. No Go change (the credential-process reads `federated_role_arn`, never the provider ARN or role name).

## Operator note

When reusing a provider, its `ClientIdList` must already include the new profile's client ID, or `sts:AssumeRoleWithWebIdentity` is denied at runtime. In **direct** federation mode the role trusts the provider without an `aud` condition, so a shared provider whose `ClientIdList` includes multiple client IDs lets a token for any of them assume any direct-mode role trusting that provider — set the ARN only for providers you control. (The default Cognito-Identity path is unaffected: it scopes by the per-profile identity pool's `aud`.)

## How / Why this is safe

ARN set → `CreateOIDCProvider=false` → no provider resource, no `CreateOIDCProvider` API call, all references resolve to the supplied ARN. ARN empty (default, and for every existing config) → `CreateOIDCProvider=true` → provider created and all `!If` resolve to `!GetAtt` — identical to pre-change behavior, so existing single-profile deploys and stack updates are unaffected. `FederatedRoleName` is passed only when set, so existing profiles keep their role ARN stable.

## Testing

- [x] cfn-lint passes on all 6 templates (cfn-lint 1.51.4)
- [x] New regression tests: CFN structure (all 6 templates, no bare provider `!GetAtt` remains), config backward-compat (both new fields default to `None`, old configs load), deploy param-threading (real boto3 kwarg, passed-when-set / absent-when-None), init role-name derivation (pattern + ≤64, new derives / existing preserved) + init round-trip restore of `existing_oidc_provider_arn`
- [x] Falsified against beta: each regression test fails on beta's files, passes on the fix
- [x] Live-validated on Azure/Entra direct mode (two profiles, one account, ap-southeast-1): collision reproduced on the unfixed path, both stacks reach `CREATE_COMPLETE` with the fix — one shared provider, two distinct roles
- [x] Rebased on latest `beta`; full targeted suite green; mypy + ruff clean on changed lines

## Notes

This bundles two same-account collisions (OIDC provider + IAM role name) because fixing only the provider leaves the feature non-functional for same-provider-type direct-mode deploys. Happy to split into two PRs if preferred. The Lambda auto-append of the client ID to an existing provider's `ClientIdList` (the issue's "bonus") is intentionally deferred — the manual step is documented above.
