### PR TITLE
docs: clarify Claude Desktop supports native otlpHeaders (no proxy required for static auth)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ flowchart LR
 The **otel-helper** binary operates in two modes depending on the surface:
 
 - **Header mode** (Claude Code CLI): Called once per OTLP export as a header provider. Returns JSON headers containing user identity (email, team, department) extracted from the cached JWT. Claude Code's OTLP exporter attaches these headers to each request.
-- **Proxy mode** (Claude Desktop): Runs as a local HTTP reverse proxy on `localhost:4318`. Claude Desktop sends OTLP to this local endpoint, and the proxy injects per-user identity headers + SigV4-signs the request before forwarding to the upstream collector.
+- **Proxy mode** (Claude Desktop): Auto-spawned by `credential-process` after each successful auth. Runs as a local identity-injecting proxy that reads the user's decoded JWT from the local cache and injects `x-user-email`, `x-department`, `x-team-id` headers into every OTLP request. In central mode it listens on port 4318 (forwarding to the remote ALB); in sidecar mode it listens on port 4319 (forwarding to the local otelcol on 4318 to avoid port conflicts).
 
 ```mermaid
 flowchart LR
@@ -153,27 +153,24 @@ flowchart LR
 
 ### Usage Monitoring
 
-Both Claude Code (CLI) and Claude Desktop (Cowork) emit OpenTelemetry (OTLP) telemetry. The otel-helper attaches user identity — as a one-shot header provider for Claude Code, or as a local proxy for Claude Desktop — so CloudWatch dashboards show per-user metrics. See [Monitoring Guide](assets/docs/MONITORING.md) for detailed configuration.
+Both Claude Code (CLI) and Claude Desktop (Cowork) emit OpenTelemetry (OTLP) telemetry. The otel-helper attaches user identity — as a one-shot header provider for Claude Code, or as an auto-spawned local proxy for Claude Desktop — so CloudWatch dashboards show per-user metrics. See [Monitoring Guide](assets/docs/MONITORING.md) for detailed configuration.
 
 ```mermaid
 flowchart LR
     CC[Claude Code CLI] -->|OTLP| OH1[otel-helper<br/>header mode]
-    CW[Claude Desktop] -->|OTLP via localhost:4318| OH2[otel-helper<br/>proxy mode]
-    CW -.->|or direct via otlpHeaders| COLL
+    CW[Claude Desktop] -->|OTLP to proxy| OH2[otel-helper<br/>proxy mode]
     OH1 -->|"user identity + Bearer JWT"| COLL[Collector]
