### PR TITLE
feat(websearch): hosted web search via AgentCore gateway (provider-agnostic id_token)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This guidance enables enterprise deployment of Claude Code and Claude Cowork on 
 - **One Deployment, Two Surfaces**: Same infrastructure powers both Claude Code CLI and Claude Desktop (which features Chat, Cowork and Code)
 - **Model Flexibility**: Choose from Opus, Sonnet, Haiku with model aliases (e.g. `opusplan` for Opus planning + Sonnet execution)
 - **Native Desktop Experience**: Deploy and manage Claude Cowork (Claude Desktop) via MDM (Jamf, Intune, Group Policy)
+- **Web Search (AgentCore)**: Optionally give Claude Code a hosted web-search tool via an Amazon Bedrock AgentCore gateway, authorized by the same OIDC identity — no proxy, no extra IAM grant. See the [Web Search Guide](assets/docs/WEB_SEARCH.md)
 - **Data Residency**: Select your cross-region inference profile (US, EU, AU) to keep data within your compliance boundary
 - **AWS-Native**: Your data, your AWS account, your compliance controls — no Anthropic licensing required
 

--- a/assets/docs/CLI_REFERENCE.md
+++ b/assets/docs/CLI_REFERENCE.md
@@ -111,7 +111,7 @@ poetry run ccwb deploy [stack] [options]
 
 **Arguments:**
 
-- `stack` - Specific stack to deploy: auth, networking, monitoring, dashboard, analytics, or quota (optional)
+- `stack` - Specific stack to deploy: auth, networking, monitoring, dashboard, analytics, quota, codebuild, or websearch (optional)
 
 **Options:**
 
@@ -135,6 +135,7 @@ poetry run ccwb deploy [stack] [options]
 5. **analytics** - Kinesis Firehose and Athena SQL query pipeline (central mode only, optional)
 6. **quota** - Per-user token quota monitoring and alerts (optional, requires dashboard)
 7. **codebuild** - AWS CodeBuild for Windows binary builds (optional, only if enabled during init)
+8. **websearch** - Amazon Bedrock AgentCore web-search gateway (optional, OIDC deployments only; always deployed to us-east-1). See [WEB_SEARCH.md](./WEB_SEARCH.md)
 
 > **Note**: In sidecar monitoring mode, the auth and dashboard stacks are deployed. The networking, monitoring, and analytics stacks are skipped because the OpenTelemetry collector runs locally on each developer's machine. Both modes include the same PromQL CloudWatch dashboard with full metric analytics.
 
@@ -149,6 +150,9 @@ poetry run ccwb deploy auth
 
 # Deploy quota monitoring (requires dashboard stack first)
 poetry run ccwb deploy quota
+
+# Deploy the web-search gateway (OIDC only; always us-east-1)
+poetry run ccwb deploy websearch
 
 # Show commands without executing
 poetry run ccwb deploy --show-commands

--- a/assets/docs/README.md
+++ b/assets/docs/README.md
@@ -51,6 +51,12 @@ Once you have your IdP **provider domain** and **client ID**, follow one of thes
 - **Purpose**: Per-user and per-group token quota enforcement and alerts
 - **Audience**: IT administrators managing usage costs
 
+### Web Search (AgentCore)
+
+- **File**: [WEB_SEARCH.md](./WEB_SEARCH.md)
+- **Purpose**: Enable a hosted web-search tool for Claude Code via an Amazon Bedrock AgentCore gateway (OIDC deployments), including cost, the us-east-1 constraint, and acceptable-use obligations
+- **Audience**: IT administrators enabling web search; OIDC deployments only
+
 ### Cost Estimates
 
 - **File**: [COST_ESTIMATES.md](./COST_ESTIMATES.md)

--- a/assets/docs/WEB_SEARCH.md
+++ b/assets/docs/WEB_SEARCH.md
@@ -106,6 +106,13 @@ failed or absent, see Troubleshooting below.
 - **Deploy reports the target never reached READY** — The connector provisions
   asynchronously after the CloudFormation stack completes. Re-run `ccwb deploy websearch`
   to re-check; the error message includes the target's status reason.
+- **Google: `403 insufficient_scope` despite a valid login** — Google issues the `iss`
+  (issuer) claim as either `https://accounts.google.com` or the bare `accounts.google.com`,
+  and the gateway matches the issuer strictly. Claude Code's normal browser sign-in uses the
+  authorization-code flow, which emits the `https://` form the gateway expects, so this works
+  out of the box. You'd only hit the bare-issuer form with a manually minted token (e.g.
+  `gcloud auth print-identity-token` or a service-account token) — use a real interactive
+  sign-in instead.
 
 ## Install caveat — preserve your own `mcpServers`
 

