### PR TITLE
fix(otel-collector): replace target group when load balancer is replaced

### DIFF
--- a/deployment/infrastructure/otel-collector.yaml
+++ b/deployment/infrastructure/otel-collector.yaml
@@ -226,9 +226,18 @@ Resources:
   HTTPTargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
-      # Name omitted intentionally — CloudFormation auto-generates a unique name
-      # that respects the 32-char limit. Previously used !Sub '${AWS::StackName}-tg'
-      # which failed when stack names exceeded 29 characters (issue #86).
+      # Name is derived from the ALB's unique hex ID (last segment of its ARN).
+      # When the LoadBalancer is replaced its unique ID changes, so this name
+      # changes too — CloudFormation replaces the target group alongside the LB.
+      # Without this coupling, CF tries to attach the old TG to the new LB while
+      # the old LB still owns it, producing:
+      #   "target group cannot be associated with more than one load balancer"
+      # Using the ALB ID keeps the name within the 32-char limit: "tg-" (3) +
+      # 16-char hex ID = 19 chars max. (issue #86 used !Sub '${AWS::StackName}-tg'
+      # which exceeded the limit for long stack names; this approach avoids that.)
+      Name: !Sub
+        - 'tg-${AlbId}'
+        - AlbId: !Select [3, !Split ['/', !Ref LoadBalancer]]
       Port: 4318
       Protocol: HTTP
       TargetType: ip

--- a/source/tests/test_cfn_naming_limits.py
+++ b/source/tests/test_cfn_naming_limits.py
@@ -87,11 +87,15 @@ class TestCFResourceNamingLimits:
             pytest.skip("No CF templates found")
         return templates
 
-    def test_no_explicit_target_group_name(self, templates):
-        """Target groups must NOT have explicit Name (32-char limit too easy to exceed).
+    def test_no_stack_name_derived_target_group_name(self, templates):
+        """Target groups must NOT derive Name from ${AWS::StackName} (32-char overflow).
 
         With stack names like 'claude-code-auth-otel-collector' (31 chars),
-        any suffix pushes past 32. Let CloudFormation auto-generate.
+        any suffix pushes past 32. Names derived from other sources (e.g. an
+        ALB's unique hex ID via !Sub) are acceptable when provably within limits.
+
+        Allowed: !Sub with resource-ID references (bounded length, no StackName).
+        Forbidden: plain strings or !Sub '${AWS::StackName}-*' patterns.
         """
         violations = []
         for template_path in templates:
@@ -108,16 +112,30 @@ class TestCFResourceNamingLimits:
                 if not isinstance(resource, dict):
                     continue
                 rtype = resource.get("Type", "")
-                if rtype in RESOURCE_NAME_LIMITS:
-                    props = resource.get("Properties", {})
-                    if isinstance(props, dict) and "Name" in props:
-                        violations.append(
-                            f"{template_path.name}:{logical_id} ({rtype}) has explicit Name "
-                            f"— limit is {RESOURCE_NAME_LIMITS[rtype]} chars, "
-                            f"remove Name to let CloudFormation auto-generate"
-                        )
+                if rtype not in RESOURCE_NAME_LIMITS:
+                    continue
+                props = resource.get("Properties", {})
+                if not isinstance(props, dict) or "Name" not in props:
+                    continue
 
-        assert not violations, "CF templates have explicit Name on length-limited resources:\n" + "\n".join(
+                name_val = props["Name"]
+                # Allow intrinsic-function-derived names (!Sub, !Join, etc.)
+                # that do NOT reference AWS::StackName. These are loaded by
+                # CFLoader as lists (sequence nodes) or dicts (mapping nodes).
+                # The dangerous pattern is ${AWS::StackName} which can overflow.
+                if isinstance(name_val, (list, dict)):
+                    # Check the template string for StackName references
+                    template_str = name_val[0] if isinstance(name_val, list) else str(name_val)
+                    if "${AWS::StackName}" not in str(template_str):
+                        continue
+                # Plain string Name or stack-name-derived — flag it
+                violations.append(
+                    f"{template_path.name}:{logical_id} ({rtype}) has explicit Name "
+                    f"that may exceed {RESOURCE_NAME_LIMITS[rtype]} chars "
+                    f"— use a bounded derivation or let CloudFormation auto-generate"
+                )
+
+        assert not violations, "CF templates have unsafe explicit Name on length-limited resources:\n" + "\n".join(
             f"  • {v}" for v in violations
         )
 


### PR DESCRIPTION
## Why

When a stack update forces `LoadBalancer` replacement (e.g. changing `Subnets`, `Scheme`, or `SecurityGroups`), CloudFormation creates the new LB but then tries to attach the existing `HTTPTargetGroup` to it while the old LB still owns it, producing:

```
Resource handler returned message: "The following target groups cannot be
associated with more than one load balancer: arn:aws:elasticloadbalancing:
us-east-1:...:targetgroup/claude-HTTPT-VTF44BENVVF2/..."
(Service: ElasticLoadBalancingV2, Status Code: 400)
```

Root cause: `HTTPTargetGroup` had no `Name`, so CloudFormation never replaced it — the logical ID was stable and the TG was reused across LB replacements. A target group can only be associated with one LB at a time.

## What

Derive the TG `Name` from the ALB's unique hex ID (last path segment of its ARN):

```yaml
Name: !Sub
  - 'tg-${AlbId}'
  - AlbId: !Select [3, !Split ['/', !Ref LoadBalancer]]
```

When the LB is replaced its hex ID changes → the TG Name changes → CloudFormation replaces the TG alongside the LB → no dual-LB conflict.

The name stays within the 32-char limit: `"tg-"` (3) + 16-char hex ID = 19 chars max. This avoids the >29-char stack name issue from #86 that previously made `!Sub '${AWS::StackName}-tg'` unusable.

## ⚠️ Upgrade note for existing stacks

**First `update-stack` after this change will replace the target group and ECS service (one-time).**

Adding `Name` to a TG that previously had no explicit name forces CloudFormation to replace it. Because the ECS service's `LoadBalancers` property references the TG ARN (which changes on replacement), the ECS service is also replaced. The replacement chain is:

`HTTPTargetGroup` replaced → `ECSServiceHTTP`/`ECSServiceHTTPS` replaced

This is a **graceful replacement**: CloudFormation creates the new resources before deleting the old ones (create-before-delete). There will be a brief overlap where old and new tasks run simultaneously during ECS task draining. Expect ~60 seconds of overlap while tasks deregister and re-register. No data loss occurs.

This one-time cost is the tradeoff for preventing the unrecoverable `400` error on all future LB replacements.

## Test plan

- [ ] Deploy a fresh stack — verify TG is created with name `tg-<hex-id>`
- [ ] Update the stack with a change that forces LB replacement (e.g. add/remove a subnet) — verify both the LB and TG are replaced together with no `400` error
- [ ] Verify ECS service health checks pass after update
- [ ] Update an **existing** stack (no LB replacement) — verify only TG+ECS service are replaced (one-time migration), no `400` error