-    OH2 -->|"user identity + SigV4/auth"| COLL
+    OH2 -->|"user identity from JWT cache"| COLL
     COLL --> DASH[CloudWatch Dashboards]
 ```
 
 | Surface | otel-helper mode | What it does | Collector mode | Identity in telemetry |
 |---------|-----------------|--------------|----------------|----------------------|
 | **Claude Code (CLI)** | Header mode | Called once per export, returns identity headers as JSON | Central (ECS/ALB) or Sidecar (local) | User's JWT claims (email, team, department) |
-| **Claude Desktop (Cowork)** | Proxy mode | Listens on `localhost:4318`, injects identity headers, SigV4-signs (sidecar) or forwards with auth token (central) | Central (ECS/ALB) or Sidecar (local) | User's JWT claims (email, team, department) |
-| **Claude Desktop (no proxy)** | Not used | Desktop sends directly using native `otlpHeaders` MDM key | Central (ECS/ALB) | None (org-level only) |
+| **Claude Desktop (Cowork)** | Proxy mode | Auto-spawned by credential-process; injects identity headers from JWT cache | Central: proxy on `localhost:4318` → ALB | Full JWT claims (email, team, department) |
+| **Claude Desktop (Cowork)** | Proxy mode | Same as above, chains through local otelcol | Sidecar: proxy on `localhost:4319` → otelcol:4318 | Full JWT claims (email, team, department) |
 
-> **When is the proxy needed?** Claude Desktop natively supports [`otlpHeaders`](https://claude.com/docs/third-party/claude-desktop/configuration#otlp) and [`otlpResourceAttributes`](https://claude.com/docs/third-party/claude-desktop/configuration#otlp) for static values set at MDM config time. If your collector only needs **static auth** (e.g. a bearer token), set it directly via `otlpHeaders` — no proxy needed. The proxy is required when you need:
-> - **Per-user identity** in telemetry (the proxy reads the user's decoded JWT claims at runtime — these vary per user and can't be baked into a shared MDM profile)
-> - **SigV4 signing** for sidecar mode (forwarding directly to CloudWatch's `monitoring.{region}.amazonaws.com` endpoint)
+> **Proxy auto-spawn:** The proxy is automatically started by `credential-process` after each successful authentication — no manual startup or daemon configuration required. If the proxy dies, the next credential refresh (~1h) restarts it (self-healing). Claude Desktop natively supports [`otlpHeaders`](https://claude.com/docs/third-party/claude-desktop/configuration#otlp) for static values, but the proxy is required for **per-user identity** (JWT claims vary per user and can't be baked into a shared MDM profile).
 
 **Cost attribution:** Since April 2026, Amazon Bedrock supports [IAM principal cost tracking via CUR 2.0](assets/docs/COST_ATTRIBUTION.md) — per-user costs appear in Cost Explorer automatically from the STS session tags set by credential-process. Note: real-time quota enforcement relies on telemetry emitted from the client rather than actual costs metered by AWS, so figures may differ from CUR.
 

--- a/README.md
+++ b/README.md
@@ -167,10 +167,13 @@ flowchart LR
 | Surface | otel-helper mode | What it does | Collector mode | Identity in telemetry |
 |---------|-----------------|--------------|----------------|----------------------|
 | **Claude Code (CLI)** | Header mode | Called once per export, returns identity headers as JSON | Central (ECS/ALB) or Sidecar (local) | User's JWT claims (email, team, department) |
-| **Claude Desktop (Cowork)** | Proxy mode | Auto-spawned by credential-process; injects identity headers from JWT cache | Central: proxy on `localhost:4318` → ALB | Full JWT claims (email, team, department) |
-| **Claude Desktop (Cowork)** | Proxy mode | Same as above, chains through local otelcol | Sidecar: proxy on `localhost:4319` → otelcol:4318 | Full JWT claims (email, team, department) |
+| **Claude Desktop (Cowork)** | Proxy mode | Auto-spawned by credential-process; injects identity headers from JWT cache | Central or Sidecar | Full JWT claims (email, team, department) |
+| **Claude Desktop (bootstrap server)** | Not used | Bootstrap server delivers per-user `otlpHeaders` at sign-in | Central (ECS/ALB) | Per-user (from OIDC token) |
 
-> **Proxy auto-spawn:** The proxy is automatically started by `credential-process` after each successful authentication — no manual startup or daemon configuration required. If the proxy dies, the next credential refresh (~1h) restarts it (self-healing). Claude Desktop natively supports [`otlpHeaders`](https://claude.com/docs/third-party/claude-desktop/configuration#otlp) for static values, but the proxy is required for **per-user identity** (JWT claims vary per user and can't be baked into a shared MDM profile).
+> **When is the proxy needed?** The proxy is **not needed** if you use the [Bootstrap Server](assets/docs/BOOTSTRAP_SERVER.md) (OIDC only) — it delivers per-user `otlpHeaders` at sign-in. Similarly, Claude Desktop natively supports [`otlpHeaders`](https://claude.com/docs/third-party/claude-desktop/configuration#otlp) for static values set via MDM. The proxy is only required when:
+> - **No bootstrap server** and you need per-user identity (the proxy reads JWT claims at runtime)
+> - **IDC deployments** (bootstrap server is OIDC-only)
+> - **SigV4 signing** for sidecar mode (forwarding to CloudWatch's OTLP endpoint directly)
 
 **Cost attribution:** Since April 2026, Amazon Bedrock supports [IAM principal cost tracking via CUR 2.0](assets/docs/COST_ATTRIBUTION.md) — per-user costs appear in Cost Explorer automatically from the STS session tags set by credential-process. Note: real-time quota enforcement relies on telemetry emitted from the client rather than actual costs metered by AWS, so figures may differ from CUR.
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,10 @@ flowchart LR
     IDC --> OUT
 ```
 
-The **otel-helper** attaches user identity to telemetry so CloudWatch dashboards can show per-user metrics:
+The **otel-helper** binary operates in two modes depending on the surface:
+
+- **Header mode** (Claude Code CLI): Called once per OTLP export as a header provider. Returns JSON headers containing user identity (email, team, department) extracted from the cached JWT. Claude Code's OTLP exporter attaches these headers to each request.
+- **Proxy mode** (Claude Desktop): Runs as a local HTTP reverse proxy on `localhost:4318`. Claude Desktop sends OTLP to this local endpoint, and the proxy injects per-user identity headers + SigV4-signs the request before forwarding to the upstream collector.
 
 ```mermaid
 flowchart LR
@@ -155,18 +158,22 @@ Both Claude Code (CLI) and Claude Desktop (Cowork) emit OpenTelemetry (OTLP) tel
 ```mermaid
 flowchart LR
     CC[Claude Code CLI] -->|OTLP| OH1[otel-helper<br/>header mode]
