### PR TITLE
fix(deploy): IDC auth stack path + CAPABILITY_NAMED_IAM for quota

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -392,7 +392,7 @@ class DeployCommand(Command):
                         stack_name=stack_name,
                         template_path=template_path,
                         parameters=boto3_params,
-                        capabilities=capabilities or ["CAPABILITY_IAM"],
+                        capabilities=capabilities or ["CAPABILITY_NAMED_IAM"],
                         on_event=lambda e: progress.update(
                             task,
                             description=f"{e.get('LogicalResourceId', 'Stack')} - {e.get('ResourceStatus', '')}"
@@ -435,7 +435,33 @@ class DeployCommand(Command):
 
             # Deploy based on stack type
             if stack_type == "auth":
-                # Select template based on provider type
+                # IAM Identity Center uses a dedicated template
+                if profile.effective_auth_type == "idc":
+                    template = project_root / "deployment" / "infrastructure" / "bedrock-auth-idc.yaml"
+                    stack_name = profile.stack_names.get("auth", f"{profile.identity_pool_name}-stack")
+
+                    from claude_code_with_bedrock.models import get_all_bedrock_regions
+
+                    bedrock_regions = profile.allowed_bedrock_regions
+                    if not bedrock_regions:
+                        bedrock_regions = [r for r in get_all_bedrock_regions() if "gov" not in r]
+
+                    idc_role_name = getattr(profile, "idc_permission_set_name", None) or "BedrockIDCFederatedRole"
+                    params = [
+                        f"FederatedRoleName={idc_role_name}",
+                        f"IdentityPoolName={profile.identity_pool_name}",
+                        f"AllowedBedrockRegions={','.join(bedrock_regions)}",
+                        f"EnableMonitoring={str(profile.monitoring_enabled).lower()}",
+                    ]
+                    return deploy_with_cf(
+                        template,
+                        stack_name,
+                        params,
+                        ["CAPABILITY_NAMED_IAM"],
+                        task_description="Deploying IAM Identity Center auth stack...",
+                    )
+
+                # Select template based on provider type (OIDC)
                 provider_type = profile.provider_type or "okta"
                 template_map = {
                     "okta": "bedrock-auth-okta.yaml",
@@ -1035,7 +1061,7 @@ class DeployCommand(Command):
         region = get_codebuild_region(profile) if stack_type == "codebuild" else profile.aws_region
 
         def print_deploy_cmd(template, stack_name, params, capabilities=None):
-            caps_str = " ".join(capabilities or ["CAPABILITY_IAM"])
+            caps_str = " ".join(capabilities or ["CAPABILITY_NAMED_IAM"])
             lines = [
                 "aws cloudformation deploy \\",
                 f"    --template-file {template} \\",

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -2283,7 +2283,9 @@ RUN pyinstaller \
                     config[profile_name]["idc_account_id"] = profile.idc_account_id
                 if getattr(profile, "idc_permission_set_name", None):
                     config[profile_name]["idc_permission_set_name"] = profile.idc_permission_set_name
-                idc_region = getattr(profile, "idc_region", None) or profile.aws_region
+                idc_region = (
+                    getattr(profile, "sso_region", None) or getattr(profile, "idc_region", None) or profile.aws_region
+                )
                 config[profile_name]["idc_region"] = idc_region
         elif federation_type == "direct":
             config[profile_name]["federated_role_arn"] = federation_identifier


### PR DESCRIPTION
## Problem

Three bugs affecting IDC deployments (reported by @qing-at-work):

1. **"OktaClientId constraint" error** — `ccwb deploy auth` for IDC users hits the OIDC path, selects `bedrock-auth-okta.yaml`, and passes empty `OktaClientId` which fails validation.
2. **"Requires CAPABILITY_NAMED_IAM"** — Quota stack deploy uses `CAPABILITY_IAM` but PR #598 added `ManagedPolicyName` requiring the stronger capability.
3. **Windows IDC login not triggering** — `idc_region` in config.json was resolving from a non-existent profile field, falling back to `aws_region` instead of the SSO region.

## Root Cause

Commit `a777677` reverted IDC logic from deploy.py. The print path (`_show_deployment_commands`) was re-added but the execution path (`_deploy_stack`) was not.

## Fixes

| File | Change |
|------|--------|
| `deploy.py` | Added `if profile.effective_auth_type == "idc":` branch using `bedrock-auth-idc.yaml` |
| `deploy.py` | Default capability: `CAPABILITY_IAM` → `CAPABILITY_NAMED_IAM` (superset, all stacks) |
| `package.py` | `idc_region` resolves from `sso_region` first (set by PR #650 init wizard) |

## Review Findings (sub-agent deep trace)

**Env var threading:** ✅ All 4 CFn params match `bedrock-auth-idc.yaml` template exactly
**Go/Python parity:** ✅ Package writes `"idc_region"` → Go reads `json:"idc_region"`
**Config schema:** ✅ All fields exist in Profile dataclass
**Blast radius:** 11 files (2 changed + 5 test files + 4 importers)
**Backward compat:** ✅ No regression — IDC branch returns early; OIDC/None paths untouched; NAMED_IAM is superset of IAM

**Minor notes (non-blocking):**
- `getattr(profile, "idc_region", None)` in fallback chain is dead code (field doesn't exist on Profile) — harmless
- `idc_permission_set_name` used as `FederatedRoleName` is a naming convention choice, not a bug

## Risk: Very Low

- Only fires for `auth_type == "idc"` profiles (cannot affect OIDC/None users)
- CAPABILITY_NAMED_IAM is strictly a superset
- sso_region defaults to None (old profiles fall through to existing behavior)
