### PR TITLE
fix(managed-settings): add lock_default_model opt-out for model env vars (#665)

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1516,6 +1516,19 @@ class InitCommand(Command):
         if config["settings_target"] == "managed":
             console.print("[green]✓[/green] Settings will be deployed to OS-level managed path")
             console.print("[dim]  Users will need sudo (Unix) or Administrator (Windows) to install[/dim]")
+
+            # Ask whether to lock model selection in managed settings
+            console.print()
+            saved_lock = config.get("lock_default_model", False)
+            lock_model = questionary.confirm(
+                "Lock default model for all users? (Prevents users from changing model via /model)",
+                default=saved_lock,
+            ).ask()
+            config["lock_default_model"] = lock_model if lock_model is not None else False
+            if not config["lock_default_model"]:
+                console.print("[green]✓[/green] Users can freely select models via /model (CRIS routing still applied)")
+            else:
+                console.print("[yellow]![/yellow] Default model will be enforced for all users via managed-settings")
         else:
             console.print("[green]✓[/green] Settings will be deployed to user-scope path")
 
@@ -2568,6 +2581,7 @@ class InitCommand(Command):
             "settings_target": "managed"
             if (self._io and self.option("managed"))
             else config_data.get("settings_target", "user"),
+            "lock_default_model": config_data.get("lock_default_model", False),
             "tags": config_data.get("tags", {}),
             "redirect_port": config_data.get("redirect_port"),
         }
@@ -2900,6 +2914,10 @@ class InitCommand(Command):
             # Add selected model if present
             if hasattr(profile, "selected_model") and profile.selected_model:
                 existing_config["aws"]["selected_model"] = profile.selected_model
+
+            # Add lock_default_model if present
+            if hasattr(profile, "lock_default_model"):
+                existing_config["lock_default_model"] = profile.lock_default_model
 
             # Add cross-region profile if present
             if hasattr(profile, "cross_region_profile") and profile.cross_region_profile:

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -3250,8 +3250,17 @@ Available metrics include:
             if profile.credential_storage == "session":
                 settings["awsAuthRefresh"] = f"__CREDENTIAL_PROCESS_PATH__ --profile {profile_name}"
 
-            # Add ANTHROPIC_MODEL if user selected a model during init
-            if hasattr(profile, "selected_model") and profile.selected_model:
+            # Add ANTHROPIC_MODEL if user selected a model during init.
+            # For managed-settings: only write when lock_default_model is True (admin opt-in).
+            # For user-scope settings: always write (users can override via /model).
+            settings_target = getattr(profile, "settings_target", "user")
+            lock_model = getattr(profile, "lock_default_model", False)
+            should_write_model = (
+                hasattr(profile, "selected_model")
+                and profile.selected_model
+                and (settings_target != "managed" or lock_model)
+            )
+            if should_write_model:
                 from claude_code_with_bedrock.models import get_claude_code_alias, resolve_model_for_tier
 
                 # Use a Claude Code alias (sonnet/opus/opusplan/haiku) so ANTHROPIC_MODEL

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -34,6 +34,9 @@ class Profile:
     cross_region_profile: str | None = None  # Cross-region profile: "us", "europe", "apac"
     selected_model: str | None = None  # Selected Claude model ID (e.g., "us.anthropic.claude-3-7-sonnet-20250805-v1:0")
     model_alias: str | None = None  # Claude Code alias for ANTHROPIC_MODEL: "sonnet", "opus", "opusplan", "haiku"
+    lock_default_model: bool = (
+        False  # Write ANTHROPIC_MODEL + DEFAULT_*_MODEL into managed-settings (locks users to admin's choice)
+    )
     selected_source_region: str | None = None  # User-selected source region for AWS config and Claude Code settings
     created_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
     updated_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())

