### PR TITLE
feat(quota): add unified 'quota set' command matching documented API

### DIFF
--- a/source/claude_code_with_bedrock/cli/__init__.py
+++ b/source/claude_code_with_bedrock/cli/__init__.py
@@ -31,6 +31,7 @@ from .commands.quota import (
     QuotaExportCommand,
     QuotaImportCommand,
     QuotaListCommand,
+    QuotaSetCommand,
     QuotaSetDefaultCommand,
     QuotaSetGroupCommand,
     QuotaSetUserCommand,
@@ -77,6 +78,7 @@ def create_application() -> Application:
 
     # Quota management commands
     application.add(QuotaCommand())
+    application.add(QuotaSetCommand())
     application.add(QuotaSetUserCommand())
     application.add(QuotaSetGroupCommand())
     application.add(QuotaSetDefaultCommand())

--- a/source/claude_code_with_bedrock/cli/commands/quota.py
+++ b/source/claude_code_with_bedrock/cli/commands/quota.py
@@ -231,6 +231,7 @@ class QuotaCommand(Command):
         self.line("  quota <subcommand> [options]")
         self.line("")
         self.line("<info>Available subcommands:</info>")
+        self.line("  <comment>quota set</comment>          Set quota (user, group, or default)")
         self.line("  <comment>quota set-user</comment>     Set quota policy for a specific user")
         self.line("  <comment>quota set-group</comment>    Set quota policy for a group")
         self.line("  <comment>quota set-default</comment>  Set the default quota policy")
@@ -244,6 +245,87 @@ class QuotaCommand(Command):
         self.line("")
         self.line("Run <comment>ccwb quota <subcommand> --help</comment> for details on a subcommand.")
         return 0
+
+
+class QuotaSetCommand(Command):
+    """Set quota policy (unified interface).
+
+    Routes to set-user, set-group, or set-default based on arguments:
+      ccwb quota set user@co.com --budget 50          → per-user policy
+      ccwb quota set --group engineering --budget 200 → per-group policy
+      ccwb quota set --default --budget 30            → default policy
+    """
+
+    name = "quota set"
+    description = "Set quota policy for a user, group, or default"
+
+    arguments = [
+        argument("identifier", description="User email or group name (omit for --default)", optional=True),
+    ]
+
+    options = [
+        option("profile", description="Configuration profile", flag=False, default=None),
+        option("group", "g", description="Set policy for a group (identifier is group name)", flag=True),
+        option("default", None, description="Set the default policy for all users", flag=True),
+        option("monthly-limit", "m", description="Monthly token limit (e.g., 300M, 1B)", flag=False),
+        option("daily-limit", "d", description="Daily token limit (e.g., 15M)", flag=False),
+        option("monthly-cost-limit", None, description="Monthly cost limit in USD (e.g., 50)", flag=False),
+        option("daily-cost-limit", None, description="Daily cost limit in USD (e.g., 10)", flag=False),
+        option("budget", "b", description="Monthly budget in USD (e.g., 50)", flag=False),
+        option("daily-budget", None, description="Daily budget in USD (e.g., 10)", flag=False),
+        option("enforcement", "e", description="Enforcement mode: 'alert' (default) or 'block'", flag=False),
+        option("daily-enforcement", None, description="Daily enforcement mode: 'alert' or 'block'", flag=False),
+        option("disabled", None, description="Create policy in disabled state", flag=True),
+    ]
+
+    def handle(self) -> int:
+        """Route to the appropriate set-* subcommand."""
+        identifier = self.argument("identifier")
+        is_group = self.option("group")
+        is_default = self.option("default")
+
+        if is_default and is_group:
+            self.line("<error>Cannot use both --default and --group</error>")
+            return 1
+
+        # Build option args to pass through
+        pass_opts = []
+        for opt_name in (
+            "profile",
+            "monthly-limit",
+            "daily-limit",
+            "monthly-cost-limit",
+            "daily-cost-limit",
+            "budget",
+            "daily-budget",
+            "enforcement",
+            "daily-enforcement",
+        ):
+            val = self.option(opt_name)
+            if val:
+                pass_opts.append(f"--{opt_name}={val}")
+        if self.option("disabled"):
+            pass_opts.append("--disabled")
+
+        opts_str = " ".join(pass_opts)
+
+        if is_default:
+            return self.call("quota set-default", f"set-default {opts_str}")
+        elif is_group:
+            if not identifier:
+                self.line("<error>Group name is required: ccwb quota set --group GROUP_NAME</error>")
+                return 1
+            return self.call("quota set-group", f"set-group {identifier} {opts_str}")
+        else:
+            if not identifier:
+                self.line("<error>Email is required: ccwb quota set user@example.com</error>")
+                self.line("  Or use --group GROUP_NAME or --default")
+                return 1
+            # Validate email format
+            if not _validate_email(identifier):
+                self.line(f"<error>Invalid email: {identifier}. Did you mean --group {identifier}?</error>")
+                return 1
+            return self.call("quota set-user", f"set-user {identifier} {opts_str}")
 
 
 class QuotaSetUserCommand(Command):

--- a/source/tests/cli/commands/test_quota_set_alias.py
+++ b/source/tests/cli/commands/test_quota_set_alias.py
@@ -1,0 +1,149 @@
+# ABOUTME: Tests for 'ccwb quota set' unified command that routes to set-user/set-group/set-default
+# ABOUTME: Verifies argument routing, validation, and error messages
+
+"""Tests for the unified 'quota set' command alias.
+
+Addresses #634 comment: users expect 'ccwb quota set user@co.com --budget 50'
+syntax as documented in PR #633, but only set-user/set-group/set-default existed.
+"""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+from cleo.testers.application_tester import ApplicationTester
+from cleo.testers.command_tester import CommandTester
+
+from claude_code_with_bedrock.cli import create_application
+
+
+class TestQuotaSetRouting:
+    """Verify quota set routes to the correct subcommand."""
+
+    @pytest.fixture
+    def app_tester(self):
+        app = create_application()
+        return ApplicationTester(app)
+
+    def test_no_args_shows_helpful_error(self, app_tester):
+        """quota set with no args tells user what to provide."""
+        app_tester.execute("quota set")
+        output = app_tester.io.fetch_output()
+        assert app_tester.status_code == 1
+        assert "Email is required" in output
+
+    def test_invalid_email_suggests_group(self, app_tester):
+        """quota set with non-email suggests --group."""
+        app_tester.execute("quota set engineering")
+        output = app_tester.io.fetch_output()
+        assert app_tester.status_code == 1
+        assert "--group" in output
+
+    def test_both_group_and_default_rejects(self, app_tester):
+        """quota set --group --default is an error."""
+        app_tester.execute("quota set --group --default blah")
+        output = app_tester.io.fetch_output()
+        assert app_tester.status_code == 1
+        assert "Cannot use both" in output
+
+    def test_group_without_identifier_shows_error(self, app_tester):
+        """quota set --group without a name shows error."""
+        app_tester.execute("quota set --group")
+        output = app_tester.io.fetch_output()
+        assert app_tester.status_code == 1
+        assert "Group name is required" in output
+
+    @patch("claude_code_with_bedrock.cli.commands.quota._get_quota_manager")
+    @patch("claude_code_with_bedrock.cli.commands.quota.Config")
+    def test_routes_to_set_user(self, mock_config_cls, mock_get_manager):
+        """quota set user@co.com --budget 50 --monthly-limit 1B routes to set-user."""
+        mock_config = MagicMock()
+        mock_profile = MagicMock()
+        mock_profile.aws_region = "us-west-2"
+        mock_config.active_profile = "default"
+        mock_config.get_profile.return_value = mock_profile
+        mock_config_cls.load.return_value = mock_config
+
+        mock_manager = MagicMock()
+        mock_policy = MagicMock()
+        mock_policy.monthly_token_limit = 1_000_000_000
+        mock_policy.daily_token_limit = None
+        mock_policy.enforcement_mode = MagicMock(value="alert")
+        mock_policy.daily_enforcement_mode = MagicMock(value="alert")
+        mock_manager.create_policy.return_value = mock_policy
+        mock_get_manager.return_value = mock_manager
+
+        app = create_application()
+        tester = ApplicationTester(app)
+        tester.execute("quota set alice@company.com --budget 50 --monthly-limit 1B")
+
+        assert tester.status_code == 0
+        mock_manager.create_policy.assert_called_once()
+
+    @patch("claude_code_with_bedrock.cli.commands.quota._get_quota_manager")
+    @patch("claude_code_with_bedrock.cli.commands.quota.Config")
+    def test_routes_to_set_group(self, mock_config_cls, mock_get_manager):
+        """quota set --group engineering --budget 200 --monthly-limit 1B routes to set-group."""
+        mock_config = MagicMock()
+        mock_profile = MagicMock()
+        mock_profile.aws_region = "us-west-2"
+        mock_config.active_profile = "default"
+        mock_config.get_profile.return_value = mock_profile
+        mock_config_cls.load.return_value = mock_config
+
+        mock_manager = MagicMock()
+        mock_policy = MagicMock()
+        mock_policy.monthly_token_limit = 1_000_000_000
+        mock_policy.daily_token_limit = None
+        mock_policy.enforcement_mode = MagicMock(value="alert")
+        mock_policy.daily_enforcement_mode = MagicMock(value="alert")
+        mock_manager.create_policy.return_value = mock_policy
+        mock_get_manager.return_value = mock_manager
+
+        app = create_application()
+        tester = ApplicationTester(app)
+        tester.execute("quota set --group engineering --budget 200 --monthly-limit 1B")
+
+        assert tester.status_code == 0
+        mock_manager.create_policy.assert_called_once()
+
+    @patch("claude_code_with_bedrock.cli.commands.quota._get_quota_manager")
+    @patch("claude_code_with_bedrock.cli.commands.quota.Config")
+    def test_routes_to_set_default(self, mock_config_cls, mock_get_manager):
+        """quota set --default --budget 30 --monthly-limit 1B routes to set-default."""
+        mock_config = MagicMock()
+        mock_profile = MagicMock()
+        mock_profile.aws_region = "us-west-2"
+        mock_config.active_profile = "default"
+        mock_config.get_profile.return_value = mock_profile
+        mock_config_cls.load.return_value = mock_config
+
+        mock_manager = MagicMock()
+        mock_policy = MagicMock()
+        mock_policy.monthly_token_limit = 1_000_000_000
+        mock_policy.daily_token_limit = None
+        mock_policy.enforcement_mode = MagicMock(value="alert")
+        mock_policy.daily_enforcement_mode = MagicMock(value="alert")
+        mock_manager.create_policy.return_value = mock_policy
+        mock_get_manager.return_value = mock_manager
+
+        app = create_application()
+        tester = ApplicationTester(app)
+        tester.execute("quota set --default --budget 30 --monthly-limit 1B")
+
+        assert tester.status_code == 0
+        mock_manager.create_policy.assert_called_once()
+
+    def test_quota_help_lists_set_command(self, app_tester):
+        """ccwb quota shows 'quota set' in subcommand list."""
+        app_tester.execute("quota")
+        output = app_tester.io.fetch_output()
+        assert "quota set" in output
+        assert "Set quota (user, group, or default)" in output
+
+    def test_help_shows_unified_options(self, app_tester):
+        """quota set --help shows --group, --default, --budget."""
+        app_tester.execute("quota set --help")
+        output = app_tester.io.fetch_output()
+        assert "--group" in output
+        assert "--default" in output
+        assert "--budget" in output


### PR DESCRIPTION
## Fixes

Addresses [#634 comment](https://github.com/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock/pull/634#issuecomment-4764054469) from @adiospeds.

## Background: What PR #633 Added vs What It Missed

PR #633 (cost-based enforcement) added:
- ✅ `--budget`, `--monthly-cost-limit`, `--daily-cost-limit` options to `QuotaSetUserCommand`
- ✅ Same options to `QuotaSetGroupCommand` and `QuotaSetDefaultCommand`
- ✅ `QuotaUsageCommand` with cost breakdown display
- ✅ `_write_cost_limits()` helper and per-model pricing logic
- ✅ Lambda-side cost enforcement in `quota_check` and `quota_monitor`

But the PR description documented the API as:
```bash
ccwb quota set alice@co.com --monthly-cost-limit 50
ccwb quota set --group engineering --monthly-cost-limit 200
ccwb quota set --default --monthly-cost-limit 30
```

**What was missed:** A unified `quota set` command was never created — the options were added to the existing `set-user`/`set-group`/`set-default` commands, but no router for `quota set` was registered. Running `ccwb quota set` failed with:
```
No arguments expected for "quota" command, got "set"
```

## This PR: Add the Missing `quota set` Router

A thin `QuotaSetCommand` that routes to the correct subcommand based on arguments:

| Syntax | Routes to |
|--------|-----------|
| `ccwb quota set user@co.com --budget 50` | `quota set-user` |
| `ccwb quota set --group engineering --budget 200` | `quota set-group` |
| `ccwb quota set --default --budget 30` | `quota set-default` |

## Backwards Compatibility

**Purely additive** — no existing code modified:

- `quota set-user`, `quota set-group`, `quota set-default` continue working identically (zero changes to those classes)
- `quota set` is a new Command class that validates args and delegates via Cleo's `self.call()`
- Existing scripts/automation calling `ccwb quota set-user ...` are unaffected

### Help Output

All commands appear in help — they're independent Cleo Command classes, not aliases:
```
Available subcommands:
  quota set          Set quota (user, group, or default)     ← NEW (router)
  quota set-user     Set quota policy for a specific user    ← unchanged
  quota set-group    Set quota policy for a group            ← unchanged
  quota set-default  Set the default quota policy            ← unchanged
```

The `set-*` variants could be hidden from help in a future PR if desired, but remain functional regardless.

## Validation

- Email-like identifiers → routes to `set-user`
- `--group` flag → routes to `set-group`
- `--default` flag → routes to `set-default`
- Non-email without `--group` → helpful error: "Did you mean --group?"
- All options pass through: `--budget`, `--monthly-limit`, `--enforcement`, etc.

## Testing

- 9 new tests in `test_quota_set_alias.py`
- All 1190 existing tests pass (0 failures)

## Technical Note

> [Cleo](https://github.com/python-poetry/cleo) is the Python CLI framework used by ccwb (same library that powers Poetry). It handles command registration, argument/option parsing, and namespaced subcommands.

Cleo's `Command.call()` with namespaced subcommands (e.g. `quota set-user`) requires the subcommand suffix as the first token in the args string — it gets consumed as the internal `command` argument during `merge_application_definition()`.