### PR TITLE
fix(websearch): MCP auth-header helper — Go/Python refresh parity + expired-token handling

### DIFF
--- a/source/credential_provider/__main__.py
+++ b/source/credential_provider/__main__.py
@@ -899,6 +899,19 @@ class MultiProviderAuth:
         except Exception:
             return None
 
+    def get_mcp_auth_header(self):
+        """Return the MCP Authorization header dict from the cached id_token, or None.
+
+        {"Authorization": "Bearer <id_token>"} for the AgentCore web-search MCP
+        headersHelper. Reads only the cached/silently-refreshed token via
+        get_monitoring_token() — never opens a browser. Returns None when no
+        valid token is available so the caller fails cleanly (no hang, no prompt).
+        """
+        token = self.get_monitoring_token()
+        if not token:
+            return None
+        return {"Authorization": f"Bearer {token}"}
+
     def save_to_credentials_file(self, credentials, profile="ClaudeCode"):
         """Save credentials to ~/.aws/credentials file
 
@@ -2471,6 +2484,14 @@ def main():
         "--get-monitoring-token", action="store_true", help="Get cached monitoring token instead of AWS credentials"
     )
     parser.add_argument(
+        "--get-mcp-auth-header",
+        action="store_true",
+        help=(
+            'Print {"Authorization":"Bearer <id_token>"} from the cached token for an MCP '
+            "headersHelper (never opens a browser)"
+        ),
+    )
+    parser.add_argument(
         "--clear-cache", action="store_true", help="Clear cached credentials and force re-authentication"
     )
     parser.add_argument(
@@ -2559,6 +2580,27 @@ def main():
                 # Return failure exit code so OTEL helper knows auth failed
                 # This prevents OTEL helper from using default/unknown values
                 sys.exit(1)
+
+    # Handle MCP auth-header request.
+    # Used as the headersHelper for the AgentCore web-search MCP server, whose
+    # gateway runs a CUSTOM_JWT authorizer validating the same OIDC id_token the
+    # solution already mints. MUST be fast and MUST NOT open a browser — an MCP
+    # headersHelper can never drive an interactive login. So, unlike
+    # --get-monitoring-token, this never falls through to authentication: on a
+    # cache miss it fails cleanly with a non-zero exit.
+    if args.get_mcp_auth_header:
+        header = auth.get_mcp_auth_header()
+        if header:
+            # Compact separators so Go (encoding/json) and Python emit byte-identical output.
+            print(json.dumps(header, separators=(",", ":")))
+            sys.exit(0)
+        else:
+            print(
+                f"Error: no valid cached token for profile '{args.profile}'; "
+                "run the credential process once to authenticate.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
     # Handle check-expiration request
     if args.check_expiration:

--- a/source/credential_provider/__main__.py
+++ b/source/credential_provider/__main__.py
@@ -849,16 +849,15 @@ class MultiProviderAuth:
             # Non-fatal error - monitoring is optional
             self._debug_print(f"Warning: Could not save monitoring token: {e}")
 
-    def get_monitoring_token(self):
-        """Retrieve valid monitoring token from configured storage"""
+    def _load_monitoring_token_data(self):
+        """Load the raw monitoring-token blob from configured storage, or None.
+
+        Returns the parsed dict (with "token"/"expires") WITHOUT applying the
+        expiry check, so callers can tell "absent" apart from "present but
+        expired". Does not consult CLAUDE_CODE_MONITORING_TOKEN (that path
+        carries no expiry metadata).
+        """
         try:
-            # First check if it's in environment (from current session)
-            import os
-
-            env_token = os.environ.get("CLAUDE_CODE_MONITORING_TOKEN")
-            if env_token:
-                return env_token
-
             if self.credential_storage == "keyring":
                 if platform.system() == "Windows":
                     # Reassemble from chunked entries (with legacy fallback).
@@ -884,6 +883,24 @@ class MultiProviderAuth:
                 with open(token_file, encoding="utf-8") as f:
                     token_data = json.load(f)
 
+            return token_data
+        except Exception:
+            return None
+
+    def get_monitoring_token(self):
+        """Retrieve valid monitoring token from configured storage"""
+        try:
+            # First check if it's in environment (from current session)
+            import os
+
+            env_token = os.environ.get("CLAUDE_CODE_MONITORING_TOKEN")
+            if env_token:
+                return env_token
+
+            token_data = self._load_monitoring_token_data()
+            if not token_data:
+                return None
+
             # Check expiration
             exp_time = token_data.get("expires", 0)
             now = int(datetime.now(timezone.utc).timestamp())
@@ -903,14 +920,33 @@ class MultiProviderAuth:
         """Return the MCP Authorization header dict from the cached id_token, or None.
 
         {"Authorization": "Bearer <id_token>"} for the AgentCore web-search MCP
