### PR TITLE
feat(init): add IAM Identity Center configuration prompts to init wizard

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -401,9 +401,7 @@ class InitCommand(Command):
 
             # SSO region (auto-suggest from start URL if possible)
             suggested_region = "us-east-1"
-            import re as _re
-
-            _region_match = _re.search(r"\.(us|eu|ap|sa|ca|me|af|il)-[a-z]+-\d+\.", idc_start_url)
+            _region_match = re.search(r"\.(us|eu|ap|sa|ca|me|af|il)-[a-z]+-\d+\.", idc_start_url)
             if _region_match:
                 suggested_region = _region_match.group(0).strip(".")
 
@@ -768,7 +766,7 @@ class InitCommand(Command):
                 config["client_certificate_key_path"] = client_certificate_key_path
 
             # Credential Storage Method
-            from claude_code_with_bedrock.cli.utils.helpers import is_wsl, is_keyring_available
+            from claude_code_with_bedrock.cli.utils.helpers import is_keyring_available, is_wsl
 
             wsl_detected = is_wsl()
             keyring_available = is_keyring_available()

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -379,6 +379,72 @@ class InitCommand(Command):
             config["auth_type"] = auth_method
             config["sso_enabled"] = auth_method == "oidc"
 
+        # IAM Identity Center Configuration
+        if not skip_okta and config.get("auth_type") == "idc":
+            console.print("\n[bold blue]IAM Identity Center Configuration[/bold blue]")
+            console.print("─" * 30)
+            console.print()
+            console.print("Configure your IAM Identity Center (SSO) connection.")
+            console.print("Users will authenticate via their SSO portal and receive")
+            console.print("temporary credentials for Bedrock access.\n")
+
+            # IDC start URL
+            idc_start_url = questionary.text(
+                "Enter your IAM Identity Center start URL:",
+                instruction="(e.g., https://company.awsapps.com/start)",
+                default=config.get("idc_start_url", ""),
+                validate=lambda x: bool(x.strip()) or "Start URL cannot be empty",
+            ).ask()
+            if idc_start_url is None:
+                return None
+            config["idc_start_url"] = idc_start_url.strip().rstrip("/")
+
+            # SSO region (auto-suggest from start URL if possible)
+            suggested_region = "us-east-1"
+            import re as _re
+
+            _region_match = _re.search(r"\.(us|eu|ap|sa|ca|me|af|il)-[a-z]+-\d+\.", idc_start_url)
+            if _region_match:
+                suggested_region = _region_match.group(0).strip(".")
+
+            sso_region = questionary.text(
+                "Enter your SSO region (where Identity Center is configured):",
+                default=config.get("sso_region", suggested_region),
+                validate=lambda x: bool(x.strip()) or "SSO region cannot be empty",
+            ).ask()
+            if sso_region is None:
+                return None
+            config["sso_region"] = sso_region.strip()
+
+            # AWS account ID
+            account_id = questionary.text(
+                "Enter the AWS account ID for Bedrock access:",
+                default=config.get("idc_account_id", ""),
+                validate=lambda x: (
+                    (len(x.strip()) == 12 and x.strip().isdigit()) or "Must be a 12-digit AWS account ID"
+                ),
+            ).ask()
+            if account_id is None:
+                return None
+            config["idc_account_id"] = account_id.strip()
+
+            # Permission set name
+            permission_set = questionary.text(
+                "Enter the permission set name (IAM role users will assume):",
+                instruction="(e.g., BedrockDeveloperAccess)",
+                default=config.get("idc_permission_set_name", "BedrockDeveloperAccess"),
+                validate=lambda x: bool(x.strip()) or "Permission set name cannot be empty",
+            ).ask()
+            if permission_set is None:
+                return None
+            config["idc_permission_set_name"] = permission_set.strip()
+
+            console.print("\n[green]✓[/green] IAM Identity Center configured")
+            console.print(f"  Start URL: {config['idc_start_url']}")
+            console.print(f"  Region: {config['sso_region']}")
+            console.print(f"  Account: {config['idc_account_id']}")
+            console.print(f"  Permission Set: {config['idc_permission_set_name']}")
+
         # OIDC Provider Configuration
         if not skip_okta and config.get("sso_enabled", True):
             console.print("\n[bold blue]OIDC Provider Configuration[/bold blue]")
