### PR TITLE
fix(cowork): add landing page for browser auth re-authentication

### DIFF
--- a/source/go/internal/oidc/callback.go
+++ b/source/go/internal/oidc/callback.go
@@ -17,10 +17,78 @@ type CallbackResult struct {
 
 // StartCallbackServer starts an HTTP server on 127.0.0.1:port that handles
 // a single OAuth2 callback request. It returns a channel that receives the result.
-func StartCallbackServer(port int, expectedState string) (chan CallbackResult, *http.Server, error) {
+// authURL is the IdP authorization URL — the landing page links to it.
+func StartCallbackServer(port int, expectedState string, authURL string) (chan CallbackResult, *http.Server, error) {
 	resultCh := make(chan CallbackResult, 1)
 
 	mux := http.NewServeMux()
+
+	// Landing page — explains what's happening and provides a login button.
+	// This page is what the browser opens first (instead of jumping directly
+	// to the IdP), giving CoWork users context about why a browser appeared.
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(200)
+		page := fmt.Sprintf(`<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Claude Desktop — Authentication Required</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: #f8f9fa;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    padding: 20px;
+  }
+  .card {
+    background: white;
+    border-radius: 12px;
+    box-shadow: 0 4px 24px rgba(0,0,0,0.08);
+    padding: 48px;
+    max-width: 440px;
+    width: 100%%;
+    text-align: center;
+  }
+  .icon { font-size: 48px; margin-bottom: 16px; }
+  h1 { font-size: 20px; color: #1a1a1a; margin-bottom: 12px; }
+  p { font-size: 14px; color: #666; line-height: 1.6; margin-bottom: 24px; }
+  .btn {
+    display: inline-block;
+    background: #d97706;
+    color: white;
+    padding: 12px 32px;
+    border-radius: 8px;
+    text-decoration: none;
+    font-size: 15px;
+    font-weight: 500;
+    transition: background 0.2s;
+  }
+  .btn:hover { background: #b45309; }
+  .note { font-size: 12px; color: #999; margin-top: 20px; }
+</style>
+</head>
+<body>
+<div class="card">
+  <div class="icon">&#x1f510;</div>
+  <h1>Authentication Required</h1>
+  <p>Your Claude Desktop session has expired.<br>Please log in to continue.</p>
+  <a class="btn" href="%s">Log in</a>
+  <p class="note">After logging in, this window will close automatically<br>and Claude Desktop will resume.</p>
+</div>
+</body>
+</html>`, html.EscapeString(authURL))
+		w.Write([]byte(page)) //nolint:errcheck
+	})
+
 	mux.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
 		q := r.URL.Query()
 
@@ -29,7 +97,7 @@ func StartCallbackServer(port int, expectedState string) (chan CallbackResult, *
 			if desc == "" {
 				desc = errMsg
 			}
-			sendHTML(w, 400, "Authentication failed")
+			sendErrorHTML(w, desc)
 			resultCh <- CallbackResult{Error: desc}
 			return
 		}
@@ -38,12 +106,12 @@ func StartCallbackServer(port int, expectedState string) (chan CallbackResult, *
 		code := q.Get("code")
 
 		if state != expectedState || code == "" {
-			sendHTML(w, 400, "Invalid response")
+			sendErrorHTML(w, "Invalid response from identity provider")
 			resultCh <- CallbackResult{Error: "Invalid state or missing code"}
 			return
 		}
 
-		sendHTML(w, 200, "Authentication successful! You can close this window.")
+		sendSuccessHTML(w)
 		resultCh <- CallbackResult{Code: code}
 	})
 
@@ -82,14 +150,91 @@ func WaitForCallback(resultCh chan CallbackResult, srv *http.Server, timeout tim
 	}
 }
 
