### PR TITLE
fix(go): quota recheck silently fails open after id_token expiry + Azure refresh 404

### DIFF
--- a/source/go/cmd/credential-process/main.go
+++ b/source/go/cmd/credential-process/main.go
@@ -641,18 +641,15 @@ func (a *credentialApp) tryRefreshToken() *federation.AWSCredentials {
 
 	debugPrint("Found cached refresh_token, attempting token exchange...")
 
-	// Resolve token endpoint URL
+	// Resolve token endpoint URL. Generic providers supply an absolute URL
+	// directly; named providers go through the shared builder that normalizes
+	// the domain (e.g. strips Azure's trailing /v2.0) so this refresh path and
+	// the authorization-code flow always produce the same URL.
 	var tokenURL string
 	if a.providerType == "generic" {
 		tokenURL = a.cfg.OIDCTokenEndpoint
 	} else {
-		provCfg := provider.ConfigFor(a.providerType, a.cfg.OktaAuthServerID)
-		if strings.HasPrefix(provCfg.TokenEndpoint, "https://") {
-			tokenURL = provCfg.TokenEndpoint
-		} else {
-			domain := a.cfg.ProviderDomain
-			tokenURL = "https://" + domain + provCfg.TokenEndpoint
-		}
+		tokenURL = provider.TokenEndpointURL(a.providerType, a.cfg.OktaAuthServerID, a.cfg.ProviderDomain)
 	}
 
 	// Resolve confidential client auth (Azure secret/cert)
@@ -757,7 +754,24 @@ func (a *credentialApp) shouldRecheckQuota() bool {
 func (a *credentialApp) performQuotaRecheck() bool {
 	token, _ := storage.GetMonitoringToken(a.profile, a.cfg.CredentialStorage)
 	if token == "" {
-		return true // no token to check with — allow (fail-open for missing token)
+		// Cached id_token aged past the 10-min buffer in GetMonitoringToken.
+		// This path is OIDC-only (IDC/passthrough have separate entrypoints),
+		// so the quota API expects a JWT — a SigV4 call would 401. Mirror the
+		// getMonitoringToken() handler: try a silent refresh_token exchange to
+		// mint a fresh id_token before giving up, so an over-quota user is still
+		// warned/blocked on the cache-hit fast path instead of silently passing.
+		if creds := a.tryRefreshToken(); creds != nil {
+			token, _ = storage.GetMonitoringToken(a.profile, a.cfg.CredentialStorage)
+		}
+	}
+	if token == "" {
+		// No cached token and no usable refresh_token (revoked/absent). The only
+		// remaining recovery is a browser flow, which must NOT fire on the
+		// cache-hit fast path (runs on every AWS API call). Fail open, but leave
+		// the quota-state timestamp unset so the next invocation retries once a
+		// fresh token is available.
+		debugPrint("Quota recheck skipped: no cached id_token and no usable refresh_token")
+		return true
 	}
 	qr := quota.Check(a.cfg.QuotaAPIEndpoint, token, a.cfg.QuotaCheckTimeout, a.cfg.QuotaFailMode)
 

--- a/source/go/cmd/credential-process/quota_recheck_refresh_test.go
+++ b/source/go/cmd/credential-process/quota_recheck_refresh_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"ccwb-go/internal/config"
+	"ccwb-go/internal/storage"
+)
+
+// TestPerformQuotaRecheck_AttemptsRefreshWhenTokenExpired is the regression
+// guard for the bug where an over-quota OIDC user got NO warning on the
+// cache-hit fast path.
+//
+// Background: run() serves cached AWS credentials immediately and the ONLY
+// quota logic on that path is performQuotaRecheck(). It read the cached
+// monitoring token (id_token) and, when that token had aged past the 10-min
+// buffer in storage.GetMonitoringToken, returned true (fail-open) WITHOUT
+// attempting a refresh_token exchange. Since cached AWS creds last ~12h but
+// the id_token expires in ~1h, the steady state for an active user is
+// "valid AWS creds + expired id_token" — so the quota API was never called,
+// printQuotaWarning()/printQuotaBlocked() never fired, and the user blew
+// past quota silently. PRs #655/#657/#658 fixed the warning *display* but
+// all of it sits downstream of a successful quota.Check() that never ran.
+//
+// The fix mirrors the getMonitoringToken() handler: when the cached id_token
+// is empty, attempt tryRefreshToken() to silently mint a fresh id_token
+// before giving up.
+//
+// This test proves the exchange is *attempted*: with a refresh_token stored
+// but an unreachable IdP, tryRefreshToken fails and clears the (presumed
+// revoked) refresh_token. Before the fix, performQuotaRecheck returned on the
+// empty-token check and NEVER touched the refresh_token, so it would remain
+// stored. The cleared-token assertion therefore fails without the fix and
+// passes with it.
+func TestPerformQuotaRecheck_AttemptsRefreshWhenTokenExpired(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir) // Windows
+	// Ensure no ambient env token short-circuits storage.GetMonitoringToken.
+	t.Setenv("CLAUDE_CODE_MONITORING_TOKEN", "")
+	if err := os.MkdirAll(tmpDir+"/.claude-code-session", 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	profile := "test-quota-recheck-refresh-attempted"
+	t.Cleanup(func() {
+		storage.ClearRefreshToken(profile)
+	})
+
+	if err := storage.SaveRefreshToken(profile, "session", "rt_test_value"); err != nil {
+		t.Fatalf("SaveRefreshToken: %v", err)
+	}
+
+	cfg := &config.ProfileConfig{
+		ClientID:          "test-client",
+		ProviderDomain:    "test.invalid.example.com", // unreachable — exchange must fail
+		CredentialStorage: "session",
+		QuotaAPIEndpoint:  "https://quota.invalid.example.com",
+		QuotaFailMode:     "open",
+		QuotaCheckTimeout: 1,
+	}
+	app := &credentialApp{profile: profile, cfg: cfg, providerType: "okta"}
+
+	// Exchange fails (unreachable IdP); with no usable token the recheck
+	// fails open and allows cached credentials through.
+	if allowed := app.performQuotaRecheck(); !allowed {
+		t.Fatalf("performQuotaRecheck returned false (blocked) when it should fail open on no usable token")
+	}
+
+	// The core regression assertion: the refresh_token was consumed by a
+	// failed exchange. If it is still present, performQuotaRecheck never
+	// attempted the exchange — the fix is not wired in.
+	if got := storage.LoadRefreshToken(profile, "session"); got != "" {
+		t.Errorf("refresh_token not cleared after failed exchange (got %q); "+
+			"performQuotaRecheck did NOT attempt tryRefreshToken — quota recheck "+
+			"will silently fail open for over-quota users with expired id_tokens", got)
+	}
+
+	// And because no usable token was obtained, the quota API was never
+	// queried, so the check timestamp must NOT have been persisted — the
+	// next invocation should retry once a fresh token is available.
+	if ts := storage.ReadQuotaState(profile); !ts.IsZero() {
+		t.Errorf("quota-state timestamp was saved (%v) despite no quota check running; "+
+			"a frozen timestamp would suppress rechecks for the full interval", ts)
+	}
+}
+
+// TestPerformQuotaRecheck_NoTokenNoRefreshFailsOpenQuietly preserves the
+// genuinely-unrecoverable behavior: no cached id_token AND no stored
+// refresh_token. performQuotaRecheck must fail open (return true) without a
+// browser flow — the cache-hit path runs on every AWS API call and must
+// never block on it — and must not persist a check timestamp, so the next
+// invocation retries once credentials are available.
+func TestPerformQuotaRecheck_NoTokenNoRefreshFailsOpenQuietly(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+	t.Setenv("CLAUDE_CODE_MONITORING_TOKEN", "")
+	if err := os.MkdirAll(tmpDir+"/.claude-code-session", 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	profile := "test-quota-recheck-no-creds"
+
+	cfg := &config.ProfileConfig{
+		ClientID:          "test-client",
+		ProviderDomain:    "test.invalid.example.com",
+		CredentialStorage: "session",
+		QuotaAPIEndpoint:  "https://quota.invalid.example.com",
+		QuotaFailMode:     "open",
+		QuotaCheckTimeout: 1,
+	}
+	app := &credentialApp{profile: profile, cfg: cfg, providerType: "okta"}
+
+	if allowed := app.performQuotaRecheck(); !allowed {
+		t.Fatalf("performQuotaRecheck returned false (blocked) with no token and no refresh_token; must fail open")
+	}
+
+	if ts := storage.ReadQuotaState(profile); !ts.IsZero() {
+		t.Errorf("quota-state timestamp saved (%v) when no quota check ran", ts)
+	}
+}

--- a/source/go/internal/oidc/flow.go
+++ b/source/go/internal/oidc/flow.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"strings"
 	"time"
 
 	"ccwb-go/internal/browser"
@@ -86,17 +85,13 @@ func Authenticate(providerDomain, clientID, providerType, oktaAuthServerID strin
 		authURL = generic.AuthorizeURL + "?" + params.Encode()
 		tokenURL = generic.TokenURL
 	} else {
-		domain := providerDomain
-		if providerType == "azure" && strings.HasSuffix(domain, "/v2.0") {
-			domain = domain[:len(domain)-5]
-		}
-		baseURL := "https://" + domain
+		// Normalize once (e.g. strip Azure's trailing /v2.0) so the authorize
+		// and token URLs are built from the same base. TokenEndpointURL applies
+		// the identical normalization, keeping this flow and the refresh_token
+		// exchange in lockstep.
+		baseURL := "https://" + provider.NormalizeDomain(providerType, providerDomain)
 		authURL = baseURL + provCfg.AuthorizeEndpoint + "?" + params.Encode()
-		if strings.HasPrefix(provCfg.TokenEndpoint, "https://") {
-			tokenURL = provCfg.TokenEndpoint
-		} else {
-			tokenURL = baseURL + provCfg.TokenEndpoint
-		}
+		tokenURL = provider.TokenEndpointURL(providerType, oktaAuthServerID, providerDomain)
 	}
 
 	// Start callback server

--- a/source/go/internal/provider/endpoints.go
+++ b/source/go/internal/provider/endpoints.go
@@ -114,3 +114,41 @@ func IsKnown(providerType string) bool {
 	_, ok := Configs[providerType]
 	return ok
 }
+
+// NormalizeDomain returns the provider domain with any provider-specific
+// suffix removed so that ConfigFor().TokenEndpoint / .AuthorizeEndpoint can be
+// appended without duplication.
+//
+// Azure AD's provider_domain is stored with a trailing "/v2.0"
+// (e.g. "login.microsoftonline.com/<tenant>/v2.0") while its endpoints already
+// carry the version segment ("/oauth2/v2.0/token"). Concatenating the two
+// verbatim yields ".../v2.0/oauth2/v2.0/token" — a doubled segment the IdP
+// rejects with HTTP 404. Stripping the trailing "/v2.0" here keeps the auth
+// and refresh paths building identical URLs.
+func NormalizeDomain(providerType, providerDomain string) string {
+	if providerType == "azure" {
+		return strings.TrimSuffix(providerDomain, "/v2.0")
+	}
+	return providerDomain
+}
+
+// TokenEndpointURL returns the absolute token endpoint URL for a named provider
+// given its configured provider_domain. It centralizes the domain
+// normalization + endpoint concatenation that the authorization-code flow and
+// the refresh_token exchange must share — keeping them in lockstep so an Azure
+// (or future provider) URL quirk can't be fixed in one path and missed in the
+// other. Returns "" for an unknown provider type.
+//
+// Generic providers are intentionally not handled here: they supply absolute
+// endpoint URLs directly via ProfileConfig, with no domain to normalize.
+func TokenEndpointURL(providerType, oktaAuthServerID, providerDomain string) string {
+	cfg := ConfigFor(providerType, oktaAuthServerID)
+	if cfg.Name == "" {
+		return ""
+	}
+	if strings.HasPrefix(cfg.TokenEndpoint, "https://") {
+		return cfg.TokenEndpoint
+	}
+	domain := NormalizeDomain(providerType, providerDomain)
+	return "https://" + domain + cfg.TokenEndpoint
+}

--- a/source/go/internal/provider/token_url_test.go
+++ b/source/go/internal/provider/token_url_test.go
@@ -1,0 +1,98 @@
+package provider
+
+import "testing"
+
+// TestTokenEndpointURL_AzureNoDoubledVersion is the regression guard for the
+// Azure refresh_token 404. Azure's provider_domain is stored WITH a trailing
+// "/v2.0" while its token endpoint is "/oauth2/v2.0/token". A naive
+// "https://" + domain + endpoint concatenation produced
+// ".../v2.0/oauth2/v2.0/token" — a doubled version segment Azure rejects with
+// HTTP 404. The browser auth flow stripped the suffix but the refresh path did
+// not, so silent refresh (and therefore the quota recheck that depends on it)
+// always 404'd for Azure and then wrongly cleared a valid refresh_token.
+//
+// TokenEndpointURL is the single shared builder both paths now use; this test
+// pins its Azure output so the two can never drift apart again.
+func TestTokenEndpointURL_AzureNoDoubledVersion(t *testing.T) {
+	const tenant = "b39bc2da-e3c8-4f92-960e-4151a1ae16ad"
+	domain := "login.microsoftonline.com/" + tenant + "/v2.0"
+
+	got := TokenEndpointURL("azure", "", domain)
+	want := "https://login.microsoftonline.com/" + tenant + "/oauth2/v2.0/token"
+	if got != want {
+		t.Errorf("TokenEndpointURL(azure) = %q, want %q", got, want)
+	}
+}
+
+func TestTokenEndpointURL_PerProvider(t *testing.T) {
+	tests := []struct {
+		name         string
+		providerType string
+		oktaCASID    string
+		domain       string
+		want         string
+	}{
+		{
+			name:         "okta org auth server",
+			providerType: "okta",
+			domain:       "myorg.okta.com",
+			want:         "https://myorg.okta.com/oauth2/v1/token",
+		},
+		{
+			name:         "okta custom auth server",
+			providerType: "okta",
+			oktaCASID:    "default",
+			domain:       "myorg.okta.com",
+			want:         "https://myorg.okta.com/oauth2/default/v1/token",
+		},
+		{
+			name:         "auth0",
+			providerType: "auth0",
+			domain:       "myorg.auth0.com",
+			want:         "https://myorg.auth0.com/oauth/token",
+		},
+		{
+			name:         "cognito",
+			providerType: "cognito",
+			domain:       "myorg.auth.us-east-1.amazoncognito.com",
+			want:         "https://myorg.auth.us-east-1.amazoncognito.com/oauth2/token",
+		},
+		{
+			name:         "google uses absolute endpoint",
+			providerType: "google",
+			domain:       "accounts.google.com",
+			want:         "https://oauth2.googleapis.com/token",
+		},
+		{
+			name:         "unknown provider returns empty",
+			providerType: "nope",
+			domain:       "example.com",
+			want:         "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := TokenEndpointURL(tt.providerType, tt.oktaCASID, tt.domain); got != tt.want {
+				t.Errorf("TokenEndpointURL(%q) = %q, want %q", tt.providerType, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeDomain(t *testing.T) {
+	tests := []struct {
+		providerType string
+		domain       string
+		want         string
+	}{
+		{"azure", "login.microsoftonline.com/tenant/v2.0", "login.microsoftonline.com/tenant"},
+		{"azure", "login.microsoftonline.com/tenant", "login.microsoftonline.com/tenant"}, // idempotent
+		{"okta", "myorg.okta.com", "myorg.okta.com"},                                      // non-Azure untouched
+		{"auth0", "myorg.auth0.com/v2.0", "myorg.auth0.com/v2.0"},                         // suffix only stripped for Azure
+	}
+	for _, tt := range tests {
+		if got := NormalizeDomain(tt.providerType, tt.domain); got != tt.want {
+			t.Errorf("NormalizeDomain(%q, %q) = %q, want %q", tt.providerType, tt.domain, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Why

Over-quota OIDC users got **no warning and no block** during normal day-to-day use, even though the warning/block display from #655 / #657 / #658 was present and correct. Quota enforcement worked for ~1h after authentication, then silently stopped for the lifetime of the AWS session (~12h).

A second, pre-existing bug surfaced while fixing the first: Azure's token endpoint URL was built incorrectly on the refresh path (doubled `/v2.0` segment → HTTP 404), and the 404 caused the code to **delete a valid refresh_token** on every failed attempt.

Observed in a live Azure OIDC deployment with `quota_fail_mode = block`. Daily usage was ~19× over limit (3.7M / 200K tokens). No warning or block ever appeared in Claude Code.

---

## Root Cause 1 — `performQuotaRecheck` fails open after id_token expiry

`run()` serves cached AWS credentials on a fast path and immediately returns. The **only** quota gate on that path is `performQuotaRecheck()`. It read the cached monitoring id_token and, when that token had aged past `GetMonitoringToken`'s 10-minute expiry buffer, did this:

```go
// BEFORE
token, _ := storage.GetMonitoringToken(...)
if token == "" {
    return true // no token to check with — allow (fail-open for missing token)
}
qr := quota.Check(...)   // ← never reached when id_token expired
```

Since cached AWS credentials last **~12h** while the id_token lives **~1h**, the steady state for any active user after their first hour is "valid AWS creds + expired id_token" → `performQuotaRecheck` silently returns `true` on every single invocation → quota API never queried → `printQuotaWarning()` / `printQuotaBlocked()` never fires → user bypasses quota enforcement indefinitely.

**Evidence:**
- `--get-monitoring-token` returned empty (id_token aged out)
- Quota-state `last_check_unix` frozen across 130+ minutes despite 30-minute interval, proving the early-return branch was taken on every invocation

### Fix

Mirror the existing `getMonitoringToken()` handler (which already escalates cached → refresh_token → browser). Attempt a silent `tryRefreshToken()` exchange before giving up:

```go
// AFTER
token, _ := storage.GetMonitoringToken(...)
if token == "" {
    // Try silent refresh before giving up
    if creds := a.tryRefreshToken(); creds != nil {
        token, _ = storage.GetMonitoringToken(...)
    }
}
if token == "" {
    // No token, no refresh_token — fail open but DON'T save the timestamp
    // so the next invocation retries once a fresh token is available
    debugPrint("Quota recheck skipped: no cached id_token and no usable refresh_token")
    return true
}
qr := quota.Check(...)
```

This path is OIDC-only — IDC and passthrough dispatch to `runIDC()` / `runPassthrough()` before `run()` is ever called, so an empty token here unambiguously means an expired OIDC JWT. The quota API uses JWT Bearer auth, not SigV4, so a SigV4 fallback would 401.

The quota-state timestamp is intentionally **not** persisted when no usable token was obtained, so the next invocation retries immediately rather than suppressing the recheck for the full interval.

---

## Root Cause 2 — Azure refresh token URL doubles `/v2.0` (HTTP 404 → valid token deleted)

Fixing Bug 1 made the credential-process actually attempt a refresh exchange on the recheck path — which immediately exposed a second, pre-existing bug.

Azure's `provider_domain` is stored **with** a trailing `/v2.0`
(`login.microsoftonline.com/<tenant>/v2.0`) while its token endpoint already carries that version segment (`/oauth2/v2.0/token`). Two different URL builders existed:

| Path | Suffix stripped? | Result |
|---|---|---|
| `oidc/flow.go` (browser auth) | ✅ Yes | `…/<tenant>/oauth2/v2.0/token` ✓ |
| `tryRefreshToken()` in `main.go` | ❌ No | `…/<tenant>/v2.0/oauth2/v2.0/token` → **HTTP 404** |

On exchange failure, `tryRefreshToken` called `storage.ClearRefreshToken()` — treating the 404 as a revoked token. A **valid refresh_token was silently deleted** on every recheck attempt. This affected every Azure silent-refresh caller: `--get-monitoring-token`, CoWork 3P silent refresh, and the main credential flow.

This went unnoticed because nothing reached the Azure refresh path cleanly until Bug 1 wired it into the high-frequency recheck.

### Fix

Extract `NormalizeDomain()` and `TokenEndpointURL()` into `internal/provider/endpoints.go` as a **single shared builder**. Both `oidc/flow.go` (auth flow) and `tryRefreshToken()` (refresh exchange) now call `TokenEndpointURL()` — eliminating the drift that caused the 404:

```go
// internal/provider/endpoints.go

// NormalizeDomain strips provider-specific suffixes so endpoints can be
// appended without duplication.
func NormalizeDomain(providerType, providerDomain string) string {
    if providerType == "azure" {
        return strings.TrimSuffix(providerDomain, "/v2.0")
    }
    return providerDomain
}

// TokenEndpointURL is the single source of truth for a provider's token URL.
// Both flow.go (auth) and main.go (refresh) now call this.
func TokenEndpointURL(providerType, oktaAuthServerID, providerDomain string) string {
    cfg := ConfigFor(providerType, oktaAuthServerID)
    if cfg.Name == "" {
        return ""
    }
    if strings.HasPrefix(cfg.TokenEndpoint, "https://") {
        return cfg.TokenEndpoint // Google and generic use absolute URLs
    }
    return "https://" + NormalizeDomain(providerType, providerDomain) + cfg.TokenEndpoint
}
```

This is the same class of bug `.claude/rules/issuer-url-format.md` documents — provider-specific URL/trailing-slash quirks that must be handled in one place.

---

## Observed vs Expected

| Behaviour | Before | After |
|---|---|---|
| Quota check on cache-hit path after id_token expiry | Skipped (fail open) | Runs after silent refresh |
| Warning at 80–100% during steady-state use | Never shown | Shown (stderr + browser) |
| Block at >100% (`enforcement=block`) | Never enforced | Enforced |
| Azure `refresh_token` exchange URL | HTTP 404 (doubled `/v2.0`) | Correct URL |
| Valid Azure `refresh_token` after a recheck | Deleted on 404 | Preserved |
| Quota-state timestamp when no token available | Never persisted (frozen state) | Left unset → retried next run |

---

## Steps to Reproduce (Bug 1, isolating the recheck path)

After a successful auth (valid AWS creds + refresh + monitoring tokens stored):

```bash
# 1. Delete only the monitoring token (keep AWS creds + refresh token)
security delete-generic-password -s "claude-code-with-bedrock" -a "<profile>-monitoring"

# 2. Age the quota-state so a recheck fires
echo '{"last_check_unix":1}' > ~/claude-code-with-bedrock/.quota-state-<profile>.json

# 3. Invoke the binary and watch stderr
COGNITO_AUTH_DEBUG=1 ~/claude-code-with-bedrock/credential-process --profile <profile> 2>&1 >/dev/null
```

**Before:** empty token → silent `return true` → exit 0, credentials emitted, quota-state timestamp stays frozen.

**After:** `attempting token exchange...` → success → `quota.Check()` runs → warning or block displays on stderr + browser notification.

---

## Regression Tests

**`cmd/credential-process/quota_recheck_refresh_test.go`**

- `TestPerformQuotaRecheck_AttemptsRefreshWhenTokenExpired` — stores a refresh_token, invokes `performQuotaRecheck()` with no cached id_token and an unreachable IdP. The exchange fails and clears the refresh_token. **Before the fix**, `performQuotaRecheck` returned on the empty-token check and never touched the refresh_token. The cleared-token assertion therefore fails without the fix and passes with it. Also asserts quota-state timestamp was not saved.
- `TestPerformQuotaRecheck_NoTokenNoRefreshFailsOpenQuietly` — no id_token, no refresh_token. Must fail open (return true) without a browser flow and without saving a timestamp.

**`internal/provider/token_url_test.go`**

- `TestTokenEndpointURL_AzureNoDoubledVersion` — pins the Azure token URL output: no doubled version segment.
- `TestTokenEndpointURL_PerProvider` — full per-provider URL table (Okta org AS, Okta custom AS, Auth0, Cognito, Google absolute URL, unknown provider returns "").
- `TestNormalizeDomain` — strips only for Azure; idempotent; non-Azure untouched.

---

## Scope and Impact

- **All active OIDC users** effectively bypassed quota warnings and blocks after ~1h of any session — the #655/#657/#658 display logic is correct but is gated behind a `quota.Check()` that rarely ran.
- **All Azure deployments** had every silent-refresh path returning HTTP 404, degrading to repeated browser re-auth and silently deleting valid refresh_tokens.
- **Affected files** are Tier 1 per `.claude/rules/review-tiers.md` (`credential-process/main.go`). Cross-platform CI must pass.
- Python credential-provider not modified (slated for deprecation; has a related but differently-shaped gap — out of scope, noted in docs).

## Related

- #655 / #657 / #658 — added the warning/block display this fix sits upstream of
- `.claude/rules/issuer-url-format.md` — same class as Bug 2
- `.claude/rules/quota-requires-oidc.md`, `credential-flow.md`, `credential-helper-parity.md`