@@ -2459,6 +2525,11 @@ class InitCommand(Command):
             "federation_type": config_data.get("federation_type", "cognito"),
             "max_session_duration": config_data.get("max_session_duration", 28800),
             "sso_enabled": config_data.get("sso_enabled", True),
+            "auth_type": config_data.get("auth_type", "oidc"),
+            "idc_start_url": config_data.get("idc_start_url"),
+            "idc_account_id": config_data.get("idc_account_id"),
+            "idc_permission_set_name": config_data.get("idc_permission_set_name"),
+            "sso_region": config_data.get("sso_region"),
             "azure_auth_mode": config_data.get("azure_auth_mode"),
             "client_certificate_path": config_data.get("client_certificate_path"),
             "client_certificate_key_path": config_data.get("client_certificate_key_path"),

--- a/source/claude_code_with_bedrock/cli/utils/helpers.py
+++ b/source/claude_code_with_bedrock/cli/utils/helpers.py
@@ -20,7 +20,7 @@ def is_wsl() -> bool:
     try:
         version_info = Path("/proc/version").read_text().lower()
         return "microsoft" in version_info or "wsl" in version_info
-    except (OSError, IOError):
+    except OSError:
         return False
 
 

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -114,6 +114,7 @@ class Profile:
     idc_start_url: str | None = None  # e.g. https://company.awsapps.com/start
     idc_account_id: str | None = None  # AWS account ID for IDC access
     idc_permission_set_name: str | None = None  # Permission set / role name
+    sso_region: str | None = None  # AWS region where Identity Center is configured
 
     # Confidential client authentication (Azure AD / Entra ID)
     # If neither is set, public client flow is used (current default).

--- a/source/tests/cli/commands/test_package_managed_settings.py
+++ b/source/tests/cli/commands/test_package_managed_settings.py
@@ -325,13 +325,13 @@ class TestInstallerSudoOwnership:
         """User-space paths (~/claude-code-with-bedrock, ~/.claude, ~/.aws) must use ACTUAL_HOME."""
         script = self._get_installer_script(self._make_profile())
         # Must not hard-code ~ for user-space directories
-        assert 'mkdir -p ~/claude-code-with-bedrock' not in script
-        assert 'mkdir -p ~/.claude' not in script
-        assert 'mkdir -p ~/.aws' not in script
+        assert "mkdir -p ~/claude-code-with-bedrock" not in script
+        assert "mkdir -p ~/.claude" not in script
+        assert "mkdir -p ~/.aws" not in script
         # Must use ACTUAL_HOME variable instead
-        assert '$ACTUAL_HOME/claude-code-with-bedrock' in script
-        assert '$ACTUAL_HOME/.claude' in script
-        assert '$ACTUAL_HOME/.aws' in script
+        assert "$ACTUAL_HOME/claude-code-with-bedrock" in script
+        assert "$ACTUAL_HOME/.claude" in script
+        assert "$ACTUAL_HOME/.aws" in script
 
     def test_installer_managed_settings_does_not_exit_if_not_root(self):
         """Managed settings must not exit 1 when script runs as non-root; use inline sudo instead."""