-func sendHTML(w http.ResponseWriter, code int, message string) {
+func sendSuccessHTML(w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "text/html")
-	w.WriteHeader(code)
-	page := fmt.Sprintf(`<html>
-<head><title>Authentication</title></head>
-<body style="font-family: sans-serif; text-align: center; padding: 50px;">
-    <h1>%s</h1>
-    <p>Return to your terminal to continue.</p>
+	w.WriteHeader(200)
+	w.Write([]byte(`<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Authentication Complete</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: #f8f9fa;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    padding: 20px;
+  }
+  .card {
+    background: white;
+    border-radius: 12px;
+    box-shadow: 0 4px 24px rgba(0,0,0,0.08);
+    padding: 48px;
+    max-width: 440px;
+    width: 100%;
+    text-align: center;
+  }
+  .icon { font-size: 48px; margin-bottom: 16px; }
+  h1 { font-size: 20px; color: #1a1a1a; margin-bottom: 12px; }
+  p { font-size: 14px; color: #666; line-height: 1.6; }
+</style>
+</head>
+<body>
+<div class="card">
+  <div class="icon">&#x2705;</div>
+  <h1>Authentication Complete</h1>
+  <p>You can close this tab.<br>Claude Desktop will resume automatically.</p>
+</div>
+<script>setTimeout(function(){ window.close(); }, 3000);</script>
+</body>
+</html>`)) //nolint:errcheck
+}
+
+func sendErrorHTML(w http.ResponseWriter, message string) {
+	w.Header().Set("Content-Type", "text/html")
+	w.WriteHeader(400)
+	page := fmt.Sprintf(`<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Authentication Failed</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: #f8f9fa;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    padding: 20px;
+  }
+  .card {
+    background: white;
+    border-radius: 12px;
+    box-shadow: 0 4px 24px rgba(0,0,0,0.08);
+    padding: 48px;
+    max-width: 440px;
+    width: 100%%;
+    text-align: center;
+  }
+  .icon { font-size: 48px; margin-bottom: 16px; }
+  h1 { font-size: 20px; color: #c53030; margin-bottom: 12px; }
+  p { font-size: 14px; color: #666; line-height: 1.6; }
+  .error { background: #fff5f5; border: 1px solid #fed7d7; border-radius: 6px; padding: 12px; margin-top: 16px; font-size: 13px; color: #c53030; }
+</style>
+</head>
+<body>
+<div class="card">
+  <div class="icon">&#x274c;</div>
+  <h1>Authentication Failed</h1>
+  <p>Please close this tab and try again, or contact your administrator.</p>
+  <div class="error">%s</div>
+</div>
 </body>
 </html>`, html.EscapeString(message))
 	w.Write([]byte(page)) //nolint:errcheck

--- a/source/go/internal/oidc/callback_test.go
+++ b/source/go/internal/oidc/callback_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestStartCallbackServer_ListensOnPort(t *testing.T) {
-	resultCh, srv, err := StartCallbackServer(0, "test-state")
+	resultCh, srv, err := StartCallbackServer(0, "test-state", "https://example.com/authorize")
 	if err != nil {
 		t.Fatalf("StartCallbackServer failed: %v", err)
 	}
@@ -25,7 +25,7 @@ func TestStartCallbackServer_ValidCallback(t *testing.T) {
 	port := 19876 // Use a high port to avoid conflicts
 	state := "test-state-abc123"
 
-	resultCh, srv, err := StartCallbackServer(port, state)
+	resultCh, srv, err := StartCallbackServer(port, state, "https://example.com/authorize")
 	if err != nil {
 		t.Fatalf("StartCallbackServer failed: %v", err)
 	}
@@ -61,7 +61,7 @@ func TestStartCallbackServer_InvalidState(t *testing.T) {
 	port := 19877
 	state := "correct-state"
 
-	resultCh, srv, err := StartCallbackServer(port, state)
+	resultCh, srv, err := StartCallbackServer(port, state, "https://example.com/authorize")
 	if err != nil {
 		t.Fatalf("StartCallbackServer failed: %v", err)
 	}
@@ -93,7 +93,7 @@ func TestStartCallbackServer_MissingCode(t *testing.T) {
 	port := 19878
 	state := "my-state"
 
-	resultCh, srv, err := StartCallbackServer(port, state)
+	resultCh, srv, err := StartCallbackServer(port, state, "https://example.com/authorize")
 	if err != nil {
 		t.Fatalf("StartCallbackServer failed: %v", err)
 	}
@@ -125,7 +125,7 @@ func TestStartCallbackServer_ErrorCallback(t *testing.T) {
 	port := 19879
 	state := "my-state"
 
-	resultCh, srv, err := StartCallbackServer(port, state)
+	resultCh, srv, err := StartCallbackServer(port, state, "https://example.com/authorize")
 	if err != nil {
 		t.Fatalf("StartCallbackServer failed: %v", err)
 	}
@@ -150,6 +150,36 @@ func TestStartCallbackServer_ErrorCallback(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("Timeout waiting for callback result")
+	}
+}
+
+func TestStartCallbackServer_LandingPage(t *testing.T) {
+	port := 19880
+	state := "my-state"
+	authURL := "https://idp.example.com/oauth2/authorize?client_id=abc"
+
+	_, srv, err := StartCallbackServer(port, state, authURL)
+	if err != nil {
+		t.Fatalf("StartCallbackServer failed: %v", err)
+	}
+	defer srv.Close()
+
+	// Request the landing page
+	url := fmt.Sprintf("http://127.0.0.1:%d/", port)
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("HTTP GET failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Errorf("Expected 200, got %d", resp.StatusCode)
+	}
+
+	// Verify content type is HTML
+	ct := resp.Header.Get("Content-Type")
+	if ct != "text/html" {
+		t.Errorf("Expected text/html, got %s", ct)
 	}
 }
 

--- a/source/go/internal/oidc/flow.go
+++ b/source/go/internal/oidc/flow.go
@@ -94,15 +94,21 @@ func Authenticate(providerDomain, clientID, providerType, oktaAuthServerID strin
 		tokenURL = provider.TokenEndpointURL(providerType, oktaAuthServerID, providerDomain)
 	}
 
-	// Start callback server
-	resultCh, srv, err := StartCallbackServer(redirectPort, state)
+	// Start callback server (serves landing page + handles /callback)
+	resultCh, srv, err := StartCallbackServer(redirectPort, state, authURL)
 	if err != nil {
 		return nil, fmt.Errorf("starting callback server: %w", err)
 	}
 
-	// Open browser
-	if err := browser.OpenURL(authURL); err != nil {
-		fmt.Fprintf(os.Stderr, "Could not open browser. Visit: %s\n", authURL)
+	// Open browser to the local landing page, which explains what's happening
+	// and provides a button to proceed to the IdP. This gives CoWork (GUI) users
+	// context about why a browser window appeared.
+	landingURL := fmt.Sprintf("http://localhost:%d/", redirectPort)
+	if err := browser.OpenURL(landingURL); err != nil {
+		// Fallback: try opening the IdP directly
+		if err2 := browser.OpenURL(authURL); err2 != nil {
+			fmt.Fprintf(os.Stderr, "Could not open browser. Visit: %s\n", landingURL)
+		}
 	}
 
 	// Wait for callback (5 min timeout)


### PR DESCRIPTION
## Why

When Claude Desktop needs to re-authenticate after all cached tokens expire, the credential-process opens a browser tab directly to the IdP login URL. On Windows, this tab often appears in the background without any context — users don't know what it is, why it appeared, or that Claude Desktop is waiting for them. After a 5-minute timeout, Claude Desktop silently fails with a credential error.

See #664 for full diagnosis.

## How It's Triggered (Step by Step)

Claude Desktop calls `credential-process` (via the AWS SDK) every time it needs AWS credentials. The binary has a 4-step cascade:

```
1. getCachedCredentials()
   └─ Cached AWS creds valid? → return immediately (fast path, ~0ms)
   └─ TTL: 8-12 hours

2. trySilentRefresh()
   └─ Cached id_token not expired? → exchange for fresh AWS creds
   └─ TTL: ~50 min (1h token - 10min buffer)

3. tryRefreshToken()
   └─ refresh_token valid? → POST to IdP token endpoint → get new tokens
   └─ TTL: 7-30 days (admin-configured)

4. authenticate()  ← THIS IS WHERE THE FIX APPLIES
   └─ All tokens expired → must open browser for interactive login
   └─ BEFORE: Opens browser directly to IdP (Okta/Entra login page)
   └─ AFTER:  Opens browser to localhost landing page first
```

Step 4 triggers when:
- First-time setup (no tokens cached yet)
- Refresh token expired (Okta default: 7 days if rotation disabled)
- Token file corrupted (concurrent credential-process instances on Windows)
- IdP revoked the refresh token (admin action or policy change)

## What

Adds a self-explanatory landing page that the browser opens **first**, before redirecting to the IdP:

```
Before: browser → Okta login page (no context, may be in background)
After:  browser → localhost landing page → user clicks 'Log in' → Okta → callback → success page
```

**Landing page:**
> 🔐 Authentication Required
> Your Claude Desktop session has expired. Please log in to continue.
> \[ Log in \]
> After logging in, this window will close automatically and Claude Desktop will resume.

**Success page (auto-closes after 3s):**
> ✅ Authentication Complete
> You can close this tab. Claude Desktop will resume automatically.

**Error page:**
> ❌ Authentication Failed
> Please close this tab and try again, or contact your administrator.
> `error details from IdP`

### Files changed

| File | Change |
|------|--------|
| `source/go/internal/oidc/callback.go` | Add `/` handler serving landing HTML; styled success/error pages with auto-close |
| `source/go/internal/oidc/flow.go` | Open browser to `localhost:<port>/` (landing page) instead of IdP URL directly |
| `source/go/internal/oidc/callback_test.go` | Add landing page test, update `StartCallbackServer` call signatures |

~200 lines added, ~20 removed. No new dependencies. No new binaries.

## Testing

- `gofmt`: clean on all modified files
- Python tests: 1208 passed (no regressions)
- Go build: requires 1.24 (CI validates)

## Closes

Fixes #664