-    CW[Claude Desktop] -->|OTLP| OH2[otel-helper<br/>proxy mode]
+    CW[Claude Desktop] -->|OTLP via localhost:4318| OH2[otel-helper<br/>proxy mode]
+    CW -.->|or direct via otlpHeaders| COLL
     OH1 -->|"user identity + Bearer JWT"| COLL[Collector]
-    OH2 -->|"user identity + X-Cowork-Token"| COLL
+    OH2 -->|"user identity + SigV4/auth"| COLL
     COLL --> DASH[CloudWatch Dashboards]
 ```
 
-| Surface | How otel-helper is used | Collector mode | Identity in telemetry |
-|---------|------------------------|----------------|----------------------|
-| **Claude Code (CLI)** | Header provider — called once per request, returns JSON headers | Central (ECS/ALB) or Sidecar (local) | User's JWT (email, team, department) |
-| **Claude Desktop (Cowork)** | Local proxy — runs on `localhost:4318`, injects user headers, forwards to collector | Central (ECS/ALB) | Email from IAM ARN (no team/department without OIDC) |
+| Surface | otel-helper mode | What it does | Collector mode | Identity in telemetry |
+|---------|-----------------|--------------|----------------|----------------------|
+| **Claude Code (CLI)** | Header mode | Called once per export, returns identity headers as JSON | Central (ECS/ALB) or Sidecar (local) | User's JWT claims (email, team, department) |
+| **Claude Desktop (Cowork)** | Proxy mode | Listens on `localhost:4318`, injects identity headers, SigV4-signs (sidecar) or forwards with auth token (central) | Central (ECS/ALB) or Sidecar (local) | User's JWT claims (email, team, department) |
+| **Claude Desktop (no proxy)** | Not used | Desktop sends directly using native `otlpHeaders` MDM key | Central (ECS/ALB) | None (org-level only) |
 
-**Local proxy explained:** Claude Desktop doesn't support custom OTLP headers natively. When using a central collector (ECS/ALB), otel-helper runs as a lightweight HTTP proxy on the user's machine. Cowork sends telemetry to `localhost:4318` (configured via MDM), and otel-helper adds user identity headers before forwarding to the remote central collector. This proxy is not needed in sidecar mode, where the local collector reads identity from a cache file directly.
+> **When is the proxy needed?** Claude Desktop natively supports [`otlpHeaders`](https://claude.com/docs/third-party/claude-desktop/configuration#otlp) and [`otlpResourceAttributes`](https://claude.com/docs/third-party/claude-desktop/configuration#otlp) for static values set at MDM config time. If your collector only needs **static auth** (e.g. a bearer token), set it directly via `otlpHeaders` — no proxy needed. The proxy is required when you need:
+> - **Per-user identity** in telemetry (the proxy reads the user's decoded JWT claims at runtime — these vary per user and can't be baked into a shared MDM profile)
+> - **SigV4 signing** for sidecar mode (forwarding directly to CloudWatch's `monitoring.{region}.amazonaws.com` endpoint)
 
 **Cost attribution:** Since April 2026, Amazon Bedrock supports [IAM principal cost tracking via CUR 2.0](assets/docs/COST_ATTRIBUTION.md) — per-user costs appear in Cost Explorer automatically from the STS session tags set by credential-process. Note: real-time quota enforcement relies on telemetry emitted from the client rather than actual costs metered by AWS, so figures may differ from CUR.
 


### PR DESCRIPTION
## Depends on

- #660 (feat: per-user identity for Cowork in central + sidecar modes)

Merge #660 first — this PR documents the proxy behaviour it implements.

---

## Why

The README monitoring section needed updating to reflect the proxy auto-spawn architecture implemented in PR #660. Previously it described the proxy as manually started and only for central mode.

## What Changed

- Proxy is **auto-spawned by credential-process** (ensureProxyRunning) — no manual startup
- Port split: Central on **4318**, Sidecar on **4319** (avoids otelcol conflict)
- Self-healing: proxy restarts on next credential refresh (~1h)
- Identity injection from decoded JWT cache (x-user-email, x-department, x-team-id)
- Removed "no proxy" table row — proxy is the default for per-user identity
- Updated mermaid diagram to match #660 architecture
- Split Desktop table into Central vs Sidecar rows with port numbers

## Testing

- README-only change, no code impact
- Content verified against PR #660 implementation