### PR TITLE
feat(websearch): inject AgentCore web search gateway into CoWork MDM config

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/cowork.py
+++ b/source/claude_code_with_bedrock/cli/commands/cowork.py
@@ -12,6 +12,7 @@ from rich.panel import Panel
 
 from claude_code_with_bedrock.cli.utils.cowork_3p import (
     add_monitoring_config,
+    add_websearch_mcp_config,
     build_mdm_config,
     derive_model_aliases,
     generate_json,
@@ -124,6 +125,9 @@ class CoworkGenerateCommand(Command):
 
         # Add monitoring OTLP endpoint if available
         add_monitoring_config(mdm_config, profile, console)
+
+        # Add the AgentCore web search gateway as a managed MCP server (if enabled)
+        add_websearch_mcp_config(mdm_config, profile, console)
 
         # Generate requested formats
         generated = []

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -256,7 +256,11 @@ def _poll_websearch_target_ready(
     while time.time() < deadline:
         try:
             resp = client.list_gateway_targets(gatewayIdentifier=gateway_id, maxResults=1)
-            targets = resp.get("gatewayTargets", [])
+            # ListGatewayTargets returns the targets under "items" (per the
+            # bedrock-agentcore-control API). Reading any other key yields an
+            # empty list, so the poll would never observe READY and would spin
+            # silently until the timeout.
+            targets = resp.get("items", [])
             if targets:
                 status = targets[0].get("status", "")
                 if status == "READY":

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -3456,8 +3456,11 @@ echo
         # Web search headersHelper (Windows): when web search is enabled (OIDC),
         # write %USERPROFILE%\claude-code-with-bedrock\websearch-headers.cmd, a
         # wrapper that runs credential-process.exe --get-mcp-auth-header (the
-        # browserless MCP-header mode). %USERPROFILE% is expanded at install time
-        # so the .cmd carries an absolute path.
+        # browserless MCP-header mode). The .cmd itself keeps %USERPROFILE%: that
+        # is fine because cmd.exe expands it at runtime when the wrapper EXECUTES.
+        # (The registry path that points AT this .cmd is the one that must be
+        # absolute — Claude reads it literally — handled via __CCWB_HOME__ in the
+        # .reg, resolved by the cowork-3p.reg substitution block below.)
         windows_websearch_block = ""
         _ws_enabled = getattr(profile, "web_search_enabled", False)
         _ws_auth = getattr(profile, "effective_auth_type", getattr(profile, "auth_type", "oidc"))
@@ -3589,6 +3592,19 @@ if exist "collector-config.yaml" (
 REM Copy configuration
 echo Copying configuration...
 copy /Y "config.json" "%USERPROFILE%\\claude-code-with-bedrock\\" >nul
+
+REM Resolve __CCWB_HOME__ to the absolute home in the CoWork MDM .reg. Claude
+REM Desktop does NOT expand %USERPROFILE% (or other env vars) in registry MDM
+REM string values, and cowork-3p.reg is generated centrally, so the headersHelper
+REM / inferenceCredentialHelper absolute paths must be baked in here before the
+REM admin/user imports it. The .reg escapes backslashes, so the home is escaped
+REM (\\ -> \\\\) to match the .reg format; reg import un-escapes it back to a
+REM single backslash in the stored REG_SZ value.
+if exist "cowork-3p.reg" (
+    echo Resolving home directory in cowork-3p.reg...
+    powershell -NoProfile -Command "$h = $env:USERPROFILE.Replace('\\','\\\\'); (Get-Content 'cowork-3p.reg' -Raw).Replace('__CCWB_HOME__', $h) | Set-Content 'cowork-3p.reg'"
+    echo OK Resolved home directory in cowork-3p.reg ^(import it with: reg import cowork-3p.reg, then fully restart Claude^)
+)
 
 REM Copy Claude Code settings if they exist
 if exist "claude-settings" (

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -3011,6 +3011,30 @@ if [ ! -f "$CREDENTIAL_BINARY" ]; then
 fi
 """
 
+        # Web search headersHelper: when web search is enabled (OIDC only), the
+        # installer drops a small wrapper next to credential-process that emits
+        # {"Authorization":"Bearer <id_token>"} for Claude Desktop's
+        # managedMcpServers headersHelper. Bound to this deployment profile.
+        websearch_helper_block = ""
+        _ws_enabled = getattr(profile, "web_search_enabled", False)
+        _ws_auth = getattr(profile, "effective_auth_type", getattr(profile, "auth_type", "oidc"))
+        if _ws_enabled and _ws_auth != "idc":
+            websearch_helper_block = f"""
+# Web search headersHelper (Cowork web search via AgentCore Gateway).
+# Emits {{"Authorization":"Bearer <id_token>"}} so Claude Desktop authenticates
+# managedMcpServers requests to the gateway. Bound to the '{profile.name}' profile.
+echo
+echo "Installing web search headersHelper..."
+WS_HELPER="$ACTUAL_HOME/claude-code-with-bedrock/websearch-headers"
+cat > "$WS_HELPER" <<WS_EOF
+#!/bin/sh
+exec "$ACTUAL_HOME/claude-code-with-bedrock/credential-process" --profile {profile.name} --get-mcp-auth-header
+WS_EOF
+chmod +x "$WS_HELPER"
+if [ -n "$SUDO_USER" ]; then chown "$ACTUAL_USER" "$WS_HELPER"; fi
+echo "OK Web search headersHelper installed: $WS_HELPER"
+"""
+
         installer_content += f"""
 # Create directory
 echo
@@ -3028,7 +3052,7 @@ chmod +x "$ACTUAL_HOME/claude-code-with-bedrock/credential-process"
 if [ -n "$SUDO_USER" ]; then
     chown -R "$ACTUAL_USER" "$ACTUAL_HOME/claude-code-with-bedrock"
 fi
-
+{websearch_helper_block}
 # macOS Gatekeeper + Keychain notices
 if [[ "$OSTYPE" == "darwin"* ]]; then
     # Remove quarantine flag added by macOS when downloading unsigned binaries.

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -4229,6 +4229,7 @@ Available metrics include:
         """
         from claude_code_with_bedrock.cli.utils.cowork_3p import (
             add_monitoring_config,
+            add_websearch_mcp_config,
             build_mdm_config,
             derive_model_aliases,
             generate_all,
@@ -4258,6 +4259,7 @@ Available metrics include:
                 mdm_config["inferenceSessionLifetimeSec"] = profile.cowork_inference_session_lifetime_sec
 
             add_monitoring_config(mdm_config, profile, console)
+            add_websearch_mcp_config(mdm_config, profile, console)
             generate_all(output_dir, mdm_config, console)
 
         except Exception as e:

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -3053,6 +3053,18 @@ if [ -n "$SUDO_USER" ]; then
     chown -R "$ACTUAL_USER" "$ACTUAL_HOME/claude-code-with-bedrock"
 fi
 {websearch_helper_block}
+# Resolve __CCWB_HOME__ to the real home in the CoWork MDM files. Claude Desktop
+# on macOS does NOT expand ~ or env vars in MDM string values, and the
+# .mobileconfig is generated centrally, so the absolute paths (headersHelper,
+# inferenceCredentialHelper) must be substituted here on the user's machine.
+for _ccwb_mdm in "cowork-3p.mobileconfig" "cowork-3p-config.json"; do
+    if [ -f "$_ccwb_mdm" ] && grep -q "__CCWB_HOME__" "$_ccwb_mdm" 2>/dev/null; then
+        sed -i.bak "s|__CCWB_HOME__|$ACTUAL_HOME|g" "$_ccwb_mdm" && rm -f "$_ccwb_mdm.bak"
+        if [ -n "$SUDO_USER" ]; then chown "$ACTUAL_USER" "$_ccwb_mdm"; fi
+        echo "OK Resolved home directory in $_ccwb_mdm"
+    fi
+done
+
 # macOS Gatekeeper + Keychain notices
 if [[ "$OSTYPE" == "darwin"* ]]; then
     # Remove quarantine flag added by macOS when downloading unsigned binaries.

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -3441,6 +3441,27 @@ echo
         # harmless and the copy stays best-effort.
         _otel_missing_is_fatal = bool(profile.monitoring_enabled)
 
+        # Web search headersHelper (Windows): when web search is enabled (OIDC),
+        # write %USERPROFILE%\claude-code-with-bedrock\websearch-headers.cmd, a
+        # wrapper that runs credential-process.exe --get-mcp-auth-header (the
+        # browserless MCP-header mode). %USERPROFILE% is expanded at install time
+        # so the .cmd carries an absolute path.
+        windows_websearch_block = ""
+        _ws_enabled = getattr(profile, "web_search_enabled", False)
+        _ws_auth = getattr(profile, "effective_auth_type", getattr(profile, "auth_type", "oidc"))
+        if _ws_enabled and _ws_auth != "idc":
+            windows_websearch_block = f"""
+REM Web search headersHelper (Cowork web search via AgentCore Gateway).
+REM Emits {{"Authorization":"Bearer <id_token>"}} via the browserless
+REM --get-mcp-auth-header mode, bound to the '{profile.name}' profile.
+echo Installing web search headersHelper...
+(
+echo @echo off
+echo "%USERPROFILE%\\claude-code-with-bedrock\\credential-process.exe" --profile {profile.name} --get-mcp-auth-header
+) > "%USERPROFILE%\\claude-code-with-bedrock\\websearch-headers.cmd"
+echo OK Web search headersHelper installed
+"""
+
         installer_content = f"""@echo off
 SETLOCAL ENABLEDELAYEDEXPANSION
 cd /d "%~dp0"
@@ -3482,7 +3503,7 @@ if %errorlevel% neq 0 (
     pause
     exit /b 1
 )
-
+{windows_websearch_block}
 REM Copy OTEL helper if it exists with renamed target
 if exist "otel-helper-windows.exe" (
     echo Copying OTEL helper...

--- a/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
+++ b/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
@@ -254,6 +254,22 @@ def add_monitoring_config(mdm_config: dict, profile, console: Console) -> None:
 
 WEBSEARCH_MCP_SERVER_NAME = "agentcore-websearch"
 
+# Filename of the headersHelper script the installer drops next to the
+# credential-process binary (in ~/claude-code-with-bedrock/). It prints
+# {"Authorization": "Bearer <id_token>"} on stdout for Claude Desktop to attach
+# to every MCP request to the gateway.
+WEBSEARCH_HEADERS_HELPER_NAME = "websearch-headers"
+
+# Default install location (mirrors where 'ccwb package' installs
+# credential-process). Used as the default headersHelper path; tilde-expanded
+# per-user. Admins can override with an absolute path via the profile attribute
+# ``websearch_headers_helper_path`` if their MDM/Claude build does not expand ~.
+WEBSEARCH_HEADERS_HELPER_DEFAULT = f"~/claude-code-with-bedrock/{WEBSEARCH_HEADERS_HELPER_NAME}"
+
+# How often (seconds) Claude Desktop re-invokes the headersHelper. Kept below the
+# Cognito id_token lifetime (~1h) so a fresh bearer is fetched before expiry.
+WEBSEARCH_HEADERS_TTL_SEC = 900
+
 
 def _resolve_websearch_gateway_url(profile) -> str | None:
     """Resolve the gateway MCP endpoint, profile-first with a CloudFormation fallback.
@@ -282,11 +298,25 @@ def add_websearch_mcp_config(mdm_config: dict, profile, console: Console) -> Non
 
     No-op unless ``web_search_enabled``. Resolves the gateway endpoint at
     generation time (never a stale stored value beyond the profile cache) and
-    emits a native ``managedMcpServers`` ``websearch`` entry (Claude Desktop
-    v1.15962.0+): ``server: "websearch"`` + ``provider: "custom"`` + ``customUrl``.
-    Claude Desktop authenticates natively by reusing the user's existing OIDC
-    session, so no OAuth block or secret is stored in the MDM config. Preserves
-    any administrator-defined ``managedMcpServers`` and de-dupes by name.
+    emits a **remote MCP** ``managedMcpServers`` entry authenticated with a
+    ``headersHelper`` script: ``{name, url, headersHelper, headersHelperTtlSec}``.
+
+    Claude Desktop treats this as a generic remote MCP server and speaks standard
+    MCP JSON-RPC that the AgentCore Gateway understands. The gateway's
+    ``CUSTOM_JWT`` authorizer validates the OIDC id_token the ``headersHelper``
+    emits (``Authorization: Bearer <id_token>``); the id_token's ``aud`` is the
+    app client ID, so the gateway must be deployed with ``AllowedAudience``
+    (the template default) — universal across Cognito/Entra/Okta.
+
+    The built-in ``server:"websearch"``/``provider:"custom"`` shape is NOT used:
+    that connector sends a request body the AgentCore Gateway cannot parse
+    ("Invalid JSON format"), even though auth succeeds.
+
+    The ``headersHelper`` path defaults to ``~/claude-code-with-bedrock/
+    websearch-headers`` (where ``ccwb package`` installs the wrapper) and can be
+    overridden with an absolute path via the profile attribute
+    ``websearch_headers_helper_path``. Preserves any administrator-defined
+    ``managedMcpServers`` and de-dupes by name.
     """
     if not getattr(profile, "web_search_enabled", False):
         return
@@ -311,14 +341,18 @@ def add_websearch_mcp_config(mdm_config: dict, profile, console: Console) -> Non
         )
         return
 
-    # Native managedMcpServers "websearch" server type (Claude Desktop v1.15962.0+),
-    # "custom" provider pointing at our AgentCore Gateway. Desktop authenticates
-    # natively via the user's existing OIDC session — no oauth block needed.
+    # Remote MCP entry authenticated via a headersHelper script (Metodo 1).
+    # Claude Desktop invokes the helper, attaches the returned
+    # {"Authorization": "Bearer <id_token>"} header to each MCP request, and
+    # re-fetches every headersHelperTtlSec so an expiring token is refreshed.
+    headers_helper = (
+        getattr(profile, "websearch_headers_helper_path", "") or ""
+    ).strip() or WEBSEARCH_HEADERS_HELPER_DEFAULT
     entry = {
         "name": WEBSEARCH_MCP_SERVER_NAME,
-        "server": "websearch",
-        "provider": "custom",
-        "customUrl": url,
+        "url": url,
+        "headersHelper": headers_helper,
+        "headersHelperTtlSec": WEBSEARCH_HEADERS_TTL_SEC,
     }
 
     # managedMcpServers is a JSON-encoded string in the MDM config. Merge with any
@@ -373,7 +407,7 @@ def generate_mobileconfig(output_dir: Path, mdm_config: dict) -> Path:
         payload_items.append(f"\t\t\t<key>{xml_escape(key)}</key>")
         if isinstance(value, bool):
             string_value = "true" if value else "false"
-        elif isinstance(value, (list, dict)):
+        elif isinstance(value, list | dict):
             string_value = json.dumps(value)
         else:
             string_value = str(value)
@@ -452,7 +486,7 @@ def generate_reg_file(output_dir: Path, mdm_config: dict) -> Path:
     for key, value in _mdm_keys(config).items():
         if isinstance(value, bool):
             string_value = "true" if value else "false"
-        elif isinstance(value, (list, dict)):
+        elif isinstance(value, list | dict):
             string_value = json.dumps(value)
         else:
             string_value = str(value)
@@ -578,7 +612,7 @@ def generate_intune_script(output_dir: Path, mdm_config: dict) -> Path:
     for key, value in keys.items():
         if isinstance(value, bool):
             ps_value = "true" if value else "false"
-        elif isinstance(value, (list, dict)):
+        elif isinstance(value, list | dict):
             ps_value = json.dumps(value)
         else:
             ps_value = str(value)

--- a/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
+++ b/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
@@ -252,6 +252,96 @@ def add_monitoring_config(mdm_config: dict, profile, console: Console) -> None:
         )
 
 
+WEBSEARCH_MCP_SERVER_NAME = "agentcore-websearch"
+
+
+def _resolve_websearch_gateway_url(profile) -> str | None:
+    """Resolve the gateway MCP endpoint, profile-first with a CloudFormation fallback.
+
+    Prefers ``websearch_gateway_url`` saved on the profile by ``ccwb deploy``
+    (mirrors the OTLP-endpoint discovery precedent), falling back to the
+    ``websearch`` stack's ``GatewayMcpEndpoint`` output (the gateway is pinned to
+    us-east-1). Ensures exactly one ``/mcp`` suffix. Returns None when unresolved.
+    """
+    url = (getattr(profile, "websearch_gateway_url", "") or "").strip()
+    if not url:
+        stack = (getattr(profile, "stack_names", None) or {}).get("websearch")
+        region = getattr(profile, "websearch_region", None) or "us-east-1"
+        if stack:
+            try:
+                url = (get_stack_outputs(stack, region).get("GatewayMcpEndpoint") or "").strip()
+            except Exception:
+                url = ""
+    if not url:
+        return None
+    return url if url.rstrip("/").endswith("/mcp") else url.rstrip("/") + "/mcp"
+
+
+def add_websearch_mcp_config(mdm_config: dict, profile, console: Console) -> None:
+    """Inject the AgentCore web search gateway as a CoWork managed MCP server.
+
+    No-op unless ``web_search_enabled``. Resolves the gateway endpoint at
+    generation time (never a stale stored value beyond the profile cache) and
+    emits a native ``managedMcpServers`` ``websearch`` entry (Claude Desktop
+    v1.15962.0+): ``server: "websearch"`` + ``provider: "custom"`` + ``customUrl``.
+    Claude Desktop authenticates natively by reusing the user's existing OIDC
+    session, so no OAuth block or secret is stored in the MDM config. Preserves
+    any administrator-defined ``managedMcpServers`` and de-dupes by name.
+    """
+    if not getattr(profile, "web_search_enabled", False):
+        return
+
+    # IDC deployments authorize the gateway with IAM (SigV4), which Claude
+    # Desktop does not yet support for managed MCP servers. Skip the CoWork
+    # injection for IDC (Claude Code CLI handles IDC web search separately).
+    auth_type = getattr(profile, "effective_auth_type", getattr(profile, "auth_type", "oidc"))
+    if auth_type == "idc":
+        console.print(
+            "[dim]Web search: skipping CoWork config (IDC uses IAM/SigV4 auth, "
+            "not yet supported for Claude Desktop managed MCP servers)[/dim]"
+        )
+        return
+
+    url = _resolve_websearch_gateway_url(profile)
+    if not url:
+        console.print(
+            "[yellow]⚠ Web search is enabled but the gateway endpoint could not be resolved; "
+            "generating CoWork config without the web search MCP server.[/yellow]\n"
+            "[dim]  Run 'ccwb deploy websearch' first.[/dim]"
+        )
+        return
+
+    # Native managedMcpServers "websearch" server type (Claude Desktop v1.15962.0+),
+    # "custom" provider pointing at our AgentCore Gateway. Desktop authenticates
+    # natively via the user's existing OIDC session — no oauth block needed.
+    entry = {
+        "name": WEBSEARCH_MCP_SERVER_NAME,
+        "server": "websearch",
+        "provider": "custom",
+        "customUrl": url,
+    }
+
+    # managedMcpServers is a JSON-encoded string in the MDM config. Merge with any
+    # admin-defined entries (e.g. from cowork_3p_extra_keys), keeping all and
+    # de-duping by name so a re-run never creates a duplicate web search entry.
+    existing_raw = mdm_config.get("managedMcpServers")
+    servers: list = []
+    if isinstance(existing_raw, str) and existing_raw.strip():
+        try:
+            parsed = json.loads(existing_raw)
+            if isinstance(parsed, list):
+                servers = parsed
+        except (ValueError, TypeError):
+            servers = []
+    elif isinstance(existing_raw, list):
+        servers = list(existing_raw)
+
+    servers = [s for s in servers if not (isinstance(s, dict) and s.get("name") == WEBSEARCH_MCP_SERVER_NAME)]
+    servers.append(entry)
+    mdm_config["managedMcpServers"] = json.dumps(servers)
+    console.print(f"[dim]Added {WEBSEARCH_MCP_SERVER_NAME} MCP server to CoWork config ({url})[/dim]")
+
+
 def _mdm_keys(config: dict) -> dict:
     """Return config without internal underscore-prefixed keys."""
     return {k: v for k, v in config.items() if not k.startswith("_")}

--- a/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
+++ b/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
@@ -122,11 +122,13 @@ def _credential_process_path(profile_name: str) -> dict[str, str]:
 
     The installer places the binary at a predictable location per-platform:
     - macOS/Linux: <home>/claude-code-with-bedrock/credential-process
-    - Windows: %USERPROFILE%\\claude-code-with-bedrock\\credential-process.exe
+    - Windows: <home>\\claude-code-with-bedrock\\credential-process.exe
 
-    Claude Desktop on macOS does NOT expand "~"/env vars in MDM values, so the
-    unix path embeds CCWB_HOME_PLACEHOLDER, which `install.sh` substitutes with
-    the real $HOME at install time. Windows uses the native %USERPROFILE%.
+    Claude Desktop does NOT expand "~"/env vars in MDM values on EITHER platform,
+    so both paths embed CCWB_HOME_PLACEHOLDER. `install.sh` (macOS/Linux) and
+    `install.bat` (Windows) substitute it with the real home at install time —
+    Windows escapes it for the .reg (see generate_reg_file). Using %USERPROFILE%
+    here would NOT work: Claude reads the literal string from the registry.
     """
     return {
         "unix": f"{CCWB_HOME_PLACEHOLDER}/claude-code-with-bedrock/credential-process --desktop --profile {profile_name}",
@@ -276,7 +278,13 @@ WEBSEARCH_HEADERS_HELPER_NAME = "websearch-headers"
 # override with an explicit absolute path via ``websearch_headers_helper_path``.
 WEBSEARCH_HEADERS_HELPER_PLACEHOLDER = "__WEBSEARCH_HEADERS_HELPER__"
 WEBSEARCH_HEADERS_HELPER_POSIX = f"{CCWB_HOME_PLACEHOLDER}/claude-code-with-bedrock/{WEBSEARCH_HEADERS_HELPER_NAME}"
-WEBSEARCH_HEADERS_HELPER_WINDOWS = rf"%USERPROFILE%\claude-code-with-bedrock\{WEBSEARCH_HEADERS_HELPER_NAME}.cmd"
+# Windows path also embeds the home placeholder (NOT %USERPROFILE%): Claude
+# Desktop does NOT expand env vars in registry MDM string values (same class of
+# bug as "~" on macOS, confirmed by live Windows testing). install.bat
+# substitutes __CCWB_HOME__ with the absolute home (the .reg-escaped
+# %USERPROFILE%) before the .reg is imported; the Intune .ps1 resolves it via
+# $env:USERPROFILE at deploy time.
+WEBSEARCH_HEADERS_HELPER_WINDOWS = rf"{CCWB_HOME_PLACEHOLDER}\claude-code-with-bedrock\{WEBSEARCH_HEADERS_HELPER_NAME}.cmd"
 
 # Back-compat alias (POSIX default) for callers/tests that referenced the old name.
 WEBSEARCH_HEADERS_HELPER_DEFAULT = WEBSEARCH_HEADERS_HELPER_POSIX
@@ -526,33 +534,46 @@ def generate_mobileconfig(output_dir: Path, mdm_config: dict) -> Path:
     return mobileconfig_path
 
 
+def _to_windows_credential_helper(value: str) -> str:
+    """Convert the unix inferenceCredentialHelper path to the Windows form.
+
+    ``__CCWB_HOME__/claude-code-with-bedrock/credential-process --profile X``
+    becomes ``__CCWB_HOME__\\claude-code-with-bedrock\\credential-process.exe --profile X``.
+    Keeps the ``__CCWB_HOME__`` placeholder (resolved at install/deploy time by
+    install.bat / the Intune .ps1); only rewrites slashes and adds the ``.exe``
+    suffix. No-op when the value is not a placeholder path.
+    """
+    if not (isinstance(value, str) and value.startswith(f"{CCWB_HOME_PLACEHOLDER}/")):
+        return value
+    parts = value.split(" ", 1)
+    binary_part = parts[0].replace("/", "\\")
+    if not binary_part.endswith(".exe"):
+        binary_part += ".exe"
+    return f"{binary_part} {parts[1]}" if len(parts) > 1 else binary_part
+
+
 def generate_reg_file(output_dir: Path, mdm_config: dict) -> Path:
     """Generate a Windows .reg file for Claude Cowork 3P.
 
     All values are stored as REG_SZ strings — booleans, integers, and arrays
     included — matching what Claude Desktop reads from the registry.
 
-    If inferenceCredentialHelper is present and uses a Unix-style path (~/ prefix),
-    it is rewritten to the Windows equivalent (%USERPROFILE%\\ + .exe suffix).
+    Paths embed the __CCWB_HOME__ home placeholder (NOT %USERPROFILE%): Claude
+    Desktop does not expand env vars in registry MDM values. inferenceCredentialHelper's
+    Unix path is converted to backslashes + .exe suffix (keeping the placeholder);
+    install.bat substitutes __CCWB_HOME__ with the .reg-escaped absolute home
+    before the file is imported.
 
     Returns the path to the generated file.
     """
     reg_key = r"HKEY_CURRENT_USER\SOFTWARE\Policies\Claude"
 
-    # Create a copy with Windows-specific credential helper path
+    # Create a copy with the Windows credential helper path (backslashes + .exe),
+    # keeping the __CCWB_HOME__ placeholder for install.bat to resolve.
     config = dict(mdm_config)
     helper_key = "inferenceCredentialHelper"
-    if helper_key in config and isinstance(config[helper_key], str) and config[helper_key].startswith(
-        f"{CCWB_HOME_PLACEHOLDER}/"
-    ):
-        # Convert __CCWB_HOME__/claude-code-with-bedrock/credential-process --profile X
-        # to %USERPROFILE%\claude-code-with-bedrock\credential-process.exe --profile X
-        unix_path = config[helper_key]
-        parts = unix_path.split(" ", 1)
-        binary_part = parts[0].replace(f"{CCWB_HOME_PLACEHOLDER}/", "%USERPROFILE%\\").replace("/", "\\")
-        if not binary_part.endswith(".exe"):
-            binary_part += ".exe"
-        config[helper_key] = f"{binary_part} {parts[1]}" if len(parts) > 1 else binary_part
+    if helper_key in config:
+        config[helper_key] = _to_windows_credential_helper(config[helper_key])
 
     lines = ["Windows Registry Editor Version 5.00", "", f"[{reg_key}]"]
 
@@ -652,6 +673,11 @@ def generate_intune_script(output_dir: Path, mdm_config: dict) -> Path:
     Returns the path to the generated .ps1 file.
     """
     keys = _mdm_keys_resolved(mdm_config, WEBSEARCH_HEADERS_HELPER_WINDOWS)
+    # Convert the unix credential-helper path to the Windows form (keeps the
+    # __CCWB_HOME__ placeholder, resolved at deploy time below).
+    if "inferenceCredentialHelper" in keys:
+        keys = dict(keys)
+        keys["inferenceCredentialHelper"] = _to_windows_credential_helper(keys["inferenceCredentialHelper"])
 
     lines = [
         "<#",
@@ -674,6 +700,12 @@ def generate_intune_script(output_dir: Path, mdm_config: dict) -> Path:
         "",
         '$regPath = "HKCU:\\SOFTWARE\\Policies\\Claude"',
         "",
+        "# Resolve the home-directory placeholder to this user's absolute home.",
+        "# Claude Desktop does NOT expand %USERPROFILE% (or other env vars) in",
+        "# registry MDM values, so headersHelper / inferenceCredentialHelper paths",
+        "# must be absolute. This script writes the literal (single-backslash) path.",
+        "$ccwbHome = $env:USERPROFILE",
+        "",
         "# Create registry key if it does not exist",
         "if (-not (Test-Path $regPath)) {",
         "    New-Item -Path $regPath -Force | Out-Null",
@@ -691,7 +723,14 @@ def generate_intune_script(output_dir: Path, mdm_config: dict) -> Path:
             ps_value = str(value)
         # Escape single quotes for PowerShell
         escaped = ps_value.replace("'", "''")
-        lines.append(f"Set-ItemProperty -Path $regPath -Name '{key}' -Value '{escaped}' -Type String")
+        # Values carrying the home placeholder are resolved at deploy time to the
+        # user's absolute home ($ccwbHome). %USERPROFILE% would NOT work — Claude
+        # reads the registry string literally.
+        if CCWB_HOME_PLACEHOLDER in ps_value:
+            value_expr = f"'{escaped}'.Replace('{CCWB_HOME_PLACEHOLDER}', $ccwbHome)"
+        else:
+            value_expr = f"'{escaped}'"
+        lines.append(f"Set-ItemProperty -Path $regPath -Name '{key}' -Value {value_expr} -Type String")
 
     lines.extend(
         [

--- a/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
+++ b/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
@@ -254,17 +254,22 @@ def add_monitoring_config(mdm_config: dict, profile, console: Console) -> None:
 
 WEBSEARCH_MCP_SERVER_NAME = "agentcore-websearch"
 
-# Filename of the headersHelper script the installer drops next to the
-# credential-process binary (in ~/claude-code-with-bedrock/). It prints
+# Filename of the headersHelper the installer drops next to the credential-process
+# binary (in ~/claude-code-with-bedrock/). It prints
 # {"Authorization": "Bearer <id_token>"} on stdout for Claude Desktop to attach
-# to every MCP request to the gateway.
+# to every MCP request to the gateway. On Windows it is a .cmd wrapper.
 WEBSEARCH_HEADERS_HELPER_NAME = "websearch-headers"
 
-# Default install location (mirrors where 'ccwb package' installs
-# credential-process). Used as the default headersHelper path; tilde-expanded
-# per-user. Admins can override with an absolute path via the profile attribute
-# ``websearch_headers_helper_path`` if their MDM/Claude build does not expand ~.
-WEBSEARCH_HEADERS_HELPER_DEFAULT = f"~/claude-code-with-bedrock/{WEBSEARCH_HEADERS_HELPER_NAME}"
+# Per-OS default headersHelper paths. The MDM config is generated once but
+# rendered into per-OS formats (.mobileconfig vs .reg/.ps1), so the entry stores
+# a placeholder that each generator resolves to the right path. Admins can still
+# override with an explicit absolute path via ``websearch_headers_helper_path``.
+WEBSEARCH_HEADERS_HELPER_PLACEHOLDER = "__WEBSEARCH_HEADERS_HELPER__"
+WEBSEARCH_HEADERS_HELPER_POSIX = f"~/claude-code-with-bedrock/{WEBSEARCH_HEADERS_HELPER_NAME}"
+WEBSEARCH_HEADERS_HELPER_WINDOWS = rf"%USERPROFILE%\claude-code-with-bedrock\{WEBSEARCH_HEADERS_HELPER_NAME}.cmd"
+
+# Back-compat alias (POSIX default) for callers/tests that referenced the old name.
+WEBSEARCH_HEADERS_HELPER_DEFAULT = WEBSEARCH_HEADERS_HELPER_POSIX
 
 # How often (seconds) Claude Desktop re-invokes the headersHelper. Kept below the
 # Cognito id_token lifetime (~1h) so a fresh bearer is fetched before expiry.
@@ -312,11 +317,14 @@ def add_websearch_mcp_config(mdm_config: dict, profile, console: Console) -> Non
     that connector sends a request body the AgentCore Gateway cannot parse
     ("Invalid JSON format"), even though auth succeeds.
 
-    The ``headersHelper`` path defaults to ``~/claude-code-with-bedrock/
-    websearch-headers`` (where ``ccwb package`` installs the wrapper) and can be
-    overridden with an absolute path via the profile attribute
-    ``websearch_headers_helper_path``. Preserves any administrator-defined
-    ``managedMcpServers`` and de-dupes by name.
+    The ``headersHelper`` path is OS-specific. Unless overridden, the entry
+    carries a placeholder that each generator resolves to the per-OS default
+    (``~/claude-code-with-bedrock/websearch-headers`` on macOS/Linux,
+    ``%USERPROFILE%\\claude-code-with-bedrock\\websearch-headers.cmd`` on
+    Windows) — the same path where ``ccwb package`` installs the wrapper. An
+    explicit ``websearch_headers_helper_path`` override is used verbatim across
+    all formats. Preserves any administrator-defined ``managedMcpServers`` and
+    de-dupes by name.
     """
     if not getattr(profile, "web_search_enabled", False):
         return
@@ -341,13 +349,36 @@ def add_websearch_mcp_config(mdm_config: dict, profile, console: Console) -> Non
         )
         return
 
-    # Remote MCP entry authenticated via a headersHelper script (Metodo 1).
-    # Claude Desktop invokes the helper, attaches the returned
-    # {"Authorization": "Bearer <id_token>"} header to each MCP request, and
-    # re-fetches every headersHelperTtlSec so an expiring token is refreshed.
-    headers_helper = (
-        getattr(profile, "websearch_headers_helper_path", "") or ""
-    ).strip() or WEBSEARCH_HEADERS_HELPER_DEFAULT
+    # Remote MCP entry authenticated via a headersHelper script. Claude Desktop
+    # invokes the helper, attaches the returned {"Authorization": "Bearer
+    # <id_token>"} header to each MCP request, and re-fetches every
+    # headersHelperTtlSec so an expiring token is refreshed.
+    #
+    # The path is OS-specific, but this one MDM dict is rendered into both macOS
+    # (.mobileconfig) and Windows (.reg/.ps1) formats. So unless the admin sets
+    # an explicit override, store a placeholder that each generator resolves to
+    # the right per-OS default. An override wins verbatim across all formats.
+    override = (getattr(profile, "websearch_headers_helper_path", "") or "").strip()
+    if override:
+        headers_helper = override
+        looks_absolute = (
+            override.startswith("/")
+            or override.startswith("~")
+            or override.startswith("%")
+            or (len(override) > 2 and override[1] == ":")  # Windows drive, e.g. C:\
+        )
+        if not looks_absolute:
+            console.print(
+                "[yellow]⚠ websearch_headers_helper_path is not an absolute path; "
+                "Claude Desktop may not resolve it.[/yellow]"
+            )
+        console.print(
+            "[dim]Web search: using a custom headersHelper path. The installer only creates the "
+            "default path \u2014 ensure an executable helper exists at this path on every user's "
+            "machine, and that it matches the target OS, especially with --target-platform all.[/dim]"
+        )
+    else:
+        headers_helper = WEBSEARCH_HEADERS_HELPER_PLACEHOLDER
     entry = {
         "name": WEBSEARCH_MCP_SERVER_NAME,
         "url": url,
@@ -381,6 +412,23 @@ def _mdm_keys(config: dict) -> dict:
     return {k: v for k, v in config.items() if not k.startswith("_")}
 
 
+def _mdm_keys_resolved(config: dict, helper_path: str) -> dict:
+    """Like ``_mdm_keys`` but resolves the headersHelper placeholder for one OS.
+
+    ``add_websearch_mcp_config`` stores ``WEBSEARCH_HEADERS_HELPER_PLACEHOLDER``
+    in the ``managedMcpServers`` entry (unless the admin set an explicit path).
+    Each generator calls this with its platform default so the macOS plist and
+    the Windows .reg/.ps1 each get the correct path from the same MDM dict.
+    No-op when the placeholder is absent (e.g. an explicit override).
+    """
+    keys = _mdm_keys(config)
+    raw = keys.get("managedMcpServers")
+    if isinstance(raw, str) and WEBSEARCH_HEADERS_HELPER_PLACEHOLDER in raw:
+        keys = dict(keys)
+        keys["managedMcpServers"] = raw.replace(WEBSEARCH_HEADERS_HELPER_PLACEHOLDER, helper_path)
+    return keys
+
+
 def generate_json(output_dir: Path, mdm_config: dict) -> Path:
     """Generate raw MDM configuration JSON file.
 
@@ -388,7 +436,7 @@ def generate_json(output_dir: Path, mdm_config: dict) -> Path:
     """
     json_path = output_dir / "cowork-3p-config.json"
     with open(json_path, "w", encoding="utf-8") as f:
-        json.dump(_mdm_keys(mdm_config), f, indent=2)
+        json.dump(_mdm_keys_resolved(mdm_config, WEBSEARCH_HEADERS_HELPER_POSIX), f, indent=2)
     return json_path
 
 
@@ -403,7 +451,7 @@ def generate_mobileconfig(output_dir: Path, mdm_config: dict) -> Path:
     # Per Claude CoWork docs: all values are stored as strings in the OS preference
     # store, even booleans, integers, and arrays. Arrays must be JSON-encoded strings.
     payload_items = []
-    for key, value in _mdm_keys(mdm_config).items():
+    for key, value in _mdm_keys_resolved(mdm_config, WEBSEARCH_HEADERS_HELPER_POSIX).items():
         payload_items.append(f"\t\t\t<key>{xml_escape(key)}</key>")
         if isinstance(value, bool):
             string_value = "true" if value else "false"
@@ -483,7 +531,7 @@ def generate_reg_file(output_dir: Path, mdm_config: dict) -> Path:
 
     lines = ["Windows Registry Editor Version 5.00", "", f"[{reg_key}]"]
 
-    for key, value in _mdm_keys(config).items():
+    for key, value in _mdm_keys_resolved(config, WEBSEARCH_HEADERS_HELPER_WINDOWS).items():
         if isinstance(value, bool):
             string_value = "true" if value else "false"
         elif isinstance(value, list | dict):
@@ -578,7 +626,7 @@ def generate_intune_script(output_dir: Path, mdm_config: dict) -> Path:
 
     Returns the path to the generated .ps1 file.
     """
-    keys = _mdm_keys(mdm_config)
+    keys = _mdm_keys_resolved(mdm_config, WEBSEARCH_HEADERS_HELPER_WINDOWS)
 
     lines = [
         "<#",

--- a/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
+++ b/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
@@ -12,6 +12,15 @@ from rich.console import Console
 
 from claude_code_with_bedrock.cli.utils.aws import get_stack_outputs
 
+# Placeholder for the user's home directory in macOS MDM path values. Claude
+# Desktop on macOS does NOT expand "~" (or env vars) in MDM string values, and
+# the .mobileconfig is generated centrally (the packaging host's home may not be
+# the user's). So macOS paths embed this token and `install.sh` substitutes it
+# with the real $HOME on each user's machine at install time — mirroring the
+# __CREDENTIAL_PROCESS_PATH__ pattern used for managed-settings.json. Windows
+# paths use the native %USERPROFILE% env var instead.
+CCWB_HOME_PLACEHOLDER = "__CCWB_HOME__"
+
 # CoWork 3P model aliases — defined by Anthropic's Claude Desktop client.
 # These may differ from the model IDs used by Claude Code (ANTHROPIC_MODEL env var).
 # The ccwb cowork generate --models flag allows admins to override if needed.
@@ -112,15 +121,16 @@ def _credential_process_path(profile_name: str) -> dict[str, str]:
     """Return platform-specific credential-process paths for inferenceCredentialHelper.
 
     The installer places the binary at a predictable location per-platform:
-    - macOS/Linux: ~/claude-code-with-bedrock/credential-process
+    - macOS/Linux: <home>/claude-code-with-bedrock/credential-process
     - Windows: %USERPROFILE%\\claude-code-with-bedrock\\credential-process.exe
 
-    For MDM deployment we use the tilde (~) shorthand which Claude Desktop
-    resolves to the user's home directory on all platforms.
+    Claude Desktop on macOS does NOT expand "~"/env vars in MDM values, so the
+    unix path embeds CCWB_HOME_PLACEHOLDER, which `install.sh` substitutes with
+    the real $HOME at install time. Windows uses the native %USERPROFILE%.
     """
     return {
-        "unix": f"~/claude-code-with-bedrock/credential-process --desktop --profile {profile_name}",
-        "windows": f"%USERPROFILE%\\claude-code-with-bedrock\\credential-process.exe --desktop --profile {profile_name}",
+        "unix": f"{CCWB_HOME_PLACEHOLDER}/claude-code-with-bedrock/credential-process --desktop --profile {profile_name}",
+        "windows": f"{CCWB_HOME_PLACEHOLDER}\\claude-code-with-bedrock\\credential-process.exe --desktop --profile {profile_name}",
     }
 
 
@@ -265,7 +275,7 @@ WEBSEARCH_HEADERS_HELPER_NAME = "websearch-headers"
 # a placeholder that each generator resolves to the right path. Admins can still
 # override with an explicit absolute path via ``websearch_headers_helper_path``.
 WEBSEARCH_HEADERS_HELPER_PLACEHOLDER = "__WEBSEARCH_HEADERS_HELPER__"
-WEBSEARCH_HEADERS_HELPER_POSIX = f"~/claude-code-with-bedrock/{WEBSEARCH_HEADERS_HELPER_NAME}"
+WEBSEARCH_HEADERS_HELPER_POSIX = f"{CCWB_HOME_PLACEHOLDER}/claude-code-with-bedrock/{WEBSEARCH_HEADERS_HELPER_NAME}"
 WEBSEARCH_HEADERS_HELPER_WINDOWS = rf"%USERPROFILE%\claude-code-with-bedrock\{WEBSEARCH_HEADERS_HELPER_NAME}.cmd"
 
 # Back-compat alias (POSIX default) for callers/tests that referenced the old name.
@@ -406,6 +416,19 @@ def add_websearch_mcp_config(mdm_config: dict, profile, console: Console) -> Non
     mdm_config["managedMcpServers"] = json.dumps(servers)
     console.print(f"[dim]Added {WEBSEARCH_MCP_SERVER_NAME} MCP server to CoWork config ({url})[/dim]")
 
+    # Web Fetch egress: the Cowork sandbox blocks outbound egress by default, so
+    # opening the URLs that web search returns fails with "failed to fetch".
+    # Default to allowing all hosts so search results are usable out of the box.
+    # Only set it when the admin hasn't already provided a value (e.g. a narrower
+    # allowlist via cowork_3p_extra_keys), and warn loudly: "*" is broad.
+    if "coworkEgressAllowedHosts" not in mdm_config:
+        mdm_config["coworkEgressAllowedHosts"] = json.dumps(["*"])
+        console.print(
+            "[yellow]⚠ Web search: set coworkEgressAllowedHosts=[\"*\"] so Web Fetch can open result "
+            "pages. This allows sandbox egress to ALL hosts \u2014 narrow it to a targeted domain list "
+            "for production (set coworkEgressAllowedHosts via cowork_3p_extra_keys).[/yellow]"
+        )
+
 
 def _mdm_keys(config: dict) -> dict:
     """Return config without internal underscore-prefixed keys."""
@@ -519,12 +542,14 @@ def generate_reg_file(output_dir: Path, mdm_config: dict) -> Path:
     # Create a copy with Windows-specific credential helper path
     config = dict(mdm_config)
     helper_key = "inferenceCredentialHelper"
-    if helper_key in config and isinstance(config[helper_key], str) and config[helper_key].startswith("~/"):
-        # Convert ~/claude-code-with-bedrock/credential-process --profile X
+    if helper_key in config and isinstance(config[helper_key], str) and config[helper_key].startswith(
+        f"{CCWB_HOME_PLACEHOLDER}/"
+    ):
+        # Convert __CCWB_HOME__/claude-code-with-bedrock/credential-process --profile X
         # to %USERPROFILE%\claude-code-with-bedrock\credential-process.exe --profile X
         unix_path = config[helper_key]
         parts = unix_path.split(" ", 1)
-        binary_part = parts[0].replace("~/", "%USERPROFILE%\\").replace("/", "\\")
+        binary_part = parts[0].replace(f"{CCWB_HOME_PLACEHOLDER}/", "%USERPROFILE%\\").replace("/", "\\")
         if not binary_part.endswith(".exe"):
             binary_part += ".exe"
         config[helper_key] = f"{binary_part} {parts[1]}" if len(parts) > 1 else binary_part

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -177,6 +177,7 @@ class Profile:
     websearch_region: str | None = None  # Region for the gateway stack (allow-list; None = default us-east-1)
     websearch_jwt_audience: str | None = None  # Entra ID (audience mode) only: aud the authorizer accepts
     websearch_domain_denylist: list[str] = field(default_factory=list)  # Optional domains to exclude from results
+    websearch_headers_helper_path: str = ""  # Absolute path override for the Cowork headersHelper (default: ~/claude-code-with-bedrock/websearch-headers)
 
     # Legacy field support
     @property

--- a/source/tests/test_cowork_credential_helper.py
+++ b/source/tests/test_cowork_credential_helper.py
@@ -7,6 +7,7 @@ import json
 
 from claude_code_with_bedrock.cli.utils.cowork_3p import (
     build_mdm_config,
+    generate_intune_script,
     generate_json,
     generate_reg_file,
 )
@@ -114,7 +115,12 @@ class TestGenerateRegFileCredentialHelper:
     """Test Windows .reg generation with credential helper path rewriting."""
 
     def test_reg_file_rewrites_unix_path_to_windows(self, tmp_path):
-        """Unix ~/... path should become %USERPROFILE%\\... with .exe suffix."""
+        """Unix path becomes __CCWB_HOME__\\...credential-process.exe (placeholder kept).
+
+        The placeholder is NOT %USERPROFILE%: Claude Desktop reads the registry
+        value literally and does not expand env vars. install.bat substitutes
+        __CCWB_HOME__ with the absolute home before importing the .reg.
+        """
         config = build_mdm_config(
             bedrock_region="us-west-2",
             model_aliases=["sonnet"],
@@ -122,8 +128,10 @@ class TestGenerateRegFileCredentialHelper:
         )
         reg_path = generate_reg_file(tmp_path, config)
         content = reg_path.read_text(encoding="utf-8")
-        # Should contain Windows-style path
-        assert "%USERPROFILE%" in content
+        # Placeholder kept, env var NOT used
+        assert "__CCWB_HOME__" in content
+        assert "%USERPROFILE%" not in content
+        # Windows binary form: backslashes + .exe suffix
         assert "credential-process.exe" in content
         assert "--profile Test" in content
 
@@ -137,6 +145,35 @@ class TestGenerateRegFileCredentialHelper:
         reg_path = generate_reg_file(tmp_path, config)
         content = reg_path.read_text(encoding="utf-8")
         assert "inferenceCredentialHelper" not in content
+
+
+class TestGenerateIntuneScript:
+    """Test Intune .ps1 generation resolves the home placeholder at deploy time."""
+
+    def test_ps1_resolves_home_placeholder_at_runtime(self, tmp_path):
+        """The .ps1 resolves __CCWB_HOME__ to $env:USERPROFILE when it runs.
+
+        Claude Desktop does not expand env vars in registry MDM values, so the
+        script must write an absolute path. It resolves the placeholder at deploy
+        time rather than emitting a literal %USERPROFILE%.
+        """
+        config = build_mdm_config(
+            bedrock_region="us-west-2",
+            model_aliases=["sonnet"],
+            profile_name="Test",
+        )
+        ps1_path = generate_intune_script(tmp_path, config)
+        content = ps1_path.read_text(encoding="utf-8")
+        assert "$ccwbHome = $env:USERPROFILE" in content
+        assert ".Replace('__CCWB_HOME__', $ccwbHome)" in content
+        # credential helper converted to the Windows .exe form
+        assert "credential-process.exe" in content
+        assert "--profile Test" in content
+        # no emitted registry VALUE carries the unexpanded env var (comments may
+        # mention it, so check the Set-ItemProperty lines specifically)
+        value_lines = [ln for ln in content.splitlines() if ln.startswith("Set-ItemProperty")]
+        assert value_lines  # sanity: we did emit values
+        assert all("%USERPROFILE%" not in ln for ln in value_lines)
 
 
 class TestGenerateJsonCredentialHelper:

--- a/source/tests/test_cowork_credential_helper.py
+++ b/source/tests/test_cowork_credential_helper.py
@@ -64,13 +64,13 @@ class TestBuildMdmConfigCredentialHelper:
         assert config["inferenceBedrockProfile"] == "ClaudeCode"
 
     def test_helper_mode_uses_unix_path_by_default(self):
-        """Default path should use ~/ prefix (Unix convention)."""
+        """Default macOS path uses the __CCWB_HOME__ placeholder (install.sh resolves it)."""
         config = build_mdm_config(
             bedrock_region="us-west-2",
             model_aliases=["sonnet"],
             profile_name="Test",
         )
-        assert config["inferenceCredentialHelper"].startswith("~/")
+        assert config["inferenceCredentialHelper"].startswith("__CCWB_HOME__/")
 
 
 class TestBuildMdmConfigProfileMode:
@@ -153,7 +153,7 @@ class TestGenerateJsonCredentialHelper:
         data = json.loads(json_path.read_text(encoding="utf-8"))
         assert (
             data["inferenceCredentialHelper"]
-            == "~/claude-code-with-bedrock/credential-process --desktop --profile MyProfile"
+            == "__CCWB_HOME__/claude-code-with-bedrock/credential-process --desktop --profile MyProfile"
         )
         assert data["inferenceCredentialHelperTtlSec"] == "3500"
         assert data["inferenceCredentialHelperSilentRefreshEnabled"] == "true"

--- a/source/tests/test_cowork_websearch_mdm.py
+++ b/source/tests/test_cowork_websearch_mdm.py
@@ -1,11 +1,13 @@
 # ABOUTME: Tests for injecting the AgentCore web search gateway into the CoWork MDM config (PR4)
-# ABOUTME: Covers add_websearch_mcp_config: opt-in gating, native entry shape, IDC skip, merge/dedup
+# ABOUTME: Covers add_websearch_mcp_config: opt-in gating, headersHelper entry shape, IDC skip, merge/dedup
 
 """Unit tests for add_websearch_mcp_config (CoWork managedMcpServers injection).
 
-Uses the native Claude Desktop v1.15962.0+ ``managedMcpServers`` ``websearch``
-server type (``server``/``provider``/``customUrl``); auth is handled natively by
-Claude Desktop reusing the user's OIDC session, so there is no ``oauth`` block.
+Uses the remote-MCP ``managedMcpServers`` entry authenticated with a
+``headersHelper`` script (Metodo 1): ``{name, url, headersHelper,
+headersHelperTtlSec}``. The built-in ``server:"websearch"``/``provider:"custom"``
+shape is intentionally NOT used — the AgentCore Gateway cannot parse the body
+that connector sends.
 """
 
 import json
@@ -13,6 +15,8 @@ import json
 from rich.console import Console
 
 from claude_code_with_bedrock.cli.utils.cowork_3p import (
+    WEBSEARCH_HEADERS_HELPER_DEFAULT,
+    WEBSEARCH_HEADERS_TTL_SEC,
     WEBSEARCH_MCP_SERVER_NAME,
     add_websearch_mcp_config,
 )
@@ -49,19 +53,28 @@ def test_disabled_is_noop():
     assert "managedMcpServers" not in mdm
 
 
-def test_enabled_adds_native_websearch_entry():
+def test_enabled_adds_headers_helper_entry():
     mdm = {}
     add_websearch_mcp_config(mdm, _profile(), _CONSOLE)
     servers = _servers(mdm)
     assert len(servers) == 1
     entry = servers[0]
     assert entry["name"] == WEBSEARCH_MCP_SERVER_NAME
-    assert entry["server"] == "websearch"
-    assert entry["provider"] == "custom"
-    assert entry["customUrl"] == "https://gw-abc.gateway.bedrock-agentcore.us-east-1.amazonaws.com/mcp"
-    # Native auth → no oauth block / raw transport in the entry.
+    assert entry["url"] == "https://gw-abc.gateway.bedrock-agentcore.us-east-1.amazonaws.com/mcp"
+    assert entry["headersHelper"] == WEBSEARCH_HEADERS_HELPER_DEFAULT
+    assert entry["headersHelperTtlSec"] == WEBSEARCH_HEADERS_TTL_SEC
+    # Remote MCP entry → not the built-in websearch connector, no oauth block.
+    assert "server" not in entry
+    assert "provider" not in entry
+    assert "customUrl" not in entry
     assert "oauth" not in entry
-    assert "transport" not in entry
+
+
+def test_headers_helper_path_override():
+    mdm = {}
+    custom = "/opt/org/bin/websearch-headers"
+    add_websearch_mcp_config(mdm, _profile(websearch_headers_helper_path=custom), _CONSOLE)
+    assert _servers(mdm)[0]["headersHelper"] == custom
 
 
 def test_managed_mcp_servers_is_json_encoded_string():
@@ -77,19 +90,19 @@ def test_appends_mcp_suffix_when_missing():
         _profile(websearch_gateway_url="https://gw-abc.gateway.bedrock-agentcore.us-east-1.amazonaws.com"),
         _CONSOLE,
     )
-    customurl = _servers(mdm)[0]["customUrl"]
-    assert customurl.endswith("/mcp")
-    assert not customurl.endswith("/mcp/mcp")
+    url = _servers(mdm)[0]["url"]
+    assert url.endswith("/mcp")
+    assert not url.endswith("/mcp/mcp")
 
 
 def test_does_not_double_mcp_suffix():
     mdm = {}
     add_websearch_mcp_config(mdm, _profile(), _CONSOLE)
-    assert _servers(mdm)[0]["customUrl"].count("/mcp") == 1
+    assert _servers(mdm)[0]["url"].count("/mcp") == 1
 
 
-def test_native_entry_is_provider_agnostic_for_azure():
-    """The native entry shape is identical regardless of IdP (no per-provider auth)."""
+def test_entry_is_provider_agnostic_for_azure():
+    """The entry shape is identical regardless of IdP (id_token aud=client_id is universal)."""
     profile = _profile(
         provider_type="azure",
         provider_domain="login.microsoftonline.com/11111111-2222-3333-4444-555555555555/v2.0",
@@ -99,8 +112,8 @@ def test_native_entry_is_provider_agnostic_for_azure():
     mdm = {}
     add_websearch_mcp_config(mdm, profile, _CONSOLE)
     entry = _servers(mdm)[0]
-    assert entry["server"] == "websearch"
-    assert entry["provider"] == "custom"
+    assert entry["url"].endswith("/mcp")
+    assert "headersHelper" in entry
     assert "oauth" not in entry
 
 

--- a/source/tests/test_cowork_websearch_mdm.py
+++ b/source/tests/test_cowork_websearch_mdm.py
@@ -111,9 +111,14 @@ def test_reg_resolves_windows_helper_path(tmp_path):
     add_websearch_mcp_config(mdm, _profile(), _CONSOLE)
     generate_reg_file(tmp_path, mdm)
     content = (tmp_path / "cowork-3p.reg").read_text()
-    # .reg JSON-escapes backslashes; check on the unescaped form.
+    # .reg JSON-escapes backslashes; check on the escaped form.
     assert WEBSEARCH_HEADERS_HELPER_WINDOWS.replace("\\", "\\\\") in content
     assert WEBSEARCH_HEADERS_HELPER_PLACEHOLDER not in content
+    # Windows path now carries the __CCWB_HOME__ placeholder (install.bat resolves
+    # it to the absolute home), NOT %USERPROFILE% — Claude Desktop reads the
+    # registry value literally and does not expand env vars.
+    assert CCWB_HOME_PLACEHOLDER in content
+    assert "%USERPROFILE%" not in content
 
 
 def test_override_skips_placeholder_in_all_formats(tmp_path):

--- a/source/tests/test_cowork_websearch_mdm.py
+++ b/source/tests/test_cowork_websearch_mdm.py
@@ -15,6 +15,7 @@ import json
 from rich.console import Console
 
 from claude_code_with_bedrock.cli.utils.cowork_3p import (
+    CCWB_HOME_PLACEHOLDER,
     WEBSEARCH_HEADERS_HELPER_PLACEHOLDER,
     WEBSEARCH_HEADERS_HELPER_POSIX,
     WEBSEARCH_HEADERS_HELPER_WINDOWS,
@@ -82,6 +83,27 @@ def test_mobileconfig_resolves_posix_helper_path(tmp_path):
     content = (tmp_path / "cowork-3p.mobileconfig").read_text()
     assert WEBSEARCH_HEADERS_HELPER_POSIX in content
     assert WEBSEARCH_HEADERS_HELPER_PLACEHOLDER not in content
+    # macOS path carries the home placeholder for install.sh to substitute
+    # (Claude Desktop does not expand ~/$HOME in MDM values).
+    assert CCWB_HOME_PLACEHOLDER in content
+
+
+def test_egress_allowed_hosts_defaults_to_wildcard():
+    mdm = {}
+    add_websearch_mcp_config(mdm, _profile(), _CONSOLE)
+    assert mdm["coworkEgressAllowedHosts"] == json.dumps(["*"])
+
+
+def test_egress_allowed_hosts_respects_existing_admin_value():
+    mdm = {"coworkEgressAllowedHosts": json.dumps(["example.com"])}
+    add_websearch_mcp_config(mdm, _profile(), _CONSOLE)
+    assert mdm["coworkEgressAllowedHosts"] == json.dumps(["example.com"])
+
+
+def test_egress_not_set_when_web_search_disabled():
+    mdm = {}
+    add_websearch_mcp_config(mdm, _profile(web_search_enabled=False), _CONSOLE)
+    assert "coworkEgressAllowedHosts" not in mdm
 
 
 def test_reg_resolves_windows_helper_path(tmp_path):

--- a/source/tests/test_cowork_websearch_mdm.py
+++ b/source/tests/test_cowork_websearch_mdm.py
@@ -15,10 +15,14 @@ import json
 from rich.console import Console
 
 from claude_code_with_bedrock.cli.utils.cowork_3p import (
-    WEBSEARCH_HEADERS_HELPER_DEFAULT,
+    WEBSEARCH_HEADERS_HELPER_PLACEHOLDER,
+    WEBSEARCH_HEADERS_HELPER_POSIX,
+    WEBSEARCH_HEADERS_HELPER_WINDOWS,
     WEBSEARCH_HEADERS_TTL_SEC,
     WEBSEARCH_MCP_SERVER_NAME,
     add_websearch_mcp_config,
+    generate_mobileconfig,
+    generate_reg_file,
 )
 from claude_code_with_bedrock.config import Profile
 
@@ -61,7 +65,8 @@ def test_enabled_adds_headers_helper_entry():
     entry = servers[0]
     assert entry["name"] == WEBSEARCH_MCP_SERVER_NAME
     assert entry["url"] == "https://gw-abc.gateway.bedrock-agentcore.us-east-1.amazonaws.com/mcp"
-    assert entry["headersHelper"] == WEBSEARCH_HEADERS_HELPER_DEFAULT
+    # Without an override, the entry carries the OS placeholder; generators resolve it.
+    assert entry["headersHelper"] == WEBSEARCH_HEADERS_HELPER_PLACEHOLDER
     assert entry["headersHelperTtlSec"] == WEBSEARCH_HEADERS_TTL_SEC
     # Remote MCP entry → not the built-in websearch connector, no oauth block.
     assert "server" not in entry
@@ -70,11 +75,33 @@ def test_enabled_adds_headers_helper_entry():
     assert "oauth" not in entry
 
 
-def test_headers_helper_path_override():
+def test_mobileconfig_resolves_posix_helper_path(tmp_path):
+    mdm = {}
+    add_websearch_mcp_config(mdm, _profile(), _CONSOLE)
+    generate_mobileconfig(tmp_path, mdm)
+    content = (tmp_path / "cowork-3p.mobileconfig").read_text()
+    assert WEBSEARCH_HEADERS_HELPER_POSIX in content
+    assert WEBSEARCH_HEADERS_HELPER_PLACEHOLDER not in content
+
+
+def test_reg_resolves_windows_helper_path(tmp_path):
+    mdm = {}
+    add_websearch_mcp_config(mdm, _profile(), _CONSOLE)
+    generate_reg_file(tmp_path, mdm)
+    content = (tmp_path / "cowork-3p.reg").read_text()
+    # .reg JSON-escapes backslashes; check on the unescaped form.
+    assert WEBSEARCH_HEADERS_HELPER_WINDOWS.replace("\\", "\\\\") in content
+    assert WEBSEARCH_HEADERS_HELPER_PLACEHOLDER not in content
+
+
+def test_override_skips_placeholder_in_all_formats(tmp_path):
     mdm = {}
     custom = "/opt/org/bin/websearch-headers"
     add_websearch_mcp_config(mdm, _profile(websearch_headers_helper_path=custom), _CONSOLE)
+    # Entry carries the literal override (no placeholder), so generators emit it verbatim.
     assert _servers(mdm)[0]["headersHelper"] == custom
+    generate_mobileconfig(tmp_path, mdm)
+    assert custom in (tmp_path / "cowork-3p.mobileconfig").read_text()
 
 
 def test_managed_mcp_servers_is_json_encoded_string():

--- a/source/tests/test_cowork_websearch_mdm.py
+++ b/source/tests/test_cowork_websearch_mdm.py
@@ -1,0 +1,137 @@
+# ABOUTME: Tests for injecting the AgentCore web search gateway into the CoWork MDM config (PR4)
+# ABOUTME: Covers add_websearch_mcp_config: opt-in gating, native entry shape, IDC skip, merge/dedup
+
+"""Unit tests for add_websearch_mcp_config (CoWork managedMcpServers injection).
+
+Uses the native Claude Desktop v1.15962.0+ ``managedMcpServers`` ``websearch``
+server type (``server``/``provider``/``customUrl``); auth is handled natively by
+Claude Desktop reusing the user's OIDC session, so there is no ``oauth`` block.
+"""
+
+import json
+
+from rich.console import Console
+
+from claude_code_with_bedrock.cli.utils.cowork_3p import (
+    WEBSEARCH_MCP_SERVER_NAME,
+    add_websearch_mcp_config,
+)
+from claude_code_with_bedrock.config import Profile
+
+_CONSOLE = Console()
+
+
+def _profile(**overrides) -> Profile:
+    data = {
+        "name": "test",
+        "provider_domain": "us-east-1abc.auth.eu-central-1.amazoncognito.com",
+        "client_id": "client123",
+        "credential_storage": "keyring",
+        "aws_region": "eu-central-1",
+        "identity_pool_name": "ccwb",
+        "provider_type": "cognito",
+        "cognito_user_pool_id": "eu-central-1_AbCdEf",
+        "web_search_enabled": True,
+        "websearch_gateway_url": "https://gw-abc.gateway.bedrock-agentcore.us-east-1.amazonaws.com/mcp",
+    }
+    data.update(overrides)
+    return Profile.from_dict(data)
+
+
+def _servers(mdm_config: dict) -> list:
+    raw = mdm_config.get("managedMcpServers")
+    return json.loads(raw) if raw else []
+
+
+def test_disabled_is_noop():
+    mdm = {}
+    add_websearch_mcp_config(mdm, _profile(web_search_enabled=False), _CONSOLE)
+    assert "managedMcpServers" not in mdm
+
+
+def test_enabled_adds_native_websearch_entry():
+    mdm = {}
+    add_websearch_mcp_config(mdm, _profile(), _CONSOLE)
+    servers = _servers(mdm)
+    assert len(servers) == 1
+    entry = servers[0]
+    assert entry["name"] == WEBSEARCH_MCP_SERVER_NAME
+    assert entry["server"] == "websearch"
+    assert entry["provider"] == "custom"
+    assert entry["customUrl"] == "https://gw-abc.gateway.bedrock-agentcore.us-east-1.amazonaws.com/mcp"
+    # Native auth → no oauth block / raw transport in the entry.
+    assert "oauth" not in entry
+    assert "transport" not in entry
+
+
+def test_managed_mcp_servers_is_json_encoded_string():
+    mdm = {}
+    add_websearch_mcp_config(mdm, _profile(), _CONSOLE)
+    assert isinstance(mdm["managedMcpServers"], str)
+
+
+def test_appends_mcp_suffix_when_missing():
+    mdm = {}
+    add_websearch_mcp_config(
+        mdm,
+        _profile(websearch_gateway_url="https://gw-abc.gateway.bedrock-agentcore.us-east-1.amazonaws.com"),
+        _CONSOLE,
+    )
+    customurl = _servers(mdm)[0]["customUrl"]
+    assert customurl.endswith("/mcp")
+    assert not customurl.endswith("/mcp/mcp")
+
+
+def test_does_not_double_mcp_suffix():
+    mdm = {}
+    add_websearch_mcp_config(mdm, _profile(), _CONSOLE)
+    assert _servers(mdm)[0]["customUrl"].count("/mcp") == 1
+
+
+def test_native_entry_is_provider_agnostic_for_azure():
+    """The native entry shape is identical regardless of IdP (no per-provider auth)."""
+    profile = _profile(
+        provider_type="azure",
+        provider_domain="login.microsoftonline.com/11111111-2222-3333-4444-555555555555/v2.0",
+        oidc_issuer_url="https://login.microsoftonline.com/11111111-2222-3333-4444-555555555555/v2.0",
+        cognito_user_pool_id=None,
+    )
+    mdm = {}
+    add_websearch_mcp_config(mdm, profile, _CONSOLE)
+    entry = _servers(mdm)[0]
+    assert entry["server"] == "websearch"
+    assert entry["provider"] == "custom"
+    assert "oauth" not in entry
+
+
+def test_idc_auth_is_skipped():
+    """IDC uses IAM/SigV4 — not supported for Claude Desktop managed MCP; skip."""
+    mdm = {}
+    add_websearch_mcp_config(mdm, _profile(auth_type="idc"), _CONSOLE)
+    assert "managedMcpServers" not in mdm
+
+
+def test_preserves_admin_defined_servers_and_dedupes():
+    admin_entry = {"name": "github", "transport": "http", "url": "https://example/mcp"}
+    mdm = {"managedMcpServers": json.dumps([admin_entry])}
+    add_websearch_mcp_config(mdm, _profile(), _CONSOLE)
+    servers = _servers(mdm)
+    names = [s["name"] for s in servers]
+    assert "github" in names
+    assert names.count(WEBSEARCH_MCP_SERVER_NAME) == 1
+    assert len(servers) == 2
+
+
+def test_rerun_does_not_duplicate_websearch_entry():
+    mdm = {}
+    add_websearch_mcp_config(mdm, _profile(), _CONSOLE)
+    add_websearch_mcp_config(mdm, _profile(), _CONSOLE)
+    servers = _servers(mdm)
+    assert [s["name"] for s in servers].count(WEBSEARCH_MCP_SERVER_NAME) == 1
+
+
+def test_unresolved_endpoint_warns_and_skips():
+    mdm = {}
+    # No profile URL and no websearch stack → cannot resolve, must skip cleanly.
+    add_websearch_mcp_config(mdm, _profile(websearch_gateway_url="", stack_names={}), _CONSOLE)
+    assert "managedMcpServers" not in mdm

--- a/source/tests/test_websearch_gateway.py
+++ b/source/tests/test_websearch_gateway.py
@@ -3,7 +3,10 @@
 
 """Unit tests for the AgentCore web search gateway deploy wiring (PR 2)."""
 
+from unittest.mock import Mock
+
 from claude_code_with_bedrock.cli.commands.deploy import (
+    _poll_websearch_target_ready,
     _websearch_discovery_url,
     build_websearch_params,
     get_websearch_region,
@@ -246,3 +249,34 @@ def test_deploy_all_treats_websearch_failure_as_non_fatal():
     # Non-websearch failures still abort.
     assert "failed = True" in loop
     assert "break" in loop
+
+
+def _fake_session(target_status):
+    """Build a fake boto3 session whose list_gateway_targets returns one target."""
+    client = Mock()
+    item = {"status": target_status}
+    if target_status == "FAILED":
+        item["statusReason"] = "boom"
+    client.list_gateway_targets.return_value = {"items": [item]}
+    session = Mock()
+    session.client.return_value = client
+    return session
+
+
+def test_poll_target_ready_reads_items_key():
+    """Regression: ListGatewayTargets returns targets under 'items'.
+
+    Reading any other key yields an empty list, so the poll would never see
+    READY and would spin until the timeout.
+    """
+    ok = _poll_websearch_target_ready(
+        "gw-123", "us-east-1", Mock(), timeout=5, interval=0, session=_fake_session("READY")
+    )
+    assert ok is True
+
+
+def test_poll_target_failed_returns_false():
+    ok = _poll_websearch_target_ready(
+        "gw-123", "us-east-1", Mock(), timeout=5, interval=0, session=_fake_session("FAILED")
+    )
+    assert ok is False


### PR DESCRIPTION
## Why

Final code PR of the Claude Cowork web search series. #607 (template, merged) and #641 (deploy wiring) provision the AgentCore Gateway; this PR makes it **usable from Claude Cowork** by injecting the gateway as a managed MCP server into the generated Cowork MDM config.

> ⚠️ **Stacked on #641 — please merge that first.** This branch is based on `feat/websearch-deploy-wiring` (#641), so until #641 lands the diff here also shows #641's commits. The PR4-specific change is the last commit (`feat(websearch): inject AgentCore web search gateway into CoWork MDM config`).

## What

When `web_search_enabled`, `ccwb package` and `ccwb cowork generate` emit a `managedMcpServers` **`agentcore-websearch`** entry into the generated MDM config (`.json` / `.mobileconfig` / `.reg`):

- **`cowork_3p.py`** — `add_websearch_mcp_config()`:
  - Resolves the gateway MCP endpoint **profile-first** (`websearch_gateway_url`, saved by `ccwb deploy`) with a CloudFormation fallback (`GatewayMcpEndpoint` output); ensures exactly one `/mcp` suffix.
  - Builds a native **OAuth authorization-code** entry against the same IdP (`oauth.clientId` + `authorizationServer` = OIDC issuer + `scope` + `localhost` callback) — **no secret** is stored in the MDM config. Reuses the `localhost:<redirect_port>` callback already registered for Claude Code.
  - `_oidc_issuer_for_profile` reuses deploy.py's per-provider discovery-URL derivation (single source of truth) stripped of the well-known suffix, so the issuer matches what the gateway authorizer validates.
  - Preserves admin-defined `managedMcpServers` and de-dupes the web search entry by name.
- Wired into `package.py` (`_generate_cowork_3p_mdm_config`) and the standalone `cowork generate` command, right after `add_monitoring_config`.

## Relationship with #640

This is the **Cowork** counterpart to #640's **Claude Code** injection (`mcpServers.agentcore-websearch` in `settings.json` via the credential helper). The two **coexist** on the same #607 gateway — different surfaces, no file overlap. See the plan on #641.

## Testing Evidence

- New `tests/test_cowork_websearch_mdm.py` (10 tests): opt-in gating (disabled = no-op), entry shape, `/mcp` suffix handling, admin-entry preservation + dedup, re-run idempotency, default callback port, Azure issuer derivation, unresolved-endpoint warn+skip.
- Full suite: **1231 passed, 0 failed** (`pytest tests/`); `ruff check` / `ruff format` clean (pre-existing `UP038` in the MDM generators left untouched).

## References
- Stacked on #641 (deploy wiring); builds on #607 (template, merged)
- Coexists with #640 (Claude Code surface)
- Relates to #363 (Cowork web search)