--- a/assets/docs/WEB_SEARCH.md
+++ b/assets/docs/WEB_SEARCH.md
@@ -1,0 +1,124 @@
+# Web Search for Claude Code (Amazon Bedrock AgentCore)
+
+This guide explains how to give Claude Code a hosted **web-search tool** through an
+[Amazon Bedrock AgentCore](https://docs.aws.amazon.com/bedrock-agentcore/) gateway, using
+the same OIDC identity your deployment already mints. No local proxy and no new developer
+prerequisite — Claude Code connects to the gateway natively as a remote MCP server.
+
+## Overview
+
+When web search is enabled, `ccwb deploy` provisions an AgentCore **Gateway** (an MCP
+server) with a managed **web-search** connector target. The gateway's authorizer is
+`CUSTOM_JWT`: it validates the **same id_token** your identity provider issues for Bedrock
+access, so any user who can already authenticate can use web search — no extra IAM grant.
+
+`ccwb package` then writes an `mcpServers.agentcore-websearch` block into the generated
+`settings.json`. Claude Code connects to the gateway over HTTPS and attaches the Bearer
+JWT per request via the credential helper's `--get-mcp-auth-header` mode.
+
+```
+OIDC id_token  ──▶  AgentCore Gateway (CUSTOM_JWT, us-east-1)  ──▶  web-search connector
+   (minted by your IdP)        validates the token               returns cited results
+```
+
+> **Availability:** This is the path for **OIDC** deployments (an external IdP such as
+> Okta, Microsoft Entra ID, Auth0, Google, or a Cognito User Pool). Non-SSO deployments
+> (AWS IAM Identity Center or no-auth) have no id_token to validate and are not yet
+> supported — enabling web search on those deployments is skipped at deploy time.
+
+## Cost
+
+Web search is **billed to your AWS account at approximately $7 per 1,000 queries** (in
+addition to Bedrock model usage). There is no built-in per-user cap.
+
+> **Recommendation:** Before rolling this out broadly, set an **[AWS Budget](https://docs.aws.amazon.com/cost-management/latest/userguide/budgets-managing-costs.html)**
+> or a **[Cost Anomaly Detection](https://docs.aws.amazon.com/cost-management/latest/userguide/getting-started-ad.html)**
+> alert so unexpected query volume surfaces quickly. Hard per-user capping is not part of
+> this feature in v1.
+
+## Region constraint
+
+The AgentCore web-search connector is a managed service available in **us-east-1 only**.
+`ccwb` therefore deploys the web-search gateway to **us-east-1 regardless of your
+deployment's primary region** — the rest of your infrastructure stays where you configured
+it. This is the one deliberate region-pin in the solution; you do not need to change your
+`aws_region` to use web search.
+
+## Acceptable use — citation retention
+
+The web-search results include **source citations**. Per the service's acceptable-use
+terms you **must retain and display these citations** to end users. Do not use the tool for
+bulk content extraction or to build a competing search index. Claude Code surfaces the
+citations in its responses by default; do not strip them.
+
+## Enabling web search
+
+### New deployment
+
+1. Run `ccwb init`. In the **Web Search (AgentCore)** prompt, answer **yes** (the prompt
+   discloses the ~$7/1,000-query cost and the us-east-1-only constraint). This is optional
+   and skippable — declining leaves it off.
+2. Run `ccwb deploy`. The web-search gateway deploys to us-east-1; `ccwb` waits for the
+   connector target to reach **READY** and saves the gateway URL to your profile.
+3. Run `ccwb package` and distribute/install the package as usual. The generated
+   `settings.json` now contains the `agentcore-websearch` MCP server.
+
+### Existing deployment (late enablement)
+
+You can adopt web search without tearing anything down:
+
+```bash
+# 1. Re-run init and answer "yes" to the web-search prompt (other answers round-trip).
+poetry run ccwb init
+
+# 2. Deploy just the web-search stack (us-east-1).
+poetry run ccwb deploy websearch
+
+# 3. Rebuild and reinstall the package so settings.json gains the MCP server.
+poetry run ccwb package
+```
+
+## Verifying it works
+
+After installing the package, confirm Claude Code sees and connects to the gateway:
+
+```bash
+# The agentcore-websearch server should be listed and show as connected.
+claude mcp list
+```
+
+Then ask Claude Code something that requires current information, for example:
+
+> What are the AWS service announcements from this week?
+
+A working setup returns **current results with source citations**. If the server shows as
+failed or absent, see Troubleshooting below.
+
+## Troubleshooting
+
+- **`claude mcp list` doesn't show `agentcore-websearch`** — The block is only written when
+  web search is enabled *and* a gateway URL is known. Run `ccwb deploy websearch` first,
+  then re-run `ccwb package` and reinstall.
+- **Server shows as failed / authentication errors** — The gateway validates your OIDC
+  id_token. Make sure you have a current session (the credential helper refreshes tokens
+  silently; if it can't, re-authenticate). The `--get-mcp-auth-header` mode never opens a
+  browser, so an expired, unrefreshable token fails cleanly rather than hanging.
+- **Deploy reports the target never reached READY** — The connector provisions
+  asynchronously after the CloudFormation stack completes. Re-run `ccwb deploy websearch`
+  to re-check; the error message includes the target's status reason.
+
+## Install caveat — preserve your own `mcpServers`
+
+> ⚠️ **Re-running the installer overwrites `~/.claude/settings.json`.** It does **not**
+> merge — any `mcpServers` (or other settings) you added yourself are replaced by the
+> generated file. On **macOS/Linux** the installer first writes a timestamped backup
+> (`~/.claude/settings.json.backup-<timestamp>`); on **Windows** there is **no backup**.
+>
+> If you maintain your own MCP servers or custom settings, **back up
+> `~/.claude/settings.json` before reinstalling** and re-merge your entries afterward.
+
+## See also
+
+- [CLI Reference](./CLI_REFERENCE.md) — `ccwb deploy websearch`
+- [Cost Estimates](./COST_ESTIMATES.md) — overall deployment cost planning
+- [Quick Start](../../QUICK_START.md) — full deployment walkthrough

--- a/deployment/infrastructure/agentcore-websearch.yaml
+++ b/deployment/infrastructure/agentcore-websearch.yaml
@@ -24,9 +24,12 @@ Parameters:
   ClientId:
     Type: String
     Description: >-
-      OIDC client_id. Becomes the gateway's allowedClients entry; the minted
+      OIDC client_id. Becomes the gateway's allowedAudience entry; the minted
       id_token carries aud == client_id (no per-resource audience requested),
-      so the same token validates here as at the quota authorizer.
+      so matching on the audience validates the same uniform id_token across
+      every OIDC provider (Cognito, Okta, Auth0, Azure, Google) with no
+      customer-side IdP config. Matching on allowedClients instead would reject
+      the id_token, whose client identity lives in aud, not a client_id claim.
     MinLength: 1
 
   DomainExcludeList:
@@ -88,7 +91,10 @@ Resources:
       AuthorizerConfiguration:
         CustomJWTAuthorizer:
           DiscoveryUrl: !Ref DiscoveryUrl
-          AllowedClients:
+          # Match on audience, not client. The uniform OIDC id_token carries the
+          # client_id in aud (not in a client_id claim), so AllowedAudience
+          # validates it across every provider; AllowedClients would 403 it.
+          AllowedAudience:
             - !Ref ClientId
       RoleArn: !GetAtt WebSearchGatewayRole.Arn
 

--- a/deployment/infrastructure/agentcore-websearch.yaml
+++ b/deployment/infrastructure/agentcore-websearch.yaml
@@ -1,0 +1,150 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >-
+  Claude Code web search via Amazon Bedrock AgentCore. Deploys an AgentCore
+  Gateway (CUSTOM_JWT authorizer validating the same OIDC id_token the solution
+  already mints) fronting a managed web-search connector target, plus the
+  service role the gateway assumes to invoke the web-search tool. us-east-1 only.
+
+# NOTE (us-east-1 pin): AgentCore Web Search and the web-search connector tool
+# (arn:aws:bedrock-agentcore:us-east-1:aws:tool/web-search.v1) are only available
+# in us-east-1. deploy.py deploys this stack via a region-pinned CloudFormation
+# manager regardless of profile.aws_region (see .claude/rules/region-availability.md).
+
+Parameters:
+  DiscoveryUrl:
+    Type: String
+    Description: >-
+      OIDC discovery (.well-known/openid-configuration) URL for the identity
+      provider. Derived per-provider from the profile by deploy.py so the
+      gateway's expected issuer matches the id_token's actual issuer
+      (Okta /oauth2/default, Auth0 trailing slash, Azure /v2.0, Cognito pool URL).
+    AllowedPattern: '^https://.+'
+    ConstraintDescription: must be an https:// URL
+
+  ClientId:
+    Type: String
+    Description: >-
+      OIDC client_id. Becomes the gateway's allowedClients entry; the minted
+      id_token carries aud == client_id (no per-resource audience requested),
+      so the same token validates here as at the quota authorizer.
+    MinLength: 1
+
+  DomainExcludeList:
+    Type: CommaDelimitedList
+    Default: ''
+    Description: >-
+      Optional list of domains to exclude from web-search results
+      (domainFilter.exclude). Empty by default.
+
+Conditions:
+  HasDomainExcludeList: !Not [!Equals [!Join ['', !Ref DomainExcludeList], '']]
+
+Resources:
+  # IAM role the gateway assumes to invoke the managed web-search tool.
+  # Trust is scoped to this account + this gateway (confused-deputy guard).
+  WebSearchGatewayRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub '${AWS::StackName}-gateway-role'
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: bedrock-agentcore.amazonaws.com
+            Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                aws:SourceAccount: !Ref AWS::AccountId
+              ArnLike:
+                aws:SourceArn: !Sub 'arn:${AWS::Partition}:bedrock-agentcore:${AWS::Region}:${AWS::AccountId}:gateway/*'
+      Policies:
+        - PolicyName: WebSearchInvoke
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: InvokeWebSearchTool
+                Effect: Allow
+                Action:
+                  - bedrock-agentcore:InvokeWebSearch
+                Resource:
+                  - !Sub 'arn:${AWS::Partition}:bedrock-agentcore:${AWS::Region}:aws:tool/web-search.v1'
+              - Sid: InvokeGateway
+                Effect: Allow
+                Action:
+                  - bedrock-agentcore:InvokeGateway
+                Resource:
+                  - !Sub 'arn:${AWS::Partition}:bedrock-agentcore:${AWS::Region}:${AWS::AccountId}:gateway/*'
+
+  # AgentCore Gateway: MCP protocol, CUSTOM_JWT authorizer validating the
+  # solution's OIDC id_token (same token the quota HTTP API authorizer accepts).
+  WebSearchGateway:
+    Type: AWS::BedrockAgentCore::Gateway
+    Properties:
+      Name: !Sub '${AWS::StackName}-gw'
+      Description: Claude Code web search gateway (CUSTOM_JWT, OIDC id_token)
+      ProtocolType: MCP
+      AuthorizerType: CUSTOM_JWT
+      AuthorizerConfiguration:
+        CustomJWTAuthorizer:
+          DiscoveryUrl: !Ref DiscoveryUrl
+          AllowedClients:
+            - !Ref ClientId
+      RoleArn: !GetAtt WebSearchGatewayRole.Arn
+
+  # Managed web-search connector target. Validates asynchronously (~30s) →
+  # deploy.py polls Status until READY. The gateway invokes the tool with the
+  # GATEWAY_IAM_ROLE credential provider (WebSearchGatewayRole above).
+  WebSearchTarget:
+    Type: AWS::BedrockAgentCore::GatewayTarget
+    # cfn-lint spec lag (tracking): the bundled GatewayTarget schema (cfn-lint 1.51.x)
+    # only models TargetConfiguration.Mcp variants OpenApiSchema | SmithyModel | Lambda |
+    # McpServer | ApiGateway — it lacks the "Connector" branch entirely. The live
+    # AgentCore CloudFormation schema DOES accept Mcp.Connector (verified by a real
+    # us-east-1 deploy reaching READY, 2026-06-19). A valid template therefore trips
+    # E3002/E3003/E3018 on this resource only. Scoped here (not in the global CI ignore
+    # list) so every other template keeps full schema coverage. Remove when cfn-lint
+    # ships the connector shape (track against the registry schema, not docs).
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
+            - E3003
+            - E3018
+    Properties:
+      Name: !Sub '${AWS::StackName}-web-search'
+      GatewayIdentifier: !GetAtt WebSearchGateway.GatewayIdentifier
+      Description: Managed web-search connector target
+      TargetConfiguration:
+        Mcp:
+          Connector:
+            Source:
+              ConnectorId: web-search
+            Configurations:
+              # ParameterValues must always be present (the service rejects an empty
+              # config entry). Empty object = no domain filter; otherwise a nested
+              # domainFilter.exclude array (NOT a dotted key / comma-string).
+              - Name: WebSearch
+                ParameterValues: !If
+                  - HasDomainExcludeList
+                  - domainFilter:
+                      exclude: !Ref DomainExcludeList
+                  - {}
+      CredentialProviderConfigurations:
+        - CredentialProviderType: GATEWAY_IAM_ROLE
+
+Outputs:
+  GatewayUrl:
+    Description: MCP endpoint URL of the web-search gateway (ends in /mcp)
+    Value: !GetAtt WebSearchGateway.GatewayUrl
+    Export:
+      Name: !Sub '${AWS::StackName}-GatewayUrl'
+
+  GatewayArn:
+    Description: ARN of the web-search gateway
+    Value: !GetAtt WebSearchGateway.GatewayArn
+
+  GatewayId:
+    Description: ID of the web-search gateway
+    Value: !GetAtt WebSearchGateway.GatewayIdentifier

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -189,10 +189,25 @@ class DeployCommand(Command):
                 else:
                     console.print("[yellow]CodeBuild is not enabled in your configuration.[/yellow]")
                     return 1
+            elif stack_arg == "websearch":
+                # Late-enablement path (AC10): adopt web search on an existing
+                # deployment via `ccwb deploy websearch` without teardown.
+                if not getattr(profile, "web_search_enabled", False):
+                    console.print("[yellow]Web search is not enabled in your configuration.[/yellow]")
+                    console.print("Run 'poetry run ccwb init' and enable web search.")
+                    return 1
+                if profile.effective_auth_type != "oidc":
+                    console.print(
+                        "[yellow]Web search requires OIDC authentication "
+                        "(its gateway validates the OIDC id_token via CUSTOM_JWT).[/yellow]"
+                    )
+                    return 1
+                stacks_to_deploy.append(("websearch", "AgentCore Web Search Gateway (us-east-1)"))
             else:
                 console.print(f"[red]Unknown stack: {stack_arg}[/red]")
                 console.print(
-                    "Valid stacks: auth, distribution, networking, monitoring, dashboard, cowork-dashboard, analytics, quota, codebuild\n"
+                    "Valid stacks: auth, distribution, networking, monitoring, dashboard, "
+                    "cowork-dashboard, analytics, quota, codebuild, websearch\n"
                 )
                 console.print("[dim]Tip: Use 'ccwb deploy' without arguments to deploy all enabled stacks.[/dim]")
                 console.print("[dim]Use 'ccwb deploy quota' for quota-specific updates or late enablement.[/dim]")
@@ -256,6 +271,12 @@ class DeployCommand(Command):
             if getattr(profile, "enable_codebuild", False):
                 stacks_to_deploy.append(("codebuild", "CodeBuild for Windows binary builds"))
 
+            # Web search gateway (Story A). Only for OIDC — its CUSTOM_JWT
+            # authorizer validates the OIDC id_token; idc/none have none.
+            # Pinned to us-east-1 at deploy time regardless of aws_region.
+            if self._should_deploy_websearch(profile):
+                stacks_to_deploy.append(("websearch", "AgentCore Web Search Gateway (us-east-1)"))
+
         # Initialize CloudFormation manager
         cf_manager = CloudFormationManager(region=profile.aws_region)
 
@@ -274,6 +295,8 @@ class DeployCommand(Command):
                 cb_region = get_codebuild_region(profile)
                 if cb_region != profile.aws_region:
                     status_manager = CloudFormationManager(region=cb_region)
+            elif stack_type == "websearch":
+                status_manager = self._websearch_cf_manager(profile, cf_manager)
             status = status_manager.get_stack_status(stack_name)
             if status and status in ["CREATE_COMPLETE", "UPDATE_COMPLETE", "UPDATE_ROLLBACK_COMPLETE"]:
                 status_display = "[green]Update[/green]"
@@ -310,6 +333,8 @@ class DeployCommand(Command):
                             cb_region = get_codebuild_region(profile)
                             if cb_region != profile.aws_region:
                                 del_mgr = CloudFormationManager(region=cb_region)
+                        elif stack_type == "websearch":
+                            del_mgr = self._websearch_cf_manager(profile, cf_manager)
                         del_mgr.delete_stack(stack_name)
                         console.print(f"[green]✓ {stack_type} stack deletion initiated[/green]")
                     except Exception as e:
@@ -1016,6 +1041,63 @@ class DeployCommand(Command):
                     cf=cf,
                 )
 
+            elif stack_type == "websearch":
+                # Web-search gateway is region-pinned to us-east-1 regardless of
+                # the deployment's primary region (managed connector availability).
+                ws_region = self.WEBSEARCH_REGION
+                cf = self._websearch_cf_manager(profile, cf_manager)
+                template = project_root / "deployment" / "infrastructure" / "agentcore-websearch.yaml"
+                stack_name = profile.stack_names.get("websearch", f"{profile.identity_pool_name}-websearch")
+
+                # Derive the CUSTOM_JWT discovery URL per-provider so the gateway's
+                # expected issuer matches the id_token (AC3).
+                try:
+                    discovery_url = self._resolve_websearch_discovery_url(profile)
+                except ValueError as e:
+                    console.print(f"[red]✗ Cannot deploy web search: {e}[/red]")
+                    return 1
+
+                # DomainExcludeList is an optional template param (defaults empty);
+                # no profile field feeds it yet, so we accept the template default.
+                params = [
+                    f"DiscoveryUrl={discovery_url}",
+                    f"ClientId={profile.client_id}",
+                ]
+
+                if profile.aws_region != ws_region:
+                    console.print(
+                        f"[dim]Web search gateway pinned to {ws_region} "
+                        f"(deployment region is {profile.aws_region}).[/dim]"
+                    )
+
+                result = deploy_with_cf(
+                    template,
+                    stack_name,
+                    params,
+                    # The gateway service role uses an explicit RoleName
+                    # (${AWS::StackName}-gateway-role), so CFN requires
+                    # CAPABILITY_NAMED_IAM — not the CAPABILITY_IAM default.
+                    capabilities=["CAPABILITY_NAMED_IAM"],
+                    task_description=f"Deploying web-search gateway in {ws_region}...",
+                    cf=cf,
+                )
+                if result != 0:
+                    return result
+
+                # CFN CREATE_COMPLETE precedes the connector target reaching READY;
+                # poll explicitly so a half-provisioned gateway is surfaced (AC1).
+                outputs = get_stack_outputs(stack_name, ws_region)
+                gateway_id = outputs.get("GatewayId", "") if outputs else ""
+                if gateway_id:
+                    ready = self._poll_websearch_target_ready(gateway_id, ws_region, console)
+                    if not ready:
+                        return 1
+                    console.print("[green]✓ Web-search connector target is READY[/green]")
+
+                # Persist the gateway URL so package can read it (AC8).
+                self._persist_websearch_gateway_url(profile, outputs, console)
+                return result
+
             else:
                 console.print(f"[red]Unknown stack type: {stack_type}[/red]")
                 return 1
@@ -1031,8 +1113,14 @@ class DeployCommand(Command):
         """Show AWS CLI commands for manual deployment."""
         project_root = Path(__file__).parents[4]
         # CodeBuild may deploy to a different region than the main infrastructure;
-        # print the command for the region it actually deploys to.
-        region = get_codebuild_region(profile) if stack_type == "codebuild" else profile.aws_region
+        # web search is region-pinned to us-east-1. Print each command for the
+        # region it actually deploys to.
+        if stack_type == "codebuild":
+            region = get_codebuild_region(profile)
+        elif stack_type == "websearch":
+            region = self.WEBSEARCH_REGION
+        else:
+            region = profile.aws_region
 
         def print_deploy_cmd(template, stack_name, params, capabilities=None):
             caps_str = " ".join(capabilities or ["CAPABILITY_IAM"])
@@ -1213,6 +1301,19 @@ class DeployCommand(Command):
             params = [f"ProjectNamePrefix={profile.identity_pool_name}"]
             print_deploy_cmd(template, stack_name, params)
 
+        elif stack_type == "websearch":
+            template = project_root / "deployment" / "infrastructure" / "agentcore-websearch.yaml"
+            stack_name = profile.stack_names.get("websearch", f"{profile.identity_pool_name}-websearch")
+            try:
+                discovery_url = self._resolve_websearch_discovery_url(profile)
+            except ValueError:
+                discovery_url = "<derived per-provider from profile>"
+            params = [
+                f"DiscoveryUrl={discovery_url}",
+                f"ClientId={profile.client_id}",
+            ]
+            print_deploy_cmd(template, stack_name, params)
+
         elif stack_type == "distribution":
             stack_name = profile.stack_names.get("distribution", f"{profile.identity_pool_name}-distribution")
             if profile.distribution_type == "landing-page":
@@ -1382,6 +1483,7 @@ class DeployCommand(Command):
             "analytics": "Analytics Pipeline",
             "quota": "Quota Monitoring",
             "codebuild": "CodeBuild",
+            "websearch": "AgentCore Web Search Gateway",
         }
 
         # Stack types that are being deployed
@@ -1392,14 +1494,17 @@ class DeployCommand(Command):
         for stack_type in all_stack_types:
             if stack_type not in deploying_types:
                 # This stack type is not being deployed - check if it exists.
-                # CodeBuild may live in a different region (cross-region builds), so
-                # check it there or a cross-region orphan is never detected.
+                # CodeBuild may live in a different region (cross-region builds)
+                # and web search is region-pinned to us-east-1, so check those
+                # in their own region or a cross-region orphan is never detected.
                 stack_name = profile.stack_names.get(stack_type, f"{profile.identity_pool_name}-{stack_type}")
                 mgr = cf_manager
                 if stack_type == "codebuild":
                     cb_region = get_codebuild_region(profile)
                     if cb_region != profile.aws_region:
                         mgr = CloudFormationManager(region=cb_region)
+                elif stack_type == "websearch":
+                    mgr = self._websearch_cf_manager(profile, cf_manager)
                 status = mgr.get_stack_status(stack_name)
 
                 if status and status not in ["DELETE_COMPLETE", "DELETE_IN_PROGRESS"]:
@@ -1482,3 +1587,153 @@ class DeployCommand(Command):
             issuer_url += "/"
 
         return issuer_url, profile.client_id
+
+    # ------------------------------------------------------------------
+    # Web search (AgentCore Gateway, CUSTOM_JWT) — Story A
+    # ------------------------------------------------------------------
+    # The gateway lives ONLY in us-east-1 (AgentCore web-search connector
+    # availability), independent of the deployment's primary region. This is
+    # the single deliberate region-pin exception in the deploy path
+    # (.claude/rules/region-availability.md — "never hardcode us-east-1
+    # without a reason"; here the reason is the managed tool's region).
+    WEBSEARCH_REGION = "us-east-1"
+
+    def _should_deploy_websearch(self, profile) -> bool:
+        """Web search deploys only when enabled AND on an OIDC deployment.
+
+        Story A's gateway authorizer is CUSTOM_JWT, which validates the OIDC
+        id_token the solution already mints. idc/none deployments have no
+        id_token — they are Story B (AWS_IAM + SigV4 proxy), deferred. Gating
+        here mirrors the quota rule (.claude/rules/quota-requires-oidc.md).
+        """
+        if not getattr(profile, "web_search_enabled", False):
+            return False
+        return profile.effective_auth_type == "oidc"
+
+    def _websearch_cf_manager(self, profile, primary_manager: CloudFormationManager) -> CloudFormationManager:
+        """Return the CFN manager for the websearch stack (always us-east-1).
+
+        Reuses the primary manager when the deployment is already in us-east-1;
+        otherwise builds a region-pinned manager. Mirrors the cross-region
+        CodeBuild pattern already in this file.
+        """
+        if profile.aws_region == self.WEBSEARCH_REGION:
+            return primary_manager
+        return CloudFormationManager(region=self.WEBSEARCH_REGION)
+
+    def _resolve_websearch_discovery_url(self, profile) -> str:
+        """Build the OIDC discovery URL for the gateway's CUSTOM_JWT authorizer.
+
+        The gateway's expected issuer must match the id_token's actual `iss`
+        claim, so this reuses the same per-provider issuer logic as the ALB /
+        quota authorizers (NOT the quota issuer shortcut) and appends the
+        well-known discovery suffix (.claude/rules/issuer-url-format.md).
+        """
+        provider_type = profile.provider_type or ""
+        provider_domain = (profile.provider_domain or "").rstrip("/")
+
+        if provider_type == "azure":
+            tenant_id = _extract_azure_tenant_id(provider_domain)
+            issuer = f"https://login.microsoftonline.com/{tenant_id}/v2.0"
+        elif provider_type == "okta":
+            issuer = f"https://{provider_domain}/oauth2/default"
+        elif provider_type == "auth0":
+            # Auth0 iss carries a trailing slash; the discovery suffix follows it.
+            issuer = f"https://{provider_domain}"
+        elif provider_type == "cognito":
+            pool_id = getattr(profile, "cognito_user_pool_id", "")
+            if not pool_id:
+                raise ValueError(
+                    "Cognito User Pool ID is required to derive the web-search gateway "
+                    "discovery URL. Set cognito_user_pool_id in your profile."
+                )
+            pool_region = pool_id.split("_")[0] if "_" in pool_id else profile.aws_region
+            issuer = f"https://cognito-idp.{pool_region}.amazonaws.com/{pool_id}"
+        elif provider_type == "google":
+            issuer = "https://accounts.google.com"
+        elif provider_type == "generic":
+            issuer = (getattr(profile, "oidc_issuer_url", "") or "").rstrip("/")
+            if not issuer:
+                raise ValueError(
+                    "Generic OIDC provider requires oidc_issuer_url to derive the "
+                    "web-search gateway discovery URL. Re-run `ccwb init`."
+                )
+            if not issuer.startswith(("http://", "https://")):
+                issuer = f"https://{issuer}"
+        else:
+            raise ValueError(
+                f"Unsupported provider_type '{provider_type}' for web search. "
+                "Web search requires an OIDC provider."
+            )
+
+        return f"{issuer}/.well-known/openid-configuration"
+
+    def _poll_websearch_target_ready(
+        self, gateway_id: str, region: str, console: Console, timeout: int = 600, interval: int = 15
+    ) -> bool:
+        """Poll the gateway's connector target until READY (returns True).
+
+        CFN CREATE_COMPLETE precedes the target reaching READY — the connector
+        provisions asynchronously, so we must not assume it's ready when the
+        stack completes (.claude/rules/stack-ordering.md). Returns False on a
+        FAILED status (surfacing the reason) or on timeout.
+        """
+        import time
+
+        try:
+            import boto3
+
+            client = boto3.client("bedrock-agentcore-control", region_name=region)
+        except Exception as e:  # pragma: no cover - defensive
+            console.print(f"[yellow]⚠ Could not create AgentCore client to poll target: {e}[/yellow]")
+            return False
+
+        deadline = time.monotonic() + timeout
+        while True:
+            try:
+                resp = client.list_gateway_targets(gatewayIdentifier=gateway_id)
+            except Exception as e:
+                console.print(f"[yellow]⚠ Error polling web-search target: {e}[/yellow]")
+                return False
+
+            targets = resp.get("items", [])
+            if targets:
+                target = targets[0]
+                status = target.get("status", "")
+                if status == "READY":
+                    return True
+                if status in ("FAILED", "CREATE_PENDING_AUTH", "UPDATE_UNSUCCESSFUL"):
+                    reasons = "; ".join(target.get("statusReasons", []) or [])
+                    console.print(
+                        f"[red]✗ Web-search target did not reach READY (status={status}). "
+                        f"{reasons}[/red]"
+                    )
+                    return False
+
+            if time.monotonic() >= deadline:
+                console.print(
+                    "[yellow]⚠ Timed out waiting for the web-search target to reach READY. "
+                    "It may still be provisioning — re-run `ccwb deploy websearch` to re-check.[/yellow]"
+                )
+                return False
+
+            time.sleep(interval)
+
+    def _persist_websearch_gateway_url(self, profile, outputs: dict, console: Console) -> str:
+        """Save the gateway URL to the profile (best-effort). Returns the URL.
+
+        Mirrors the OTel-endpoint save precedent: persist immediately after
+        deploy so `ccwb package` can read it profile-first (AC8). A save failure
+        is non-fatal — the stack deployed fine and package has a CFN-output
+        fallback.
+        """
+        url = outputs.get("GatewayUrl", "") if outputs else ""
+        if not url:
+            return ""
+        profile.agentcore_gateway_url = url
+        try:
+            Config.load().save_profile(profile)
+            console.print(f"[dim]Saved web-search gateway URL to profile: {url}[/dim]")
+        except Exception:
+            pass
+        return url

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -1088,11 +1088,23 @@ class DeployCommand(Command):
                 # poll explicitly so a half-provisioned gateway is surfaced (AC1).
                 outputs = get_stack_outputs(stack_name, ws_region)
                 gateway_id = outputs.get("GatewayId", "") if outputs else ""
-                if gateway_id:
-                    ready = self._poll_websearch_target_ready(gateway_id, ws_region, console)
-                    if not ready:
-                        return 1
-                    console.print("[green]✓ Web-search connector target is READY[/green]")
+                if not gateway_id:
+                    # GatewayId is an unconditional template output, so an empty
+                    # value here means the outputs read failed (get_stack_outputs
+                    # swallows errors to {}), NOT a legitimately absent value. We
+                    # cannot verify READY or persist the URL, so this is a deploy
+                    # failure — do not silently exit 0 (Exit Code Contract).
+                    console.print(
+                        "[red]✗ Web-search stack deployed but its outputs could not be read "
+                        f"(no GatewayId in {stack_name}). Cannot verify the connector target "
+                        "reached READY or save the gateway URL. Re-run `ccwb deploy websearch`.[/red]"
+                    )
+                    return 1
+
+                ready = self._poll_websearch_target_ready(gateway_id, ws_region, console)
+                if not ready:
+                    return 1
+                console.print("[green]✓ Web-search connector target is READY[/green]")
 
                 # Persist the gateway URL so package can read it (AC8).
                 self._persist_websearch_gateway_url(profile, outputs, console)

--- a/source/claude_code_with_bedrock/cli/commands/destroy.py
+++ b/source/claude_code_with_bedrock/cli/commands/destroy.py
@@ -17,6 +17,7 @@ from claude_code_with_bedrock.config import Config
 # All destroyable stacks in reverse dependency order (destroy-all uses this sequence).
 # Keep in sync with deploy.py's stack types when adding new stacks.
 DESTROYABLE_STACKS = [
+    "websearch",
     "codebuild",
     "analytics",
     "quota",
@@ -143,12 +144,21 @@ class DestroyCommand(Command):
                 continue
             if stack == "codebuild" and not getattr(profile, "enable_codebuild", False):
                 continue
+            if stack == "websearch" and not getattr(profile, "web_search_enabled", False):
+                continue
 
             stack_name = profile.stack_names.get(stack, f"{profile.identity_pool_name}-{stack}")
             # CodeBuild may have been deployed cross-region (Windows container fleet
             # isn't in every region); delete it where it actually lives, or it's
             # silently orphaned in the build region while the destroy reports success.
-            stack_region = get_codebuild_region(profile) if stack == "codebuild" else profile.aws_region
+            # Web search is region-pinned to us-east-1 (managed connector availability),
+            # so it must be deleted there regardless of the deployment's primary region.
+            if stack == "codebuild":
+                stack_region = get_codebuild_region(profile)
+            elif stack == "websearch":
+                stack_region = "us-east-1"
+            else:
+                stack_region = profile.aws_region
             console.print(f"Destroying {stack} stack: [cyan]{stack_name}[/cyan]")
 
             result = self._delete_stack(stack_name, stack_region, console)

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1455,6 +1455,23 @@ class InitCommand(Command):
         else:
             console.print("[green]✓[/green] Settings will be deployed to user-scope path")
 
+        # Web search (AgentCore Gateway) support
+        console.print("\n[bold]Web Search (AgentCore)[/bold]")
+        console.print("Give Claude Code a hosted web-search tool via an Amazon Bedrock AgentCore gateway")
+        console.print("[dim]  • Cost: ~$7 per 1,000 queries (billed to your AWS account)[/dim]")
+        console.print("[dim]  • Region: the gateway is deployed in us-east-1 only (managed connector)[/dim]")
+        enable_web_search = questionary.confirm(
+            "Enable web search?",
+            default=config.get("web_search", {}).get("enabled", False),
+        ).ask()
+
+        if "web_search" not in config:
+            config["web_search"] = {}
+        config["web_search"]["enabled"] = enable_web_search
+
+        if enable_web_search:
+            console.print("[green]✓[/green] Web search gateway will be deployed (us-east-1)")
+
         # Package distribution support
         console.print("\n[bold]Package Distribution[/bold]")
         console.print("Choose how to distribute Claude Code packages to end users:")
@@ -2499,6 +2516,9 @@ class InitCommand(Command):
             "settings_target": "managed"
             if (self._io and self.option("managed"))
             else config_data.get("settings_target", "user"),
+            # bool() coerces a cancelled prompt (questionary returns None on Ctrl-C)
+            # to a real False so the typed Profile field stays a clean bool.
+            "web_search_enabled": bool(config_data.get("web_search", {}).get("enabled", False)),
             "tags": config_data.get("tags", {}),
             "redirect_port": config_data.get("redirect_port"),
         }
@@ -2860,6 +2880,9 @@ class InitCommand(Command):
             if profile.cowork_service_token:
                 cowork_3p_config["service_token"] = profile.cowork_service_token
             existing_config["cowork_3p"] = cowork_3p_config
+
+            # Web search round-trip so re-init defaults the prompt to its saved value.
+            existing_config["web_search"] = {"enabled": getattr(profile, "web_search_enabled", False)}
 
             # Add distribution configuration if present
             if hasattr(profile, "enable_distribution"):

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -3360,6 +3360,35 @@ Available metrics include:
                     console.print("[red]ERROR: Monitoring enabled but no OTel endpoint configured.[/red]")
                     console.print("[red]Run 'ccwb deploy' first or set otel_collector_endpoint in the profile.[/red]")
 
+            # If web search is enabled, emit the agentcore-websearch MCP server
+            # block (AC5). The gateway is a remote type:http MCP server; the
+            # Bearer JWT is supplied per-request by the credential binary's
+            # --get-mcp-auth-header mode (T3). Omit the block entirely when the
+            # feature is off or no gateway URL can be resolved.
+            if getattr(profile, "web_search_enabled", False):
+                gateway_url = self._resolve_websearch_gateway_url(profile, console)
+                if gateway_url:
+                    settings.setdefault("mcpServers", {})["agentcore-websearch"] = {
+                        "type": "http",
+                        "url": gateway_url,
+                        # __CREDENTIAL_PROCESS_PATH__ is replaced by the installer
+                        # with the real binary path (same placeholder as the SDK
+                        # credential process above).
+                        "headersHelper": (
+                            f"__CREDENTIAL_PROCESS_PATH__ --get-mcp-auth-header --profile {profile_name}"
+                        ),
+                    }
+                    console.print("[dim]Added agentcore-websearch MCP server to settings[/dim]")
+                else:
+                    console.print(
+                        "[yellow]Warning: web search is enabled but no gateway URL was found "
+                        "in the profile or CloudFormation.[/yellow]"
+                    )
+                    console.print(
+                        "[yellow]Run 'ccwb deploy websearch' first; the agentcore-websearch "
+                        "MCP server was omitted from settings.json.[/yellow]"
+                    )
+
             # Determine output filename based on settings_target
             settings_target = getattr(profile, "settings_target", "user")
             if settings_target == "managed":
@@ -3376,6 +3405,47 @@ Available metrics include:
 
         except Exception as e:
             console.print(f"[yellow]Warning: Could not create Claude Code settings: {e}[/yellow]")
+
+    # The web-search gateway is always pinned to us-east-1 (managed connector
+    # availability); deploy.py uses the same constant for the region pin.
+    WEBSEARCH_REGION = "us-east-1"
+
+    def _resolve_websearch_gateway_url(self, profile, console) -> str:
+        """Resolve the AgentCore gateway URL, profile-first with CFN fallback (AC8).
+
+        Mirrors the OTel-endpoint discovery precedent: prefer the
+        `agentcore_gateway_url` saved on the profile by `ccwb deploy`, and only
+        fall back to the websearch stack's `GatewayUrl` output (in us-east-1,
+        where the gateway is region-pinned) when the profile field is empty.
+        A discovered URL is saved back to the profile (best-effort) so this is
+        a one-time lookup. Returns "" when neither source yields a URL.
+        """
+        url = (getattr(profile, "agentcore_gateway_url", "") or "").strip()
+        if url:
+            return url
+
+        stack_name = profile.stack_names.get("websearch") if profile.stack_names else None
+        if not stack_name:
+            stack_name = f"{profile.identity_pool_name}-websearch" if profile.identity_pool_name else None
+        if not stack_name:
+            return ""
+
+        outputs = get_stack_outputs(stack_name, self.WEBSEARCH_REGION)
+        url = (outputs.get("GatewayUrl", "") if outputs else "").strip()
+        if not url:
+            return ""
+
+        # Save to the profile so future packaging skips the CFN query.
+        profile.agentcore_gateway_url = url
+        try:
+            from claude_code_with_bedrock.config import Config
+
+            config = Config.load()
+            config.save_profile(profile)
+            console.print(f"[dim]Found gateway URL from stack '{stack_name}', saved to profile[/dim]")
+        except Exception:
+            pass
+        return url
 
     def _generate_cowork_3p_mdm_config(
         self,

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -149,6 +149,13 @@ class Profile:
     cowork_3p_extra_keys: dict[str, str] = field(default_factory=dict)  # Custom MDM keys merged into CoWork 3P output
     cowork_service_token: str = ""  # Static token for CoWork ALB auth bypass (set during init)
 
+    # AgentCore Web Search (CUSTOM_JWT gateway, OIDC deployments)
+    # web_search_enabled gates deploy of the us-east-1 websearch stack and emission
+    # of the mcpServers block during packaging. agentcore_gateway_url is saved from
+    # the websearch stack output post-deploy and read profile-first during packaging.
+    web_search_enabled: bool = False  # Enable AgentCore Gateway web search MCP server
+    agentcore_gateway_url: str = ""  # AgentCore Gateway MCP endpoint URL (saved from deploy)
+
     # Legacy field support
     @property
     def okta_domain(self) -> str:

--- a/source/credential_provider/__main__.py
+++ b/source/credential_provider/__main__.py
@@ -899,6 +899,19 @@ class MultiProviderAuth:
         except Exception:
             return None
 
+    def get_mcp_auth_header(self):
+        """Return the MCP Authorization header dict from the cached id_token, or None.
+
+        {"Authorization": "Bearer <id_token>"} for the AgentCore web-search MCP
+        headersHelper. Reads only the cached/silently-refreshed token via
+        get_monitoring_token() — never opens a browser. Returns None when no
+        valid token is available so the caller fails cleanly (no hang, no prompt).
+        """
+        token = self.get_monitoring_token()
+        if not token:
+            return None
+        return {"Authorization": f"Bearer {token}"}
+
     def save_to_credentials_file(self, credentials, profile="ClaudeCode"):
         """Save credentials to ~/.aws/credentials file
 
@@ -2471,6 +2484,14 @@ def main():
         "--get-monitoring-token", action="store_true", help="Get cached monitoring token instead of AWS credentials"
     )
     parser.add_argument(
+        "--get-mcp-auth-header",
+        action="store_true",
+        help=(
+            'Print {"Authorization":"Bearer <id_token>"} from the cached token for an MCP '
+            "headersHelper (never opens a browser)"
+        ),
+    )
+    parser.add_argument(
         "--clear-cache", action="store_true", help="Clear cached credentials and force re-authentication"
     )
     parser.add_argument(
@@ -2559,6 +2580,27 @@ def main():
                 # Return failure exit code so OTEL helper knows auth failed
                 # This prevents OTEL helper from using default/unknown values
                 sys.exit(1)
+
+    # Handle MCP auth-header request.
+    # Used as the headersHelper for the AgentCore web-search MCP server, whose
+    # gateway runs a CUSTOM_JWT authorizer validating the same OIDC id_token the
+    # solution already mints. MUST be fast and MUST NOT open a browser — an MCP
+    # headersHelper can never drive an interactive login. So, unlike
+    # --get-monitoring-token, this never falls through to authentication: on a
+    # cache miss it fails cleanly with a non-zero exit.
+    if args.get_mcp_auth_header:
+        header = auth.get_mcp_auth_header()
+        if header:
+            # Compact separators so Go (encoding/json) and Python emit byte-identical output.
+            print(json.dumps(header, separators=(",", ":")))
+            sys.exit(0)
+        else:
+            print(
+                f"Error: no valid cached token for profile '{args.profile}'; "
+                "run the credential process once to authenticate.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
     # Handle check-expiration request
     if args.check_expiration:

--- a/source/go/cmd/credential-process/main.go
+++ b/source/go/cmd/credential-process/main.go
@@ -280,11 +280,17 @@ func (a *credentialApp) getMCPAuthHeader() int {
 	token, err := storage.GetMonitoringToken(a.profile, a.cfg.CredentialStorage)
 	if (err != nil || token == "") && a.cfg.IsSsoEnabled() && !a.cfg.IsIDC() {
 		// Cached id_token expired/near-expiry. Try the silent refresh_token
-		// exchange (no browser) before giving up — mirrors getMonitoringToken
-		// but stops here: an MCP headersHelper can never drive an interactive
-		// login. Only attempt for OIDC; idc/none have no id_token (Story B).
-		if creds := a.tryRefreshToken(); creds != nil {
-			token, err = storage.GetMonitoringToken(a.profile, a.cfg.CredentialStorage)
+		// exchange (no browser) before giving up — but stop here: an MCP
+		// headersHelper can never drive an interactive login. Only attempt for
+		// OIDC; idc/none have no id_token (Story B).
+		//
+		// Use refreshIDTokenOnly (NOT tryRefreshToken): the gateway's CUSTOM_JWT
+		// authorizer only needs the id_token, so a successful refresh must NOT be
+		// thrown away just because the unrelated AWS STS/IAM credential exchange
+		// fails or times out. tryRefreshToken couples the two and would discard a
+		// perfectly valid refreshed id_token on a Cognito/STS hiccup.
+		if fresh := a.refreshIDTokenOnly(); fresh != "" {
+			token, err = fresh, nil
 		}
 	}
 	if err != nil || token == "" {
@@ -744,6 +750,74 @@ func (a *credentialApp) tryRefreshToken() *federation.AWSCredentials {
 
 	debugPrint("Refresh token exchange succeeded — credentials renewed without browser")
 	return creds
+}
+
+// refreshIDTokenOnly performs the browserless refresh_token exchange and returns
+// a fresh id_token WITHOUT exchanging it for AWS credentials. It exists for the
+// MCP headersHelper path (--get-mcp-auth-header): the AgentCore CUSTOM_JWT gateway
+// authorizer validates only the id_token, so the header must still be emitted even
+// when the AWS STS/IAM credential exchange would fail or time out — a failure mode
+// unrelated to gateway auth. (tryRefreshToken couples the two and returns nil if
+// cred exchange fails, which would discard a valid refreshed id_token.)
+//
+// It mirrors tryRefreshToken's endpoint/confidential-auth resolution and persists
+// the refreshed monitoring token + rotated refresh_token so the next cache read
+// hits, but never opens a browser. Returns "" on any failure so the caller fails
+// cleanly. Only meaningful for OIDC (idc/none have no id_token — Story B).
+func (a *credentialApp) refreshIDTokenOnly() string {
+	refreshToken := storage.LoadRefreshToken(a.profile, a.cfg.CredentialStorage)
+	if refreshToken == "" {
+		debugPrint("No cached refresh_token, cannot refresh id_token silently")
+		return ""
+	}
+
+	// Resolve token endpoint URL (same logic as tryRefreshToken).
+	var tokenURL string
+	if a.providerType == "generic" {
+		tokenURL = a.cfg.OIDCTokenEndpoint
+	} else {
+		provCfg := provider.ConfigFor(a.providerType, a.cfg.OktaAuthServerID)
+		if strings.HasPrefix(provCfg.TokenEndpoint, "https://") {
+			tokenURL = provCfg.TokenEndpoint
+		} else {
+			tokenURL = "https://" + a.cfg.ProviderDomain + provCfg.TokenEndpoint
+		}
+	}
+
+	confidential, err := a.resolveConfidentialAuth()
+	if err != nil {
+		debugPrint("Failed to resolve confidential auth for id_token refresh: %v", err)
+		return ""
+	}
+
+	tokenResp, err := oidc.RefreshTokenExchange(tokenURL, refreshToken, a.cfg.ClientID, confidential)
+	if err != nil {
+		debugPrint("Refresh token exchange failed: %v", err)
+		// Token may be revoked/expired — clear it so we don't retry next time.
+		storage.ClearRefreshToken(a.profile)
+		return ""
+	}
+	if tokenResp.IDToken == "" {
+		debugPrint("Refresh response did not contain an id_token")
+		return ""
+	}
+
+	claims, err := jwt.DecodePayload(tokenResp.IDToken)
+	if err != nil {
+		debugPrint("Failed to decode refreshed id_token: %v", err)
+		return ""
+	}
+
+	// Persist the refreshed monitoring token so the next cache read hits, and
+	// rotate the refresh_token (some IdPs rotate on every use). Deliberately no
+	// AWS credential exchange here — see the doc comment above.
+	a.saveMonitoringTokenAndHeaders(tokenResp.IDToken, map[string]interface{}(claims))
+	if tokenResp.RefreshToken != "" {
+		_ = storage.SaveRefreshToken(a.profile, a.cfg.CredentialStorage, tokenResp.RefreshToken)
+	}
+
+	debugPrint("id_token refreshed without browser (no AWS credential exchange)")
+	return tokenResp.IDToken
 }
 
 // saveMonitoringTokenAndHeaders persists the monitoring token and also writes

--- a/source/go/cmd/credential-process/main.go
+++ b/source/go/cmd/credential-process/main.go
@@ -44,6 +44,7 @@ func main() {
 	versionFlag := flag.Bool("version", false, "Show version")
 	shortVersion := flag.Bool("v", false, "Show version (short)")
 	getMonitoring := flag.Bool("get-monitoring-token", false, "Get cached monitoring token")
+	getMCPAuthHeader := flag.Bool("get-mcp-auth-header", false, "Print {\"Authorization\":\"Bearer <id_token>\"} from the cached token for an MCP headersHelper (never opens a browser)")
 	clearCache := flag.Bool("clear-cache", false, "Clear cached credentials")
 	checkExpiration := flag.Bool("check-expiration", false, "Check if credentials are expired")
 	refreshIfNeeded := flag.Bool("refresh-if-needed", false, "Refresh credentials if expired")
@@ -95,6 +96,9 @@ func main() {
 	}
 	if *getMonitoring {
 		os.Exit(app.getMonitoringToken())
+	}
+	if *getMCPAuthHeader {
+		os.Exit(app.getMCPAuthHeader())
 	}
 	if *checkExpiration {
 		os.Exit(app.checkExpiration())
@@ -261,6 +265,39 @@ func (a *credentialApp) getMonitoringToken() int {
 	a.saveMonitoringTokenAndHeaders(authResult.IDToken, map[string]interface{}(authResult.TokenClaims))
 
 	fmt.Println(authResult.IDToken)
+	return 0
+}
+
+// getMCPAuthHeader prints {"Authorization":"Bearer <id_token>"} to stdout for
+// use as an MCP server headersHelper (the AgentCore web-search gateway uses a
+// CUSTOM_JWT authorizer that validates the same OIDC id_token the solution
+// already mints). It MUST NOT open a browser and MUST return quickly so it fits
+// inside Claude Code's headersHelper budget — so unlike getMonitoringToken it
+// never falls through to authenticate(). On a cache miss it attempts only the
+// browserless refresh_token exchange; if that also fails it exits non-zero with
+// a clear stderr message rather than hanging or prompting.
+func (a *credentialApp) getMCPAuthHeader() int {
+	token, err := storage.GetMonitoringToken(a.profile, a.cfg.CredentialStorage)
+	if (err != nil || token == "") && a.cfg.IsSsoEnabled() && !a.cfg.IsIDC() {
+		// Cached id_token expired/near-expiry. Try the silent refresh_token
+		// exchange (no browser) before giving up — mirrors getMonitoringToken
+		// but stops here: an MCP headersHelper can never drive an interactive
+		// login. Only attempt for OIDC; idc/none have no id_token (Story B).
+		if creds := a.tryRefreshToken(); creds != nil {
+			token, err = storage.GetMonitoringToken(a.profile, a.cfg.CredentialStorage)
+		}
+	}
+	if err != nil || token == "" {
+		fmt.Fprintf(os.Stderr, "Error: no valid cached token for profile '%s'; run the credential process once to authenticate.\n", a.profile)
+		return 1
+	}
+
+	out, mErr := json.Marshal(map[string]string{"Authorization": "Bearer " + token})
+	if mErr != nil {
+		fmt.Fprintf(os.Stderr, "Error: failed to encode auth header: %v\n", mErr)
+		return 1
+	}
+	fmt.Println(string(out))
 	return 0
 }
 

--- a/source/go/cmd/credential-process/mcp_auth_header_test.go
+++ b/source/go/cmd/credential-process/mcp_auth_header_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"ccwb-go/internal/config"
+	"ccwb-go/internal/storage"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+// writeMonitoringToken seeds a session-mode monitoring token file with the
+// given token and expiry so storage.GetMonitoringToken returns it.
+func writeMonitoringToken(t *testing.T, home, profile, token string, exp int64) {
+	t.Helper()
+	dir := filepath.Join(home, ".claude-code-session")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	data := map[string]interface{}{
+		"token":   token,
+		"expires": exp,
+		"email":   "test@example.com",
+		"profile": profile,
+	}
+	raw, err := json.Marshal(data)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	path := filepath.Join(dir, profile+"-monitoring.json")
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+// TestGetMCPAuthHeader_OutputShape pins the exact JSON the header mode emits,
+// which is the contract Python must match byte-for-byte (credential-helper-parity).
+func TestGetMCPAuthHeader_OutputShape(t *testing.T) {
+	out, err := json.Marshal(map[string]string{"Authorization": "Bearer tok"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	const want = `{"Authorization":"Bearer tok"}`
+	if string(out) != want {
+		t.Fatalf("header JSON shape = %q, want %q", string(out), want)
+	}
+}
+
+// TestGetMCPAuthHeader_CachedToken verifies a valid cached token is returned as
+// a Bearer auth header without any browser/network side effects.
+func TestGetMCPAuthHeader_CachedToken(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir) // Windows
+	// Ensure no env token leaks in from the host.
+	t.Setenv("CLAUDE_CODE_MONITORING_TOKEN", "")
+
+	profile := "test-mcp-auth-cached"
+	// Expiry well beyond the 600s buffer in storage.GetMonitoringToken.
+	writeMonitoringToken(t, tmpDir, profile, "cached-id-token", time.Now().Unix()+3600)
+
+	cfg := &config.ProfileConfig{
+		ClientID:          "test-client",
+		ProviderDomain:    "test.example.com",
+		CredentialStorage: "session",
+		SsoEnabled:        boolPtr(true),
+	}
+	app := &credentialApp{profile: profile, cfg: cfg, providerType: "okta"}
+
+	if code := app.getMCPAuthHeader(); code != 0 {
+		t.Fatalf("getMCPAuthHeader exit = %d, want 0", code)
+	}
+}
+
+// TestGetMCPAuthHeader_NoToken verifies a clean non-zero exit when no valid
+// token is cached and no refresh_token is available — never hangs, never opens
+// a browser (getMCPAuthHeader has no authenticate() fall-through by design).
+func TestGetMCPAuthHeader_NoToken(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+	t.Setenv("CLAUDE_CODE_MONITORING_TOKEN", "")
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".claude-code-session"), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	profile := "test-mcp-auth-empty"
+	t.Cleanup(func() { storage.ClearRefreshToken(profile) })
+
+	cfg := &config.ProfileConfig{
+		ClientID:          "test-client",
+		ProviderDomain:    "test.invalid.example.com", // unreachable if refresh were attempted
+		CredentialStorage: "session",
+		SsoEnabled:        boolPtr(true),
+	}
+	app := &credentialApp{profile: profile, cfg: cfg, providerType: "okta"}
+
+	if code := app.getMCPAuthHeader(); code != 1 {
+		t.Fatalf("getMCPAuthHeader exit = %d, want 1 (clean failure)", code)
+	}
+}
+
+// TestGetMCPAuthHeader_EnvToken verifies the env-var token shortcut also works,
+// matching getMonitoringToken's CLAUDE_CODE_MONITORING_TOKEN precedence.
+func TestGetMCPAuthHeader_EnvToken(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+	t.Setenv("CLAUDE_CODE_MONITORING_TOKEN", "env-supplied-token")
+
+	cfg := &config.ProfileConfig{
+		ClientID:          "test-client",
+		ProviderDomain:    "test.example.com",
+		CredentialStorage: "session",
+		SsoEnabled:        boolPtr(true),
+	}
+	app := &credentialApp{profile: "test-mcp-auth-env", cfg: cfg, providerType: "okta"}
+
+	if code := app.getMCPAuthHeader(); code != 0 {
+		t.Fatalf("getMCPAuthHeader exit = %d, want 0 with env token", code)
+	}
+}

--- a/source/go/cmd/credential-process/mcp_auth_header_test.go
+++ b/source/go/cmd/credential-process/mcp_auth_header_test.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"encoding/base64"
 	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,6 +14,44 @@ import (
 	"ccwb-go/internal/config"
 	"ccwb-go/internal/storage"
 )
+
+// mcpStdoutResult bundles an exit code with whatever the function printed.
+type mcpStdoutResult struct {
+	code   int
+	stdout string
+}
+
+// captureMCPStdout runs fn with os.Stdout redirected to a pipe and returns its
+// exit code plus what it printed — used to assert the exact bearer value emitted.
+func captureMCPStdout(t *testing.T, fn func() int) mcpStdoutResult {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	code := fn()
+	_ = w.Close()
+	os.Stdout = orig
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read pipe: %v", err)
+	}
+	return mcpStdoutResult{code: code, stdout: string(out)}
+}
+
+// fakeJWT builds a syntactically valid 3-part JWT with the given payload claims
+// so jwt.DecodePayload (which does not verify the signature) accepts it.
+func fakeJWT(t *testing.T, claims map[string]interface{}) string {
+	t.Helper()
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal claims: %v", err)
+	}
+	enc := base64.RawURLEncoding.EncodeToString
+	return enc([]byte(`{"alg":"none"}`)) + "." + enc(payload) + ".sig"
+}
 
 func boolPtr(b bool) *bool { return &b }
 
@@ -101,6 +143,72 @@ func TestGetMCPAuthHeader_NoToken(t *testing.T) {
 
 	if code := app.getMCPAuthHeader(); code != 1 {
 		t.Fatalf("getMCPAuthHeader exit = %d, want 1 (clean failure)", code)
+	}
+}
+
+// TestGetMCPAuthHeader_RefreshSucceedsWithoutAWSCreds is the regression test for
+// the Codex P2 finding: on an expired/absent cached id_token, the MCP header path
+// must silently refresh and emit the FRESH id_token even when AWS STS/IAM
+// credential exchange would fail — the gateway's CUSTOM_JWT authorizer only needs
+// the id_token, so refresh success must not be coupled to cred exchange.
+//
+// Setup: a generic OIDC provider whose token endpoint is a local httptest server
+// returning a fresh id_token, a stored refresh_token, and NO cached monitoring
+// token. There is no STS endpoint configured, so if the code path attempted an
+// AWS credential exchange (the old tryRefreshToken behavior) it would fail and the
+// header would NOT be emitted. Asserting exit 0 + the fresh token proves the
+// decoupling (refreshIDTokenOnly).
+func TestGetMCPAuthHeader_RefreshSucceedsWithoutAWSCreds(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+	t.Setenv("CLAUDE_CODE_MONITORING_TOKEN", "")
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".claude-code-session"), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	freshIDToken := fakeJWT(t, map[string]interface{}{
+		"email": "user@example.com",
+		"exp":   time.Now().Unix() + 3600,
+	})
+
+	// Mock token endpoint: any refresh_token request returns the fresh id_token.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"id_token":      freshIDToken,
+			"refresh_token": "rotated-refresh-token",
+		})
+	}))
+	defer srv.Close()
+
+	profile := "test-mcp-auth-refresh"
+	if err := storage.SaveRefreshToken(profile, "session", "stored-refresh-token"); err != nil {
+		t.Fatalf("seed refresh token: %v", err)
+	}
+	t.Cleanup(func() { storage.ClearRefreshToken(profile) })
+
+	// Generic provider → refreshIDTokenOnly uses cfg.OIDCTokenEndpoint directly.
+	// No QuotaAPIEndpoint / STS config: an AWS cred exchange would fail here.
+	cfg := &config.ProfileConfig{
+		ClientID:          "test-client",
+		ProviderDomain:    "generic.example.com",
+		CredentialStorage: "session",
+		SsoEnabled:        boolPtr(true),
+		OIDCTokenEndpoint: srv.URL,
+	}
+	app := &credentialApp{profile: profile, cfg: cfg, providerType: "generic"}
+
+	out := captureMCPStdout(t, func() int { return app.getMCPAuthHeader() })
+	if out.code != 0 {
+		t.Fatalf("getMCPAuthHeader exit = %d, want 0 (refresh must emit header without AWS creds)", out.code)
+	}
+	var header map[string]string
+	if err := json.Unmarshal([]byte(out.stdout), &header); err != nil {
+		t.Fatalf("emitted header not JSON: %v (raw=%q)", err, out.stdout)
+	}
+	if got, want := header["Authorization"], "Bearer "+freshIDToken; got != want {
+		t.Errorf("Authorization = %q, want the freshly refreshed id_token %q", got, want)
 	}
 }
 

--- a/source/go/cmd/credential-process/mcp_auth_header_test.go
+++ b/source/go/cmd/credential-process/mcp_auth_header_test.go
@@ -213,12 +213,17 @@ func TestGetMCPAuthHeader_RefreshSucceedsWithoutAWSCreds(t *testing.T) {
 }
 
 // TestGetMCPAuthHeader_EnvToken verifies the env-var token shortcut also works,
-// matching getMonitoringToken's CLAUDE_CODE_MONITORING_TOKEN precedence.
+// matching getMonitoringToken's CLAUDE_CODE_MONITORING_TOKEN precedence. The env
+// token must be a valid (non-expired) JWT: GetMonitoringToken drops an expired or
+// unparseable env token (PR #602, jwt.IsTokenExpired) so callers fall through to
+// refresh rather than attaching a stale token — so this test supplies a real JWT
+// with a future exp.
 func TestGetMCPAuthHeader_EnvToken(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 	t.Setenv("USERPROFILE", tmpDir)
-	t.Setenv("CLAUDE_CODE_MONITORING_TOKEN", "env-supplied-token")
+	envToken := fakeJWT(t, map[string]interface{}{"exp": time.Now().Unix() + 3600})
+	t.Setenv("CLAUDE_CODE_MONITORING_TOKEN", envToken)
 
 	cfg := &config.ProfileConfig{
 		ClientID:          "test-client",
@@ -228,7 +233,15 @@ func TestGetMCPAuthHeader_EnvToken(t *testing.T) {
 	}
 	app := &credentialApp{profile: "test-mcp-auth-env", cfg: cfg, providerType: "okta"}
 
-	if code := app.getMCPAuthHeader(); code != 0 {
-		t.Fatalf("getMCPAuthHeader exit = %d, want 0 with env token", code)
+	out := captureMCPStdout(t, func() int { return app.getMCPAuthHeader() })
+	if out.code != 0 {
+		t.Fatalf("getMCPAuthHeader exit = %d, want 0 with a valid env token", out.code)
+	}
+	var header map[string]string
+	if err := json.Unmarshal([]byte(out.stdout), &header); err != nil {
+		t.Fatalf("emitted header not JSON: %v (raw=%q)", err, out.stdout)
+	}
+	if header["Authorization"] != "Bearer "+envToken {
+		t.Errorf("Authorization = %q, want the env-supplied JWT", header["Authorization"])
 	}
 }

--- a/source/tests/cli/commands/test_deploy_orphan_region.py
+++ b/source/tests/cli/commands/test_deploy_orphan_region.py
@@ -48,9 +48,14 @@ def test_orphan_check_uses_codebuild_region_for_codebuild_stack():
     assert any(stack_type == "codebuild" for stack_type, _, _ in orphaned)
 
 
-def test_orphan_check_no_extra_manager_when_codebuild_same_region():
-    """No region-specific manager is built when codebuild uses the main region."""
-    profile = _profile(codebuild_region=None)  # -> aws_region
+def test_orphan_check_no_extra_manager_when_all_stacks_in_main_region():
+    """No region-specific manager is built when every stack uses the main region.
+
+    Orphan detection checks all stack types (to find orphans of disabled
+    features), so both codebuild and the us-east-1-pinned websearch reuse the
+    primary manager only when the deployment region is itself us-east-1.
+    """
+    profile = _profile(codebuild_region=None, aws_region="us-east-1")  # codebuild -> aws_region
     main_mgr = MagicMock()
     main_mgr.get_stack_status.return_value = None
 
@@ -62,5 +67,28 @@ def test_orphan_check_no_extra_manager_when_codebuild_same_region():
     ):
         cmd._check_orphaned_stacks([], profile, main_mgr, MagicMock())
 
-    # codebuild_region resolves to aws_region, so no separate manager is constructed.
+    # Everything resolves to the main region (us-east-1), so no separate manager.
     assert built == []
+
+
+def test_orphan_check_pins_websearch_to_us_east_1():
+    """Web search orphan status must be checked in us-east-1, not the main region.
+
+    Orphan detection is not gated on web_search_enabled — a disabled-but-extant
+    gateway is exactly the orphan we want to surface — so the us-east-1 manager
+    is always built when the deployment region differs.
+    """
+    profile = _profile(codebuild_region=None)  # aws_region defaults to ap-southeast-1
+    main_mgr = MagicMock()
+    main_mgr.get_stack_status.return_value = None
+
+    built = []
+    cmd = DeployCommand()
+    with patch(
+        "claude_code_with_bedrock.cli.commands.deploy.CloudFormationManager",
+        side_effect=lambda region: built.append(region) or MagicMock(),
+    ):
+        cmd._check_orphaned_stacks([], profile, main_mgr, MagicMock())
+
+    # aws_region is ap-southeast-1, so the websearch check builds a us-east-1 manager.
+    assert built == ["us-east-1"]

--- a/source/tests/cli/commands/test_destroy_stacks.py
+++ b/source/tests/cli/commands/test_destroy_stacks.py
@@ -60,3 +60,29 @@ class TestDestroyReverseDependencyOrder:
         monitoring_idx = DESTROYABLE_STACKS.index("monitoring")
         for dependent in ("dashboard", "cowork-dashboard", "analytics", "quota"):
             assert DESTROYABLE_STACKS.index(dependent) < monitoring_idx
+
+    def test_websearch_destroyed_before_auth(self):
+        # websearch is a leaf (no dependents) and is torn down before auth.
+        assert DESTROYABLE_STACKS.index("websearch") < DESTROYABLE_STACKS.index("auth")
+
+
+class TestDestroyWebSearch:
+    """Web search teardown must be gated + region-pinned to us-east-1."""
+
+    _SOURCE = (
+        Path(__file__).resolve().parents[3] / "claude_code_with_bedrock" / "cli" / "commands" / "destroy.py"
+    ).read_text(encoding="utf-8")
+
+    def test_websearch_is_destroyable(self):
+        assert "websearch" in DESTROYABLE_STACKS
+
+    def test_websearch_gated_on_enable_flag(self):
+        # Destroy must skip websearch when the feature was never enabled,
+        # mirroring the codebuild/distribution skip guards.
+        assert 'stack == "websearch" and not getattr(profile, "web_search_enabled"' in self._SOURCE
+
+    def test_websearch_region_pinned_to_us_east_1(self):
+        # The gateway lives only in us-east-1; deleting in the profile's region
+        # would silently orphan it (it reports success against a non-existent stack).
+        assert 'elif stack == "websearch":' in self._SOURCE
+        assert 'stack_region = "us-east-1"' in self._SOURCE

--- a/source/tests/cli/commands/test_init_websearch.py
+++ b/source/tests/cli/commands/test_init_websearch.py
@@ -1,0 +1,161 @@
+# ABOUTME: Tests for the optional web-search prompt in `ccwb init` (T5, AC7)
+# ABOUTME: Flag persists via _save_configuration and round-trips via _check_existing_deployment
+
+"""AC7: `ccwb init` shows an optional, skippable web-search prompt.
+
+The prompt discloses the ~$7/1,000-queries cost and the us-east-1-only
+constraint, sets `web_search_enabled`, and **round-trips on re-init**. Unlike
+quota, it is offered in all auth modes (the gating to OIDC happens at deploy
+time, not in the wizard).
+
+These tests exercise the persistence + round-trip contract (the questionary
+prompt itself is interactive and covered by the wizard flow); they assert that
+`_save_configuration` maps the wizard's `web_search.enabled` to the profile and
+that `_check_existing_deployment` reflects it back into the config dict.
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from claude_code_with_bedrock.config import Config
+
+
+@pytest.fixture
+def cmd():
+    from claude_code_with_bedrock.cli.commands.init import InitCommand
+
+    return InitCommand()
+
+
+@pytest.fixture
+def base_aws():
+    return {
+        "region": "ap-southeast-2",
+        "identity_pool_name": "demo-pool",
+        "allowed_bedrock_regions": ["us-east-1"],
+        "stacks": {},
+        "cross_region_profile": "us",
+        "selected_model": None,
+    }
+
+
+def _config_dirs(tmp_path, active="ws-test"):
+    config_dir = tmp_path / ".ccwb"
+    config_dir.mkdir()
+    profiles_dir = config_dir / "profiles"
+    profiles_dir.mkdir()
+    config_file = config_dir / "config.json"
+    config_file.write_text(json.dumps({"schema_version": "2.0", "active_profile": active}))
+    return config_dir, profiles_dir, config_file
+
+
+class TestWebSearchPersistence:
+    def test_enabled_flag_saved_to_profile(self, cmd, base_aws, tmp_path):
+        config_data = {
+            "sso_enabled": True,
+            "aws": base_aws,
+            "monitoring": {"enabled": False},
+            "credential_storage": "session",
+            "web_search": {"enabled": True},
+        }
+        config_dir, profiles_dir, config_file = _config_dirs(tmp_path)
+
+        with (
+            patch.object(Config, "CONFIG_DIR", config_dir),
+            patch.object(Config, "CONFIG_FILE", config_file),
+            patch.object(Config, "PROFILES_DIR", profiles_dir),
+        ):
+            cmd._save_configuration(config_data, "ws-test")
+            saved = json.loads((profiles_dir / "ws-test.json").read_text())
+
+        assert saved["web_search_enabled"] is True
+
+    def test_declining_leaves_flag_false(self, cmd, base_aws, tmp_path):
+        """No web_search block (user skipped/declined) → flag defaults False."""
+        config_data = {
+            "sso_enabled": True,
+            "aws": base_aws,
+            "monitoring": {"enabled": False},
+            "credential_storage": "session",
+            # no "web_search" key at all
+        }
+        config_dir, profiles_dir, config_file = _config_dirs(tmp_path)
+
+        with (
+            patch.object(Config, "CONFIG_DIR", config_dir),
+            patch.object(Config, "CONFIG_FILE", config_file),
+            patch.object(Config, "PROFILES_DIR", profiles_dir),
+        ):
+            cmd._save_configuration(config_data, "ws-test")
+            saved = json.loads((profiles_dir / "ws-test.json").read_text())
+
+        assert saved["web_search_enabled"] is False
+
+    def test_explicit_false_leaves_flag_false(self, cmd, base_aws, tmp_path):
+        config_data = {
+            "sso_enabled": True,
+            "aws": base_aws,
+            "monitoring": {"enabled": False},
+            "credential_storage": "session",
+            "web_search": {"enabled": False},
+        }
+        config_dir, profiles_dir, config_file = _config_dirs(tmp_path)
+
+        with (
+            patch.object(Config, "CONFIG_DIR", config_dir),
+            patch.object(Config, "CONFIG_FILE", config_file),
+            patch.object(Config, "PROFILES_DIR", profiles_dir),
+        ):
+            cmd._save_configuration(config_data, "ws-test")
+            saved = json.loads((profiles_dir / "ws-test.json").read_text())
+
+        assert saved["web_search_enabled"] is False
+
+
+class TestWebSearchRoundTrip:
+    def test_reinit_round_trips_enabled_flag(self, cmd, base_aws, tmp_path):
+        """A profile saved with web_search enabled reloads with the prompt defaulting on."""
+        config_data = {
+            "sso_enabled": True,
+            "aws": base_aws,
+            "monitoring": {"enabled": False},
+            "credential_storage": "session",
+            "web_search": {"enabled": True},
+        }
+        config_dir, profiles_dir, config_file = _config_dirs(tmp_path)
+
+        with (
+            patch.object(Config, "CONFIG_DIR", config_dir),
+            patch.object(Config, "CONFIG_FILE", config_file),
+            patch.object(Config, "PROFILES_DIR", profiles_dir),
+        ):
+            cmd._save_configuration(config_data, "ws-test")
+
+            # Reload the profile and run the existing-deployment reader.
+            existing = cmd._check_existing_deployment("ws-test")
+
+        assert existing is not None
+        assert existing.get("web_search", {}).get("enabled") is True
+
+    def test_reinit_round_trips_disabled_flag(self, cmd, base_aws, tmp_path):
+        config_data = {
+            "sso_enabled": True,
+            "aws": base_aws,
+            "monitoring": {"enabled": False},
+            "credential_storage": "session",
+            "web_search": {"enabled": False},
+        }
+        config_dir, profiles_dir, config_file = _config_dirs(tmp_path)
+
+        with (
+            patch.object(Config, "CONFIG_DIR", config_dir),
+            patch.object(Config, "CONFIG_FILE", config_file),
+            patch.object(Config, "PROFILES_DIR", profiles_dir),
+        ):
+            cmd._save_configuration(config_data, "ws-test")
+            existing = cmd._check_existing_deployment("ws-test")
+
+        assert existing is not None
+        assert existing.get("web_search", {}).get("enabled") is False

--- a/source/tests/cli/commands/test_package_websearch.py
+++ b/source/tests/cli/commands/test_package_websearch.py
@@ -1,0 +1,142 @@
+# ABOUTME: Contract tests for the agentcore-websearch mcpServers block in settings.json
+# ABOUTME: T6 (AC5 emit/omit, AC8 URL read-half: profile-first with CFN-output fallback)
+
+"""Contract tests: `ccwb package` emits an mcpServers.agentcore-websearch block.
+
+AC5: when `web_search_enabled`, settings.json gains an `mcpServers` block with
+`agentcore-websearch = {type:http, url:<GatewayUrl>, headersHelper:"…credential-process
+--get-mcp-auth-header --profile <name>"}`; the block is omitted entirely when disabled.
+
+AC8 (read-half): the gateway URL is resolved profile-first (`agentcore_gateway_url`),
+falling back to the websearch stack's `GatewayUrl` CloudFormation output (us-east-1) —
+mirroring the OTel-endpoint discovery precedent. The headersHelper path uses the
+`__CREDENTIAL_PROCESS_PATH__` placeholder the installer substitutes.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from claude_code_with_bedrock.cli.commands.package import PackageCommand
+from claude_code_with_bedrock.config import Profile
+
+
+def _base_profile(**overrides) -> Profile:
+    kwargs = {
+        "name": "test",
+        "provider_domain": "test.okta.com",
+        "client_id": "test-client-id",
+        "credential_storage": "keyring",
+        "aws_region": "us-east-1",
+        "identity_pool_name": "test-pool",
+        "allowed_bedrock_regions": ["us-east-1", "us-west-2"],
+        "cross_region_profile": "us",
+        "monitoring_enabled": False,
+    }
+    kwargs.update(overrides)
+    return Profile(**kwargs)
+
+
+def _read_settings(output_dir: Path) -> dict:
+    settings_path = output_dir / "claude-settings" / "settings.json"
+    with open(settings_path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+class TestMcpServersOmittedWhenDisabled:
+    def test_no_mcpservers_when_web_search_disabled(self):
+        command = PackageCommand()
+        profile = _base_profile(web_search_enabled=False)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            command._create_claude_settings(output_dir, profile, profile_name="ClaudeCode")
+            settings = _read_settings(output_dir)
+
+        assert "mcpServers" not in settings
+
+
+class TestMcpServersEmittedWhenEnabled:
+    def test_block_present_and_wellformed_from_profile_url(self):
+        command = PackageCommand()
+        profile = _base_profile(
+            web_search_enabled=True,
+            agentcore_gateway_url="https://gw-abc.gateway.bedrock-agentcore.us-east-1.amazonaws.com/mcp",
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            command._create_claude_settings(output_dir, profile, profile_name="MyProfile")
+            settings = _read_settings(output_dir)
+
+        assert "mcpServers" in settings
+        block = settings["mcpServers"]["agentcore-websearch"]
+        assert block["type"] == "http"
+        assert block["url"] == "https://gw-abc.gateway.bedrock-agentcore.us-east-1.amazonaws.com/mcp"
+        # headersHelper uses the installer-substituted placeholder + the mode flag + profile.
+        assert block["headersHelper"] == ("__CREDENTIAL_PROCESS_PATH__ --get-mcp-auth-header --profile MyProfile")
+
+    def test_profile_url_takes_precedence_over_cfn(self):
+        """Profile-first: when agentcore_gateway_url is set, CFN is never queried."""
+        command = PackageCommand()
+        profile = _base_profile(
+            web_search_enabled=True,
+            agentcore_gateway_url="https://profile-url.example.com/mcp",
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            with patch("claude_code_with_bedrock.cli.commands.package.get_stack_outputs") as mock_outputs:
+                command._create_claude_settings(output_dir, profile, profile_name="ClaudeCode")
+                settings = _read_settings(output_dir)
+            mock_outputs.assert_not_called()
+
+        assert settings["mcpServers"]["agentcore-websearch"]["url"] == "https://profile-url.example.com/mcp"
+
+
+class TestUrlCfnFallback:
+    def test_falls_back_to_cfn_output_when_profile_empty(self):
+        command = PackageCommand()
+        profile = _base_profile(
+            web_search_enabled=True,
+            agentcore_gateway_url="",
+            stack_names={"websearch": "test-pool-websearch"},
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            with patch(
+                "claude_code_with_bedrock.cli.commands.package.get_stack_outputs",
+                return_value={"GatewayUrl": "https://cfn-fallback.example.com/mcp"},
+            ) as mock_outputs:
+                command._create_claude_settings(output_dir, profile, profile_name="ClaudeCode")
+                settings = _read_settings(output_dir)
+
+            # Fallback must query the websearch stack in us-east-1 (region-pinned).
+            assert mock_outputs.called
+            _args, kwargs = mock_outputs.call_args
+            call = list(_args) + list(kwargs.values())
+            assert "us-east-1" in call
+
+        assert settings["mcpServers"]["agentcore-websearch"]["url"] == "https://cfn-fallback.example.com/mcp"
+
+    def test_no_block_when_enabled_but_no_url_resolvable(self):
+        """Enabled but neither profile nor CFN yields a URL → omit the block (no broken entry)."""
+        command = PackageCommand()
+        profile = _base_profile(
+            web_search_enabled=True,
+            agentcore_gateway_url="",
+            stack_names={"websearch": "test-pool-websearch"},
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            with patch(
+                "claude_code_with_bedrock.cli.commands.package.get_stack_outputs",
+                return_value={},
+            ):
+                command._create_claude_settings(output_dir, profile, profile_name="ClaudeCode")
+                settings = _read_settings(output_dir)
+
+        assert "mcpServers" not in settings

--- a/source/tests/e2e/test_cfn_contracts.py
+++ b/source/tests/e2e/test_cfn_contracts.py
@@ -99,6 +99,7 @@ class TestIAMPolicyValidity:
     # Valid IAM action prefixes for services used in this project
     VALID_ACTION_PREFIXES = {
         "bedrock",
+        "bedrock-agentcore",
         "cloudtrail",
         "cognito-identity",
         "cognito-idp",

--- a/source/tests/test_config_websearch.py
+++ b/source/tests/test_config_websearch.py
@@ -1,0 +1,176 @@
+# ABOUTME: Contract tests for web_search_enabled + agentcore_gateway_url Profile fields
+# ABOUTME: Tests AgentCore web search config persistence and backward compatibility (AC6)
+
+"""Tests for the web_search_enabled and agentcore_gateway_url fields (AgentCore Web Search).
+
+Encodes acceptance criterion AC6: Profile gains web_search_enabled (default False) +
+agentcore_gateway_url (default ""); old configs without these fields still load.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from claude_code_with_bedrock.config import Config, Profile
+
+
+class TestWebSearchFields:
+    """Tests for the web_search_enabled / agentcore_gateway_url fields in Profile."""
+
+    def test_defaults_when_not_specified(self):
+        """AC6 contract point 1: a Profile built without the new fields defaults
+        web_search_enabled to False and agentcore_gateway_url to an empty string."""
+        profile = Profile(
+            name="test",
+            provider_domain="test.okta.com",
+            client_id="test-client",
+            credential_storage="session",
+            aws_region="us-east-1",
+            identity_pool_name="test-pool",
+        )
+
+        assert profile.web_search_enabled is False
+        assert profile.agentcore_gateway_url == ""
+
+    def test_explicit_values_retained_and_serialized(self):
+        """AC6 contract point 2: explicit field values are retained and to_dict()
+        includes both keys with those values."""
+        profile = Profile(
+            name="test",
+            provider_domain="test.okta.com",
+            client_id="test-client",
+            credential_storage="session",
+            aws_region="us-east-1",
+            identity_pool_name="test-pool",
+            web_search_enabled=True,
+            agentcore_gateway_url="https://gw.example.com/mcp",
+        )
+
+        assert profile.web_search_enabled is True
+        assert profile.agentcore_gateway_url == "https://gw.example.com/mcp"
+
+        result = profile.to_dict()
+        assert result["web_search_enabled"] is True
+        assert result["agentcore_gateway_url"] == "https://gw.example.com/mcp"
+
+    def test_from_dict_round_trips_the_fields(self):
+        """AC6 contract point 3: Profile.from_dict round-trips both fields when set."""
+        data = {
+            "name": "test",
+            "provider_domain": "test.okta.com",
+            "client_id": "test-client",
+            "credential_storage": "session",
+            "aws_region": "us-east-1",
+            "identity_pool_name": "test-pool",
+            "web_search_enabled": True,
+            "agentcore_gateway_url": "https://gw.example.com/mcp",
+        }
+
+        profile = Profile.from_dict(data)
+
+        assert profile.web_search_enabled is True
+        assert profile.agentcore_gateway_url == "https://gw.example.com/mcp"
+
+    def test_backward_compatibility_from_dict_without_fields(self):
+        """AC6 contract point 4 (from_dict path): a config dict lacking both fields
+        loads with web_search_enabled=False and agentcore_gateway_url="", while
+        other fields are preserved."""
+        data = {
+            "name": "default",
+            "provider_domain": "test.okta.com",
+            "client_id": "test-client",
+            "credential_storage": "session",
+            "aws_region": "us-east-1",
+            "identity_pool_name": "test-pool",
+            "allowed_bedrock_regions": ["us-east-1", "us-west-2"],
+            "cross_region_profile": "us",
+            # web_search_enabled and agentcore_gateway_url intentionally absent
+        }
+
+        profile = Profile.from_dict(data)
+
+        assert profile.web_search_enabled is False
+        assert profile.agentcore_gateway_url == ""
+        # Other fields preserved
+        assert profile.cross_region_profile == "us"
+        assert profile.allowed_bedrock_regions == ["us-east-1", "us-west-2"]
+
+
+class TestConfigManagerWithWebSearch:
+    """Tests for Config save/load round-trips with the web search fields."""
+
+    def test_backward_compatibility_without_websearch(self):
+        """AC6 contract point 4 (Config.load + get_profile path): an old-style
+        profile JSON on disk that lacks both fields loads via the save/load path
+        with web_search_enabled=False and agentcore_gateway_url="" and other
+        fields preserved. Mirrors test_backward_compatibility_without_model."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_file = Path(tmpdir) / "config.json"
+            profiles_dir = Path(tmpdir) / "profiles"
+            profiles_dir.mkdir()
+
+            config_data = {"schema_version": "2.0", "active_profile": "default", "profiles_dir": str(profiles_dir)}
+
+            with open(config_file, "w", encoding="utf-8") as f:
+                json.dump(config_data, f)
+
+            # Old-style profile without the web search fields
+            profile_data = {
+                "name": "default",
+                "provider_domain": "test.okta.com",
+                "client_id": "test-client",
+                "credential_storage": "session",
+                "aws_region": "us-east-1",
+                "identity_pool_name": "test-pool",
+                "allowed_bedrock_regions": ["us-east-1", "us-west-2"],
+                "cross_region_profile": "us",
+                "monitoring_enabled": True,
+                "created_at": "2024-01-01T00:00:00",
+                "updated_at": "2024-01-01T00:00:00",
+            }
+
+            with open(profiles_dir / "default.json", "w", encoding="utf-8") as f:
+                json.dump(profile_data, f)
+
+            with patch.object(Config, "CONFIG_FILE", config_file):
+                with patch.object(Config, "CONFIG_DIR", Path(tmpdir)):
+                    with patch.object(Config, "PROFILES_DIR", profiles_dir):
+                        loaded_config = Config.load()
+                        profile = loaded_config.get_profile()
+
+                        assert profile is not None
+                        assert profile.web_search_enabled is False
+                        assert profile.agentcore_gateway_url == ""
+                        # Other fields preserved
+                        assert profile.cross_region_profile == "us"
+                        assert profile.allowed_bedrock_regions == ["us-east-1", "us-west-2"]
+
+    def test_save_and_load_with_websearch(self):
+        """AC6 contract points 2+3 (full persistence path): explicit web search
+        field values survive a Config save/load round-trip."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_file = Path(tmpdir) / "config.json"
+
+            with patch.object(Config, "CONFIG_FILE", config_file):
+                with patch.object(Config, "CONFIG_DIR", Path(tmpdir)):
+                    config = Config()
+                    profile = Profile(
+                        name="test",
+                        provider_domain="test.okta.com",
+                        client_id="test-client",
+                        credential_storage="keyring",
+                        aws_region="us-west-2",
+                        identity_pool_name="test-pool",
+                        web_search_enabled=True,
+                        agentcore_gateway_url="https://gw.example.com/mcp",
+                    )
+                    config.add_profile(profile)
+                    config.save()
+
+                    loaded_config = Config.load()
+                    loaded_profile = loaded_config.get_profile("test")
+
+                    assert loaded_profile is not None
+                    assert loaded_profile.web_search_enabled is True
+                    assert loaded_profile.agentcore_gateway_url == "https://gw.example.com/mcp"

--- a/source/tests/test_mcp_auth_header.py
+++ b/source/tests/test_mcp_auth_header.py
@@ -1,0 +1,136 @@
+# ABOUTME: Tests for the --get-mcp-auth-header mode (AC4, T3) of the credential process.
+# ABOUTME: Verifies cached-token header output, clean no-browser failure, and Go↔Python output parity.
+"""Tests for credential-process --get-mcp-auth-header (Python side + Go parity).
+
+The AgentCore web-search MCP server uses a CUSTOM_JWT gateway authorizer that
+validates the same OIDC id_token the solution mints. Claude Code calls
+`credential-process --get-mcp-auth-header` as the MCP server's headersHelper to
+supply `{"Authorization":"Bearer <id_token>"}`. This mode MUST:
+  - print the header from the cached/silently-refreshed token,
+  - NEVER open a browser (a headersHelper can't drive interactive login),
+  - fail cleanly (non-zero, no hang) when no valid token is available,
+  - emit output byte-identical to the Go variant (credential-helper-parity).
+"""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def _make_config():
+    return {
+        "provider_domain": "test.okta.com",
+        "client_id": "test-client-id",
+        "identity_pool_id": "us-east-1:test-pool",
+        "aws_region": "us-east-1",
+        "credential_storage": "session",
+        "provider_type": "okta",
+        "federation_type": "cognito",
+        "max_session_duration": 28800,
+    }
+
+
+@pytest.fixture
+def auth_instance(tmp_path):
+    """A MultiProviderAuth instance with config + storage init mocked out."""
+    with (
+        patch("credential_provider.__main__.MultiProviderAuth._load_config") as mock_load,
+        patch("credential_provider.__main__.MultiProviderAuth._init_credential_storage"),
+    ):
+        mock_load.return_value = _make_config()
+        from credential_provider.__main__ import MultiProviderAuth
+
+        instance = MultiProviderAuth(profile="TestProfile")
+        instance.cache_dir = tmp_path / "cache"
+        instance.cache_dir.mkdir(parents=True, exist_ok=True)
+        return instance
+
+
+class TestGetMCPAuthHeader:
+    """Unit tests for MultiProviderAuth.get_mcp_auth_header."""
+
+    def test_returns_bearer_header_from_cached_token(self, auth_instance):
+        """A cached valid token yields {"Authorization": "Bearer <token>"}."""
+        with patch.object(auth_instance, "get_monitoring_token", return_value="cached-id-token"):
+            header = auth_instance.get_mcp_auth_header()
+        assert header == {"Authorization": "Bearer cached-id-token"}
+
+    def test_returns_none_when_no_cached_token(self, auth_instance):
+        """No valid cached token → None (caller fails cleanly, no browser)."""
+        with patch.object(auth_instance, "get_monitoring_token", return_value=None) as mock_token:
+            header = auth_instance.get_mcp_auth_header()
+        assert header is None
+        mock_token.assert_called_once()
+
+    def test_never_triggers_browser_authentication(self, auth_instance):
+        """The header path must not call any interactive/browser auth method."""
+        with (
+            patch.object(auth_instance, "get_monitoring_token", return_value=None),
+            patch.object(auth_instance, "authenticate_for_monitoring") as mock_auth_mon,
+            patch.object(auth_instance, "authenticate_oidc") as mock_auth_oidc,
+        ):
+            result = auth_instance.get_mcp_auth_header()
+        assert result is None
+        mock_auth_mon.assert_not_called()
+        mock_auth_oidc.assert_not_called()
+
+    def test_output_uses_compact_json_for_go_parity(self, auth_instance):
+        """The serialized line must match Go's encoding/json (no spaces after : or ,)."""
+        with patch.object(auth_instance, "get_monitoring_token", return_value="tok"):
+            header = auth_instance.get_mcp_auth_header()
+        line = json.dumps(header, separators=(",", ":"))
+        assert line == '{"Authorization":"Bearer tok"}'
+
+
+# Resolve the Go credential-process package dir for the parity test.
+# __file__ = source/tests/test_mcp_auth_header.py → parents[1] = source/ → source/go.
+_GO_DIR = Path(__file__).resolve().parents[1] / "go"
+
+
+def _go_available():
+    if not (_GO_DIR / "go.mod").exists():
+        return False
+    from shutil import which
+
+    return which("go") is not None
+
+
+@pytest.mark.skipif(not _go_available(), reason="Go toolchain or source not available")
+class TestGoPythonParity:
+    """The Go and Python variants must emit byte-identical header output (credential-helper-parity)."""
+
+    def test_compact_json_shape_matches_go_marshal(self, tmp_path):
+        """Python's compact json.dumps matches Go's json.Marshal(map[string]string) shape.
+
+        Run a tiny Go program that marshals the same map the credential-process builds,
+        and assert it equals the Python serialization for the same token.
+        """
+        token = "header.payload.signature"
+        go_src = (
+            "package main\n"
+            'import ("encoding/json";"fmt")\n'
+            "func main(){\n"
+            'b,_ := json.Marshal(map[string]string{"Authorization":"Bearer ' + token + '"})\n'
+            "fmt.Println(string(b))\n"
+            "}\n"
+        )
+        # Write a standalone .go file in an isolated temp dir (outside the module so
+        # `go run` doesn't try to resolve module deps) and execute it.
+        go_file = tmp_path / "parity_main.go"
+        go_file.write_text(go_src, encoding="utf-8")
+        proc = subprocess.run(
+            ["go", "run", str(go_file)],
+            capture_output=True,
+            text=True,
+            cwd=str(tmp_path),
+            env={**os.environ, "GOTOOLCHAIN": "local", "GO111MODULE": "off"},
+        )
+        assert proc.returncode == 0, f"go run failed: {proc.stderr}"
+        go_line = proc.stdout.strip()
+
+        py_line = json.dumps({"Authorization": f"Bearer {token}"}, separators=(",", ":"))
+        assert go_line == py_line == '{"Authorization":"Bearer header.payload.signature"}'

--- a/source/tests/test_websearch_deploy.py
+++ b/source/tests/test_websearch_deploy.py
@@ -246,3 +246,43 @@ class TestWebSearchDeployCapabilities:
         assert ws_manager.deploy_stack.called
         _, kwargs = ws_manager.deploy_stack.call_args
         assert kwargs["capabilities"] == ["CAPABILITY_NAMED_IAM"]
+
+
+class TestWebSearchDeployOutputsUnreadable:
+    """Regression — a successful CFN deploy whose outputs cannot be read must NOT
+    exit 0. GatewayId is an unconditional template output; get_stack_outputs
+    swallows describe-stacks failures to {} (cli/utils/aws.py), so an empty result
+    after CREATE_COMPLETE means a read failure. Without this guard the command
+    skipped the READY poll, persisted no gateway URL, and returned success — a
+    silent half-provisioned deploy (Exit Code Contract, .claude/rules/pr-standards.md;
+    same class as PRs #559/#565). Surfaced by /review + /codex-review.
+    """
+
+    def test_empty_outputs_after_deploy_returns_1_and_skips_poll(self):
+        import io
+
+        from rich.console import Console
+
+        profile = _profile(aws_region="eu-west-1")
+        console = Console(file=io.StringIO())
+
+        ws_manager = Mock()
+        ws_manager.deploy_stack.return_value = Mock(success=True)
+
+        cmd = DeployCommand()
+        with (
+            patch.object(cmd, "_websearch_cf_manager", return_value=ws_manager),
+            patch.object(cmd, "_poll_websearch_target_ready") as poll,
+            patch.object(cmd, "_persist_websearch_gateway_url") as persist,
+            patch(
+                "claude_code_with_bedrock.cli.commands.deploy.get_stack_outputs",
+                return_value={},  # read failure → no GatewayId
+            ),
+        ):
+            rc = cmd._deploy_stack("websearch", profile, console, Mock())
+
+        assert rc == 1, "unreadable outputs after a successful deploy must exit non-zero"
+        # The READY poll cannot run without a gateway id, and we must not claim
+        # success by persisting a URL we never resolved.
+        poll.assert_not_called()
+        persist.assert_not_called()

--- a/source/tests/test_websearch_deploy.py
+++ b/source/tests/test_websearch_deploy.py
@@ -1,0 +1,248 @@
+# ABOUTME: Contract tests for T4 — deploy.py web-search gateway wiring.
+# ABOUTME: Covers AC2 (us-east-1 region-pin), AC3 (per-provider discovery URL),
+# AC8 (GatewayUrl→profile save), AC10/OIDC gating, and the target READY poll.
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from claude_code_with_bedrock.cli.commands.deploy import DeployCommand
+from claude_code_with_bedrock.config import Profile
+
+
+def _profile(**overrides):
+    """Build a minimal valid OIDC profile, overridable per test."""
+    base = {
+        "name": "test-profile",
+        "provider_domain": "company.okta.com",
+        "client_id": "test-client",
+        "credential_storage": "session",
+        "aws_region": "eu-west-1",
+        "identity_pool_name": "test-pool",
+        "auth_type": "oidc",
+        "provider_type": "okta",
+        "web_search_enabled": True,
+    }
+    base.update(overrides)
+    return Profile(**base)
+
+
+class TestWebSearchRegionPin:
+    """AC2 — websearch stack pins to us-east-1 regardless of profile.aws_region."""
+
+    def test_uses_us_east_1_manager_when_region_differs(self):
+        profile = _profile(aws_region="eu-west-1")
+        primary = Mock()
+        primary.region = "eu-west-1"
+        cmd = DeployCommand()
+        mgr = cmd._websearch_cf_manager(profile, primary)
+        assert mgr is not primary
+        assert mgr.region == "us-east-1"
+
+    def test_reuses_primary_manager_when_us_east_1(self):
+        profile = _profile(aws_region="us-east-1")
+        primary = Mock()
+        primary.region = "us-east-1"
+        cmd = DeployCommand()
+        mgr = cmd._websearch_cf_manager(profile, primary)
+        assert mgr is primary
+
+
+class TestWebSearchDiscoveryUrl:
+    """AC3 — CUSTOM_JWT discovery URL derived per-provider from the profile."""
+
+    def setup_method(self):
+        self.cmd = DeployCommand()
+
+    def test_okta_uses_oauth2_default(self):
+        url = self.cmd._resolve_websearch_discovery_url(
+            _profile(provider_type="okta", provider_domain="company.okta.com")
+        )
+        assert url == "https://company.okta.com/oauth2/default/.well-known/openid-configuration"
+
+    def test_auth0_trailing_slash_issuer(self):
+        url = self.cmd._resolve_websearch_discovery_url(
+            _profile(provider_type="auth0", provider_domain="company.auth0.com")
+        )
+        assert url == "https://company.auth0.com/.well-known/openid-configuration"
+
+    def test_azure_v2_issuer(self):
+        tenant = "12345678-1234-1234-1234-123456789012"
+        url = self.cmd._resolve_websearch_discovery_url(
+            _profile(
+                provider_type="azure",
+                provider_domain=f"login.microsoftonline.com/{tenant}/v2.0",
+            )
+        )
+        assert url == (f"https://login.microsoftonline.com/{tenant}/v2.0/.well-known/openid-configuration")
+
+    def test_cognito_pool_issuer(self):
+        url = self.cmd._resolve_websearch_discovery_url(
+            _profile(
+                provider_type="cognito",
+                provider_domain="mypool.auth.us-west-2.amazoncognito.com",
+                cognito_user_pool_id="us-west-2_AbCdEfGhI",
+            )
+        )
+        assert url == (
+            "https://cognito-idp.us-west-2.amazonaws.com/us-west-2_AbCdEfGhI/.well-known/openid-configuration"
+        )
+
+    def test_cognito_missing_pool_id_raises(self):
+        with pytest.raises(ValueError):
+            self.cmd._resolve_websearch_discovery_url(_profile(provider_type="cognito", cognito_user_pool_id=""))
+
+    def test_google_fixed_issuer(self):
+        url = self.cmd._resolve_websearch_discovery_url(
+            _profile(provider_type="google", provider_domain="accounts.google.com")
+        )
+        assert url == "https://accounts.google.com/.well-known/openid-configuration"
+
+    def test_generic_uses_issuer_url(self):
+        url = self.cmd._resolve_websearch_discovery_url(
+            _profile(
+                provider_type="generic",
+                oidc_issuer_url="https://idp.example.com/oauth2",
+            )
+        )
+        assert url == "https://idp.example.com/oauth2/.well-known/openid-configuration"
+
+    def test_generic_missing_issuer_raises(self):
+        with pytest.raises(ValueError):
+            self.cmd._resolve_websearch_discovery_url(_profile(provider_type="generic", oidc_issuer_url=""))
+
+
+class TestWebSearchGating:
+    """AC10 + Story-A scope — websearch deploys only for OIDC + when enabled."""
+
+    def setup_method(self):
+        self.cmd = DeployCommand()
+
+    def test_enabled_oidc_deploys(self):
+        assert self.cmd._should_deploy_websearch(_profile(auth_type="oidc")) is True
+
+    def test_disabled_does_not_deploy(self):
+        assert self.cmd._should_deploy_websearch(_profile(web_search_enabled=False)) is False
+
+    def test_idc_does_not_deploy(self):
+        # Story B (AWS_IAM) handles idc/none; Story A's CUSTOM_JWT needs an id_token.
+        p = _profile(auth_type="idc", web_search_enabled=True)
+        assert self.cmd._should_deploy_websearch(p) is False
+
+    def test_none_does_not_deploy(self):
+        p = _profile(auth_type="none", web_search_enabled=True)
+        assert self.cmd._should_deploy_websearch(p) is False
+
+
+class TestWebSearchUrlSave:
+    """AC8 — GatewayUrl output is persisted to profile.agentcore_gateway_url."""
+
+    def test_saves_gateway_url_to_profile(self):
+        profile = _profile()
+        console = Mock()
+        with patch("claude_code_with_bedrock.cli.commands.deploy.Config") as mock_config:
+            saver = Mock()
+            mock_config.load.return_value = saver
+            url = DeployCommand()._persist_websearch_gateway_url(
+                profile, {"GatewayUrl": "https://gw-abc.gateway.bedrock-agentcore.us-east-1.amazonaws.com/mcp"}, console
+            )
+        assert url.endswith("/mcp")
+        assert profile.agentcore_gateway_url == url
+        saver.save_profile.assert_called_once_with(profile)
+
+    def test_no_output_leaves_profile_unchanged(self):
+        profile = _profile()
+        console = Mock()
+        url = DeployCommand()._persist_websearch_gateway_url(profile, {}, console)
+        assert url == ""
+        assert profile.agentcore_gateway_url == ""
+
+    def test_save_failure_is_non_fatal(self):
+        profile = _profile()
+        console = Mock()
+        with patch("claude_code_with_bedrock.cli.commands.deploy.Config") as mock_config:
+            mock_config.load.side_effect = RuntimeError("disk full")
+            # Must not raise — URL persistence is best-effort.
+            url = DeployCommand()._persist_websearch_gateway_url(profile, {"GatewayUrl": "https://x/mcp"}, console)
+        assert url == "https://x/mcp"
+        assert profile.agentcore_gateway_url == "https://x/mcp"
+
+
+class TestWebSearchTargetPoll:
+    """Wires AC1 — poll the connector target to READY; surface FAILED clearly."""
+
+    def _client(self, statuses):
+        """boto3 client mock whose list_gateway_targets walks `statuses`."""
+        client = Mock()
+        calls = {"i": 0}
+
+        def list_targets(**kwargs):
+            i = min(calls["i"], len(statuses) - 1)
+            calls["i"] += 1
+            status = statuses[i]
+            return {"items": [{"targetId": "T1", "name": "ws", "status": status, "statusReasons": ["because"]}]}
+
+        client.list_gateway_targets.side_effect = list_targets
+        return client
+
+    def test_polls_until_ready(self):
+        client = self._client(["CREATING", "CREATING", "READY"])
+        with patch("boto3.client", return_value=client):
+            ok = DeployCommand()._poll_websearch_target_ready("gw-id", "us-east-1", Mock(), timeout=5, interval=0)
+        assert ok is True
+        assert client.list_gateway_targets.call_count == 3
+
+    def test_failed_status_returns_false(self):
+        client = self._client(["CREATING", "FAILED"])
+        with patch("boto3.client", return_value=client):
+            ok = DeployCommand()._poll_websearch_target_ready("gw-id", "us-east-1", Mock(), timeout=5, interval=0)
+        assert ok is False
+
+    def test_timeout_returns_false(self):
+        client = self._client(["CREATING"])
+        # interval=0, timeout=0 → one check then deadline exceeded.
+        with patch("boto3.client", return_value=client):
+            ok = DeployCommand()._poll_websearch_target_ready("gw-id", "us-east-1", Mock(), timeout=0, interval=0)
+        assert ok is False
+
+
+class TestWebSearchDeployCapabilities:
+    """Regression — the websearch service role uses an explicit RoleName, so the
+    deploy path MUST pass CAPABILITY_NAMED_IAM (not the CAPABILITY_IAM default).
+
+    Caught by the T8 live run: the real deploy omitted capabilities and CFN
+    rejected it with "Insufficient capabilities: Requires CAPABILITY_NAMED_IAM",
+    while the show-commands path already printed NAMED_IAM (the two had drifted).
+    """
+
+    def test_deploy_passes_named_iam_capability(self):
+        import io
+
+        from rich.console import Console
+
+        profile = _profile(aws_region="eu-west-1")
+        # _deploy_stack drives a rich Progress bound to this console, so it must
+        # be a real Console (a Mock can't act as a context manager).
+        console = Console(file=io.StringIO())
+
+        # CFN manager whose deploy_stack succeeds; capture its kwargs.
+        # deploy_stack returns a result object with a `.success` flag.
+        ws_manager = Mock()
+        ws_manager.deploy_stack.return_value = Mock(success=True)
+
+        cmd = DeployCommand()
+        with (
+            patch.object(cmd, "_websearch_cf_manager", return_value=ws_manager),
+            patch.object(cmd, "_poll_websearch_target_ready", return_value=True),
+            patch.object(cmd, "_persist_websearch_gateway_url", return_value="https://x/mcp"),
+            patch(
+                "claude_code_with_bedrock.cli.commands.deploy.get_stack_outputs",
+                return_value={"GatewayId": "gw-1", "GatewayUrl": "https://x/mcp"},
+            ),
+        ):
+            rc = cmd._deploy_stack("websearch", profile, console, Mock())
+
+        assert rc == 0
+        assert ws_manager.deploy_stack.called
+        _, kwargs = ws_manager.deploy_stack.call_args
+        assert kwargs["capabilities"] == ["CAPABILITY_NAMED_IAM"]

--- a/source/tests/test_websearch_template.py
+++ b/source/tests/test_websearch_template.py
@@ -7,7 +7,7 @@ Source contract: websearch-feature/spec.md AC1 / AC3 / AC9.
 
 - AC1: Gateway (CUSTOM_JWT, MCP) + web-search connector target + service role
   with bedrock-agentcore:InvokeWebSearch.
-- AC3: the CUSTOM_JWT authorizer config (discoveryUrl + allowedClients == client_id)
+- AC3: the CUSTOM_JWT authorizer config (discoveryUrl + allowedAudience == client_id)
   is parameterized (values produced per-provider by deploy.py in T4).
 - AC9: the template passes the repo's cfn-lint gate (CI ignore-check list).
 """
@@ -116,7 +116,7 @@ class TestParameters:
 
     def test_client_id_param(self, template):
         params = template.get("Parameters", {})
-        assert "ClientId" in params, "ClientId param required (becomes allowedClients)"
+        assert "ClientId" in params, "ClientId param required (becomes allowedAudience)"
 
     def test_domain_exclude_list_param_optional(self, template):
         # Optional domain filter — present and defaulted so the stack deploys without it.
@@ -144,8 +144,17 @@ class TestGateway:
         assert jwt, "AuthorizerConfiguration must carry a customJWTAuthorizer block"
         # discoveryUrl wired from the DiscoveryUrl param
         assert any("DiscoveryUrl" in s for s in _walk_strings(jwt)), "discoveryUrl must reference DiscoveryUrl param"
-        # allowedClients wired from the ClientId param
-        assert any("ClientId" in s for s in _walk_strings(jwt)), "allowedClients must reference ClientId param"
+        # Audience match (NOT client match): the uniform OIDC id_token carries the
+        # client_id in aud, not in a client_id claim, so the authorizer must match
+        # on AllowedAudience. AllowedClients would 403 the id_token (Phase 0
+        # experiment A; websearch-feature/research/idtoken-experiment.md).
+        aud = jwt.get("AllowedAudience", jwt.get("allowedAudience"))
+        assert aud, "authorizer must match on AllowedAudience (the id_token's aud), not AllowedClients"
+        assert "AllowedClients" not in jwt and "allowedClients" not in jwt, (
+            "AllowedClients matches the client_id claim, which the id_token lacks — would 403"
+        )
+        # allowedAudience wired from the ClientId param
+        assert any("ClientId" in s for s in _walk_strings(aud)), "allowedAudience must reference ClientId param"
 
     def test_gateway_name_uses_stack_name(self, resources):
         # cfn-naming rule: no hardcoded names.

--- a/source/tests/test_websearch_template.py
+++ b/source/tests/test_websearch_template.py
@@ -1,0 +1,244 @@
+# ABOUTME: Contract tests for the AgentCore web-search CloudFormation template (Story A, T2).
+# ABOUTME: Verifies AC1 (gateway/target/role shapes), AC3 (per-provider CUSTOM_JWT params), AC9 (cfn-lint).
+
+"""Tests for deployment/infrastructure/agentcore-websearch.yaml.
+
+Source contract: websearch-feature/spec.md AC1 / AC3 / AC9.
+
+- AC1: Gateway (CUSTOM_JWT, MCP) + web-search connector target + service role
+  with bedrock-agentcore:InvokeWebSearch.
+- AC3: the CUSTOM_JWT authorizer config (discoveryUrl + allowedClients == client_id)
+  is parameterized (values produced per-provider by deploy.py in T4).
+- AC9: the template passes the repo's cfn-lint gate (CI ignore-check list).
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+# CloudFormation intrinsic-function-aware YAML loader (mirrors test_cloudformation.py).
+class CloudFormationLoader(yaml.SafeLoader):
+    """YAML loader that tolerates CloudFormation short-form intrinsics."""
+
+    pass
+
+
+def _scalar(tag):
+    def ctor(loader, node):
+        return {tag: loader.construct_scalar(node)}
+
+    return ctor
+
+
+def _sequence(tag):
+    def ctor(loader, node):
+        return {tag: loader.construct_sequence(node)}
+
+    return ctor
+
+
+def _getatt(loader, node):
+    if isinstance(node, yaml.SequenceNode):
+        return {"Fn::GetAtt": loader.construct_sequence(node)}
+    return {"Fn::GetAtt": loader.construct_scalar(node).split(".", 1)}
+
+
+CloudFormationLoader.add_constructor("!Ref", _scalar("Ref"))
+CloudFormationLoader.add_constructor("!Sub", _scalar("Fn::Sub"))
+CloudFormationLoader.add_constructor("!GetAtt", _getatt)
+CloudFormationLoader.add_constructor("!Join", _sequence("Fn::Join"))
+CloudFormationLoader.add_constructor("!Equals", _sequence("Fn::Equals"))
+CloudFormationLoader.add_constructor("!If", _sequence("Fn::If"))
+CloudFormationLoader.add_constructor("!Not", _sequence("Fn::Not"))
+CloudFormationLoader.add_constructor("!And", _sequence("Fn::And"))
+CloudFormationLoader.add_constructor("!Or", _sequence("Fn::Or"))
+CloudFormationLoader.add_constructor("!Select", _sequence("Fn::Select"))
+CloudFormationLoader.add_constructor("!Split", _sequence("Fn::Split"))
+CloudFormationLoader.add_constructor("!Condition", _scalar("Condition"))
+
+
+TEMPLATE_PATH = (
+    Path(__file__).parent.parent.parent / "deployment" / "infrastructure" / "agentcore-websearch.yaml"
+)
+
+# Mirror the cfn-lint ignore-check list from .github/workflows/pytest-ci.yml so the
+# offline gate matches CI exactly (AC9).
+CI_IGNORE_CHECKS = [
+    "W3002", "W2001", "E3012", "E3005", "E0000", "W1001", "W1028", "W1030",
+    "W2010", "W2531", "W3005", "W3011", "W3037", "W8001",
+]
+
+
+def _walk_strings(obj):
+    """Yield every string anywhere in a nested dict/list — keys included.
+
+    Dict keys matter for IAM: condition operators carry their condition key as a
+    dict key (e.g. {"StringEquals": {"aws:SourceAccount": ...}}).
+    """
+    if isinstance(obj, str):
+        yield obj
+    elif isinstance(obj, dict):
+        for k, v in obj.items():
+            if isinstance(k, str):
+                yield k
+            yield from _walk_strings(v)
+    elif isinstance(obj, list):
+        for v in obj:
+            yield from _walk_strings(v)
+
+
+@pytest.fixture(scope="module")
+def template():
+    assert TEMPLATE_PATH.exists(), f"template missing: {TEMPLATE_PATH}"
+    with open(TEMPLATE_PATH, encoding="utf-8") as f:
+        return yaml.load(f, Loader=CloudFormationLoader)
+
+
+@pytest.fixture(scope="module")
+def resources(template):
+    return template.get("Resources", {})
+
+
+def _resource_of_type(resources, cfn_type):
+    return {k: v for k, v in resources.items() if v.get("Type") == cfn_type}
+
+
+class TestParameters:
+    """AC3: per-provider CUSTOM_JWT config is supplied as parameters (deploy.py fills values)."""
+
+    def test_discovery_url_param(self, template):
+        params = template.get("Parameters", {})
+        assert "DiscoveryUrl" in params, "DiscoveryUrl param required (per-provider OIDC discovery)"
+
+    def test_client_id_param(self, template):
+        params = template.get("Parameters", {})
+        assert "ClientId" in params, "ClientId param required (becomes allowedClients)"
+
+    def test_domain_exclude_list_param_optional(self, template):
+        # Optional domain filter — present and defaulted so the stack deploys without it.
+        params = template.get("Parameters", {})
+        assert "DomainExcludeList" in params
+
+
+class TestGateway:
+    """AC1: AgentCore Gateway with CUSTOM_JWT authorizer + MCP protocol."""
+
+    def test_gateway_resource_exists(self, resources):
+        gws = _resource_of_type(resources, "AWS::BedrockAgentCore::Gateway")
+        assert len(gws) == 1, "exactly one Gateway resource expected"
+
+    def test_gateway_protocol_mcp(self, resources):
+        gw = next(iter(_resource_of_type(resources, "AWS::BedrockAgentCore::Gateway").values()))
+        assert gw["Properties"].get("ProtocolType") == "MCP"
+
+    def test_gateway_custom_jwt_authorizer(self, resources):
+        gw = next(iter(_resource_of_type(resources, "AWS::BedrockAgentCore::Gateway").values()))
+        props = gw["Properties"]
+        assert props.get("AuthorizerType") == "CUSTOM_JWT"
+        cfg = props.get("AuthorizerConfiguration", {})
+        jwt = cfg.get("CustomJWTAuthorizer", cfg.get("customJWTAuthorizer", {}))
+        assert jwt, "AuthorizerConfiguration must carry a customJWTAuthorizer block"
+        # discoveryUrl wired from the DiscoveryUrl param
+        assert any("DiscoveryUrl" in s for s in _walk_strings(jwt)), "discoveryUrl must reference DiscoveryUrl param"
+        # allowedClients wired from the ClientId param
+        assert any("ClientId" in s for s in _walk_strings(jwt)), "allowedClients must reference ClientId param"
+
+    def test_gateway_name_uses_stack_name(self, resources):
+        # cfn-naming rule: no hardcoded names.
+        gw = next(iter(_resource_of_type(resources, "AWS::BedrockAgentCore::Gateway").values()))
+        name = gw["Properties"].get("Name")
+        assert isinstance(name, dict) and "Fn::Sub" in name
+        assert "${AWS::StackName}" in name["Fn::Sub"]
+
+
+class TestGatewayTarget:
+    """AC1: web-search connector target."""
+
+    def test_target_resource_exists(self, resources):
+        tgts = _resource_of_type(resources, "AWS::BedrockAgentCore::GatewayTarget")
+        assert len(tgts) == 1, "exactly one GatewayTarget resource expected"
+
+    def test_target_connector_shape_exact(self, resources):
+        # Pin the exact nesting the AgentCore control plane requires:
+        # TargetConfiguration.Mcp.Connector.Source.ConnectorId == "web-search".
+        # A live deploy proved the service rejects TargetConfiguration.Mcp.
+        # ConnectorTargetConfiguration (the cfn-lint definition name) — the real
+        # key is "Connector". This asserts the path, not just a loose substring.
+        tgt = next(iter(_resource_of_type(resources, "AWS::BedrockAgentCore::GatewayTarget").values()))
+        connector = tgt["Properties"]["TargetConfiguration"]["Mcp"]["Connector"]
+        assert connector["Source"]["ConnectorId"] == "web-search"
+
+    def test_target_parameter_values_present(self, resources):
+        # The service rejects a config entry without ParameterValues
+        # ("Connector configurations must not be empty"). Empty {} is the
+        # minimal valid form; here it's an Fn::If carrying {} on the no-filter branch.
+        tgt = next(iter(_resource_of_type(resources, "AWS::BedrockAgentCore::GatewayTarget").values()))
+        configs = tgt["Properties"]["TargetConfiguration"]["Mcp"]["Connector"]["Configurations"]
+        assert configs and "ParameterValues" in configs[0]
+
+    def test_target_credential_provider_is_gateway_iam_role(self, resources):
+        tgt = next(iter(_resource_of_type(resources, "AWS::BedrockAgentCore::GatewayTarget").values()))
+        cpc = tgt["Properties"].get("CredentialProviderConfigurations")
+        assert isinstance(cpc, list) and len(cpc) == 1, "exactly one credential provider config (max 1)"
+        assert any("GATEWAY_IAM_ROLE" in s for s in _walk_strings(cpc))
+
+    def test_target_references_gateway(self, resources):
+        tgt = next(iter(_resource_of_type(resources, "AWS::BedrockAgentCore::GatewayTarget").values()))
+        gw_name = next(iter(_resource_of_type(resources, "AWS::BedrockAgentCore::Gateway").keys()))
+        assert gw_name in list(_walk_strings(tgt["Properties"])), "target must reference the gateway"
+
+
+class TestServiceRole:
+    """AC1: service role trusts bedrock-agentcore + grants InvokeWebSearch."""
+
+    def _role(self, resources):
+        roles = _resource_of_type(resources, "AWS::IAM::Role")
+        assert roles, "a service role is required"
+        return next(iter(roles.values()))
+
+    def test_role_trusts_agentcore(self, resources):
+        role = self._role(resources)
+        trust = role["Properties"]["AssumeRolePolicyDocument"]
+        assert any("bedrock-agentcore.amazonaws.com" in s for s in _walk_strings(trust))
+
+    def test_role_trust_scoped_by_source_account(self, resources):
+        # Confused-deputy guard (findings 6m): SourceAccount / SourceArn condition.
+        role = self._role(resources)
+        trust = role["Properties"]["AssumeRolePolicyDocument"]
+        strings = list(_walk_strings(trust))
+        assert any("aws:SourceAccount" in s or "aws:SourceArn" in s for s in strings)
+
+    def test_role_grants_invoke_web_search(self, resources):
+        role = self._role(resources)
+        actions = list(_walk_strings(role["Properties"].get("Policies", [])))
+        assert any("bedrock-agentcore:InvokeWebSearch" in a for a in actions)
+
+
+class TestOutputs:
+    """AC8 plumbing: GatewayUrl (exported) + GatewayArn outputs for deploy.py to read."""
+
+    def test_gateway_url_output_exported(self, template):
+        outputs = template.get("Outputs", {})
+        assert "GatewayUrl" in outputs
+        assert "Export" in outputs["GatewayUrl"], "GatewayUrl must be exported"
+
+    def test_gateway_arn_output(self, template):
+        outputs = template.get("Outputs", {})
+        assert "GatewayArn" in outputs
+
+
+class TestCfnLint:
+    """AC9: template passes the repo's cfn-lint gate (same ignore list as CI)."""
+
+    def test_cfn_lint_passes(self):
+        if shutil.which("cfn-lint") is None:
+            pytest.skip("cfn-lint not installed")
+        args = ["cfn-lint", str(TEMPLATE_PATH)]
+        for chk in CI_IGNORE_CHECKS:
+            args += ["--ignore-checks", chk]
+        result = subprocess.run(args, capture_output=True, text=True)
+        assert result.returncode == 0, f"cfn-lint failed:\n{result.stdout}\n{result.stderr}"


### PR DESCRIPTION
## Why

Enterprises want Claude Code to answer "what happened today" questions, but there's
no built-in web search on Bedrock. This adds an optional hosted web-search tool via
an Amazon Bedrock AgentCore gateway, authorized by the **same OIDC identity the
deployment already mints** — no proxy, no extra IAM grant, no per-user setup.

It works for **any OIDC provider** (Cognito, Okta, Auth0, Entra, Google) with zero
customer-side IdP config, because the gateway validates the uniform OIDC **id_token**
by matching its `aud` claim (which every provider sets to the client_id).

## What

- **CFN template** (`agentcore-websearch.yaml`): AgentCore gateway (MCP, CUSTOM_JWT
  authorizer matching `AllowedAudience`), web-search connector target, least-privilege
  service role. Pinned to us-east-1 (the managed connector's only region).
- **credential-process** (`--get-mcp-auth-header`, Go + Python, identical output):
  emits `{"Authorization":"Bearer <id_token>"}` for the MCP headersHelper; never opens
  a browser.
- **deploy / package / init / config**: region-pinned deploy with READY polling +
  gateway-URL persistence; `mcpServers.agentcore-websearch` block emitted on package;
  optional init prompt (discloses ~$7/1k-query cost + us-east-1); two new Profile fields
  (backward compatible).
- **Docs**: `WEB_SEARCH.md` (cost, region, acceptable-use citation retention, install
  caveat) + cross-links.

## Verification

- **Live, end-to-end on two providers:**
  - **Cognito** via the Go binary: `tools/list` + `tools/call` → 200 with cited results.
  - **Google** (real OAuth id_token): `tools/list` + `tools/call` → 200 with cited
    results. Google issues opaque access_tokens, so this case only works via the
    id_token + audience-match path.
- Reviewed by both same-model personas and a cross-model pass (GPT-5.5); both surfaced
  one real defect (deploy exit-code on unreadable outputs), now fixed with a regression
  test.
- Gates: Python 1254 passed; Go build/test/vet clean; cfn-lint clean.

## Known follow-ups (not blocking)

- **Python `--get-mcp-auth-header` has no silent refresh** (Go does). Output-byte
  parity holds; the shipped binary is Go on all platforms. Documented; deferred.
- **Google dual-issuer-form**: a manually minted bare-`iss` token (gcloud) 403s; the
  normal browser auth-code flow emits the `https://` form the gateway expects.
  Documented in WEB_SEARCH.md troubleshooting.
- init offers web search regardless of auth type (deploy correctly gates on OIDC);
  could mirror quota's SSO-gated prompt.

## Pre-existing CI notes (not introduced here)

- ruff-format drift on `__main__.py` + gofmt drift on `main.go` (pre-date this branch).
- cfn-lint E2531 on `cognito-user-pool-setup.yaml` (date-triggered py3.9 deprecation).
- cfn-lint W3037 on `bedrock-agentcore:InvokeWebSearch` (real action, lint catalog lag).
