### PR TITLE
fix(idc): reliable IDC auth, credential refresh, and Windows telemetry

### DIFF
--- a/assets/docs/LOCAL_TESTING.md
+++ b/assets/docs/LOCAL_TESTING.md
@@ -192,3 +192,88 @@ unset AWS_SESSION_TOKEN
 export AWS_PROFILE=ClaudeCode
 aws sts get-caller-identity
 ```
+
+### IAM Identity Center (IDC) on headless / SSH hosts
+
+IDC profiles (`auth_type: idc`) sign in with the browser-based device-authorization
+flow. The credential process runs this automatically the first time it needs
+credentials, printing a verification URL and code. On a desktop it also opens
+your browser; on a headless box or over SSH it detects the lack of a local
+browser (via `SSH_CONNECTION`/`SSH_TTY` or no `DISPLAY`) and instead shows a URL
+you open on any other device.
+
+**Use the `claude-bedrock` launcher instead of `claude` directly.** The installer
+generates a launcher next to the binaries
+(`~/claude-code-with-bedrock/claude-bedrock`, or `claude-bedrock.cmd` on Windows).
+It signs you in (showing the verification URL live in your terminal — a no-op if
+you already have a valid session), then runs Claude Code:
+
+```bash
+~/claude-code-with-bedrock/claude-bedrock
+# First run: a verification URL + code print to your terminal.
+# Open the URL on any device with a browser, approve — then Claude Code starts.
+
+# Optional: add the folder to PATH so you can just type `claude-bedrock`:
+export PATH="$HOME/claude-code-with-bedrock:$PATH"
+
+# Use a non-default profile:
+AWS_PROFILE=ClaudeCode ~/claude-code-with-bedrock/claude-bedrock
+```
+
+You can also sign in by hand without launching Claude Code (e.g. to pre-warm the
+cache):
+
+```bash
+credential-process --login --profile ClaudeCode
+export AWS_PROFILE=ClaudeCode
+aws sts get-caller-identity
+```
+
+`--login` performs only the sign-in (it never prints credentials) and is a no-op
+when a valid session is already cached. No AWS CLI is required — the
+device-authorization login is built into the credential process binary, and the
+SSO token is cached in `~/.aws/sso/cache/` (refreshed automatically until the
+session fully expires).
+
+> **Why a launcher instead of plain `claude`?** The IDC sign-in is interactive
+> (browser approval), but Claude Code runs the credential helper
+> non-interactively and cannot display its prompt reliably — so it can't be
+> driven from inside a running session. If you start `claude` without an active
+> sign-in, the credential process fails fast and Claude Code flashes a brief
+> "Cloud authentication" error before retrying — easy to miss, leaving `claude`
+> apparently stuck. The `claude-bedrock` launcher avoids this by running the
+> sign-in first, in your terminal, where the URL is shown and persists.
+>
+> If you need to see a credential error that already scrolled away, run Claude
+> Code with debug logging: `CLAUDE_CODE_DEBUG_LOGS_DIR=~/.claude/debug claude
+> --debug` captures credential-resolution output to a file.
+
+### IDC credential refresh during a session
+
+IDC role credentials are short-lived — their lifetime is set by the IAM Identity
+Center **permission set's session duration** (AWS default: 1 hour, max 12). For
+IDC the generated `settings.json` wires **two** Claude Code credential hooks,
+which work together:
+
+- **`awsCredentialExport`** — the primary resolver. Its output is captured
+  silently, and Claude Code re-invokes it automatically ~5 minutes before the
+  credentials' `Expiration`. This drives the *silent* hourly refresh: while the
+  longer-lived SSO session is still valid, the credential process re-mints role
+  credentials via STS with no browser. (Requires Claude Code **v2.1.176+**;
+  the credential-process JSON schema is accepted in **v2.1.181+**.)
+- **`awsAuthRefresh`** (`--login`) — fires on the first credential failure and
+  its output **is displayed to the user**. This is the only channel that can
+  surface the sign-in message, because `awsCredentialExport` discards stderr.
+  When there's no valid SSO session, this is what tells the user to relaunch
+  with `claude-bedrock` instead of leaving `claude` silently retrying.
+
+Without `awsCredentialExport`, credentials are resolved only once at startup, so
+after the session duration elapses Claude Code retries expired credentials
+(`API error · Retrying…`) and, on EC2, the SDK chain falls back to the instance
+role. To prevent that silent wrong-identity fallback, IDC settings also set
+`AWS_EC2_METADATA_DISABLED=true`, so a refresh failure surfaces as a clear
+credentials error instead.
+
+The separate ~8-hour SSO **session** expiry still requires an interactive
+re-login — relaunch with `claude-bedrock`, which runs `--login` (URL shown live)
+before starting Claude Code.

--- a/assets/docs/MONITORING.md
+++ b/assets/docs/MONITORING.md
@@ -107,6 +107,29 @@ The CloudWatch Dashboard uses PromQL queries over OTLP-ingested metrics. Section
 - **Organizational Breakdown** — Token usage by department and team
 - **Bedrock API Health** — Throttles, client errors, server errors by model
 
+### Per-user attribution (`user.email`)
+
+The collector sets the `user.email` dimension from the `x-user-email` request
+header, which Claude Code sends only when `otelHeadersHelper` (the `otel-helper`
+binary) is configured in `settings.json`. How the email is resolved depends on
+the auth type:
+
+- **OIDC** — extracted from the JWT `email` claim.
+- **IDC (with the credential-process binary, e.g. when quota is enabled)** —
+  resolved from the IAM ARN session name (`assumed-role/Role/user@company.com`)
+  and cached by the credential process; the helper serves it. Per-user dashboard
+  attribution works the same as OIDC. *(Requires repackaging with a build that
+  wires `otelHeadersHelper` for IDC — older packages attributed all IDC users to
+  one static identity.)*
+- **IDC zero-binary (no credential-process)** — there is no runtime identity
+  resolver, so a single static identity is baked into the collector config at
+  package time; all telemetry is attributed to that one identity.
+
+Note: richer OTEL dimensions (department, team, project) come from JWT claims and
+are only populated for OIDC. IDC attributes `user.email` only. See
+[Cost Attribution](COST_ATTRIBUTION.md#idc-limitation) for the CUR/ABAC path to
+per-user team/department breakdowns under IDC.
+
 ## Usage Quota Monitoring
 
 Quota monitoring uses the CloudWatch Prometheus-compatible API (`monitoring.<region>.amazonaws.com/api/v1/query`) to query per-user token usage via PromQL. The quota monitor Lambda runs every 15 minutes, fetches usage data via PromQL, writes results to a DynamoDB table (`UserQuotaMetrics`), and checks against quota policies.

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -2804,6 +2804,28 @@ EOF
     echo "  ✓ Created AWS profile '$PROFILE_NAME'"
 done
 
+# Generate a 'claude-bedrock' launcher wrapper.
+# It signs in (a no-op when the session is still valid) so the verification URL
+# is shown live in the user's terminal, THEN launches Claude Code. This avoids
+# the "run claude → silent hang" trap for IDC: the interactive sign-in can't be
+# surfaced through Claude Code's own credential refresh, so we front-run it here
+# where stdout/stderr go straight to the terminal.
+CRED_PROC="$ACTUAL_HOME/claude-code-with-bedrock/credential-process"
+LAUNCHER="$ACTUAL_HOME/claude-code-with-bedrock/claude-bedrock"
+FIRST_PROFILE=$(echo $PROFILES | awk '{{print $1}}')
+cat > "$LAUNCHER" << EOF
+#!/bin/bash
+# Launch Claude Code with Bedrock authentication.
+# Signs in first (no-op if already signed in), then runs claude.
+PROFILE="\\${{AWS_PROFILE:-$FIRST_PROFILE}}"
+"$CRED_PROC" --login --profile "\\$PROFILE" || exit 1
+export AWS_PROFILE="\\$PROFILE"
+exec claude "\\$@"
+EOF
+chmod +x "$LAUNCHER"
+if [ -n "$SUDO_USER" ]; then chown "$ACTUAL_USER" "$LAUNCHER"; fi
+echo "  ✓ Created launcher: $LAUNCHER"
+
 # Post-install validation
 echo
 echo "Validating installation..."
@@ -2828,16 +2850,19 @@ for PROFILE_NAME in $PROFILES; do
     echo "  - $PROFILE_NAME"
 done
 echo
-echo "To use Claude Code authentication:"
-echo "  export AWS_PROFILE=<profile-name>"
-echo "  aws sts get-caller-identity"
+echo ">>> Start Claude Code with the launcher, NOT 'claude' directly:"
+echo "      $LAUNCHER"
 echo
-echo "Example:"
-FIRST_PROFILE=$(echo $PROFILES | awk '{{print $1}}')
-echo "  export AWS_PROFILE=$FIRST_PROFILE"
-echo "  aws sts get-caller-identity"
+echo "    The launcher signs you in (shows the sign-in URL in your terminal when"
+echo "    needed) and then starts Claude Code. If you run 'claude' directly without"
+echo "    an active sign-in, it can briefly flash a sign-in error and then keep"
+echo "    retrying — easy to miss. The launcher avoids that."
 echo
-echo "Note: Authentication will automatically open your browser when needed."
+echo "Tip: add it to your PATH so you can just run 'claude-bedrock':"
+echo "  export PATH=\\"$ACTUAL_HOME/claude-code-with-bedrock:\\$PATH\\""
+echo
+echo "To use a non-default profile, set AWS_PROFILE before launching:"
+echo "  AWS_PROFILE=<profile-name> $LAUNCHER"
 echo
 """
 
@@ -2854,6 +2879,14 @@ echo
 
     def _create_windows_installer(self, output_dir: Path, profile) -> Path:
         """Create Windows batch installer script."""
+
+        # When monitoring is enabled, Claude Code's otelHeadersHelper points at
+        # otel-helper.cmd (which falls back to otel-helper.ps1 if AV blocks the
+        # .exe). Those files are then REQUIRED: a missing .cmd silently breaks all
+        # telemetry export. So the installer must fail loudly if they're absent.
+        # When monitoring is off, the helper isn't referenced, so their absence is
+        # harmless and the copy stays best-effort.
+        _otel_missing_is_fatal = bool(profile.monitoring_enabled)
 
         installer_content = f"""@echo off
 SETLOCAL ENABLEDELAYEDEXPANSION
@@ -2903,12 +2936,40 @@ if exist "otel-helper-windows.exe" (
     copy /Y "otel-helper-windows.exe" "%USERPROFILE%\\claude-code-with-bedrock\\otel-helper.exe" >nul
 )
 
-REM Copy PowerShell OTEL helper (AV-safe alternative to the Go binary)
-if exist "otel-helper.ps1" (
-    copy /Y "otel-helper.ps1" "%USERPROFILE%\\claude-code-with-bedrock\\otel-helper.ps1" >nul
-)
+REM Copy the OTEL helper wrapper (.cmd) and its PowerShell fallback (.ps1).
+REM Claude Code's otelHeadersHelper points at otel-helper.cmd, which runs the
+REM fast .exe and falls back to the .ps1 if antivirus blocks the binary. When
+REM monitoring is enabled these files are REQUIRED — a missing .cmd makes Claude
+REM Code fail every telemetry export with "is not recognized as an internal or
+REM external command" and silently drops all metrics, so we fail the install
+REM loudly rather than leave a broken telemetry config.
 if exist "otel-helper.cmd" (
     copy /Y "otel-helper.cmd" "%USERPROFILE%\\claude-code-with-bedrock\\otel-helper.cmd" >nul
+    if %errorlevel% neq 0 (
+        echo ERROR: Failed to copy otel-helper.cmd
+        pause
+        exit /b 1
+    )
+) else (
+    echo {'ERROR' if _otel_missing_is_fatal else 'INFO'}: otel-helper.cmd not found in package.
+{'''    echo        Claude Code needs it to send telemetry [otelHeadersHelper].
+    echo        Re-extract the full package [including .cmd and .ps1 files] and retry.
+    pause
+    exit /b 1''' if _otel_missing_is_fatal else '    REM Monitoring disabled - helper not required.'}
+)
+if exist "otel-helper.ps1" (
+    copy /Y "otel-helper.ps1" "%USERPROFILE%\\claude-code-with-bedrock\\otel-helper.ps1" >nul
+    if %errorlevel% neq 0 (
+        echo ERROR: Failed to copy otel-helper.ps1
+        pause
+        exit /b 1
+    )
+) else (
+    echo {'ERROR' if _otel_missing_is_fatal else 'INFO'}: otel-helper.ps1 not found in package.
+{'''    echo        It is the antivirus fallback for otel-helper.cmd and is required.
+    echo        Re-extract the full package and run install.bat again.
+    pause
+    exit /b 1''' if _otel_missing_is_fatal else '    REM Monitoring disabled - fallback not required.'}
 )
 
 REM Copy configuration
@@ -2938,7 +2999,7 @@ if exist "claude-settings" (
         if not exist "C:\\Program Files\\ClaudeCode" mkdir "C:\\Program Files\\ClaudeCode"
 
         REM Replace placeholders and write managed settings
-        powershell -Command "$otelPath = $env:USERPROFILE + '\\claude-code-with-bedrock\\otel-helper.cmd' -replace '\\\\', '/'; $credPath = $env:USERPROFILE + '\\claude-code-with-bedrock\\credential-process.exe' -replace '\\\\', '/'; (Get-Content 'claude-settings\\managed-settings.json') -replace '__OTEL_HELPER_PATH__', $otelPath -replace '__CREDENTIAL_PROCESS_PATH__', $credPath | Set-Content 'C:\\Program Files\\ClaudeCode\\managed-settings.json'"
+        powershell -Command "$otelPath = ($env:USERPROFILE + '\\claude-code-with-bedrock\\otel-helper.cmd').Replace('\\','\\\\'); $credPath = $env:USERPROFILE + '\\claude-code-with-bedrock\\credential-process.exe' -replace '\\\\', '/'; (Get-Content 'claude-settings\\managed-settings.json') -replace '__OTEL_HELPER_PATH__', $otelPath -replace '__CREDENTIAL_PROCESS_PATH__', $credPath | Set-Content 'C:\\Program Files\\ClaudeCode\\managed-settings.json'"
         echo OK Managed settings installed: C:\\Program Files\\ClaudeCode\\managed-settings.json
         echo    These settings have highest precedence and cannot be overridden by users.
     )
@@ -2950,7 +3011,7 @@ if exist "claude-settings" (
             echo Existing Claude Code settings found - merging...
 
             REM Merge new settings into existing (preserves user customizations)
-            powershell -NoProfile -Command "$otelPath = $env:USERPROFILE + '\\claude-code-with-bedrock\\otel-helper.cmd' -replace '\\\\', '/'; $credPath = $env:USERPROFILE + '\\claude-code-with-bedrock\\credential-process.exe' -replace '\\\\', '/'; $existing = Get-Content (Join-Path $env:USERPROFILE '.claude\\settings.json') | ConvertFrom-Json; $incoming = (Get-Content 'claude-settings\\settings.json') -replace '__OTEL_HELPER_PATH__', $otelPath -replace '__CREDENTIAL_PROCESS_PATH__', $credPath | ConvertFrom-Json; foreach ($prop in $incoming.PSObject.Properties) {{{{ $existing | Add-Member -MemberType NoteProperty -Name $prop.Name -Value $prop.Value -Force }}}}; $existing | ConvertTo-Json -Depth 10 | Set-Content (Join-Path $env:USERPROFILE '.claude\\settings.json')"
+            powershell -NoProfile -Command "$otelPath = ($env:USERPROFILE + '\\claude-code-with-bedrock\\otel-helper.cmd').Replace('\\','\\\\'); $credPath = $env:USERPROFILE + '\\claude-code-with-bedrock\\credential-process.exe' -replace '\\\\', '/'; $existing = Get-Content (Join-Path $env:USERPROFILE '.claude\\settings.json') | ConvertFrom-Json; $incoming = (Get-Content 'claude-settings\\settings.json') -replace '__OTEL_HELPER_PATH__', $otelPath -replace '__CREDENTIAL_PROCESS_PATH__', $credPath | ConvertFrom-Json; foreach ($prop in $incoming.PSObject.Properties) {{{{ $existing | Add-Member -MemberType NoteProperty -Name $prop.Name -Value $prop.Value -Force }}}}; $existing | ConvertTo-Json -Depth 10 | Set-Content (Join-Path $env:USERPROFILE '.claude\\settings.json')"
             if %errorlevel% equ 0 (
                 echo OK Claude Code settings merged [user settings preserved]
             ) else (
@@ -2964,7 +3025,7 @@ if exist "claude-settings" (
 
         if not "%SKIP_SETTINGS%"=="true" if not exist "%USERPROFILE%\\.claude\\settings.json" (
             REM No existing settings - write directly
-            powershell -Command "$otelPath = $env:USERPROFILE + '\\claude-code-with-bedrock\\otel-helper.cmd' -replace '\\\\', '/'; $credPath = $env:USERPROFILE + '\\claude-code-with-bedrock\\credential-process.exe' -replace '\\\\', '/'; (Get-Content 'claude-settings\\settings.json') -replace '__OTEL_HELPER_PATH__', $otelPath -replace '__CREDENTIAL_PROCESS_PATH__', $credPath | Set-Content (Join-Path $env:USERPROFILE '.claude\\settings.json')"
+            powershell -Command "$otelPath = ($env:USERPROFILE + '\\claude-code-with-bedrock\\otel-helper.cmd').Replace('\\','\\\\'); $credPath = $env:USERPROFILE + '\\claude-code-with-bedrock\\credential-process.exe' -replace '\\\\', '/'; (Get-Content 'claude-settings\\settings.json') -replace '__OTEL_HELPER_PATH__', $otelPath -replace '__CREDENTIAL_PROCESS_PATH__', $credPath | Set-Content (Join-Path $env:USERPROFILE '.claude\\settings.json')"
             echo OK Claude Code settings configured
         )
     )
@@ -3010,6 +3071,28 @@ for /f %%p in ('powershell -NoProfile -Command "$c=Get-Content config.json|Conve
     )
 )
 
+REM Generate a 'claude-bedrock.cmd' launcher.
+REM It signs in first (no-op if the session is still valid) so the verification
+REM URL is shown live in the user's console, THEN launches Claude Code. This
+REM avoids the "run claude -> silent hang" trap for IDC, whose interactive
+REM sign-in cannot be surfaced through Claude Code's own credential refresh.
+REM
+REM Written with plain batch 'echo' redirection (NOT PowerShell) so the embedded
+REM quotes survive. In this script %%X%% becomes literal %X% in the .cmd, and
+REM %%* becomes %*, so the launcher's own runtime expansion is deferred.
+echo.
+echo Creating launcher...
+set "LAUNCHER=%USERPROFILE%\\claude-code-with-bedrock\\claude-bedrock.cmd"
+set "CRED_PROC=%USERPROFILE%\\claude-code-with-bedrock\\credential-process.exe"
+set "FIRST_PROFILE="
+for /f %%p in ('powershell -NoProfile -Command "(Get-Content config.json | ConvertFrom-Json).PSObject.Properties.Name | Select-Object -First 1"') do set "FIRST_PROFILE=%%p"
+> "%LAUNCHER%" echo @echo off
+>> "%LAUNCHER%" echo if "%%AWS_PROFILE%%"=="" set AWS_PROFILE=!FIRST_PROFILE!
+>> "%LAUNCHER%" echo "%CRED_PROC%" --login --profile %%AWS_PROFILE%%
+>> "%LAUNCHER%" echo if errorlevel 1 exit /b 1
+>> "%LAUNCHER%" echo claude %%*
+echo   OK Created launcher: %LAUNCHER%
+
 echo.
 echo ======================================
 echo Installation complete!
@@ -3020,17 +3103,19 @@ for /f %%p in ('powershell -NoProfile -Command "(Get-Content config.json | Conve
     echo   - %%p
 )
 echo.
-echo To use Claude Code authentication:
+echo ^>^>^> Start Claude Code with the launcher, NOT 'claude' directly:
+echo       %USERPROFILE%\\claude-code-with-bedrock\\claude-bedrock.cmd
+echo.
+echo     The launcher signs you in (shows the sign-in URL in your terminal when
+echo     needed) and then starts Claude Code. If you run 'claude' directly without
+echo     an active sign-in, it can briefly flash a sign-in error and then keep
+echo     retrying - easy to miss. The launcher avoids that.
+echo.
+echo Tip: add that folder to your PATH so you can just run 'claude-bedrock'.
+echo.
+echo To use a non-default profile, set AWS_PROFILE before launching:
 echo   set AWS_PROFILE=^<profile-name^>
-echo   aws sts get-caller-identity
-echo.
-echo Example:
-for /f %%p in ('powershell -NoProfile -Command "(Get-Content config.json | ConvertFrom-Json).PSObject.Properties.Name | Select-Object -First 1"') do (
-    echo   set AWS_PROFILE=%%p
-    echo   aws sts get-caller-identity
-)
-echo.
-echo Note: Authentication will automatically open your browser when needed.
+echo   %USERPROFILE%\\claude-code-with-bedrock\\claude-bedrock.cmd
 echo.
 pause
 """
@@ -3246,8 +3331,49 @@ Available metrics include:
             if not include_coauthored_by:
                 settings["includeCoAuthoredBy"] = False
 
-            # Add awsAuthRefresh for session-based credential storage
-            if profile.credential_storage == "session":
+            # For IDC, disable the EC2 instance-metadata credential provider. If a
+            # credential refresh ever fails, the AWS SDK credential chain would
+            # otherwise fall through to the instance role on EC2 — silently running
+            # Claude Code as the wrong identity (breaking cost attribution and quota,
+            # and masking the failure). With IMDS disabled, a refresh failure surfaces
+            # as a clear credentials error instead. IDC identity comes solely from the
+            # credential-process binary, so nothing legitimately needs IMDS here.
+            if profile.effective_auth_type == "idc":
+                settings["env"]["AWS_EC2_METADATA_DISABLED"] = "true"
+
+            # Credential refresh on expiry. AWS_CREDENTIAL_PROCESS (set above) is
+            # ignored by Claude Code once a hook below is set, and on its own it is
+            # resolved only at startup — so a long session would retry stale
+            # credentials (and on EC2 the SDK chain falls back to the instance role —
+            # wrong identity). Claude Code offers two hooks, which behave differently
+            # and (verified empirically) are COMPLEMENTARY when both are set:
+            #
+            #   awsCredentialExport — output captured SILENTLY as credential JSON; the
+            #                         primary resolver, re-invoked automatically ~5 min
+            #                         before the Expiration we emit (Claude Code
+            #                         >= 2.1.176; flat credential_process JSON accepted
+            #                         >= 2.1.181). Drives the silent hourly STS refresh.
+            #   awsAuthRefresh      — output is DISPLAYED to the user; fires on the FIRST
+            #                         credential failure (not on every retry). This is the
+            #                         only channel that surfaces our sign-in message —
+            #                         awsCredentialExport discards stderr.
+            #
+            # IDC needs BOTH:
+            #   - awsCredentialExport for the silent ~hourly role-credential refresh
+            #     (SSO session still valid -> re-mint via STS, no browser); and
+            #   - awsAuthRefresh so that when there is NO valid SSO session, the binary's
+            #     fail-fast message ("relaunch with claude-bedrock") is shown to the user
+            #     instead of a silent retry loop. The fail-fast guard makes the binary
+            #     exit immediately here, so awsAuthRefresh does NOT hang (the original
+            #     reason it was dropped for IDC). The ~8h SSO-session re-login itself
+            #     still happens out-of-band via the claude-bedrock launcher.
+            #
+            # Non-IDC (OIDC) session profiles keep just awsAuthRefresh — their refresh
+            # can be interactive (browser), which is exactly what that hook is for.
+            if profile.effective_auth_type == "idc":
+                settings["awsCredentialExport"] = f"__CREDENTIAL_PROCESS_PATH__ --profile {profile_name}"
+                settings["awsAuthRefresh"] = f"__CREDENTIAL_PROCESS_PATH__ --login --profile {profile_name}"
+            elif profile.credential_storage == "session":
                 settings["awsAuthRefresh"] = f"__CREDENTIAL_PROCESS_PATH__ --profile {profile_name}"
 
             # Add ANTHROPIC_MODEL if user selected a model during init.
@@ -3401,11 +3527,23 @@ Available metrics include:
                         }
                     )
 
-                    # Add the helper executable for generating OTEL headers with user attributes
-                    # IDC path uses static identity in collector config — no helper needed.
-                    # Use a placeholder that will be replaced by the installer script based on platform
+                    # Add the helper executable for generating per-user OTEL headers.
+                    # The placeholder is replaced by the installer with the platform path.
+                    #
+                    # When IS this needed?
+                    #   - OIDC: always — the helper extracts user attributes from the JWT.
+                    #   - IDC with the credential-process binary (e.g. quota enabled): the
+                    #     binary resolves the user's email from the IAM ARN session name and
+                    #     caches it (writeOtelCacheFromIDC / writeOtelCacheFromSTS); the helper
+                    #     serves that cache as x-user-email so the collector attributes metrics
+                    #     PER USER. Without the helper, IDC dashboards collapse to a single
+                    #     static identity.
+                    #   - IDC zero-binary (no credential-process): there's no binary to compute
+                    #     identity at runtime, so attribution comes from the static identity
+                    #     baked into the collector config — no helper to wire here.
                     _is_idc = getattr(profile, "effective_auth_type", profile.auth_type) == "idc"
-                    if not _is_idc:
+                    _idc_zero_binary = _is_idc and not bool(getattr(profile, "quota_api_endpoint", None))
+                    if not _idc_zero_binary:
                         settings["otelHeadersHelper"] = "__OTEL_HELPER_PATH__"
 
                     is_https = endpoint.startswith("https://")

--- a/source/go/cmd/credential-process/idc.go
+++ b/source/go/cmd/credential-process/idc.go
@@ -4,13 +4,15 @@ package main
 //
 // When config.json has auth_type=="idc" (or sso_enabled==false with idc_start_url
 // populated), credential-process drives the SSO OIDC device-authorization flow
-// directly via the AWS SDK. This opens the user's browser for approval — no
-// manual `aws sso login` required.
+// itself (RegisterClient → StartDeviceAuthorization → browser approval →
+// CreateToken), writing the resulting token to the SDK's standard cache. This
+// means no AWS CLI / `aws sso login` dependency — the binary is self-contained.
 //
 // Flow:
 //   1. Load SSO config from config.json (start_url, account, role)
 //   2. Check for cached SSO token (~/.aws/sso/cache/)
-//   3. If expired/missing → initiate SSO OIDC device auth (opens browser)
+//   3. If expired/missing → run device authorization (opens browser), then
+//      persist the token to the cache in the SDK's on-disk format
 //   4. Exchange SSO token for role credentials via STS
 //   5. Perform quota check (SigV4-signed, via CheckWithIAM)
 //   6. Write OTEL attribution cache (email from ARN session name)
@@ -19,8 +21,11 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+	"runtime"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -28,25 +33,51 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials/ssocreds"
 	"github.com/aws/aws-sdk-go-v2/service/sso"
 	"github.com/aws/aws-sdk-go-v2/service/ssooidc"
+	ssooidctypes "github.com/aws/aws-sdk-go-v2/service/ssooidc/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 
+	"ccwb-go/internal/browser"
 	"ccwb-go/internal/otel"
+	"ccwb-go/internal/portlock"
 	"ccwb-go/internal/quota"
 )
 
-// runIDC performs active SSO authentication for IAM Identity Center users.
-// It uses the AWS SDK's ssocreds package to manage the SSO token lifecycle
-// (including opening the browser for device authorization when needed).
-func (a *credentialApp) runIDC() int {
-	debugPrint("IDC active SSO mode for profile '%s'", a.profile)
+// idcRefreshLockPort serializes the SSO refresh-token exchange across concurrent
+// credential-process invocations. IAM Identity Center refresh tokens ROTATE:
+// CreateToken(refresh_token) consumes the presented token and issues a new one,
+// invalidating the old. Claude Code routinely fires several credential-process
+// calls at once (e.g. the session-title model and the main model on the same
+// turn). Without serialization, the first call rotates the token while the
+// others still hold the consumed one -> InvalidGrantException, and the bricked
+// cache then fails every subsequent call until an interactive re-login. Holding
+// an exclusive local lock around the refresh means exactly one process rotates;
+// the rest wait, then read the now-valid cached token (no second rotation).
+// Distinct from the OIDC redirect port (default 8400) so the two never collide.
+const idcRefreshLockPort = 8401
 
+// idcSettings holds the validated IDC parameters and SSO clients needed by
+// both the full credential flow (runIDC) and the login-only flow (runIDCLogin).
+type idcSettings struct {
+	region     string
+	startURL   string
+	accountID  string
+	roleName   string
+	tokenPath  string
+	ssoClient  *sso.Client
+	oidcClient *ssooidc.Client
+}
+
+// resolveIDCSettings validates the profile's IDC configuration and constructs
+// the SSO clients. On any error it prints a user-facing message and returns a
+// non-zero exit code (second return value); callers should propagate it.
+func (a *credentialApp) resolveIDCSettings(ctx context.Context) (*idcSettings, int) {
 	region := a.cfg.IDCRegion
 	if region == "" {
 		region = a.cfg.AWSRegion
 	}
 	if region == "" {
 		fmt.Fprintln(os.Stderr, "Error: no region configured for IDC. Set idc_region or aws_region in config.json.")
-		return 1
+		return nil, 1
 	}
 
 	startURL := a.cfg.IDCStartURL
@@ -66,50 +97,139 @@ func (a *credentialApp) runIDC() int {
 		}
 		fmt.Fprintln(os.Stderr, "")
 		fmt.Fprintln(os.Stderr, "Run 'ccwb init' to reconfigure, or edit config.json directly.")
-		return 1
+		return nil, 1
 	}
 
 	debugPrint("IDC config: start_url=%s account=%s role=%s region=%s", startURL, accountID, roleName, region)
-
-	// 120s timeout allows time for user to approve in browser.
-	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
-	defer cancel()
 
 	// Load minimal AWS config for the SSO region.
 	awsCfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(region))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: failed to load AWS config for IDC: %v\n", err)
-		return 1
+		return nil, 1
 	}
 
 	// Resolve the cached token file path for this SSO session.
 	tokenPath, err := ssocreds.StandardCachedTokenFilepath(startURL)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: failed to resolve SSO token cache path: %v\n", err)
+		return nil, 1
+	}
+
+	return &idcSettings{
+		region:     region,
+		startURL:   startURL,
+		accountID:  accountID,
+		roleName:   roleName,
+		tokenPath:  tokenPath,
+		ssoClient:  sso.NewFromConfig(awsCfg),
+		oidcClient: ssooidc.NewFromConfig(awsCfg),
+	}, 0
+}
+
+// runIDCLogin runs the interactive sign-in step only: it ensures a valid SSO
+// token is cached (running device authorization if needed), then exits without
+// emitting credentials. This is the recommended first step on headless/SSH
+// hosts, where the AWS SDK would otherwise capture the device-auth prompt when
+// credential-process is invoked non-interactively by Claude Code.
+func (a *credentialApp) runIDCLogin() int {
+	debugPrint("IDC login (sign-in only) for profile '%s'", a.profile)
+
+	// Generous timeout: the user must approve in a browser, possibly on another
+	// device, before this returns.
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
+	defer cancel()
+
+	s, code := a.resolveIDCSettings(ctx)
+	if code != 0 {
+		return code
+	}
+
+	if tokenValid(s.tokenPath) {
+		fmt.Fprintln(os.Stderr, "Already signed in to IAM Identity Center — cached session is still valid.")
+		return 0
+	}
+
+	// Expired access token with refresh material present: try the silent refresh
+	// before prompting. tokenRefreshable only confirms the fields EXIST — it
+	// cannot tell whether the refresh token is still accepted by AWS (a rotated/
+	// consumed or genuinely expired refresh token returns InvalidGrantException).
+	// So we must actually attempt the refresh: success means the session is still
+	// alive (no prompt needed); failure means we fall through to interactive
+	// device auth rather than falsely reporting "already signed in".
+	if tokenRefreshable(s.tokenPath) {
+		if err := a.refreshIDCTokenLocked(ctx, s.oidcClient, s.tokenPath); err == nil {
+			fmt.Fprintln(os.Stderr, "Already signed in to IAM Identity Center — session refreshed.")
+			return 0
+		} else {
+			debugPrint("Silent refresh failed (%v); falling through to interactive sign-in", err)
+		}
+	}
+
+	if err := a.runDeviceAuthorization(ctx, s.oidcClient, s.startURL, s.tokenPath); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: IDC sign-in failed: %v\n", err)
 		return 1
 	}
 
-	// Create SSO clients.
-	ssoClient := sso.NewFromConfig(awsCfg)
-	oidcClient := ssooidc.NewFromConfig(awsCfg)
+	fmt.Fprintln(os.Stderr, "Signed in to IAM Identity Center. Claude Code can now run without further prompts until the session expires.")
+	return 0
+}
+
+// runIDC performs active SSO authentication for IAM Identity Center users.
+// It drives the device-authorization flow itself when needed (see idc device
+// auth helpers below), caches the SSO token, then exchanges it for role
+// credentials via STS.
+func (a *credentialApp) runIDC() int {
+	debugPrint("IDC active SSO mode for profile '%s'", a.profile)
+
+	// 120s timeout allows time for user to approve in browser.
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	s, code := a.resolveIDCSettings(ctx)
+	if code != 0 {
+		return code
+	}
+	region := s.region
+	startURL := s.startURL
+	accountID := s.accountID
+	roleName := s.roleName
+	tokenPath := s.tokenPath
+	ssoClient := s.ssoClient
+	oidcClient := s.oidcClient
+
+	// Ensure a usable SSO token exists in ~/.aws/sso/cache/. The SDK's
+	// ssocreds.SSOTokenProvider only READS (and refreshes via refresh_token)
+	// an existing cached token — it does NOT perform device authorization.
+	// On a machine that has never run the device-auth flow, the cache file is
+	// absent and Retrieve() fails with "failed to read cached SSO token file".
+	// We drive the device-auth flow ourselves (browser approval) so end users
+	// never need the AWS CLI / `aws sso login`.
+	if err := a.ensureIDCToken(ctx, oidcClient, startURL, tokenPath); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: IDC authentication failed: %v\n", err)
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "If authentication did not complete, ensure:")
+		fmt.Fprintln(os.Stderr, "  - idc_start_url is correct in config.json")
+		fmt.Fprintln(os.Stderr, "  - Your network can reach the SSO portal")
+		fmt.Fprintln(os.Stderr, "  - You approved the request in your browser")
+		return 1
+	}
 
 	// Create SSO role credentials provider with token lifecycle management.
-	// The SSOTokenProvider handles the full device-auth flow: checks
-	// ~/.aws/sso/cache/ for a valid token, and if expired/missing, initiates
-	// OIDC device authorization (opens browser for user approval).
+	// The SSOTokenProvider reads the cached token written above (and silently
+	// refreshes it via refresh_token when expired).
 	credProvider := ssocreds.New(ssoClient, accountID, roleName, startURL, func(opts *ssocreds.Options) {
 		opts.SSOTokenProvider = ssocreds.NewSSOTokenProvider(oidcClient, tokenPath)
 	})
 
-	// Retrieve credentials — opens browser if SSO session expired.
-	debugPrint("Retrieving IDC credentials (may open browser for auth)...")
+	// Exchange the SSO token for role credentials via STS.
+	debugPrint("Retrieving IDC role credentials...")
 	creds, err := credProvider.Retrieve(ctx)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: IDC authentication failed: %v\n", err)
 		fmt.Fprintln(os.Stderr, "")
-		fmt.Fprintln(os.Stderr, "If your browser did not open, ensure:")
-		fmt.Fprintln(os.Stderr, "  - idc_start_url is correct in config.json")
-		fmt.Fprintln(os.Stderr, "  - Your network can reach the SSO portal")
+		fmt.Fprintln(os.Stderr, "If credential retrieval failed, ensure:")
+		fmt.Fprintln(os.Stderr, "  - idc_account_id and idc_permission_set_name are correct in config.json")
 		fmt.Fprintln(os.Stderr, "  - You have permission to assume the configured role")
 		return 1
 	}
@@ -201,4 +321,354 @@ func (a *credentialApp) writeOtelCacheFromIDC(creds aws.Credentials, region stri
 	if err := otel.WriteCachedHeaders(a.profile, headers, expiry); err != nil {
 		debugPrint("writeOtelCacheFromIDC: cache write failed: %v", err)
 	}
+}
+
+// ssoCachedToken mirrors the on-disk format the AWS SDK's ssocreds package
+// reads from ~/.aws/sso/cache/<sha1(startURL)>.json. We write the same shape
+// so the SDK's SSOTokenProvider can read it back (and refresh it via
+// refresh_token when expired). Field names and the RFC3339 expiresAt format
+// must match the SDK exactly.
+type ssoCachedToken struct {
+	AccessToken  string `json:"accessToken"`
+	ExpiresAt    string `json:"expiresAt"`
+	RefreshToken string `json:"refreshToken,omitempty"`
+	ClientID     string `json:"clientId,omitempty"`
+	ClientSecret string `json:"clientSecret,omitempty"`
+	Region       string `json:"region,omitempty"`
+	StartURL     string `json:"startUrl,omitempty"`
+}
+
+// ensureIDCToken guarantees a non-expired SSO access token exists at tokenPath.
+// If the cached token is present and unexpired, it returns immediately. Otherwise
+// it runs the OIDC device-authorization flow (opening the user's browser) and
+// persists the resulting token in the SDK's cache format.
+func (a *credentialApp) ensureIDCToken(ctx context.Context, oidcClient *ssooidc.Client, startURL, tokenPath string) error {
+	if tokenValid(tokenPath) {
+		debugPrint("Existing SSO token cache is valid: %s", tokenPath)
+		return nil
+	}
+	// Access token expired but the cache can be refreshed silently
+	// (refresh_token + client creds present). Perform the refresh under an
+	// exclusive lock so concurrent credential-process invocations don't each
+	// try to redeem the rotating refresh token (see idcRefreshLockPort).
+	if tokenRefreshable(tokenPath) {
+		debugPrint("SSO access token expired but refreshable; refreshing under lock")
+		return a.refreshIDCTokenLocked(ctx, oidcClient, tokenPath)
+	}
+	debugPrint("No valid or refreshable SSO token cache; starting device authorization")
+	return a.runDeviceAuthorization(ctx, oidcClient, startURL, tokenPath)
+}
+
+// refreshIDCTokenLocked refreshes the SSO access token (via the rotating
+// refresh-token grant) while holding an exclusive local lock, so that only one
+// of several concurrent credential-process invocations performs the rotation.
+// The rest wait and then read the freshly-refreshed cached token instead of
+// presenting the now-consumed refresh token (which AWS rejects with
+// InvalidGrantException, bricking the cache for every later call).
+func (a *credentialApp) refreshIDCTokenLocked(ctx context.Context, oidcClient *ssooidc.Client, tokenPath string) error {
+	ln, _ := portlock.TryAcquire(idcRefreshLockPort)
+	if ln == nil {
+		// Another process is refreshing. Wait for it, then use its result.
+		debugPrint("Another process is refreshing the SSO token; waiting...")
+		portlock.WaitForRelease(idcRefreshLockPort, 30*time.Second)
+		if tokenValid(tokenPath) {
+			debugPrint("Concurrent refresh completed; using refreshed token")
+			return nil
+		}
+		// The other process didn't leave a valid token (it failed, or its token
+		// also expired). Try to take the lock and refresh ourselves.
+		ln, _ = portlock.TryAcquire(idcRefreshLockPort)
+		if ln == nil {
+			// Still contended — fall back to an unlocked refresh attempt rather
+			// than block indefinitely. Worst case this races, which is the
+			// pre-fix behavior, not a regression.
+			debugPrint("Refresh lock still contended; attempting refresh without lock")
+			return a.doIDCRefresh(ctx, oidcClient, tokenPath)
+		}
+	}
+	defer ln.Close()
+
+	// Re-check under the lock: a winner may have refreshed between our initial
+	// check and acquiring the lock, in which case there's nothing to do.
+	if tokenValid(tokenPath) {
+		debugPrint("Token already refreshed by another process; skipping refresh")
+		return nil
+	}
+	return a.doIDCRefresh(ctx, oidcClient, tokenPath)
+}
+
+// doIDCRefresh performs the actual refresh-token exchange via the SDK's token
+// provider, which redeems the refresh token and writes the rotated token back
+// to the cache. Run only by the lock holder in the normal path.
+func (a *credentialApp) doIDCRefresh(ctx context.Context, oidcClient *ssooidc.Client, tokenPath string) error {
+	provider := ssocreds.NewSSOTokenProvider(oidcClient, tokenPath)
+	if _, err := provider.RetrieveBearerToken(ctx); err != nil {
+		return fmt.Errorf("refreshing SSO token: %w", err)
+	}
+	return nil
+}
+
+// tokenValid reports whether tokenPath holds a cached token that is present and
+// not yet expired. A missing/unreadable/expired token returns false, which
+// triggers a fresh device-authorization flow. (We intentionally don't try to
+// refresh here — the SDK's SSOTokenProvider handles refresh_token when the
+// token is merely expired but refreshable; this gate is for the "no usable
+// session at all" case.)
+func tokenValid(tokenPath string) bool {
+	data, err := os.ReadFile(tokenPath) // #nosec G304 -- path derived from SDK helper, not user input
+	if err != nil {
+		return false
+	}
+	var t ssoCachedToken
+	if err := json.Unmarshal(data, &t); err != nil {
+		return false
+	}
+	if t.AccessToken == "" || t.ExpiresAt == "" {
+		return false
+	}
+	expiresAt, err := time.Parse(time.RFC3339, t.ExpiresAt)
+	if err != nil {
+		return false
+	}
+	// Require a small safety margin so we don't hand back a token that expires
+	// mid-request.
+	return time.Now().Add(60 * time.Second).Before(expiresAt)
+}
+
+// tokenRefreshable reports whether the cached token carries the material the
+// SDK's SSOTokenProvider needs to silently exchange an EXPIRED access token for
+// a fresh one (refresh_token grant): a refresh token plus the client id/secret
+// from RegisterClient. When this is true we must NOT force interactive
+// device-authorization just because the short-lived access token expired — the
+// SSO *session* (represented by the refresh token, typically hours/days) is
+// still alive, so letting credProvider.Retrieve run performs a no-browser
+// refresh. Gating device-auth on tokenValid alone caused premature "sign-in
+// required" at the ~1h access-token boundary.
+func tokenRefreshable(tokenPath string) bool {
+	data, err := os.ReadFile(tokenPath) // #nosec G304 -- path derived from SDK helper, not user input
+	if err != nil {
+		return false
+	}
+	var t ssoCachedToken
+	if err := json.Unmarshal(data, &t); err != nil {
+		return false
+	}
+	return t.RefreshToken != "" && t.ClientID != "" && t.ClientSecret != ""
+}
+
+// isHeadless is defined in quota_notification.go (shared by the quota
+// browser-notification flow and this IDC device-auth flow): it reports whether
+// there's no usable local browser, so the flow shows a copy-to-another-device
+// prompt instead of trying to launch a browser the user can't see.
+
+// stderrIsTerminal reports whether stderr is attached to an interactive
+// terminal. When false, our device-auth prompt is being captured (e.g. by the
+// AWS SDK's credential_process handling, or by Claude Code's awsAuthRefresh
+// which only displays output AFTER the command exits) rather than shown live —
+// so a blocking poll would never surface the verification URL to the user.
+func stderrIsTerminal() bool {
+	fi, err := os.Stderr.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}
+
+// launcherPath returns the absolute path to the claude-bedrock launcher, which
+// lives in the same directory as this binary — so we derive it from
+// os.Executable() rather than assuming it's on the user's PATH. Falls back to
+// the bare command name if the executable path can't be resolved (works if it
+// happens to be on PATH).
+func (a *credentialApp) launcherPath() string {
+	launcherName := "claude-bedrock"
+	if runtime.GOOS == "windows" {
+		launcherName = "claude-bedrock.cmd"
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return launcherName
+	}
+	return filepath.Join(filepath.Dir(exe), launcherName)
+}
+
+// runDeviceAuthorization performs the full SSO OIDC device-authorization flow
+// and writes the resulting token to tokenPath in the SDK's cache format.
+func (a *credentialApp) runDeviceAuthorization(ctx context.Context, oidcClient *ssooidc.Client, startURL, tokenPath string) error {
+	// Fail fast whenever stderr is not an interactive terminal — i.e. we're being
+	// run non-interactively (the Claude Code credential-hook case on every OS).
+	// Device authorization needs the user to read a verification URL/code live,
+	// but when stderr is captured we can't surface it, so polling would just
+	// block for the full timeout and then fail. Exit immediately with an
+	// actionable instruction instead of hanging.
+	//
+	// This intentionally does NOT also require isHeadless(): that heuristic
+	// can't detect a headless WINDOWS host (no DISPLAY equivalent; the switch
+	// assumes Windows/macOS have a desktop browser), so gating on it left
+	// non-SSH headless Windows (SSM Session Manager, services, containers) able
+	// to reach the blocking poll and hang. stderrIsTerminal alone is the correct
+	// signal — even if a browser could open, a captured-stderr caller can't show
+	// the user the code to verify. isHeadless() is used only below, to decide
+	// whether attempting browser.OpenURL is worthwhile in the interactive path.
+	if !stderrIsTerminal() {
+		// Plain-language message: no AWS jargon, explicit absolute path, and a
+		// clear "exit Claude Code, run this in your shell" instruction (the old
+		// "quit ... from your terminal" was ambiguous about WHAT to quit).
+		// We offer ONLY the launcher: it both signs in and reopens Claude Code,
+		// which is the one path that reliably recovers. Running the bare --login
+		// from another terminal refreshes the cache but does NOT reliably unstick
+		// an already-failed session, so surfacing it here would mislead.
+		launcher := a.launcherPath()
+		return fmt.Errorf(
+			"Your AWS sign-in session has expired. Renewing it requires a web browser, "+
+				"which Claude Code can't open on its own from here.\n"+
+				"To sign in again:\n"+
+				"  1. Exit Claude Code (press Ctrl-C, or type /quit).\n"+
+				"  2. At your command prompt, run:\n"+
+				"       %s\n"+
+				"     It shows a sign-in link to open in any browser, then reopens Claude Code.", launcher)
+	}
+
+	// 1. Register a public client capable of the device-code + refresh grants.
+	reg, err := oidcClient.RegisterClient(ctx, &ssooidc.RegisterClientInput{
+		ClientName: aws.String("claude-code-with-bedrock"),
+		ClientType: aws.String("public"),
+		Scopes:     []string{"sso:account:access"},
+		GrantTypes: []string{"urn:ietf:params:oauth:grant-type:device_code", "refresh_token"},
+	})
+	if err != nil {
+		return fmt.Errorf("registering SSO OIDC client: %w", err)
+	}
+
+	// 2. Start device authorization to obtain a user code + verification URL.
+	devAuth, err := oidcClient.StartDeviceAuthorization(ctx, &ssooidc.StartDeviceAuthorizationInput{
+		ClientId:     reg.ClientId,
+		ClientSecret: reg.ClientSecret,
+		StartUrl:     aws.String(startURL),
+	})
+	if err != nil {
+		return fmt.Errorf("starting device authorization: %w", err)
+	}
+
+	// 3. Direct the user to approve. Prefer the complete URL (code pre-filled);
+	//    print instructions to stderr (stdout is reserved for the credential JSON).
+	verificationURI := aws.ToString(devAuth.VerificationUriComplete)
+	if verificationURI == "" {
+		verificationURI = aws.ToString(devAuth.VerificationUri)
+	}
+	userCode := aws.ToString(devAuth.UserCode)
+
+	fmt.Fprintln(os.Stderr, "")
+	if isHeadless() {
+		// No local browser (SSH/headless): the user opens the URL on another
+		// device. Don't attempt to open a browser here — it would fail or, worse,
+		// launch a browser the user can't see. Show the plain verification URL +
+		// code so it works regardless of which device they use.
+		plainURI := aws.ToString(devAuth.VerificationUri)
+		if plainURI == "" {
+			plainURI = verificationURI
+		}
+		fmt.Fprintln(os.Stderr, "To sign in to IAM Identity Center, open this URL on any device with a browser:")
+		fmt.Fprintf(os.Stderr, "  %s\n", plainURI)
+		fmt.Fprintf(os.Stderr, "and enter this code: %s\n", userCode)
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintf(os.Stderr, "(Or open the direct link with the code pre-filled: %s )\n", verificationURI)
+		debugPrint("Headless environment detected; skipping browser open")
+	} else {
+		fmt.Fprintln(os.Stderr, "Opening your browser to sign in to IAM Identity Center.")
+		fmt.Fprintln(os.Stderr, "If it does not open, paste this URL into a browser:")
+		fmt.Fprintf(os.Stderr, "  %s\n", verificationURI)
+		fmt.Fprintf(os.Stderr, "and verify this code is shown: %s\n", userCode)
+		if err := browser.OpenURL(verificationURI); err != nil {
+			debugPrint("Could not open browser automatically: %v (continuing — user can open the URL manually)", err)
+		}
+	}
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "Waiting for approval...")
+
+	// 4. Poll CreateToken until the user approves (or the device code expires).
+	token, err := pollForToken(ctx, oidcClient, reg, devAuth)
+	if err != nil {
+		return err
+	}
+
+	// 5. Persist the token in the SDK's cache format so SSOTokenProvider can use it.
+	expiresAt := time.Now().Add(time.Duration(token.ExpiresIn) * time.Second)
+	cached := ssoCachedToken{
+		AccessToken:  aws.ToString(token.AccessToken),
+		ExpiresAt:    expiresAt.UTC().Format(time.RFC3339),
+		RefreshToken: aws.ToString(token.RefreshToken),
+		ClientID:     aws.ToString(reg.ClientId),
+		ClientSecret: aws.ToString(reg.ClientSecret),
+		StartURL:     startURL,
+	}
+	if err := writeSSOTokenCache(tokenPath, cached); err != nil {
+		return fmt.Errorf("writing SSO token cache: %w", err)
+	}
+	debugPrint("Device authorization complete; token cached at %s", tokenPath)
+	return nil
+}
+
+// pollForToken repeatedly calls CreateToken with the device code, honoring the
+// service's polling interval and slow-down signals, until the user approves.
+func pollForToken(
+	ctx context.Context,
+	oidcClient *ssooidc.Client,
+	reg *ssooidc.RegisterClientOutput,
+	devAuth *ssooidc.StartDeviceAuthorizationOutput,
+) (*ssooidc.CreateTokenOutput, error) {
+	interval := time.Duration(devAuth.Interval) * time.Second
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("timed out waiting for browser approval: %w", ctx.Err())
+		case <-time.After(interval):
+		}
+
+		out, err := oidcClient.CreateToken(ctx, &ssooidc.CreateTokenInput{
+			ClientId:     reg.ClientId,
+			ClientSecret: reg.ClientSecret,
+			DeviceCode:   devAuth.DeviceCode,
+			GrantType:    aws.String("urn:ietf:params:oauth:grant-type:device_code"),
+		})
+		if err == nil {
+			return out, nil
+		}
+
+		// Still waiting for the user to approve — keep polling.
+		var pending *ssooidctypes.AuthorizationPendingException
+		if errors.As(err, &pending) {
+			debugPrint("Authorization pending; continuing to poll")
+			continue
+		}
+		// Service asked us to back off — increase the interval and keep polling.
+		var slowDown *ssooidctypes.SlowDownException
+		if errors.As(err, &slowDown) {
+			interval += 5 * time.Second
+			debugPrint("Slow down requested; polling interval now %s", interval)
+			continue
+		}
+		// Anything else (expired device code, access denied, etc.) is terminal.
+		return nil, fmt.Errorf("device authorization failed: %w", err)
+	}
+}
+
+// writeSSOTokenCache writes the cached token JSON to path, creating the cache
+// directory if needed. The file is written 0600 (user-only) since it contains
+// bearer credentials; the directory is 0700.
+func writeSSOTokenCache(path string, token ssoCachedToken) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("creating SSO cache directory: %w", err)
+	}
+	data, err := json.Marshal(token)
+	if err != nil {
+		return fmt.Errorf("marshaling SSO token: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("writing SSO token file: %w", err)
+	}
+	return nil
 }

--- a/source/go/cmd/credential-process/idc_device_auth_test.go
+++ b/source/go/cmd/credential-process/idc_device_auth_test.go
@@ -1,0 +1,496 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/credentials/ssocreds"
+
+	"ccwb-go/internal/config"
+	"ccwb-go/internal/portlock"
+)
+
+// TestRunDeviceAuthorizationFailsFastWhenHeadlessAndNoTTY is the regression
+// test for the silent-hang fix. When stderr is not a terminal (the Claude Code
+// credential-hook case), there is no way to surface the verification URL to a
+// user who can act on it, so runDeviceAuthorization must return immediately with
+// actionable instructions instead of blocking on a poll that can never succeed.
+// Under `go test`, stderr is a pipe (not a char device), so stderrIsTerminal()
+// is false. We set SSH_CONNECTION here to represent the SSH case; the no-SSH
+// case is covered separately below.
+//
+// The guard runs before any network call, so a nil OIDC client is never
+// dereferenced — if the guard regresses, the test fails fast on the nil client
+// rather than hanging, which still surfaces the regression.
+func TestRunDeviceAuthorizationFailsFastWhenHeadlessAndNoTTY(t *testing.T) {
+	for _, e := range []string{"BROWSER", "SSH_TTY", "SSH_CLIENT", "DISPLAY", "WAYLAND_DISPLAY"} {
+		t.Setenv(e, "")
+	}
+	t.Setenv("SSH_CONNECTION", "10.0.0.1 22 10.0.0.2 51000")
+
+	app := &credentialApp{profile: "idc-test"}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := app.runDeviceAuthorization(ctx, nil, "https://d-1234567890.awsapps.com/start", filepath.Join(t.TempDir(), "tok.json"))
+	if err == nil {
+		t.Fatal("expected fail-fast error when headless without a TTY, got nil")
+	}
+	msg := err.Error()
+	// Plain-language message: explains the reason (expired session, needs a
+	// browser), names the claude-bedrock launcher, tells the user to exit Claude
+	// Code, and avoids AWS jargon.
+	for _, want := range []string{"claude-bedrock", "Exit Claude Code", "expired", "browser"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("fail-fast error missing %q; got: %s", want, msg)
+		}
+	}
+	// Should offer ONLY the launcher — not the raw --login command, which
+	// refreshes the cache but does not reliably unstick an already-failed
+	// session (misleading at this point) — and no AWS jargon.
+	for _, unwanted := range []string{"--login", "IAM Identity Center", "non-interactively"} {
+		if strings.Contains(msg, unwanted) {
+			t.Errorf("fail-fast error should not contain %q; got: %s", unwanted, msg)
+		}
+	}
+}
+
+// TestRunDeviceAuthorizationFailsFastNoTTYWithoutSSH covers the headless-Windows
+// gap: a non-SSH host (no SSH_* env) where Claude Code captures stderr. Here
+// isHeadless() would return false on Windows/macOS (it assumes a desktop
+// browser), so gating the fail-fast on isHeadless() previously let this case
+// reach the blocking device-auth poll and hang. With the fix the gate is
+// stderrIsTerminal() alone, so it must STILL fail fast with no SSH env set.
+// (A nil OIDC client guarantees we never reach the network/poll.)
+func TestRunDeviceAuthorizationFailsFastNoTTYWithoutSSH(t *testing.T) {
+	// Clear every signal isHeadless() inspects so this is the "looks like a
+	// desktop" case — yet stderr is still a pipe under `go test`.
+	for _, e := range []string{"BROWSER", "SSH_CONNECTION", "SSH_TTY", "SSH_CLIENT", "DISPLAY", "WAYLAND_DISPLAY"} {
+		t.Setenv(e, "")
+	}
+
+	app := &credentialApp{profile: "idc-test"}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := app.runDeviceAuthorization(ctx, nil, "https://d-1234567890.awsapps.com/start", filepath.Join(t.TempDir(), "tok.json"))
+	if err == nil {
+		t.Fatal("expected fail-fast error when stderr is not a TTY (no SSH), got nil")
+	}
+	if !strings.Contains(err.Error(), "claude-bedrock") {
+		t.Errorf("expected launcher in fail-fast message; got: %s", err.Error())
+	}
+}
+
+// TestIsHeadless verifies the SSH/headless detection that decides whether the
+// device-auth flow tries to open a local browser or shows a copy-to-another-
+// device prompt. Getting this wrong on a remote host means the binary launches
+// a browser the user can never see, then times out waiting for approval.
+func TestIsHeadless(t *testing.T) {
+	// Clear every signal isHeadless inspects so each case starts from a known
+	// state regardless of the real test environment (which may itself be SSH).
+	for _, e := range []string{"BROWSER", "SSH_CONNECTION", "SSH_TTY", "SSH_CLIENT", "DISPLAY", "WAYLAND_DISPLAY"} {
+		t.Setenv(e, "")
+	}
+
+	t.Run("ssh_session_is_headless_on_any_os", func(t *testing.T) {
+		t.Setenv("SSH_CONNECTION", "10.0.0.1 22 10.0.0.2 51000")
+		if !isHeadless() {
+			t.Error("SSH session must be treated as headless")
+		}
+	})
+
+	t.Run("browser_override_forces_not_headless", func(t *testing.T) {
+		// Even inside an SSH session, an explicit $BROWSER means the user told us
+		// how to open a browser — honor it.
+		t.Setenv("SSH_CONNECTION", "10.0.0.1 22 10.0.0.2 51000")
+		t.Setenv("BROWSER", "/usr/bin/firefox")
+		if isHeadless() {
+			t.Error("explicit $BROWSER must force non-headless")
+		}
+	})
+
+	t.Run("linux_no_display_is_headless", func(t *testing.T) {
+		if runtime.GOOS != "linux" {
+			t.Skip("DISPLAY heuristic only applies to Linux/BSD")
+		}
+		// No SSH, no DISPLAY, no WAYLAND_DISPLAY → no GUI session.
+		if !isHeadless() {
+			t.Error("Linux with no DISPLAY/WAYLAND_DISPLAY must be headless")
+		}
+	})
+
+	t.Run("linux_with_display_is_not_headless", func(t *testing.T) {
+		if runtime.GOOS != "linux" {
+			t.Skip("DISPLAY heuristic only applies to Linux/BSD")
+		}
+		t.Setenv("DISPLAY", ":0")
+		if isHeadless() {
+			t.Error("Linux with DISPLAY set must not be headless")
+		}
+	})
+
+	t.Run("desktop_os_not_headless_without_ssh", func(t *testing.T) {
+		if runtime.GOOS != "windows" && runtime.GOOS != "darwin" {
+			t.Skip("desktop-OS assumption only applies to Windows/macOS")
+		}
+		// No SSH and a desktop OS → assume a local browser exists.
+		if isHeadless() {
+			t.Errorf("%s without SSH must not be headless", runtime.GOOS)
+		}
+	})
+}
+
+// TestTokenValid covers the gate that decides whether we can reuse a cached SSO
+// token or must run a fresh device-authorization flow. A wrong answer here
+// either re-prompts the user needlessly (false negative) or hands back an
+// about-to-expire token mid-request (false positive).
+func TestTokenValid(t *testing.T) {
+	dir := t.TempDir()
+
+	write := func(name, contents string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(contents), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		return p
+	}
+
+	future := time.Now().Add(2 * time.Hour).UTC().Format(time.RFC3339)
+	past := time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339)
+	soon := time.Now().Add(30 * time.Second).UTC().Format(time.RFC3339) // inside 60s safety margin
+
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"missing_file", filepath.Join(dir, "does-not-exist.json"), false},
+		{"valid_unexpired", write("valid.json", `{"accessToken":"tok","expiresAt":"`+future+`"}`), true},
+		{"expired", write("expired.json", `{"accessToken":"tok","expiresAt":"`+past+`"}`), false},
+		{"within_safety_margin", write("soon.json", `{"accessToken":"tok","expiresAt":"`+soon+`"}`), false},
+		{"empty_access_token", write("noaccess.json", `{"accessToken":"","expiresAt":"`+future+`"}`), false},
+		{"missing_expiry", write("noexp.json", `{"accessToken":"tok"}`), false},
+		{"malformed_json", write("bad.json", `{not json`), false},
+		{"bad_timestamp", write("badts.json", `{"accessToken":"tok","expiresAt":"not-a-date"}`), false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tokenValid(tc.path); got != tc.want {
+				t.Errorf("tokenValid(%s) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestWriteSSOTokenCacheReadableBySDK is the core regression test for the IDC
+// device-auth fix. The device-authorization flow writes the SSO token to
+// ~/.aws/sso/cache/ in the SDK's on-disk format; ssocreds.SSOTokenProvider must
+// be able to read it back. If the JSON field names or the RFC3339 expiresAt
+// format drift from what the SDK expects, IDC auth breaks with the same
+// "failed to read cached SSO token file" error this fix was meant to eliminate.
+//
+// We assert the round-trip against the REAL SDK reader (ssocreds.SSOTokenProvider,
+// the exact type runIDC wires up), not a reimplementation, so the test fails if
+// the SDK's on-disk format changes too. For an unexpired token the provider
+// reads straight from the cache file and never touches its client, so a nil
+// client is safe here.
+func TestWriteSSOTokenCacheReadableBySDK(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sso", "cache", "token.json")
+
+	expiresAt := time.Now().Add(8 * time.Hour)
+	token := ssoCachedToken{
+		AccessToken:  "access-token-value",
+		ExpiresAt:    expiresAt.UTC().Format(time.RFC3339),
+		RefreshToken: "refresh-token-value",
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		StartURL:     "https://d-1234567890.awsapps.com/start",
+	}
+
+	if err := writeSSOTokenCache(path, token); err != nil {
+		t.Fatalf("writeSSOTokenCache: %v", err)
+	}
+
+	// Cache file must be created with the parent directories.
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected cache file at %s: %v", path, err)
+	}
+
+	// The SDK's SSOTokenProvider must be able to read what we wrote. nil client
+	// is fine: the token is unexpired so no CreateToken refresh call is made.
+	provider := ssocreds.NewSSOTokenProvider(nil, path)
+	bt, err := provider.RetrieveBearerToken(context.Background())
+	if err != nil {
+		t.Fatalf("SDK SSOTokenProvider failed to read our cache: %v", err)
+	}
+	if bt.Value != token.AccessToken {
+		t.Errorf("accessToken round-trip mismatch: got %q want %q", bt.Value, token.AccessToken)
+	}
+	if !bt.CanExpire || bt.Expires.IsZero() {
+		t.Errorf("expiresAt did not round-trip: CanExpire=%v Expires=%v", bt.CanExpire, bt.Expires)
+	}
+}
+
+// TestWriteSSOTokenCachePermissions verifies the cached bearer token is written
+// with user-only (0600) permissions — it grants AWS access and must not be
+// world-readable. (No-op semantics on Windows, but enforced on POSIX where the
+// EC2/Linux installs run.)
+func TestWriteSSOTokenCachePermissions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cache", "token.json")
+	if err := writeSSOTokenCache(path, ssoCachedToken{AccessToken: "x", ExpiresAt: time.Now().UTC().Format(time.RFC3339)}); err != nil {
+		t.Fatalf("writeSSOTokenCache: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 && perm != 0o666 /* Windows */ {
+		t.Errorf("cache file perms = %o, want 0600", perm)
+	}
+}
+
+// TestTokenRefreshable covers the gate that distinguishes "expired but the SDK
+// can silently refresh via refresh_token" from "no session at all". A false
+// negative here forces a premature interactive sign-in the moment the ~1h SSO
+// access token expires (the observed 403 -> "sign-in required" regression),
+// instead of letting the SDK exchange the refresh token with no browser.
+func TestTokenRefreshable(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, contents string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(contents), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"missing_file", filepath.Join(dir, "nope.json"), false},
+		{"full_refresh_material", write("ok.json",
+			`{"accessToken":"a","expiresAt":"2020-01-01T00:00:00Z","refreshToken":"r","clientId":"c","clientSecret":"s"}`), true},
+		{"no_refresh_token", write("nort.json",
+			`{"accessToken":"a","clientId":"c","clientSecret":"s"}`), false},
+		{"no_client_id", write("nocid.json",
+			`{"refreshToken":"r","clientSecret":"s"}`), false},
+		{"no_client_secret", write("nocs.json",
+			`{"refreshToken":"r","clientId":"c"}`), false},
+		{"malformed", write("bad.json", `{nope`), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tokenRefreshable(tc.path); got != tc.want {
+				t.Errorf("tokenRefreshable(%s) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEnsureIDCToken_RefreshableDoesNotDeviceAuth is the regression test for the
+// 1-hour expiry bug. With an EXPIRED access token that still has refresh
+// material, ensureIDCToken must take the silent-refresh path, NOT interactive
+// device authorization.
+//
+// We isolate "did not device-auth" from "the refresh network call": another
+// goroutine holds the refresh lock and writes a VALID token, so ensureIDCToken
+// waits, sees the refreshed token, and returns without ever invoking the (nil)
+// oidc client. A nil client guarantees the assertion — if the logic regressed
+// to device auth or an unlocked refresh, it would dereference nil and panic.
+func TestEnsureIDCToken_RefreshableDoesNotDeviceAuth(t *testing.T) {
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, "tok.json")
+	expired := `{"accessToken":"a","expiresAt":"2020-01-01T00:00:00Z","refreshToken":"r","clientId":"c","clientSecret":"s"}`
+	if err := os.WriteFile(tokenPath, []byte(expired), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ln, err := portlock.TryAcquire(idcRefreshLockPort)
+	if err != nil || ln == nil {
+		t.Skipf("could not acquire refresh lock port %d; skipping", idcRefreshLockPort)
+	}
+	future := time.Now().Add(1 * time.Hour).UTC().Format(time.RFC3339)
+	refreshed := `{"accessToken":"new","expiresAt":"` + future + `","refreshToken":"r2","clientId":"c","clientSecret":"s"}`
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+		_ = os.WriteFile(tokenPath, []byte(refreshed), 0o600)
+		ln.Close()
+	}()
+
+	app := &credentialApp{profile: "idc-test"}
+	if err := app.ensureIDCToken(context.Background(), nil, "https://d-1.awsapps.com/start", tokenPath); err != nil {
+		t.Fatalf("expected nil (silent refresh via concurrent winner), got %v", err)
+	}
+}
+
+// TestRefreshIDCTokenLocked_WaitsForConcurrentRefresh is the regression test for
+// the rotating-refresh-token race. When another process already holds the
+// refresh lock and leaves behind a valid (refreshed) token, refreshIDCTokenLocked
+// must wait, observe the valid token, and return WITHOUT attempting its own
+// refresh — otherwise it would redeem the already-consumed refresh token and get
+// InvalidGrantException. We prove "no refresh attempt" by passing a nil oidc
+// client: if the lock logic regressed and tried to refresh, doIDCRefresh would
+// dereference nil and panic.
+func TestRefreshIDCTokenLocked_WaitsForConcurrentRefresh(t *testing.T) {
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, "tok.json")
+	// Start with an EXPIRED-but-refreshable token (what a racing caller sees).
+	expired := `{"accessToken":"old","expiresAt":"2020-01-01T00:00:00Z","refreshToken":"r","clientId":"c","clientSecret":"s"}`
+	if err := os.WriteFile(tokenPath, []byte(expired), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate the "winner" holding the refresh lock, then completing: it writes
+	// a VALID token and releases the lock shortly after.
+	ln, err := portlock.TryAcquire(idcRefreshLockPort)
+	if err != nil || ln == nil {
+		t.Skipf("could not acquire refresh lock port %d (in use); skipping", idcRefreshLockPort)
+	}
+	future := time.Now().Add(1 * time.Hour).UTC().Format(time.RFC3339)
+	refreshed := `{"accessToken":"new","expiresAt":"` + future + `","refreshToken":"r2","clientId":"c","clientSecret":"s"}`
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+		_ = os.WriteFile(tokenPath, []byte(refreshed), 0o600)
+		ln.Close() // release the lock
+	}()
+
+	app := &credentialApp{profile: "idc-test"}
+	// nil oidc client: must NOT be used, because the token becomes valid via the
+	// concurrent "winner" and this caller should just read it.
+	if err := app.refreshIDCTokenLocked(context.Background(), nil, tokenPath); err != nil {
+		t.Fatalf("expected nil after concurrent refresh, got %v", err)
+	}
+}
+
+// runIDCLoginCapturingStderr runs runIDCLogin with the given config wired into a
+// credentialApp, capturing os.Stderr so the test can assert on the user-facing
+// message. It points the SSO cache at tokenPath by pre-seeding HOME so
+// StandardCachedTokenFilepath resolves there.
+func runIDCLoginWithProfile(t *testing.T, cfg *config.ProfileConfig) (int, string) {
+	t.Helper()
+	r, w, _ := os.Pipe()
+	old := os.Stderr
+	os.Stderr = w
+	app := &credentialApp{profile: "idc-test", cfg: cfg}
+	code := app.runIDCLogin()
+	w.Close()
+	os.Stderr = old
+	var buf [4096]byte
+	n, _ := r.Read(buf[:])
+	return code, string(buf[:n])
+}
+
+// TestRunIDCLogin_ValidToken_ReportsSignedIn: a still-valid access token short-
+// circuits to "already signed in" with no refresh or device auth (nil oidc
+// client never touched).
+func TestRunIDCLogin_ValidToken_ReportsSignedIn(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	// Neutralize ambient AWS config so LoadDefaultConfig doesn't try to load a
+	// named shared-config profile (e.g. a developer's AWS_PROFILE) that won't
+	// exist under the temp HOME.
+	t.Setenv("AWS_PROFILE", "")
+	t.Setenv("AWS_REGION", "us-east-1")
+	t.Setenv("AWS_CONFIG_FILE", filepath.Join(home, "noexist-config"))
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", filepath.Join(home, "noexist-creds"))
+	startURL := "https://d-1234567890.awsapps.com/start"
+
+	tokenPath, err := ssocreds.StandardCachedTokenFilepath(startURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(tokenPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	future := time.Now().Add(2 * time.Hour).UTC().Format(time.RFC3339)
+	valid := `{"accessToken":"a","expiresAt":"` + future + `","refreshToken":"r","clientId":"c","clientSecret":"s"}`
+	if err := os.WriteFile(tokenPath, []byte(valid), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.ProfileConfig{
+		AuthType:             "idc",
+		IDCStartURL:          startURL,
+		IDCAccountID:         "123456789012",
+		IDCPermissionSetName: "Role",
+		IDCRegion:            "us-east-1",
+	}
+	code, out := runIDCLoginWithProfile(t, cfg)
+	if code != 0 {
+		t.Fatalf("expected exit 0 for valid token, got %d (stderr: %s)", code, out)
+	}
+	if !strings.Contains(out, "Already signed in") {
+		t.Errorf("expected 'Already signed in' message, got: %s", out)
+	}
+}
+
+// TestRunIDCLogin_RefreshableViaConcurrentWinner_ReportsRefreshed is the
+// regression test for the "Already signed in" bug: runIDCLogin must no longer
+// short-circuit purely because refresh FIELDS exist. It now routes through
+// refreshIDCTokenLocked; when a concurrent winner refreshes the token, this
+// caller observes the now-valid token and reports "session refreshed" without
+// device auth (nil oidc client proves no network/refresh call by this caller).
+func TestRunIDCLogin_RefreshableViaConcurrentWinner_ReportsRefreshed(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	// Neutralize ambient AWS config so LoadDefaultConfig doesn't try to load a
+	// named shared-config profile (e.g. a developer's AWS_PROFILE) that won't
+	// exist under the temp HOME.
+	t.Setenv("AWS_PROFILE", "")
+	t.Setenv("AWS_REGION", "us-east-1")
+	t.Setenv("AWS_CONFIG_FILE", filepath.Join(home, "noexist-config"))
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", filepath.Join(home, "noexist-creds"))
+	startURL := "https://d-1234567890.awsapps.com/start"
+
+	tokenPath, err := ssocreds.StandardCachedTokenFilepath(startURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(tokenPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	expired := `{"accessToken":"old","expiresAt":"2020-01-01T00:00:00Z","refreshToken":"r","clientId":"c","clientSecret":"s"}`
+	if err := os.WriteFile(tokenPath, []byte(expired), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ln, err := portlock.TryAcquire(idcRefreshLockPort)
+	if err != nil || ln == nil {
+		t.Skipf("could not acquire refresh lock port %d; skipping", idcRefreshLockPort)
+	}
+	future := time.Now().Add(1 * time.Hour).UTC().Format(time.RFC3339)
+	refreshed := `{"accessToken":"new","expiresAt":"` + future + `","refreshToken":"r2","clientId":"c","clientSecret":"s"}`
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+		_ = os.WriteFile(tokenPath, []byte(refreshed), 0o600)
+		ln.Close()
+	}()
+
+	cfg := &config.ProfileConfig{
+		AuthType:             "idc",
+		IDCStartURL:          startURL,
+		IDCAccountID:         "123456789012",
+		IDCPermissionSetName: "Role",
+		IDCRegion:            "us-east-1",
+	}
+	code, out := runIDCLoginWithProfile(t, cfg)
+	if code != 0 {
+		t.Fatalf("expected exit 0 after concurrent refresh, got %d (stderr: %s)", code, out)
+	}
+	if !strings.Contains(out, "refreshed") {
+		t.Errorf("expected session-refreshed message, got: %s", out)
+	}
+}

--- a/source/go/cmd/credential-process/main.go
+++ b/source/go/cmd/credential-process/main.go
@@ -49,6 +49,7 @@ func main() {
 	refreshIfNeeded := flag.Bool("refresh-if-needed", false, "Refresh credentials if expired")
 	showTags := flag.Bool("show-tags", false, "Print the https://aws.amazon.com/tags claim from the cached ID token (debug)")
 	getTag := flag.String("get-tag", "", "Print the value of a single principal tag from the cached ID token (e.g. --get-tag Zone). Exit codes: 0 hit, 2 absent, 4 expired.")
+	login := flag.Bool("login", false, "Interactively sign in (IDC: run device authorization and cache the SSO token), then exit. Use this once on headless/SSH hosts before Claude Code runs.")
 	flag.Parse()
 
 	if *versionFlag || *shortVersion {
@@ -98,6 +99,22 @@ func main() {
 	}
 	if *checkExpiration {
 		os.Exit(app.checkExpiration())
+	}
+	if *login {
+		// Interactive sign-in only (no credential JSON on stdout). For IDC this
+		// runs device authorization and caches the SSO token so subsequent
+		// non-interactive runs (e.g. Claude Code) reuse it silently — the
+		// recommended first step on headless/SSH hosts.
+		if cfg.IsIDC() {
+			os.Exit(app.runIDCLogin())
+		}
+		fmt.Fprintln(os.Stderr, "--login is only supported for IAM Identity Center (auth_type=idc) profiles.")
+		if cfg.IsSsoEnabled() {
+			fmt.Fprintln(os.Stderr, "OIDC profiles authenticate automatically via the browser on first use; no separate login step is needed.")
+		} else {
+			fmt.Fprintln(os.Stderr, "This profile uses the ambient AWS credential chain; no sign-in step is needed.")
+		}
+		os.Exit(1)
 	}
 
 	// Auth dispatch: IDC > legacy passthrough > OIDC
@@ -735,7 +752,6 @@ func (a *credentialApp) saveMonitoringTokenAndHeaders(idToken string, claims map
 		}
 	}
 }
-
 
 func (a *credentialApp) shouldRecheckQuota() bool {
 	if a.cfg.QuotaAPIEndpoint == "" {

--- a/source/go/cmd/credential-process/quota_notification.go
+++ b/source/go/cmd/credential-process/quota_notification.go
@@ -88,22 +88,28 @@ func showQuotaBrowserNotification(qr *quota.Result, isBlocked bool) {
 	time.Sleep(100 * time.Millisecond)
 }
 
-// isHeadless returns true if the environment appears to be headless (no GUI).
+// isHeadless returns true if the environment appears to have no usable local
+// browser — i.e. we should show a copy-to-another-device prompt rather than try
+// to open a browser. Used by both the quota browser-notification flow and the
+// IDC device-authorization flow.
 func isHeadless() bool {
-	// SSH session — no local display
-	if os.Getenv("SSH_CONNECTION") != "" || os.Getenv("SSH_TTY") != "" {
+	// An explicit $BROWSER means the user has told us how to open a browser
+	// (e.g. WSL forwarding to the Windows host) — honor it.
+	if os.Getenv("BROWSER") != "" {
+		return false
+	}
+	// SSH session — no local display, on any OS.
+	if os.Getenv("SSH_CONNECTION") != "" || os.Getenv("SSH_TTY") != "" || os.Getenv("SSH_CLIENT") != "" {
 		return true
 	}
-
-	// Linux/Unix: check for display server
-	if runtime.GOOS == "linux" {
-		if os.Getenv("DISPLAY") == "" && os.Getenv("WAYLAND_DISPLAY") == "" {
-			return true
-		}
+	switch runtime.GOOS {
+	case "windows", "darwin":
+		// Assume a desktop browser unless in an SSH session (handled above).
+		return false
+	default:
+		// Linux/BSD: a GUI session exposes DISPLAY (X11) or WAYLAND_DISPLAY.
+		return os.Getenv("DISPLAY") == "" && os.Getenv("WAYLAND_DISPLAY") == ""
 	}
-
-	// Windows and macOS always have a GUI available (if logged in)
-	return false
 }
 
 func openBrowser(url string) {

--- a/source/go/cmd/otel-helper/main.go
+++ b/source/go/cmd/otel-helper/main.go
@@ -98,6 +98,21 @@ func run(testMode bool) int {
 	// resolved below (env var, then credential-process). credential-process
 	// is the correct fallback here — it owns token refresh, keyring storage,
 	// and serve-past-expiry, none of which a direct monitoring.json read does.
+	//
+	// In test mode we still CONSULT the cache (so --test reflects what the
+	// production path would emit) but render it via the test formatter rather
+	// than printing the JSON contract. This matters for IDC, where there is no
+	// JWT: the cache (written by credential-process from the IAM ARN) is the
+	// ONLY source of attribution, so skipping it here made --test always show
+	// empty headers even when attribution was working.
+	if testMode {
+		if headers, err := otel.ReadCachedHeaders(profile); err == nil && len(headers) > 0 {
+			debugPrint("Using cached OTEL headers (test mode)")
+			printTestOutput(userInfoFromHeaders(headers), headers)
+			return 0
+		}
+		debugPrint("No cached OTEL headers; falling through to token-based extraction (test mode)")
+	}
 	if !testMode {
 		headers, err := otel.ReadCachedHeaders(profile)
 		if err == nil && headers != nil {
@@ -188,6 +203,28 @@ func run(testMode bool) int {
 	}
 
 	return 0
+}
+
+// userInfoFromHeaders reconstructs a UserInfo from cached x-* headers so the
+// test-mode formatter can display the attributes. It is the inverse of
+// otel.FormatHeaders for the fields that round-trip through headers (the cache
+// stores headers, not the full UserInfo, so JWT-only fields like account_uuid /
+// issuer / subject are not represented and remain empty — that's expected, since
+// a cache hit is the IDC path which has no JWT).
+func userInfoFromHeaders(h map[string]string) otel.UserInfo {
+	return otel.UserInfo{
+		Email:          h["x-user-email"],
+		UserID:         h["x-user-id"],
+		Username:       h["x-user-name"],
+		Department:     h["x-department"],
+		Team:           h["x-team-id"],
+		CostCenter:     h["x-cost-center"],
+		OrganizationID: h["x-organization"],
+		Location:       h["x-location"],
+		Role:           h["x-role"],
+		Manager:        h["x-manager"],
+		Project:        h["x-project"],
+	}
 }
 
 // emitEmptyHeaders satisfies Claude Code's otelHeadersHelper contract when no

--- a/source/go/cmd/otel-helper/main_test.go
+++ b/source/go/cmd/otel-helper/main_test.go
@@ -420,3 +420,69 @@ func TestRun_Layer1_CacheHit_NoToken_OmitsBearerGracefully(t *testing.T) {
 		t.Error("cache file must not contain 'authorization' after a no-token cache hit")
 	}
 }
+
+// TestUserInfoFromHeaders verifies the inverse of otel.FormatHeaders used by
+// test-mode rendering: cached x-* headers map back to the right UserInfo fields.
+func TestUserInfoFromHeaders(t *testing.T) {
+	info := userInfoFromHeaders(map[string]string{
+		"x-user-email":   "alice@example.com",
+		"x-user-id":      "u-123",
+		"x-user-name":    "alice",
+		"x-department":   "eng",
+		"x-team-id":      "team-a",
+		"x-cost-center":  "cc-9",
+		"x-organization": "org-1",
+		"x-location":     "us",
+		"x-role":         "dev",
+		"x-manager":      "bob",
+		"x-project":      "proj-x",
+	})
+	if info.Email != "alice@example.com" {
+		t.Errorf("Email = %q, want alice@example.com", info.Email)
+	}
+	if info.Department != "eng" || info.Team != "team-a" || info.Project != "proj-x" {
+		t.Errorf("field mapping mismatch: %+v", info)
+	}
+}
+
+// TestRun_TestMode_ServesCachedHeaders is the regression test for IDC --test.
+// IDC has no JWT, so attribution lives ONLY in the cache (written by
+// credential-process from the IAM ARN). Test mode previously skipped the Layer-1
+// cache read entirely and went straight to the (nonexistent) JWT path, so
+// `otel-helper --test` always printed empty headers even when attribution was
+// working. This asserts test mode now surfaces the cached x-user-email.
+func TestRun_TestMode_ServesCachedHeaders(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir)
+	t.Setenv("AWS_PROFILE", "idc-test")
+	t.Setenv("CLAUDE_CODE_MONITORING_TOKEN", "")
+
+	cacheDir := filepath.Join(tmpDir, ".claude-code-session")
+	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// schema_version 2 + future exp so Layer 1 treats it as a valid hit.
+	entry := `{"schema_version":2,"headers":{"x-user-email":"qnamzn+developer@amazon.com"},"token_exp":9999999999,"cached_at":1782315885}`
+	if err := os.WriteFile(filepath.Join(cacheDir, "idc-test-otel-headers.json"), []byte(entry), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	r, w, _ := os.Pipe()
+	old := os.Stdout
+	os.Stdout = w
+	code := run(true)
+	w.Close()
+	os.Stdout = old
+
+	if code != 0 {
+		t.Fatalf("run(testMode) = %d, want 0", code)
+	}
+
+	var buf [8192]byte
+	n, _ := r.Read(buf[:])
+	out := string(buf[:n])
+	if !strings.Contains(out, "qnamzn+developer@amazon.com") {
+		t.Errorf("test-mode output must surface the cached email; got:\n%s", out)
+	}
+}

--- a/source/tests/cli/commands/test_installer_launcher.py
+++ b/source/tests/cli/commands/test_installer_launcher.py
@@ -1,0 +1,178 @@
+# ABOUTME: Tests that installers generate a claude-bedrock launcher that signs in before running claude
+# ABOUTME: The launcher prevents the "run claude -> silent hang" trap for IDC interactive sign-in
+
+"""Tests for the generated `claude-bedrock` launcher wrapper.
+
+Claude Code's own credential refresh cannot surface an interactive IAM Identity
+Center sign-in (the verification URL is buffered until the blocking command
+exits — a deadlock). To make sign-in un-missable, the installer generates a
+`claude-bedrock` launcher that runs `credential-process --login` (URL shown live
+in the user's terminal; no-op if already signed in) and then execs `claude`.
+
+These tests generate the actual install.sh / install.bat and assert the launcher
+logic is present and, for bash, that both the installer and the launcher it
+writes are syntactically valid shell.
+"""
+
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from claude_code_with_bedrock.cli.commands.package import PackageCommand
+from claude_code_with_bedrock.config import Profile
+
+
+def _idc_profile() -> Profile:
+    return Profile(
+        name="idc-test",
+        provider_domain="",
+        client_id="",
+        credential_storage="session",
+        aws_region="us-east-1",
+        identity_pool_name="test-pool",
+        allowed_bedrock_regions=["us-east-1"],
+        cross_region_profile="us",
+        auth_type="idc",
+        sso_enabled=False,
+        idc_start_url="https://d-1234567890.awsapps.com/start",
+        idc_account_id="123456789012",
+        idc_permission_set_name="ClaudeCodeRole",
+    )
+
+
+class TestBashInstallerLauncher:
+    def _generate(self) -> str:
+        cmd = PackageCommand()
+        out = Path(tempfile.mkdtemp())
+        path = cmd._create_installer(out, _idc_profile(), [("linux", Path("/tmp/x"))])
+        return path.read_text(encoding="utf-8")
+
+    def test_installer_creates_launcher(self):
+        content = self._generate()
+        assert 'LAUNCHER="$ACTUAL_HOME/claude-code-with-bedrock/claude-bedrock"' in content
+        assert "chmod +x" in content
+
+    def test_launcher_runs_login_before_claude(self):
+        content = self._generate()
+        # --login must run, and only then exec claude; a failed login aborts.
+        assert "--login --profile" in content
+        assert "exec claude" in content
+        assert "|| exit 1" in content
+
+    def test_installer_is_valid_bash(self):
+        if shutil.which("bash") is None:
+            pytest.skip("bash not available")
+        with tempfile.TemporaryDirectory() as d:
+            script = Path(d) / "install.sh"
+            script.write_text(self._generate(), encoding="utf-8")
+            result = subprocess.run(["bash", "-n", str(script)], capture_output=True, text=True)
+            assert result.returncode == 0, f"install.sh has bash syntax errors: {result.stderr}"
+
+    def test_generated_launcher_is_valid_bash(self):
+        """Execute just the heredoc that writes the launcher, then syntax-check
+        the launcher it produces — this is where escaping bugs would surface."""
+        if shutil.which("bash") is None:
+            pytest.skip("bash not available")
+        with tempfile.TemporaryDirectory() as d:
+            launcher = Path(d) / "claude-bedrock"
+            harness = f"""
+CRED_PROC="/opt/cred/credential-process"
+LAUNCHER="{launcher}"
+FIRST_PROFILE="idc-test"
+cat > "$LAUNCHER" << EOF
+#!/bin/bash
+PROFILE="\\${{AWS_PROFILE:-$FIRST_PROFILE}}"
+"$CRED_PROC" --login --profile "\\$PROFILE" || exit 1
+export AWS_PROFILE="\\$PROFILE"
+exec claude "\\$@"
+EOF
+"""
+            subprocess.run(["bash", "-c", harness], check=True, capture_output=True, text=True)
+            generated = launcher.read_text(encoding="utf-8")
+            # Runtime placeholders must remain literal (deferred), install-time vars expanded.
+            assert "${AWS_PROFILE:-idc-test}" in generated
+            assert "/opt/cred/credential-process" in generated
+            assert 'exec claude "$@"' in generated
+            check = subprocess.run(["bash", "-n", str(launcher)], capture_output=True, text=True)
+            assert check.returncode == 0, f"generated launcher invalid: {check.stderr}"
+
+
+class TestWindowsInstallerLauncher:
+    def _generate(self) -> str:
+        cmd = PackageCommand()
+        out = Path(tempfile.mkdtemp())
+        path = cmd._create_windows_installer(out, _idc_profile())
+        return path.read_text(encoding="utf-8")
+
+    def test_installer_creates_cmd_launcher(self):
+        content = self._generate()
+        assert "claude-bedrock.cmd" in content
+
+    def test_otel_helper_path_points_at_cmd_with_backslashes(self):
+        """otelHeadersHelper must reference otel-helper.cmd (the AV-resilient
+        wrapper that runs the .exe and falls back to the .ps1), using a
+        backslash path.
+
+        Claude Code runs otelHeadersHelper through cmd.exe on Windows, where a
+        .cmd is the correct target. The path must use escaped BACKSLASHES, not
+        forward slashes: cmd.exe can misparse a forward-slash path to a .cmd
+        (treating a segment as a switch). The installer builds the value with
+        .Replace('\\\\','\\\\\\\\') so the JSON contains doubled backslashes
+        (valid JSON) that un-escape to a native Windows path.
+        """
+        content = self._generate()
+        # otelHeadersHelper targets the .cmd wrapper...
+        assert "otel-helper.cmd'" in content, "otelHeadersHelper must point at otel-helper.cmd"
+        # ...via backslash-doubling (rendered as .Replace('\','\\')), NOT the old
+        # forward-slash conversion. r"..." keeps the backslashes literal.
+        assert r".Replace('\','\\')" in content, "otel path must double backslashes for valid JSON"
+        assert r"otel-helper.cmd' -replace '\\', '/'" not in content, (
+            "otel path must not use forward slashes (cmd.exe may misparse a /-path to a .cmd)"
+        )
+
+    def test_otel_helper_missing_is_fatal_when_monitoring(self):
+        """With monitoring enabled, a missing otel-helper.cmd/.ps1 must abort the
+        install (exit /b 1) rather than silently leaving a broken telemetry
+        config — the root cause of metrics never being sent."""
+        content = self._generate()  # _idc_profile() has monitoring enabled
+        assert "otel-helper.cmd not found in package" in content
+        assert "ERROR: otel-helper.cmd not found" in content
+        assert "otel-helper.ps1 not found in package" in content
+
+    def test_launcher_runs_login_before_claude(self):
+        content = self._generate()
+        # The launcher lines: --login then claude, aborting on failure.
+        assert "--login --profile" in content
+        assert "exit /b 1" in content
+        assert "claude %%*" in content  # %%* -> %* in the generated .cmd
+
+    def test_profile_guard_has_balanced_quotes(self):
+        """Regression: the AWS_PROFILE-empty guard must be fully quoted.
+
+        The earlier PowerShell-written launcher dropped embedded quotes, producing
+        `if %AWS_PROFILE%==" set ...` which cmd.exe rejects with "The syntax of the
+        command is incorrect." Assert the balanced form is emitted. In install.bat
+        the line uses %% which cmd collapses to % when writing the .cmd, so the
+        launcher gets `if "%AWS_PROFILE%"=="" set AWS_PROFILE=...`.
+        """
+        content = self._generate()
+        assert 'echo if "%%AWS_PROFILE%%"=="" set AWS_PROFILE=' in content
+
+    def test_launcher_not_written_via_embedded_quote_powershell(self):
+        """The launcher must be written with plain batch echo redirection, not a
+        `powershell -Command "...\\"...\\"..."` with embedded quotes — that nesting
+        is what corrupted the quotes in the first place."""
+        content = self._generate()
+        launcher_section = content[content.index("Creating launcher") : content.index("Installation complete")]
+        assert "> \"%LAUNCHER%\" echo @echo off" in launcher_section
+        # No PowerShell invocation should be building the launcher lines.
+        assert "$lines" not in launcher_section
+
+    def test_closing_message_points_at_launcher(self):
+        content = self._generate()
+        assert "claude-bedrock.cmd" in content
+        # Warn users not to run claude directly (the transient sign-in-error trap).
+        assert "NOT 'claude' directly" in content

--- a/source/tests/cli/commands/test_package_idc_auth_refresh.py
+++ b/source/tests/cli/commands/test_package_idc_auth_refresh.py
@@ -1,0 +1,182 @@
+# ABOUTME: Regression tests for IDC credential-refresh hooks in generated settings.json
+# ABOUTME: IDC wires awsCredentialExport (silent refresh) + awsAuthRefresh --login (visible sign-in message)
+
+"""Regression tests: IDC profiles wire BOTH credential hooks, each for its role.
+
+Claude Code has two credential hooks that (verified empirically) work together:
+  - awsCredentialExport — output captured SILENTLY; the primary resolver,
+    re-invoked ~5 min before the emitted Expiration. Drives the silent hourly
+    STS role-credential refresh while the SSO session is still valid.
+  - awsAuthRefresh — output is DISPLAYED to the user; fires on the first
+    credential failure. The ONLY channel that surfaces the binary's sign-in
+    message, because awsCredentialExport discards stderr.
+
+IDC needs both:
+  - Without awsCredentialExport, 1-hour role creds expire mid-session with no
+    re-invoke -> retry loop -> (on EC2) silent instance-role fallback.
+  - Without awsAuthRefresh, a missing SSO session produces a silent retry loop
+    with no message (awsCredentialExport swallows the fail-fast instruction).
+
+awsAuthRefresh uses `--login` (sign-in only): its output is shown to the user, so
+it must NOT print credentials. The fail-fast guard makes `--login` exit
+immediately when run non-interactively, so it surfaces the "relaunch with
+claude-bedrock" message instead of hanging (the original reason it was dropped).
+
+Non-IDC (OIDC) session profiles keep just awsAuthRefresh (full flow), unchanged.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+
+from claude_code_with_bedrock.cli.commands.package import PackageCommand
+from claude_code_with_bedrock.config import Profile
+
+
+def _idc_profile(credential_storage: str = "session") -> Profile:
+    return Profile(
+        name="idc-test",
+        provider_domain="",
+        client_id="",
+        credential_storage=credential_storage,
+        aws_region="us-east-1",
+        identity_pool_name="test-pool",
+        allowed_bedrock_regions=["us-east-1", "us-west-2"],
+        cross_region_profile="us",
+        auth_type="idc",
+        sso_enabled=False,
+        idc_start_url="https://d-1234567890.awsapps.com/start",
+        idc_account_id="123456789012",
+        idc_permission_set_name="ClaudeCodeRole",
+    )
+
+
+def _oidc_session_profile() -> Profile:
+    return Profile(
+        name="oidc-test",
+        provider_domain="test.okta.com",
+        client_id="test-client-id",
+        credential_storage="session",
+        aws_region="us-east-1",
+        identity_pool_name="test-pool",
+        allowed_bedrock_regions=["us-east-1", "us-west-2"],
+        cross_region_profile="us",
+        auth_type="oidc",
+        sso_enabled=True,
+    )
+
+
+def _read_settings(output_dir: Path) -> dict:
+    settings_path = output_dir / "claude-settings" / "settings.json"
+    with open(settings_path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+class TestIdcCredentialHooks:
+    def test_idc_session_wires_auth_refresh_with_login(self):
+        """awsAuthRefresh is the only hook whose output is displayed, so it must
+        be wired for IDC to surface the sign-in message. It uses --login (shown
+        to the user, never prints credentials) and is safe from the old deadlock
+        because the fail-fast guard exits immediately when non-interactive."""
+        command = PackageCommand()
+        profile = _idc_profile(credential_storage="session")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            command._create_claude_settings(output_dir, profile, profile_name="idc-test")
+            settings = _read_settings(output_dir)
+
+        refresh = settings.get("awsAuthRefresh")
+        assert refresh is not None, "IDC must wire awsAuthRefresh to display the sign-in message"
+        assert "--login" in refresh, "awsAuthRefresh output is displayed, so it must use --login (no credential leak)"
+        assert "--profile idc-test" in refresh
+
+    def test_idc_keyring_wires_auth_refresh_with_login(self):
+        command = PackageCommand()
+        profile = _idc_profile(credential_storage="keyring")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            command._create_claude_settings(output_dir, profile, profile_name="idc-test")
+            settings = _read_settings(output_dir)
+
+        refresh = settings.get("awsAuthRefresh")
+        assert refresh is not None
+        assert "--login" in refresh
+
+    def test_idc_credential_process_env_is_full_flow(self):
+        """The silent AWS_CREDENTIAL_PROCESS path remains the full flow (it
+        returns credential JSON to the SDK) and is targeted at the profile."""
+        command = PackageCommand()
+        profile = _idc_profile()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            command._create_claude_settings(output_dir, profile, profile_name="idc-test")
+            settings = _read_settings(output_dir)
+
+        cred_process = settings["env"]["AWS_CREDENTIAL_PROCESS"]
+        assert "--login" not in cred_process, "credential resolution must run the full flow, not --login"
+        assert "--profile idc-test" in cred_process
+
+    def test_idc_wires_credential_export_for_refresh(self):
+        """Regression: AWS_CREDENTIAL_PROCESS is resolved once at startup and
+        cached, so IDC role creds (1h permission-set lifetime) expire mid-session
+        with no re-invoke -> retry loop -> instance-role fallback. awsCredentialExport
+        gives Claude Code a silent, timer-driven refresh (~5 min before Expiration)
+        without the interactive deadlock that ruled out awsAuthRefresh for IDC."""
+        for storage in ("session", "keyring"):
+            command = PackageCommand()
+            profile = _idc_profile(credential_storage=storage)
+            with tempfile.TemporaryDirectory() as tmpdir:
+                output_dir = Path(tmpdir)
+                command._create_claude_settings(output_dir, profile, profile_name="idc-test")
+                settings = _read_settings(output_dir)
+
+            export = settings.get("awsCredentialExport")
+            assert export is not None, f"IDC ({storage}) must wire awsCredentialExport for refresh"
+            # Refresh must run the full credential flow (returns JSON), not --login.
+            assert "--login" not in export
+            assert "--profile idc-test" in export
+
+    def test_idc_disables_instance_metadata_fallback(self):
+        """With IMDS disabled, a refresh failure surfaces as a clear credentials
+        error instead of silently falling back to the EC2 instance role (wrong
+        identity, broken attribution/quota)."""
+        command = PackageCommand()
+        profile = _idc_profile()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            command._create_claude_settings(output_dir, profile, profile_name="idc-test")
+            settings = _read_settings(output_dir)
+
+        assert settings["env"].get("AWS_EC2_METADATA_DISABLED") == "true"
+
+    def test_oidc_does_not_disable_instance_metadata(self):
+        """The IMDS guard is IDC-specific; OIDC must not get it."""
+        command = PackageCommand()
+        profile = _oidc_session_profile()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            command._create_claude_settings(output_dir, profile, profile_name="oidc-test")
+            settings = _read_settings(output_dir)
+
+        assert "AWS_EC2_METADATA_DISABLED" not in settings["env"]
+        # OIDC must NOT get awsCredentialExport (keeps awsAuthRefresh instead).
+        assert "awsCredentialExport" not in settings
+
+    def test_oidc_session_auth_refresh_unchanged(self):
+        """Non-IDC session profiles keep the existing full credential-process
+        awsAuthRefresh command (no --login) — this path is unchanged."""
+        command = PackageCommand()
+        profile = _oidc_session_profile()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            command._create_claude_settings(output_dir, profile, profile_name="oidc-test")
+            settings = _read_settings(output_dir)
+
+        refresh = settings.get("awsAuthRefresh")
+        assert refresh is not None
+        assert "--login" not in refresh
+        assert "--profile oidc-test" in refresh

--- a/source/tests/cli/commands/test_package_idc_otel_helper.py
+++ b/source/tests/cli/commands/test_package_idc_otel_helper.py
@@ -1,0 +1,110 @@
+# ABOUTME: Regression tests for otelHeadersHelper wiring across auth types
+# ABOUTME: IDC-with-binary must wire the helper so dashboards attribute metrics per user
+
+"""Regression tests: otelHeadersHelper is wired whenever a binary can resolve identity.
+
+The CloudWatch dashboards aggregate usage by `user.email`. The central collector
+sets that dimension from the `x-user-email` request header, which Claude Code only
+sends when `otelHeadersHelper` points at the otel-helper binary.
+
+For IDC, the credential-process binary resolves the user's email from the IAM ARN
+session name and caches it (writeOtelCacheFromIDC / writeOtelCacheFromSTS); the
+helper then serves it. So IDC deployments that ship the binary (e.g. quota enabled)
+MUST wire otelHeadersHelper or every IDC user collapses to one static identity on
+the dashboard.
+
+Cases:
+  - OIDC: helper wired (extracts attributes from JWT).
+  - IDC + credential-process binary (quota_api_endpoint set): helper wired.
+  - IDC zero-binary (no quota_api_endpoint): helper NOT wired — identity comes
+    from the static collector config instead.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+
+from claude_code_with_bedrock.cli.commands.package import PackageCommand
+from claude_code_with_bedrock.config import Profile
+
+
+def _base(**overrides) -> Profile:
+    kwargs = dict(
+        name="test",
+        provider_domain="test.okta.com",
+        client_id="test-client-id",
+        credential_storage="session",
+        aws_region="us-east-1",
+        identity_pool_name="test-pool",
+        allowed_bedrock_regions=["us-east-1", "us-west-2"],
+        cross_region_profile="us",
+        monitoring_enabled=True,
+        otel_collector_endpoint="https://collector.example.com",
+        stack_names={"monitoring": "test-pool-otel-collector"},
+    )
+    kwargs.update(overrides)
+    return Profile(**kwargs)
+
+
+def _oidc_profile() -> Profile:
+    return _base(auth_type="oidc", sso_enabled=True)
+
+
+def _idc_with_binary_profile() -> Profile:
+    # quota_api_endpoint set => credential-process binary is included.
+    return _base(
+        provider_domain="",
+        client_id="",
+        auth_type="idc",
+        sso_enabled=False,
+        idc_start_url="https://d-1234567890.awsapps.com/start",
+        idc_account_id="123456789012",
+        idc_permission_set_name="ClaudeCodeRole",
+        quota_api_endpoint="https://quota.example.com/check",
+    )
+
+
+def _idc_zero_binary_profile() -> Profile:
+    # No quota_api_endpoint => zero-binary IDC (static identity in collector).
+    return _base(
+        provider_domain="",
+        client_id="",
+        auth_type="idc",
+        sso_enabled=False,
+        idc_start_url="https://d-1234567890.awsapps.com/start",
+        idc_account_id="123456789012",
+        idc_permission_set_name="ClaudeCodeRole",
+    )
+
+
+def _read_settings(output_dir: Path) -> dict:
+    with open(output_dir / "claude-settings" / "settings.json", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _generate(profile: Profile) -> dict:
+    cmd = PackageCommand()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out = Path(tmpdir)
+        cmd._create_claude_settings(out, profile, profile_name="test")
+        return _read_settings(out)
+
+
+class TestOtelHeadersHelperWiring:
+    def test_oidc_wires_helper(self):
+        settings = _generate(_oidc_profile())
+        assert settings.get("otelHeadersHelper") == "__OTEL_HELPER_PATH__"
+
+    def test_idc_with_binary_wires_helper(self):
+        """The bug: IDC + binary previously skipped the helper, so dashboards
+        attributed every IDC user to one static identity."""
+        settings = _generate(_idc_with_binary_profile())
+        assert settings.get("otelHeadersHelper") == "__OTEL_HELPER_PATH__", (
+            "IDC with credential-process binary must wire otelHeadersHelper for per-user attribution"
+        )
+
+    def test_idc_zero_binary_does_not_wire_helper(self):
+        """Zero-binary IDC has no runtime identity resolver; attribution comes
+        from the static collector config, so the helper must stay unset."""
+        settings = _generate(_idc_zero_binary_profile())
+        assert "otelHeadersHelper" not in settings


### PR DESCRIPTION
## Why

IAM Identity Center (IDC) deployments — especially on headless / EC2 hosts — had several breakages that left Claude Code stuck, silently mis-attributed, or sending no telemetry. These were found and fixed iteratively while standing up an IDC + quota + monitoring deployment on EC2 (Linux and Windows):

- **Hourly credential expiry → instance-role fallback.** IDC role credentials expire at the permission set's session duration (~1h). Nothing re-invoked the credential process, so after ~1h the AWS SDK chain fell through to the EC2 **instance role** (wrong identity, broken attribution/quota) and Claude Code looped on `API error · Retrying`.
- **Rotating refresh-token race.** Claude Code fires concurrent credential-process calls (e.g. session-title + main message). They raced the **rotating** SSO refresh token; the loser presented a consumed token → `InvalidGrantException`, bricking the cache until manual re-login.
- **Silent hang / confusing error on expired session.** A genuinely expired SSO session caused a silent multi-minute hang (headless, incl. **non-SSH Windows**) or a jargon-heavy message.
- **Windows telemetry sent nothing.** `settings.json` pointed `otelHeadersHelper` at `otel-helper.cmd`, which could be absent on the host and was referenced with a cmd-unsafe forward-slash path → "is not recognized" → Claude Code dropped **all** metric exports.
- **No per-user dashboard attribution for IDC.** The helper that surfaces `x-user-email` was disabled for IDC even when the binary could resolve the email from the IAM ARN.

## What

**Credential refresh (Go + settings)**
- Wire `awsCredentialExport` (silent refresh, auto re-invoked ~5 min before `Expiration`) **and** `awsAuthRefresh --login` (the only hook whose output is displayed, so it surfaces the sign-in message) for IDC profiles.
- Gate device-auth on `tokenValid` **or** `tokenRefreshable`, so an expired-but-refreshable access token is refreshed silently via the SDK rather than forcing interactive login.
- Serialize the rotating-token refresh under an exclusive `portlock`, so concurrent credential-process invocations can't consume each other's refresh token.
- Set `AWS_EC2_METADATA_DISABLED=true` for IDC so a refresh failure surfaces a clear credentials error instead of silently using the instance role.

**Headless UX**
- Fail fast (don't hang) when stderr is not a terminal — the correct signal for "Claude Code invoked us non-interactively", covering **headless Windows without SSH**, not just SSH/Linux.
- Plain-language, no-jargon message with absolute paths, directing users to relaunch via the generated `claude-bedrock` launcher (which signs in, showing the URL live, then starts Claude Code).

**Windows telemetry**
- Point `otelHeadersHelper` at `otel-helper.cmd` (the AV-resilient wrapper: tries `.exe`, falls back to `.ps1`) using an **escaped-backslash** path that `cmd.exe` handles correctly.
- Fail the install **loudly** if the required `.cmd`/`.ps1` are missing when monitoring is enabled (was a silent skip → broken telemetry).

**Per-user OTEL attribution**
- Wire `otelHeadersHelper` for IDC-with-binary so the ARN-derived email reaches the collector; `otel-helper --test` now reads the cache so it reflects IDC attribution.

## Tests
- **Go:** token validity/refreshability gates, refresh-lock serialization, headless fail-fast (SSH and non-SSH), `isHeadless` matrix, SSO cache round-trip, otel-helper test-mode cache read.
- **Python:** IDC credential-hook wiring, IMDS guard, `otelHeadersHelper` → `.cmd` with backslashes, missing-helper-is-fatal, launcher generation + generated-bash validity.

All Go and new Python tests pass; rebased on latest `beta` (reconciled a duplicate `isHeadless` with #658 by consolidating into one shared, superset implementation).

## Notes / follow-ups
- A separate PR covers the distribution fix for including all Windows-required files (kept out of this PR per one-concern-per-PR).
- Windows behaviors were verified by inspecting generated `install.bat`/settings and cross-compiling; final on-box confirmation is recommended (multi-layer batch/PowerShell/JSON escaping).
- Tracked TODO: add an `ALBIdleTimeoutSeconds` parameter (default 300) to the OTEL collector ALB to reduce benign "socket hang up" export noise from idle-connection reaping.