### PR TITLE
feat(cowork): support anthropicFamilyTier and isFamilyDefault in inferenceModels

### DIFF
--- a/assets/docs/COWORK_3P.md
+++ b/assets/docs/COWORK_3P.md
@@ -123,9 +123,46 @@ For automated deployment at scale, create an MDM profile with the following esse
 | `inferenceBedrockProfile` | Name of the AWS named profile in `~/.aws/config` that Claude Desktop should use for Bedrock calls. The installer configures this profile with `credential_process` pointing at the bundled `credential-process` binary |
 | `inferenceBedrockRegion` | AWS region for Bedrock API calls (e.g., `us-west-2`, `us-east-1`) |
 | `inferenceBedrockAwsDir` | Path to the directory containing AWS config/credentials files (default: `~/.aws`) |
-| `inferenceModels` | JSON array of model aliases available to users (`opus`, `sonnet`, `haiku`). First entry is the default |
+| `inferenceModels` | JSON array of model entries. Supports simple aliases (`["opus", "sonnet", "haiku"]`) or object entries with tier tagging (see below). First entry is the default |
 
 > **Note:** The model aliases used by CoWork 3P (`opus`, `sonnet`, `haiku`) are resolved internally by Claude Desktop and may differ from the CRIS model IDs configured for Claude Code via `ANTHROPIC_MODEL`. The `ccwb cowork generate` command includes all available aliases by default. Use `--models` to customize the list for your organization.
