### PR TITLE
feat(websearch): add IAM Identity Center (IDC) support to gateway template

### DIFF
--- a/deployment/infrastructure/bedrock-agentcore-gateway.yaml
+++ b/deployment/infrastructure/bedrock-agentcore-gateway.yaml
@@ -1,8 +1,8 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Description: >-
   Amazon Bedrock AgentCore Gateway with the managed Web Search connector for
-  Claude Cowork. Inbound authorization (CUSTOM_JWT) reuses the same OIDC
-  identity provider as the rest of the solution. Deploy into us-east-1 (the
+  Claude Cowork. Supports both OIDC (CUSTOM_JWT) and IAM Identity Center (IAM)
+  authorization modes via the AuthType parameter. Deploy into us-east-1 (the
   only region where the Web Search connector is currently available).
   DATA RESIDENCY: web search queries are processed in us-east-1 regardless of
   where Bedrock inference or the IDE session runs. Organizations with data
@@ -18,24 +18,33 @@ Metadata:
       (e.g. GDPR, data sovereignty) before enabling.
 
 Parameters:
+  AuthType:
+    Type: String
+    Default: oidc
+    AllowedValues:
+      - oidc
+      - idc
+    Description: >-
+      Authorization mode. Use 'oidc' for OIDC providers (Cognito, Okta, Entra,
+      Auth0, Google) — validates id_token via CUSTOM_JWT. Use 'idc' for IAM
+      Identity Center — authorizes via IAM credentials (SigV4).
+
   DiscoveryUrl:
     Type: String
-    AllowedPattern: '^https://.+'
-    ConstraintDescription: must be an https:// URL
+    Default: ''
     Description: >-
-      OIDC discovery URL of the identity provider. The gateway resolves
-      .well-known/openid-configuration from this base URL automatically.
+      OIDC discovery URL (required when AuthType=oidc, ignored for idc). The
+      gateway resolves .well-known/openid-configuration from this base URL.
       Examples: https://cognito-idp.us-east-1.amazonaws.com/<pool-id>,
       https://login.microsoftonline.com/<tenant>/v2.0,
       https://<domain>.okta.com/oauth2/default
 
   ClientId:
     Type: String
-    MinLength: 1
+    Default: ''
     Description: >-
-      OIDC client_id. The gateway validates the id_token's 'aud' claim against
-      this value. Works uniformly across all OIDC providers (Cognito, Okta,
-      Auth0, Entra ID, Google) because every id_token carries client_id in aud.
+      OIDC client_id (required when AuthType=oidc, ignored for idc). The
+      gateway validates the id_token's 'aud' claim against this value.
 
   DomainExcludeList:
     Type: CommaDelimitedList
@@ -45,6 +54,7 @@ Parameters:
       denylist). Leave empty for no filtering.
 
 Conditions:
+  IsOIDC: !Equals [!Ref AuthType, 'oidc']
   HasDenylist: !Not [!Equals [!Join ['', !Ref DomainExcludeList], '']]
 
 Resources:
@@ -103,15 +113,19 @@ Resources:
         Mcp:
           SupportedVersions:
             - '2025-03-26'
-      AuthorizerType: CUSTOM_JWT
-      AuthorizerConfiguration:
-        CustomJWTAuthorizer:
-          DiscoveryUrl: !Ref DiscoveryUrl
-          # AllowedAudience validates the id_token's 'aud' claim, which every
-          # OIDC provider sets to client_id. This works uniformly across Cognito,
-          # Okta, Auth0, Entra ID, and Google — no per-provider logic needed.
-          AllowedAudience:
-            - !Ref ClientId
+      # OIDC deployments use CUSTOM_JWT (validates id_token aud claim).
+      # IDC deployments use AWS_IAM (validates caller's SigV4 credentials).
+      AuthorizerType: !If [IsOIDC, CUSTOM_JWT, AWS_IAM]
+      AuthorizerConfiguration: !If
+        - IsOIDC
+        - CustomJWTAuthorizer:
+            DiscoveryUrl: !Ref DiscoveryUrl
+            # AllowedAudience validates the id_token's 'aud' claim, which every
+            # OIDC provider sets to client_id. Works uniformly across Cognito,
+            # Okta, Auth0, Entra ID, and Google.
+            AllowedAudience:
+              - !Ref ClientId
+        - !Ref 'AWS::NoValue'
 
   WebSearchTarget:
     Type: AWS::BedrockAgentCore::GatewayTarget
@@ -169,3 +183,8 @@ Outputs:
   GatewayExecutionRoleArn:
     Description: ARN of the gateway execution IAM role.
     Value: !GetAtt GatewayExecutionRole.Arn
+
+  AuthorizerType:
+    Description: >-
+      The authorizer type configured for this gateway (CUSTOM_JWT or IAM).
+    Value: !If [IsOIDC, CUSTOM_JWT, AWS_IAM]


### PR DESCRIPTION
## Why

The web search gateway template (#607) only supports OIDC providers via CUSTOM_JWT. IAM Identity Center (IDC) users — who authenticate via `aws sso login` and get IAM temporary credentials rather than JWT tokens — cannot use web search. AgentCore Gateway already supports `AWS_IAM` authorizer type ([docs](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway-inbound-auth.html)), so we can support both auth modes in a single template.

## What

Adds a conditional `AuthType` parameter (`oidc` | `idc`, default: `oidc`) that switches the gateway's authorizer:

| AuthType | AuthorizerType | How callers authenticate |
|----------|---------------|------------------------|
| `oidc` | `CUSTOM_JWT` | Bearer token (OIDC id_token with aud=ClientId) |
| `idc` | `AWS_IAM` | SigV4-signed requests (IAM temp credentials from SSO) |

**Key design:**
- Single template, single gateway resource — only the authorizer config differs via `!If`
- `DiscoveryUrl` and `ClientId` only required for OIDC; ignored (empty default) for IDC
- Shared execution role, target, and outputs are unchanged
- New `AuthorizerType` output for deploy.py to detect the configured mode
- Fully backwards compatible — default is `oidc`, existing deployments unaffected

## Testing

- cfn-lint: clean (0 errors)
- Template validates both conditional paths (OIDC retains existing behavior, IDC omits AuthorizerConfiguration via `AWS::NoValue`)

## Closes

Closes #645

## Note

Infrastructure-only change — no CLI code modified. `deploy.py` will pass `AuthType=idc` when the profile uses IDC auth (wiring in a follow-up PR).