--- a/source/tests/cli/commands/test_quota_set_alias.py
+++ b/source/tests/cli/commands/test_quota_set_alias.py
@@ -7,11 +7,10 @@ Addresses #634 comment: users expect 'ccwb quota set user@co.com --budget 50'
 syntax as documented in PR #633, but only set-user/set-group/set-default existed.
 """
 
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from cleo.testers.application_tester import ApplicationTester
-from cleo.testers.command_tester import CommandTester
 
 from claude_code_with_bedrock.cli import create_application
 

--- a/source/tests/test_wsl_keyring_detection.py
+++ b/source/tests/test_wsl_keyring_detection.py
@@ -3,10 +3,9 @@
 
 """Tests for WSL detection and keyring availability."""
 
-from unittest.mock import patch, MagicMock
-import pytest
+from unittest.mock import MagicMock, patch
 
-from claude_code_with_bedrock.cli.utils.helpers import is_wsl, is_keyring_available
+from claude_code_with_bedrock.cli.utils.helpers import is_keyring_available, is_wsl
 
 
 class TestIsWsl:
@@ -24,25 +23,20 @@ class TestIsWsl:
     @patch("claude_code_with_bedrock.cli.utils.helpers.Path")
     def test_wsl2_detected(self, mock_path, mock_system):
         mock_path.return_value.read_text.return_value = (
-            "Linux version 5.15.153.1-microsoft-standard-WSL2 "
-            "(gcc (GCC) 11.2.0, GNU ld (GNU Binutils) 2.37)"
+            "Linux version 5.15.153.1-microsoft-standard-WSL2 (gcc (GCC) 11.2.0, GNU ld (GNU Binutils) 2.37)"
         )
         assert is_wsl() is True
 
     @patch("claude_code_with_bedrock.cli.utils.helpers.platform.system", return_value="Linux")
     @patch("claude_code_with_bedrock.cli.utils.helpers.Path")
     def test_wsl1_detected(self, mock_path, mock_system):
-        mock_path.return_value.read_text.return_value = (
-            "Linux version 4.4.0-19041-Microsoft (Microsoft@Microsoft.com)"
-        )
+        mock_path.return_value.read_text.return_value = "Linux version 4.4.0-19041-Microsoft (Microsoft@Microsoft.com)"
         assert is_wsl() is True
 
     @patch("claude_code_with_bedrock.cli.utils.helpers.platform.system", return_value="Linux")
     @patch("claude_code_with_bedrock.cli.utils.helpers.Path")
     def test_native_linux_returns_false(self, mock_path, mock_system):
-        mock_path.return_value.read_text.return_value = (
-            "Linux version 6.17.0-1017-aws (buildd@lcy02-amd64-116)"
-        )
+        mock_path.return_value.read_text.return_value = "Linux version 6.17.0-1017-aws (buildd@lcy02-amd64-116)"
         assert is_wsl() is False
 
     @patch("claude_code_with_bedrock.cli.utils.helpers.platform.system", return_value="Linux")
@@ -67,7 +61,6 @@ class TestIsKeyringAvailable:
                 wraps=is_keyring_available,
             ):
                 # When keyring import fails, should return False
-                import importlib
                 with patch("builtins.__import__", side_effect=ImportError):
                     assert is_keyring_available() is False
 
@@ -81,6 +74,7 @@ class TestIsKeyringAvailable:
             with patch("claude_code_with_bedrock.cli.utils.helpers.is_wsl", return_value=False):
                 # Simulate FailKeyring detection
                 from keyring.backends.fail import Keyring as FailKeyring
+
                 mock_keyring.get_keyring.return_value = FailKeyring()
                 # This is tricky to test due to import mechanics; covered by integration
                 pass
@@ -95,11 +89,14 @@ class TestIsKeyringAvailable:
         mock_fail_module = MagicMock()
         mock_fail_keyring_class = type("FailKeyring", (), {})
 
-        with patch.dict("sys.modules", {
-            "keyring": mock_keyring,
-            "keyring.backends": MagicMock(),
-            "keyring.backends.fail": mock_fail_module,
-        }):
+        with patch.dict(
+            "sys.modules",
+            {
+                "keyring": mock_keyring,
+                "keyring.backends": MagicMock(),
+                "keyring.backends.fail": mock_fail_module,
+            },
+        ):
             mock_fail_module.Keyring = mock_fail_keyring_class
             # backend is not an instance of FailKeyring
             assert is_keyring_available() is True


### PR DESCRIPTION
## Problem

When a user selects "IAM Identity Center" in the `ccwb init` auth method step, no further configuration is collected. The user is left to manually configure `~/.aws/config` with SSO settings. This is a regression from commit `a777677` which reverted the IDC-specific init prompts originally introduced in PR #462.

## Solution

Add a guided IDC configuration section to the init wizard that collects:
- **SSO start URL** (e.g., `https://company.awsapps.com/start`)
- **SSO region** (auto-suggested from start URL domain)
- **AWS account ID** (validated as 12-digit)
- **Permission set name** (defaults to `BedrockDeveloperAccess`)

These values are persisted to the profile config for use by `deploy` and `credential-process`.

## Changes

- `source/claude_code_with_bedrock/cli/commands/init.py` — Add IDC config wizard block between auth selection and OIDC config
- `source/claude_code_with_bedrock/config.py` — Add `sso_region` field to Profile dataclass
- Save IDC fields (`auth_type`, `idc_start_url`, `idc_account_id`, `idc_permission_set_name`, `sso_region`) in wizard_fields

## Risk

**Low** — Only triggers when `auth_type == "idc"` is selected. No changes to OIDC or None paths. Config fields already existed in dataclass (except `sso_region` which is additive).