+
+#### Model Entries with Family Tier (v1.13576+)
+
+Claude Desktop supports object entries in `inferenceModels` with `anthropicFamilyTier` and `isFamilyDefault` fields. This lets tier shortcuts (like "opus" and "sonnet" in the model picker) resolve to your specific Bedrock model IDs:
+
+```json
+"inferenceModels": [
+  {
+    "name": "global.anthropic.claude-opus-4-8",
+    "labelOverride": "Claude Opus 4.8",
+    "anthropicFamilyTier": "opus",
+    "isFamilyDefault": true
+  },
+  {
+    "name": "global.anthropic.claude-sonnet-4-6",
+    "labelOverride": "Claude Sonnet 4.6",
+    "anthropicFamilyTier": "sonnet",
+    "isFamilyDefault": true
+  },
+  {
+    "name": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+    "labelOverride": "Claude Haiku 4.5",
+    "anthropicFamilyTier": "haiku",
+    "isFamilyDefault": true
+  }
+]
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | The model ID your provider routes (e.g., CRIS inference profile ID) |
+| `labelOverride` | string | Optional display name in the model picker |
+| `anthropicFamilyTier` | string | Which Claude tier this model stands in for: `opus`, `sonnet`, `haiku`, or `fable` |
+| `isFamilyDefault` | boolean | Whether this is the default model when the tier shortcut is used |
+| `supports1m` | boolean | Whether the model supports 1M token context |
+
+> **When to use object format:** Use it when your Bedrock setup uses specific CRIS inference profile IDs (e.g., `global.anthropic.claude-opus-4-8`) and you want the tier shortcuts in the Claude Desktop model picker to resolve to those exact model IDs. The simple alias format (`["opus", "sonnet", "haiku"]`) still works and lets Claude Desktop handle resolution internally.
 
 ### How Credentials Flow
 

--- a/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
+++ b/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
@@ -17,6 +17,15 @@ from claude_code_with_bedrock.cli.utils.aws import get_stack_outputs
 # The ccwb cowork generate --models flag allows admins to override if needed.
 COWORK_DEFAULT_ALIASES = ["opus", "sonnet", "haiku"]
 
+# Mapping from tier alias to anthropicFamilyTier value used by Claude Desktop
+# for tier shortcut resolution (e.g., "opus" shortcut resolves to your configured opus model)
+FAMILY_TIER_MAP = {
+    "opus": "opus",
+    "sonnet": "sonnet",
+    "haiku": "haiku",
+    "fable": "fable",
+}
+
 
 def derive_model_aliases() -> list[str]:
     """Return the default CoWork 3P model aliases.
@@ -28,6 +37,75 @@ def derive_model_aliases() -> list[str]:
     ANTHROPIC_MODEL.
     """
     return list(COWORK_DEFAULT_ALIASES)
+
+
+def build_inference_models(model_aliases: list[str]) -> list[dict[str, str | bool]]:
+    """Build inferenceModels entries with anthropicFamilyTier and isFamilyDefault.
+
+    Claude Desktop v1.13576+ supports object entries in inferenceModels with:
+    - name: The model ID (e.g., CRIS inference profile ID for Bedrock)
+    - anthropicFamilyTier: The Claude tier this model stands in for (opus/sonnet/haiku)
+    - isFamilyDefault: Whether this is the default model for the tier
+    - labelOverride: Optional display name override
+
+    When using simple string aliases ("opus", "sonnet", "haiku"), Claude Desktop
+    resolves them internally. The object format gives administrators explicit
+    control over which model IDs map to which tier shortcuts.
+
+    For backward compatibility, if aliases are simple tier names (opus/sonnet/haiku),
+    we still use the string format since Claude Desktop handles resolution. Use
+    build_inference_models_explicit() for full CRIS model IDs with tier tagging.
+
+    Args:
+        model_aliases: List of model aliases or CRIS model IDs.
+
+    Returns:
+        List suitable for the inferenceModels MDM key. Returns simple strings
+        for tier aliases, or object entries for explicit model IDs.
+    """
+    # If all entries are simple tier aliases, return as-is for backward compat
+    all_simple = all(alias in FAMILY_TIER_MAP for alias in model_aliases)
+    if all_simple:
+        return model_aliases
+
+    # Otherwise, build object entries with anthropicFamilyTier
+    models = []
+    tier_seen: dict[str, bool] = {}  # Track which tiers have a default set
+    for alias in model_aliases:
+        if alias in FAMILY_TIER_MAP:
+            # Simple alias — keep as string
+            models.append(alias)
+        else:
+            # Looks like a full model ID — try to infer tier from name
+            entry: dict[str, str | bool] = {"name": alias}
+            tier = _infer_tier_from_model_id(alias)
+            if tier:
+                entry["anthropicFamilyTier"] = tier
+                if tier not in tier_seen:
+                    entry["isFamilyDefault"] = True
+                    tier_seen[tier] = True
+            models.append(entry)
+    return models
+
+
+def _infer_tier_from_model_id(model_id: str) -> str | None:
+    """Infer the anthropicFamilyTier from a Bedrock/CRIS model ID.
+
+    Matches patterns like:
+    - global.anthropic.claude-opus-4-8 → opus
+    - us.anthropic.claude-sonnet-4-6-v1:0 → sonnet
+    - anthropic.claude-haiku-4-5-20251001-v1:0 → haiku
+    """
+    model_lower = model_id.lower()
+    if "opus" in model_lower:
+        return "opus"
+    if "sonnet" in model_lower:
+        return "sonnet"
+    if "haiku" in model_lower:
+        return "haiku"
+    if "fable" in model_lower:
+        return "fable"
+    return None
 
 
 def build_mdm_config(
@@ -62,7 +140,7 @@ def build_mdm_config(
         "inferenceProvider": "bedrock",
         "inferenceBedrockRegion": bedrock_region,
         "inferenceBedrockProfile": profile_name,
-        "inferenceModels": model_aliases,
+        "inferenceModels": build_inference_models(model_aliases),
         "isClaudeCodeForDesktopEnabled": True,
         "isDesktopExtensionEnabled": True,
         "isDesktopExtensionDirectoryEnabled": True,


### PR DESCRIPTION
## Why

Claude Desktop v1.13576+ supports structured `inferenceModels` entries with `anthropicFamilyTier` and `isFamilyDefault` fields. This gives admins explicit visibility into which Bedrock model IDs map to which tier shortcuts in the model picker — rather than relying on Claude Desktop's internal resolution.

## What Changed

- **New utility:** `build_inference_models()` in `cowork_3p.py` — converts model aliases to object entries with tier metadata when full model IDs are provided
- **Tier inference:** `_infer_tier_from_model_id()` detects opus/sonnet/haiku/fable from CRIS model IDs
- **`isFamilyDefault` logic:** First model per tier is marked as the family default (the one Claude Desktop uses when user picks the tier shortcut)
- **Docs:** Added object format documentation to `COWORK_3P.md` with example JSON and field table

## Why This Matters for Admins

Without tier tagging, admins deploy MDM configs with opaque model aliases and have no visibility into which specific Bedrock model version backs each tier. With `anthropicFamilyTier` + `isFamilyDefault`:

- Admins can **see exactly which model ID** each tier shortcut resolves to in the MDM config
- **Audit clarity** — compliance teams can verify which model versions are deployed
- **Upgrade control** — when Anthropic ships a new model, admins explicitly choose when to update the tier default rather than relying on silent resolution changes

## Backward Compatibility

- Simple aliases (`["opus", "sonnet", "haiku"]`) pass through unchanged — string array format preserved
- Object format only emitted when explicit model IDs are provided (e.g., `global.anthropic.claude-opus-4-8`)
- Existing deployments with simple aliases: zero behavior change

## Testing

- All CI green (Python 3.10/3.11/3.12 + macOS + Windows)
- No unit tests for new functions (follow-up)