### PR TITLE
feat(cowork): enable Chat tab and advanced file analysis by default

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1473,7 +1473,6 @@ class InitCommand(Command):
                 console.print("[dim]See: assets/docs/COWORK_3P.md → Custom MDM Keys[/dim]")
             config["cowork_3p"]["extra_keys"] = existing_extra
 
-
             # Generate CoWork service token for ALB auth bypass (central mode only).
             # CoWork can't do OIDC, so this static token in X-Cowork-Token header
             # bypasses JWT validation on the ALB listener.
@@ -2567,7 +2566,9 @@ class InitCommand(Command):
             "cowork_3p_extra_keys": config_data.get("cowork_3p", {}).get("extra_keys", {}),
             "cowork_service_token": config_data.get("cowork_3p", {}).get("service_token", ""),
             "cowork_chat_tab_enabled": config_data.get("cowork_3p", {}).get("chat_tab_enabled", True),
-            "cowork_chat_advanced_file_analysis": config_data.get("cowork_3p", {}).get("chat_advanced_file_analysis", True),
+            "cowork_chat_advanced_file_analysis": config_data.get("cowork_3p", {}).get(
+                "chat_advanced_file_analysis", True
+            ),
             "settings_target": "managed"
             if (self._io and self.option("managed"))
             else config_data.get("settings_target", "user"),

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1473,6 +1473,7 @@ class InitCommand(Command):
                 console.print("[dim]See: assets/docs/COWORK_3P.md → Custom MDM Keys[/dim]")
             config["cowork_3p"]["extra_keys"] = existing_extra
 
+
             # Generate CoWork service token for ALB auth bypass (central mode only).
             # CoWork can't do OIDC, so this static token in X-Cowork-Token header
             # bypasses JWT validation on the ALB listener.
@@ -2565,6 +2566,8 @@ class InitCommand(Command):
             "cowork_3p_enabled": config_data.get("cowork_3p", {}).get("enabled", True),
             "cowork_3p_extra_keys": config_data.get("cowork_3p", {}).get("extra_keys", {}),
             "cowork_service_token": config_data.get("cowork_3p", {}).get("service_token", ""),
+            "cowork_chat_tab_enabled": config_data.get("cowork_3p", {}).get("chat_tab_enabled", True),
+            "cowork_chat_advanced_file_analysis": config_data.get("cowork_3p", {}).get("chat_advanced_file_analysis", True),
             "settings_target": "managed"
             if (self._io and self.option("managed"))
             else config_data.get("settings_target", "user"),
@@ -2928,6 +2931,10 @@ class InitCommand(Command):
                 cowork_3p_config["extra_keys"] = profile.cowork_3p_extra_keys
             if profile.cowork_service_token:
                 cowork_3p_config["service_token"] = profile.cowork_service_token
+            if profile.cowork_chat_tab_enabled:
+                cowork_3p_config["chat_tab_enabled"] = True
+            if profile.cowork_chat_advanced_file_analysis:
+                cowork_3p_config["chat_advanced_file_analysis"] = True
             existing_config["cowork_3p"] = cowork_3p_config
 
             # Add distribution configuration if present

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -3408,6 +3408,14 @@ Available metrics include:
                 extra_keys=profile.cowork_3p_extra_keys or None,
             )
 
+            # Beta features (per-feature managed configuration keys)
+            if getattr(profile, "cowork_chat_tab_enabled", False):
+                mdm_config["chatTabEnabled"] = True
+            if getattr(profile, "cowork_chat_advanced_file_analysis", False):
+                mdm_config["chatAdvancedFileAnalysisEnabled"] = True
+            if getattr(profile, "cowork_inference_session_lifetime_sec", None):
+                mdm_config["inferenceSessionLifetimeSec"] = profile.cowork_inference_session_lifetime_sec
+
             add_monitoring_config(mdm_config, profile, console)
             generate_all(output_dir, mdm_config, console)
 

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -152,7 +152,9 @@ class Profile:
 
     # Cowork beta features (managed configuration keys)
     cowork_chat_tab_enabled: bool = True  # chatTabEnabled — enables the Chat tab
-    cowork_chat_advanced_file_analysis: bool = True  # chatAdvancedFileAnalysisEnabled — code execution for file analysis
+    cowork_chat_advanced_file_analysis: bool = (
+        True  # chatAdvancedFileAnalysisEnabled — code execution for file analysis
+    )
     cowork_inference_session_lifetime_sec: int | None = None  # inferenceSessionLifetimeSec — re-auth reminder timer
 
     # Legacy field support

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -150,6 +150,11 @@ class Profile:
     cowork_3p_extra_keys: dict[str, str] = field(default_factory=dict)  # Custom MDM keys merged into CoWork 3P output
     cowork_service_token: str = ""  # Static token for CoWork ALB auth bypass (set during init)
 
+    # Cowork beta features (managed configuration keys)
+    cowork_chat_tab_enabled: bool = True  # chatTabEnabled — enables the Chat tab
+    cowork_chat_advanced_file_analysis: bool = True  # chatAdvancedFileAnalysisEnabled — code execution for file analysis
+    cowork_inference_session_lifetime_sec: int | None = None  # inferenceSessionLifetimeSec — re-auth reminder timer
+
     # Legacy field support
     @property
     def okta_domain(self) -> str:


### PR DESCRIPTION
## Why

Claude Cowork (Desktop) v1.13576.0 introduced the Chat tab as a beta feature, and v1.14271.0 renamed `chatCodeExecutionEnabled` to `chatAdvancedFileAnalysisEnabled` and deprecated the catch-all `betaFeaturesEnabled` key in favor of per-feature controls. This PR adds first-class support so these features are enabled out of the box for all deployments.

## What

**`config.py`**
- New Profile fields: `cowork_chat_tab_enabled` (default: `True`), `cowork_chat_advanced_file_analysis` (default: `True`), `cowork_inference_session_lifetime_sec` (default: not set)

**`init.py`**
- Profile mapping reads these from config, defaults to enabled
- Serializes back to `cowork_3p` config section

**`package.py`**
- Emits `chatTabEnabled: true` and `chatAdvancedFileAnalysisEnabled: true` into the generated MDM config
- Emits `inferenceSessionLifetimeSec` when configured (re-auth reminder timer)

No init wizard prompts added — features are on by default. Admins who want to disable can set `cowork_chat_tab_enabled: false` or `cowork_chat_advanced_file_analysis: false` in their profile config file.

## Managed Configuration Keys (from Anthropic changelog)

| Key | Description | Default |
|-----|-------------|---------|
| `chatTabEnabled` | Enables the Chat tab | `true` |
| `chatAdvancedFileAnalysisEnabled` | Claude can run code to analyze attachments and create files (spreadsheets, presentations) in an isolated sandbox | `true` |
| `inferenceSessionLifetimeSec` | Shows users a re-authenticate reminder before their sign-in expires | not set |

> **Note:** The deprecated `betaFeaturesEnabled` key is intentionally NOT added. Per the v1.14271.0 changelog: "use the per-feature keys `chatTabEnabled` and `chatAdvancedFileAnalysisEnabled` instead."

## Testing Evidence

- Full test suite: **1197 passed**, 22 skipped, 0 failed
- Backward compatible: existing profiles without these fields load with defaults (enabled)

## References

- [Cowork Changelog v1.14271.0](https://claude.com/docs/cowork/changelog) — renamed key, deprecated betaFeaturesEnabled
- [Cowork Changelog v1.13576.0](https://claude.com/docs/cowork/changelog) — initial Chat tab + betaFeaturesEnabled