--- a/source/tests/cli/commands/test_managed_settings_model_lock.py
+++ b/source/tests/cli/commands/test_managed_settings_model_lock.py
@@ -1,0 +1,95 @@
+"""Tests for managed-settings model lock opt-out behavior (issue #665).
+
+Ensures that ANTHROPIC_MODEL and ANTHROPIC_DEFAULT_*_MODEL env vars are only
+written to managed-settings.json when lock_default_model is True.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+
+from claude_code_with_bedrock.cli.commands.package import PackageCommand
+from claude_code_with_bedrock.config import Profile
+
+
+class TestModelLockManagedSettings:
+    """Verify model env vars are gated on lock_default_model."""
+
+    def _make_profile(self, lock_default_model=False, selected_model="us.anthropic.claude-sonnet-4-6:0"):
+        return Profile(
+            name="Test",
+            provider_domain="test.okta.com",
+            client_id="client-id",
+            credential_storage="keyring",
+            aws_region="us-east-1",
+            identity_pool_name="test-pool",
+            selected_model=selected_model,
+            model_alias="sonnet",
+            cross_region_profile="us",
+            lock_default_model=lock_default_model,
+            settings_target="managed",
+        )
+
+    def _generate_and_read_settings(self, profile):
+        """Call _create_claude_settings and return the generated JSON dict."""
+        cmd = PackageCommand()
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp)
+            cmd._create_claude_settings(output_dir, profile)
+            settings_path = output_dir / "claude-settings" / "managed-settings.json"
+            assert settings_path.exists(), f"Expected {settings_path} to be created"
+            return json.loads(settings_path.read_text(encoding="utf-8"))
+
+    def test_model_env_vars_absent_when_lock_false(self):
+        """When lock_default_model=False, managed-settings must NOT contain ANTHROPIC_MODEL."""
+        profile = self._make_profile(lock_default_model=False)
+        settings = self._generate_and_read_settings(profile)
+        env = settings.get("env", {})
+        assert "ANTHROPIC_MODEL" not in env, (
+            "ANTHROPIC_MODEL should not be in managed-settings when lock_default_model=False"
+        )
+        assert "ANTHROPIC_DEFAULT_SONNET_MODEL" not in env
+        assert "ANTHROPIC_DEFAULT_OPUS_MODEL" not in env
+        assert "ANTHROPIC_DEFAULT_HAIKU_MODEL" not in env
+        assert "ANTHROPIC_SMALL_FAST_MODEL" not in env
+
+    def test_model_env_vars_present_when_lock_true(self):
+        """When lock_default_model=True, managed-settings MUST contain model env vars."""
+        profile = self._make_profile(lock_default_model=True)
+        settings = self._generate_and_read_settings(profile)
+        env = settings.get("env", {})
+        assert "ANTHROPIC_MODEL" in env, "ANTHROPIC_MODEL should be in managed-settings when lock_default_model=True"
+        assert env["ANTHROPIC_MODEL"] == "sonnet"
+        # At least some tier models should be set
+        assert "ANTHROPIC_DEFAULT_SONNET_MODEL" in env or "ANTHROPIC_SMALL_FAST_MODEL" in env
+
+    def test_lock_default_model_defaults_to_false(self):
+        """Profile with no explicit lock_default_model should default to False."""
+        profile = Profile(
+            name="Test",
+            provider_domain="test.okta.com",
+            client_id="client-id",
+            credential_storage="keyring",
+            aws_region="us-east-1",
+            identity_pool_name="test-pool",
+            selected_model="us.anthropic.claude-sonnet-4-6:0",
+            model_alias="sonnet",
+            cross_region_profile="us",
+            settings_target="managed",
+        )
+        assert profile.lock_default_model is False, "lock_default_model should default to False"
+
+    def test_backward_compat_old_profiles_default_unlocked(self):
+        """Profiles saved before lock_default_model field existed should behave as unlocked."""
+        profile = self._make_profile(lock_default_model=False)
+        settings = self._generate_and_read_settings(profile)
+        env = settings.get("env", {})
+        # The critical assertion: old behavior (no lock field = False) means NO model lock
+        assert "ANTHROPIC_MODEL" not in env
+
+    def test_no_model_env_when_no_selected_model(self):
+        """When no model is selected, no model env vars regardless of lock setting."""
+        profile = self._make_profile(lock_default_model=True, selected_model=None)
+        settings = self._generate_and_read_settings(profile)
+        env = settings.get("env", {})
+        assert "ANTHROPIC_MODEL" not in env


### PR DESCRIPTION
## Why

When `managed-settings.json` is generated, `ANTHROPIC_MODEL` and `ANTHROPIC_DEFAULT_*_MODEL` env vars are written unconditionally. Because managed-settings has the highest precedence and is non-overridable, this:

1. Hides 1M context models from the `/model` picker
2. Prevents users from changing their default model across sessions
3. Blocks fallback to alternative models during regional outages

Fixes #665 — thanks @adiospeds for the detailed report.

## What Changed

- **New field:** `lock_default_model: bool = False` in Profile dataclass
- **Conditional writing:** Model env vars only written to managed-settings when `lock_default_model=True`
- **User-scope unchanged:** `settings.json` (user-scope) always includes model env vars (users can override)
- **New prompt in `ccwb init`:** Only shown for managed-settings target: "Lock default model for all users?"
- **Reload path:** `_check_existing_deployment` preserves `lock_default_model` on re-init

## Backward Compatibility

| Scenario | Before | After |
|----------|--------|-------|
| User-scope settings | Model env vars written | **Same** — unchanged |
| Managed-settings (new deployments) | Model env vars written | **Not written** (default: unlocked) |
| Managed-settings (existing, re-run init) | Model env vars written | Not written unless admin opts in |

⚠️ **This is a behavioral change for existing managed-settings deployments.** Admins who want the old behavior (locked model) must re-run `ccwb init` and answer `Y` to the lock prompt, then re-package.

## Testing

```
1208 passed, 22 skipped, 1 xfailed, 1 xpassed (zero regressions)
```

5 new tests in `test_managed_settings_model_lock.py`:
- `test_model_env_vars_absent_when_lock_false`
- `test_model_env_vars_present_when_lock_true`
- `test_lock_default_model_defaults_to_false`
- `test_backward_compat_old_profiles_default_unlocked`
- `test_no_model_env_when_no_selected_model`