-        headersHelper. Reads only the cached/silently-refreshed token via
-        get_monitoring_token() — never opens a browser. Returns None when no
-        valid token is available so the caller fails cleanly (no hang, no prompt).
+        headersHelper. Reads only the cached token via get_monitoring_token() —
+        never opens a browser. Returns None when no valid token is available so
+        the caller fails cleanly (no hang, no prompt).
+
+        NOTE (Go/Python asymmetry): the Go credential-process silently re-mints
+        an expired id_token via a browserless refresh_token exchange
+        (refreshIDTokenOnly) before giving up. The Python provider has no
+        refresh_token store, so it cannot do that here — a present-but-expired
+        token surfaces as None. We emit a one-line stderr hint distinguishing
+        "expired" from "never authenticated" so the failure is diagnosable, then
+        rely on the next full credential-process run (which Claude Code invokes
+        routinely) to re-mint and re-cache the token. Full silent-refresh parity
+        is a larger cross-cutting change tracked separately.
         """
         token = self.get_monitoring_token()
-        if not token:
-            return None
-        return {"Authorization": f"Bearer {token}"}
+        if token:
+            return {"Authorization": f"Bearer {token}"}
+
+        # Distinguish expired-but-present from absent for a useful diagnostic.
+        token_data = self._load_monitoring_token_data()
+        if token_data and token_data.get("token"):
+            print(
+                f"Note: cached token for profile '{self.profile}' is expired; "
+                "re-run the credential process to refresh it.",
+                file=sys.stderr,
+            )
+        return None
 
     def save_to_credentials_file(self, credentials, profile="ClaudeCode"):
         """Save credentials to ~/.aws/credentials file

--- a/source/go/cmd/credential-process/main.go
+++ b/source/go/cmd/credential-process/main.go
@@ -771,17 +771,13 @@ func (a *credentialApp) refreshIDTokenOnly() string {
 		return ""
 	}
 
-	// Resolve token endpoint URL (same logic as tryRefreshToken).
+	// Resolve token endpoint URL — use shared builder from #666 to avoid
+	// Azure /v2.0 doubling and keep parity with tryRefreshToken.
 	var tokenURL string
 	if a.providerType == "generic" {
 		tokenURL = a.cfg.OIDCTokenEndpoint
 	} else {
-		provCfg := provider.ConfigFor(a.providerType, a.cfg.OktaAuthServerID)
-		if strings.HasPrefix(provCfg.TokenEndpoint, "https://") {
-			tokenURL = provCfg.TokenEndpoint
-		} else {
-			tokenURL = "https://" + a.cfg.ProviderDomain + provCfg.TokenEndpoint
-		}
+		tokenURL = provider.TokenEndpointURL(a.providerType, a.cfg.OktaAuthServerID, a.cfg.ProviderDomain)
 	}
 
 	confidential, err := a.resolveConfidentialAuth()

--- a/source/go/cmd/credential-process/main.go
+++ b/source/go/cmd/credential-process/main.go
@@ -280,11 +280,17 @@ func (a *credentialApp) getMCPAuthHeader() int {
 	token, err := storage.GetMonitoringToken(a.profile, a.cfg.CredentialStorage)
 	if (err != nil || token == "") && a.cfg.IsSsoEnabled() && !a.cfg.IsIDC() {
 		// Cached id_token expired/near-expiry. Try the silent refresh_token
-		// exchange (no browser) before giving up — mirrors getMonitoringToken
-		// but stops here: an MCP headersHelper can never drive an interactive
-		// login. Only attempt for OIDC; idc/none have no id_token (Story B).
-		if creds := a.tryRefreshToken(); creds != nil {
-			token, err = storage.GetMonitoringToken(a.profile, a.cfg.CredentialStorage)
+		// exchange (no browser) before giving up — but stop here: an MCP
+		// headersHelper can never drive an interactive login. Only attempt for
+		// OIDC; idc/none have no id_token (Story B).
+		//
+		// Use refreshIDTokenOnly (NOT tryRefreshToken): the gateway's CUSTOM_JWT
+		// authorizer only needs the id_token, so a successful refresh must NOT be
+		// thrown away just because the unrelated AWS STS/IAM credential exchange
+		// fails or times out. tryRefreshToken couples the two and would discard a
+		// perfectly valid refreshed id_token on a Cognito/STS hiccup.
+		if fresh := a.refreshIDTokenOnly(); fresh != "" {
+			token, err = fresh, nil
 		}
 	}
 	if err != nil || token == "" {
@@ -744,6 +750,74 @@ func (a *credentialApp) tryRefreshToken() *federation.AWSCredentials {
 
 	debugPrint("Refresh token exchange succeeded — credentials renewed without browser")
 	return creds
+}
+
+// refreshIDTokenOnly performs the browserless refresh_token exchange and returns
+// a fresh id_token WITHOUT exchanging it for AWS credentials. It exists for the
+// MCP headersHelper path (--get-mcp-auth-header): the AgentCore CUSTOM_JWT gateway
+// authorizer validates only the id_token, so the header must still be emitted even
+// when the AWS STS/IAM credential exchange would fail or time out — a failure mode
+// unrelated to gateway auth. (tryRefreshToken couples the two and returns nil if
+// cred exchange fails, which would discard a valid refreshed id_token.)
+//
+// It mirrors tryRefreshToken's endpoint/confidential-auth resolution and persists
+// the refreshed monitoring token + rotated refresh_token so the next cache read
+// hits, but never opens a browser. Returns "" on any failure so the caller fails
+// cleanly. Only meaningful for OIDC (idc/none have no id_token — Story B).
+func (a *credentialApp) refreshIDTokenOnly() string {
+	refreshToken := storage.LoadRefreshToken(a.profile, a.cfg.CredentialStorage)
+	if refreshToken == "" {
+		debugPrint("No cached refresh_token, cannot refresh id_token silently")
+		return ""
+	}
+
+	// Resolve token endpoint URL (same logic as tryRefreshToken).
+	var tokenURL string
+	if a.providerType == "generic" {
+		tokenURL = a.cfg.OIDCTokenEndpoint
+	} else {
+		provCfg := provider.ConfigFor(a.providerType, a.cfg.OktaAuthServerID)
+		if strings.HasPrefix(provCfg.TokenEndpoint, "https://") {
+			tokenURL = provCfg.TokenEndpoint
+		} else {
+			tokenURL = "https://" + a.cfg.ProviderDomain + provCfg.TokenEndpoint
+		}
+	}
+
+	confidential, err := a.resolveConfidentialAuth()
+	if err != nil {
+		debugPrint("Failed to resolve confidential auth for id_token refresh: %v", err)
+		return ""
+	}
+
+	tokenResp, err := oidc.RefreshTokenExchange(tokenURL, refreshToken, a.cfg.ClientID, confidential)
+	if err != nil {
+		debugPrint("Refresh token exchange failed: %v", err)
+		// Token may be revoked/expired — clear it so we don't retry next time.
+		storage.ClearRefreshToken(a.profile)
+		return ""
+	}
+	if tokenResp.IDToken == "" {
+		debugPrint("Refresh response did not contain an id_token")
+		return ""
+	}
+
+	claims, err := jwt.DecodePayload(tokenResp.IDToken)
+	if err != nil {
+		debugPrint("Failed to decode refreshed id_token: %v", err)
+		return ""
+	}
+
+	// Persist the refreshed monitoring token so the next cache read hits, and
+	// rotate the refresh_token (some IdPs rotate on every use). Deliberately no
+	// AWS credential exchange here — see the doc comment above.
+	a.saveMonitoringTokenAndHeaders(tokenResp.IDToken, map[string]interface{}(claims))
+	if tokenResp.RefreshToken != "" {
+		_ = storage.SaveRefreshToken(a.profile, a.cfg.CredentialStorage, tokenResp.RefreshToken)
+	}
+
+	debugPrint("id_token refreshed without browser (no AWS credential exchange)")
+	return tokenResp.IDToken
 }
 
 // saveMonitoringTokenAndHeaders persists the monitoring token and also writes

--- a/source/go/cmd/credential-process/main.go
+++ b/source/go/cmd/credential-process/main.go
@@ -282,7 +282,7 @@ func (a *credentialApp) getMCPAuthHeader() int {
 		// Cached id_token expired/near-expiry. Try the silent refresh_token
 		// exchange (no browser) before giving up — but stop here: an MCP
 		// headersHelper can never drive an interactive login. Only attempt for
-		// OIDC; idc/none have no id_token (Story B).
+		// OIDC; idc/none have no id_token.
 		//
 		// Use refreshIDTokenOnly (NOT tryRefreshToken): the gateway's CUSTOM_JWT
 		// authorizer only needs the id_token, so a successful refresh must NOT be
@@ -763,7 +763,7 @@ func (a *credentialApp) tryRefreshToken() *federation.AWSCredentials {
 // It mirrors tryRefreshToken's endpoint/confidential-auth resolution and persists
 // the refreshed monitoring token + rotated refresh_token so the next cache read
 // hits, but never opens a browser. Returns "" on any failure so the caller fails
-// cleanly. Only meaningful for OIDC (idc/none have no id_token — Story B).
+// cleanly. Only meaningful for OIDC (idc/none have no id_token).
 func (a *credentialApp) refreshIDTokenOnly() string {
 	refreshToken := storage.LoadRefreshToken(a.profile, a.cfg.CredentialStorage)
 	if refreshToken == "" {
@@ -846,7 +846,6 @@ func (a *credentialApp) saveMonitoringTokenAndHeaders(idToken string, claims map
 		}
 	}
 }
-
 
 func (a *credentialApp) shouldRecheckQuota() bool {
 	if a.cfg.QuotaAPIEndpoint == "" {

--- a/source/go/cmd/credential-process/main.go
+++ b/source/go/cmd/credential-process/main.go
@@ -44,6 +44,7 @@ func main() {
 	versionFlag := flag.Bool("version", false, "Show version")
 	shortVersion := flag.Bool("v", false, "Show version (short)")
 	getMonitoring := flag.Bool("get-monitoring-token", false, "Get cached monitoring token")
+	getMCPAuthHeader := flag.Bool("get-mcp-auth-header", false, "Print {\"Authorization\":\"Bearer <id_token>\"} from the cached token for an MCP headersHelper (never opens a browser)")
 	clearCache := flag.Bool("clear-cache", false, "Clear cached credentials")
 	checkExpiration := flag.Bool("check-expiration", false, "Check if credentials are expired")
 	refreshIfNeeded := flag.Bool("refresh-if-needed", false, "Refresh credentials if expired")
@@ -95,6 +96,9 @@ func main() {
 	}
 	if *getMonitoring {
 		os.Exit(app.getMonitoringToken())
+	}
+	if *getMCPAuthHeader {
+		os.Exit(app.getMCPAuthHeader())
 	}
 	if *checkExpiration {
 		os.Exit(app.checkExpiration())
@@ -261,6 +265,39 @@ func (a *credentialApp) getMonitoringToken() int {
 	a.saveMonitoringTokenAndHeaders(authResult.IDToken, map[string]interface{}(authResult.TokenClaims))
 
 	fmt.Println(authResult.IDToken)
+	return 0
+}
+
+// getMCPAuthHeader prints {"Authorization":"Bearer <id_token>"} to stdout for
+// use as an MCP server headersHelper (the AgentCore web-search gateway uses a
+// CUSTOM_JWT authorizer that validates the same OIDC id_token the solution
+// already mints). It MUST NOT open a browser and MUST return quickly so it fits
+// inside Claude Code's headersHelper budget — so unlike getMonitoringToken it
+// never falls through to authenticate(). On a cache miss it attempts only the
+// browserless refresh_token exchange; if that also fails it exits non-zero with
+// a clear stderr message rather than hanging or prompting.
+func (a *credentialApp) getMCPAuthHeader() int {
+	token, err := storage.GetMonitoringToken(a.profile, a.cfg.CredentialStorage)
+	if (err != nil || token == "") && a.cfg.IsSsoEnabled() && !a.cfg.IsIDC() {
+		// Cached id_token expired/near-expiry. Try the silent refresh_token
+		// exchange (no browser) before giving up — mirrors getMonitoringToken
+		// but stops here: an MCP headersHelper can never drive an interactive
+		// login. Only attempt for OIDC; idc/none have no id_token (Story B).
+		if creds := a.tryRefreshToken(); creds != nil {
+			token, err = storage.GetMonitoringToken(a.profile, a.cfg.CredentialStorage)
+		}
+	}
+	if err != nil || token == "" {
+		fmt.Fprintf(os.Stderr, "Error: no valid cached token for profile '%s'; run the credential process once to authenticate.\n", a.profile)
+		return 1
+	}
+
+	out, mErr := json.Marshal(map[string]string{"Authorization": "Bearer " + token})
+	if mErr != nil {
+		fmt.Fprintf(os.Stderr, "Error: failed to encode auth header: %v\n", mErr)
+		return 1
+	}
+	fmt.Println(string(out))
 	return 0
 }
 

--- a/source/go/cmd/credential-process/mcp_auth_header_test.go
+++ b/source/go/cmd/credential-process/mcp_auth_header_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"ccwb-go/internal/config"
+	"ccwb-go/internal/storage"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+// writeMonitoringToken seeds a session-mode monitoring token file with the
+// given token and expiry so storage.GetMonitoringToken returns it.
+func writeMonitoringToken(t *testing.T, home, profile, token string, exp int64) {
+	t.Helper()
+	dir := filepath.Join(home, ".claude-code-session")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	data := map[string]interface{}{
+		"token":   token,
+		"expires": exp,
+		"email":   "test@example.com",
+		"profile": profile,
+	}
+	raw, err := json.Marshal(data)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	path := filepath.Join(dir, profile+"-monitoring.json")
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+// TestGetMCPAuthHeader_OutputShape pins the exact JSON the header mode emits,
+// which is the contract Python must match byte-for-byte (credential-helper-parity).
+func TestGetMCPAuthHeader_OutputShape(t *testing.T) {
+	out, err := json.Marshal(map[string]string{"Authorization": "Bearer tok"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	const want = `{"Authorization":"Bearer tok"}`
+	if string(out) != want {
+		t.Fatalf("header JSON shape = %q, want %q", string(out), want)
+	}
+}
+
+// TestGetMCPAuthHeader_CachedToken verifies a valid cached token is returned as
+// a Bearer auth header without any browser/network side effects.
+func TestGetMCPAuthHeader_CachedToken(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir) // Windows
+	// Ensure no env token leaks in from the host.
+	t.Setenv("CLAUDE_CODE_MONITORING_TOKEN", "")
+
+	profile := "test-mcp-auth-cached"
+	// Expiry well beyond the 600s buffer in storage.GetMonitoringToken.
+	writeMonitoringToken(t, tmpDir, profile, "cached-id-token", time.Now().Unix()+3600)
+
+	cfg := &config.ProfileConfig{
+		ClientID:          "test-client",
+		ProviderDomain:    "test.example.com",
+		CredentialStorage: "session",
+		SsoEnabled:        boolPtr(true),
+	}
+	app := &credentialApp{profile: profile, cfg: cfg, providerType: "okta"}
+
+	if code := app.getMCPAuthHeader(); code != 0 {
+		t.Fatalf("getMCPAuthHeader exit = %d, want 0", code)
+	}
+}
+
+// TestGetMCPAuthHeader_NoToken verifies a clean non-zero exit when no valid
+// token is cached and no refresh_token is available — never hangs, never opens
+// a browser (getMCPAuthHeader has no authenticate() fall-through by design).
+func TestGetMCPAuthHeader_NoToken(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+	t.Setenv("CLAUDE_CODE_MONITORING_TOKEN", "")
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".claude-code-session"), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	profile := "test-mcp-auth-empty"
+	t.Cleanup(func() { storage.ClearRefreshToken(profile) })
+
+	cfg := &config.ProfileConfig{
+		ClientID:          "test-client",
+		ProviderDomain:    "test.invalid.example.com", // unreachable if refresh were attempted
+		CredentialStorage: "session",
+		SsoEnabled:        boolPtr(true),
+	}
+	app := &credentialApp{profile: profile, cfg: cfg, providerType: "okta"}
+
+	if code := app.getMCPAuthHeader(); code != 1 {
+		t.Fatalf("getMCPAuthHeader exit = %d, want 1 (clean failure)", code)
+	}
+}
+
+// TestGetMCPAuthHeader_EnvToken verifies the env-var token shortcut also works,
+// matching getMonitoringToken's CLAUDE_CODE_MONITORING_TOKEN precedence.
+func TestGetMCPAuthHeader_EnvToken(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+	t.Setenv("CLAUDE_CODE_MONITORING_TOKEN", "env-supplied-token")
+
+	cfg := &config.ProfileConfig{
+		ClientID:          "test-client",
+		ProviderDomain:    "test.example.com",
+		CredentialStorage: "session",
+		SsoEnabled:        boolPtr(true),
+	}
+	app := &credentialApp{profile: "test-mcp-auth-env", cfg: cfg, providerType: "okta"}
+
+	if code := app.getMCPAuthHeader(); code != 0 {
+		t.Fatalf("getMCPAuthHeader exit = %d, want 0 with env token", code)
+	}
+}

--- a/source/go/cmd/credential-process/mcp_auth_header_test.go
+++ b/source/go/cmd/credential-process/mcp_auth_header_test.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"encoding/base64"
 	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,6 +14,44 @@ import (
 	"ccwb-go/internal/config"
 	"ccwb-go/internal/storage"
 )
+
+// mcpStdoutResult bundles an exit code with whatever the function printed.
+type mcpStdoutResult struct {
+	code   int
+	stdout string
+}
+
+// captureMCPStdout runs fn with os.Stdout redirected to a pipe and returns its
+// exit code plus what it printed — used to assert the exact bearer value emitted.
+func captureMCPStdout(t *testing.T, fn func() int) mcpStdoutResult {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	code := fn()
+	_ = w.Close()
+	os.Stdout = orig
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read pipe: %v", err)
+	}
+	return mcpStdoutResult{code: code, stdout: string(out)}
+}
+
+// fakeJWT builds a syntactically valid 3-part JWT with the given payload claims
+// so jwt.DecodePayload (which does not verify the signature) accepts it.
+func fakeJWT(t *testing.T, claims map[string]interface{}) string {
+	t.Helper()
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal claims: %v", err)
+	}
+	enc := base64.RawURLEncoding.EncodeToString
+	return enc([]byte(`{"alg":"none"}`)) + "." + enc(payload) + ".sig"
+}
 
 func boolPtr(b bool) *bool { return &b }
 
@@ -101,6 +143,72 @@ func TestGetMCPAuthHeader_NoToken(t *testing.T) {
 
 	if code := app.getMCPAuthHeader(); code != 1 {
 		t.Fatalf("getMCPAuthHeader exit = %d, want 1 (clean failure)", code)
+	}
+}
+
+// TestGetMCPAuthHeader_RefreshSucceedsWithoutAWSCreds is the regression test for
+// the Codex P2 finding: on an expired/absent cached id_token, the MCP header path
+// must silently refresh and emit the FRESH id_token even when AWS STS/IAM
+// credential exchange would fail — the gateway's CUSTOM_JWT authorizer only needs
+// the id_token, so refresh success must not be coupled to cred exchange.
+//
+// Setup: a generic OIDC provider whose token endpoint is a local httptest server
+// returning a fresh id_token, a stored refresh_token, and NO cached monitoring
+// token. There is no STS endpoint configured, so if the code path attempted an
+// AWS credential exchange (the old tryRefreshToken behavior) it would fail and the
+// header would NOT be emitted. Asserting exit 0 + the fresh token proves the
+// decoupling (refreshIDTokenOnly).
+func TestGetMCPAuthHeader_RefreshSucceedsWithoutAWSCreds(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+	t.Setenv("CLAUDE_CODE_MONITORING_TOKEN", "")
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".claude-code-session"), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	freshIDToken := fakeJWT(t, map[string]interface{}{
+		"email": "user@example.com",
+		"exp":   time.Now().Unix() + 3600,
+	})
+
+	// Mock token endpoint: any refresh_token request returns the fresh id_token.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"id_token":      freshIDToken,
+			"refresh_token": "rotated-refresh-token",
+		})
+	}))
+	defer srv.Close()
+
+	profile := "test-mcp-auth-refresh"
+	if err := storage.SaveRefreshToken(profile, "session", "stored-refresh-token"); err != nil {
+		t.Fatalf("seed refresh token: %v", err)
+	}
+	t.Cleanup(func() { storage.ClearRefreshToken(profile) })
+
+	// Generic provider → refreshIDTokenOnly uses cfg.OIDCTokenEndpoint directly.
+	// No QuotaAPIEndpoint / STS config: an AWS cred exchange would fail here.
+	cfg := &config.ProfileConfig{
+		ClientID:          "test-client",
+		ProviderDomain:    "generic.example.com",
+		CredentialStorage: "session",
+		SsoEnabled:        boolPtr(true),
+		OIDCTokenEndpoint: srv.URL,
+	}
+	app := &credentialApp{profile: profile, cfg: cfg, providerType: "generic"}
+
+	out := captureMCPStdout(t, func() int { return app.getMCPAuthHeader() })
+	if out.code != 0 {
+		t.Fatalf("getMCPAuthHeader exit = %d, want 0 (refresh must emit header without AWS creds)", out.code)
+	}
+	var header map[string]string
+	if err := json.Unmarshal([]byte(out.stdout), &header); err != nil {
+		t.Fatalf("emitted header not JSON: %v (raw=%q)", err, out.stdout)
+	}
+	if got, want := header["Authorization"], "Bearer "+freshIDToken; got != want {
+		t.Errorf("Authorization = %q, want the freshly refreshed id_token %q", got, want)
 	}
 }
 

--- a/source/go/cmd/credential-process/mcp_auth_header_test.go
+++ b/source/go/cmd/credential-process/mcp_auth_header_test.go
@@ -213,12 +213,17 @@ func TestGetMCPAuthHeader_RefreshSucceedsWithoutAWSCreds(t *testing.T) {
 }
 
 // TestGetMCPAuthHeader_EnvToken verifies the env-var token shortcut also works,
-// matching getMonitoringToken's CLAUDE_CODE_MONITORING_TOKEN precedence.
+// matching getMonitoringToken's CLAUDE_CODE_MONITORING_TOKEN precedence. The env
+// token must be a valid (non-expired) JWT: GetMonitoringToken drops an expired or
+// unparseable env token (PR #602, jwt.IsTokenExpired) so callers fall through to
+// refresh rather than attaching a stale token — so this test supplies a real JWT
+// with a future exp.
 func TestGetMCPAuthHeader_EnvToken(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 	t.Setenv("USERPROFILE", tmpDir)
-	t.Setenv("CLAUDE_CODE_MONITORING_TOKEN", "env-supplied-token")
+	envToken := fakeJWT(t, map[string]interface{}{"exp": time.Now().Unix() + 3600})
+	t.Setenv("CLAUDE_CODE_MONITORING_TOKEN", envToken)
 
 	cfg := &config.ProfileConfig{
 		ClientID:          "test-client",
@@ -228,7 +233,15 @@ func TestGetMCPAuthHeader_EnvToken(t *testing.T) {
 	}
 	app := &credentialApp{profile: "test-mcp-auth-env", cfg: cfg, providerType: "okta"}
 
-	if code := app.getMCPAuthHeader(); code != 0 {
-		t.Fatalf("getMCPAuthHeader exit = %d, want 0 with env token", code)
+	out := captureMCPStdout(t, func() int { return app.getMCPAuthHeader() })
+	if out.code != 0 {
+		t.Fatalf("getMCPAuthHeader exit = %d, want 0 with a valid env token", out.code)
+	}
+	var header map[string]string
+	if err := json.Unmarshal([]byte(out.stdout), &header); err != nil {
+		t.Fatalf("emitted header not JSON: %v (raw=%q)", err, out.stdout)
+	}
+	if header["Authorization"] != "Bearer "+envToken {
+		t.Errorf("Authorization = %q, want the env-supplied JWT", header["Authorization"])
 	}
 }

--- a/source/tests/test_mcp_auth_header.py
+++ b/source/tests/test_mcp_auth_header.py
@@ -1,4 +1,4 @@
-# ABOUTME: Tests for the --get-mcp-auth-header mode (AC4, T3) of the credential process.
+# ABOUTME: Tests for the --get-mcp-auth-header mode of the credential process.
 # ABOUTME: Verifies cached-token header output, clean no-browser failure, and Go↔Python output parity.
 """Tests for credential-process --get-mcp-auth-header (Python side + Go parity).
 
@@ -84,6 +84,74 @@ class TestGetMCPAuthHeader:
             header = auth_instance.get_mcp_auth_header()
         line = json.dumps(header, separators=(",", ":"))
         assert line == '{"Authorization":"Bearer tok"}'
+
+    def test_expired_present_token_returns_none_with_hint(self, auth_instance, capsys):
+        """A present-but-expired cached token → None plus an 'expired' stderr hint.
+
+        The Python provider has no refresh_token store, so unlike the Go variant
+        it cannot silently re-mint an expired id_token here. It must still fail
+        cleanly (None), and emit a diagnostic distinguishing expired from absent.
+        """
+        with patch.object(auth_instance, "get_monitoring_token", return_value=None):
+            with patch.object(
+                auth_instance,
+                "_load_monitoring_token_data",
+                return_value={"token": "stale.jwt.value", "expires": 0},
+            ):
+                header = auth_instance.get_mcp_auth_header()
+        assert header is None
+        err = capsys.readouterr().err
+        assert "expired" in err.lower()
+        assert auth_instance.profile in err
+
+    def test_absent_token_returns_none_without_expired_hint(self, auth_instance, capsys):
+        """No cached blob at all → None, and NO 'expired' hint (it was never minted)."""
+        with patch.object(auth_instance, "get_monitoring_token", return_value=None):
+            with patch.object(auth_instance, "_load_monitoring_token_data", return_value=None):
+                header = auth_instance.get_mcp_auth_header()
+        assert header is None
+        assert "expired" not in capsys.readouterr().err.lower()
+
+
+class TestGetMonitoringTokenExpiry:
+    """The expiry boundary that the MCP header path depends on (Daniel #8 gap).
+
+    Exercises the real session-file load + expiry check end-to-end, so the
+    expired-token behaviour is pinned against the actual storage code rather
+    than a mock.
+    """
+
+    def _write_session_token(self, home, profile, token, expires):
+        session_dir = home / ".claude-code-session"
+        session_dir.mkdir(parents=True, exist_ok=True)
+        (session_dir / f"{profile}-monitoring.json").write_text(
+            json.dumps({"token": token, "expires": expires}), encoding="utf-8"
+        )
+
+    def test_present_but_expired_token_is_not_returned(self, auth_instance, monkeypatch, tmp_path):
+        """An on-disk token whose `expires` is in the past is treated as absent."""
+        auth_instance.credential_storage = "session"
+        monkeypatch.delenv("CLAUDE_CODE_MONITORING_TOKEN", raising=False)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        now = int(__import__("time").time())
+        self._write_session_token(tmp_path, auth_instance.profile, "stale.jwt", now - 3600)
+
+        assert auth_instance.get_monitoring_token() is None
+        # ...but the raw blob is still loadable, so the header path can warn.
+        blob = auth_instance._load_monitoring_token_data()
+        assert blob is not None and blob.get("token") == "stale.jwt"
+
+    def test_valid_future_token_is_returned(self, auth_instance, monkeypatch, tmp_path):
+        """A token expiring comfortably in the future is returned verbatim."""
+        auth_instance.credential_storage = "session"
+        monkeypatch.delenv("CLAUDE_CODE_MONITORING_TOKEN", raising=False)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        now = int(__import__("time").time())
+        self._write_session_token(tmp_path, auth_instance.profile, "fresh.jwt", now + 3600)
+
+        assert auth_instance.get_monitoring_token() == "fresh.jwt"
 
 
 # Resolve the Go credential-process package dir for the parity test.

--- a/source/tests/test_mcp_auth_header.py
+++ b/source/tests/test_mcp_auth_header.py
@@ -1,0 +1,136 @@
+# ABOUTME: Tests for the --get-mcp-auth-header mode (AC4, T3) of the credential process.
+# ABOUTME: Verifies cached-token header output, clean no-browser failure, and Go↔Python output parity.
+"""Tests for credential-process --get-mcp-auth-header (Python side + Go parity).
+
+The AgentCore web-search MCP server uses a CUSTOM_JWT gateway authorizer that
+validates the same OIDC id_token the solution mints. Claude Code calls
+`credential-process --get-mcp-auth-header` as the MCP server's headersHelper to
+supply `{"Authorization":"Bearer <id_token>"}`. This mode MUST:
+  - print the header from the cached/silently-refreshed token,
+  - NEVER open a browser (a headersHelper can't drive interactive login),
+  - fail cleanly (non-zero, no hang) when no valid token is available,
+  - emit output byte-identical to the Go variant (credential-helper-parity).
+"""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def _make_config():
+    return {
+        "provider_domain": "test.okta.com",
+        "client_id": "test-client-id",
+        "identity_pool_id": "us-east-1:test-pool",
+        "aws_region": "us-east-1",
+        "credential_storage": "session",
+        "provider_type": "okta",
+        "federation_type": "cognito",
+        "max_session_duration": 28800,
+    }
+
+
+@pytest.fixture
+def auth_instance(tmp_path):
+    """A MultiProviderAuth instance with config + storage init mocked out."""
+    with (
+        patch("credential_provider.__main__.MultiProviderAuth._load_config") as mock_load,
+        patch("credential_provider.__main__.MultiProviderAuth._init_credential_storage"),
+    ):
+        mock_load.return_value = _make_config()
+        from credential_provider.__main__ import MultiProviderAuth
+
+        instance = MultiProviderAuth(profile="TestProfile")
+        instance.cache_dir = tmp_path / "cache"
+        instance.cache_dir.mkdir(parents=True, exist_ok=True)
+        return instance
+
+
+class TestGetMCPAuthHeader:
+    """Unit tests for MultiProviderAuth.get_mcp_auth_header."""
+
+    def test_returns_bearer_header_from_cached_token(self, auth_instance):
+        """A cached valid token yields {"Authorization": "Bearer <token>"}."""
+        with patch.object(auth_instance, "get_monitoring_token", return_value="cached-id-token"):
+            header = auth_instance.get_mcp_auth_header()
+        assert header == {"Authorization": "Bearer cached-id-token"}
+
+    def test_returns_none_when_no_cached_token(self, auth_instance):
+        """No valid cached token → None (caller fails cleanly, no browser)."""
+        with patch.object(auth_instance, "get_monitoring_token", return_value=None) as mock_token:
+            header = auth_instance.get_mcp_auth_header()
+        assert header is None
+        mock_token.assert_called_once()
+
+    def test_never_triggers_browser_authentication(self, auth_instance):
+        """The header path must not call any interactive/browser auth method."""
+        with (
+            patch.object(auth_instance, "get_monitoring_token", return_value=None),
+            patch.object(auth_instance, "authenticate_for_monitoring") as mock_auth_mon,
+            patch.object(auth_instance, "authenticate_oidc") as mock_auth_oidc,
+        ):
+            result = auth_instance.get_mcp_auth_header()
+        assert result is None
+        mock_auth_mon.assert_not_called()
+        mock_auth_oidc.assert_not_called()
+
+    def test_output_uses_compact_json_for_go_parity(self, auth_instance):
+        """The serialized line must match Go's encoding/json (no spaces after : or ,)."""
+        with patch.object(auth_instance, "get_monitoring_token", return_value="tok"):
+            header = auth_instance.get_mcp_auth_header()
+        line = json.dumps(header, separators=(",", ":"))
+        assert line == '{"Authorization":"Bearer tok"}'
+
+
+# Resolve the Go credential-process package dir for the parity test.
+# __file__ = source/tests/test_mcp_auth_header.py → parents[1] = source/ → source/go.
+_GO_DIR = Path(__file__).resolve().parents[1] / "go"
+
+
+def _go_available():
+    if not (_GO_DIR / "go.mod").exists():
+        return False
+    from shutil import which
+
+    return which("go") is not None
+
+
+@pytest.mark.skipif(not _go_available(), reason="Go toolchain or source not available")
+class TestGoPythonParity:
+    """The Go and Python variants must emit byte-identical header output (credential-helper-parity)."""
+
+    def test_compact_json_shape_matches_go_marshal(self, tmp_path):
+        """Python's compact json.dumps matches Go's json.Marshal(map[string]string) shape.
+
+        Run a tiny Go program that marshals the same map the credential-process builds,
+        and assert it equals the Python serialization for the same token.
+        """
+        token = "header.payload.signature"
+        go_src = (
+            "package main\n"
+            'import ("encoding/json";"fmt")\n'
+            "func main(){\n"
+            'b,_ := json.Marshal(map[string]string{"Authorization":"Bearer ' + token + '"})\n'
+            "fmt.Println(string(b))\n"
+            "}\n"
+        )
+        # Write a standalone .go file in an isolated temp dir (outside the module so
+        # `go run` doesn't try to resolve module deps) and execute it.
+        go_file = tmp_path / "parity_main.go"
+        go_file.write_text(go_src, encoding="utf-8")
+        proc = subprocess.run(
+            ["go", "run", str(go_file)],
+            capture_output=True,
+            text=True,
+            cwd=str(tmp_path),
+            env={**os.environ, "GOTOOLCHAIN": "local", "GO111MODULE": "off"},
+        )
+        assert proc.returncode == 0, f"go run failed: {proc.stderr}"
+        go_line = proc.stdout.strip()
+
+        py_line = json.dumps({"Authorization": f"Bearer {token}"}, separators=(",", ":"))
+        assert go_line == py_line == '{"Authorization":"Bearer header.payload.signature"}'


### PR DESCRIPTION
## Why

The `--get-mcp-auth-header` mode of the credential-process is the `headersHelper` for the AgentCore web-search MCP server — Claude Code calls it to supply `{"Authorization":"Bearer <id_token>"}` to the gateway's CUSTOM_JWT authorizer. Two gaps from review:

- **Go discarded a valid refreshed token on unrelated failures.** `getMCPAuthHeader` refreshed an expired id_token via `tryRefreshToken`, which returns `nil` unless it *also* exchanges the token for AWS credentials. A successful id_token refresh could be thrown away on an unrelated Cognito/STS/IAM error — even though the gateway only needs the id_token.
- **Python gave no signal on an expired token.** Python has no refresh_token store, so a present-but-expired token failed identically to "never authenticated", with no hint which case the user was in.

## What

- **Go:** add `refreshIDTokenOnly()` — the same browserless refresh_token exchange and monitoring-token persistence as `tryRefreshToken`, but returns the fresh id_token *without* requiring AWS credential exchange. `getMCPAuthHeader` uses it; the main credential path keeps `tryRefreshToken` unchanged. (Found by cross-model Codex review.)
- **Python:** factor the raw token-blob load into `_load_monitoring_token_data` (no expiry check) so the header path can tell "expired" from "absent". `get_mcp_auth_header` now emits a one-line stderr hint when the cached token is present-but-expired, then still returns `None` (no browser, no hang). The next full credential-process run — which Claude Code invokes routinely — re-mints and re-caches. Full silent-refresh parity is a larger cross-cutting change, documented in the docstring.

## Tests

- Go: refresh succeeds against a mock token endpoint with no STS configured → header emitted, exit 0 (red under the old coupling); env-var token uses a valid JWT.
- Python: expired-but-present → `None` + "expired" hint; absent → `None`, no hint; end-to-end session-storage expiry-boundary tests against the real storage code.
- Output contract unchanged (`{"Authorization":"Bearer <id_token>"}`); Go↔Python parity test green.

## Scope

First of a stacked series carving the web-search feature (#640) down to the Claude Code surface, atop the merged #607 template. This PR is the credential-helper layer — independent of the deploy path (#641). Config/wizard, package emit, and docs follow as separate PRs.

Python suite: 1206 passed. Go build/vet/test + gofmt clean.