### PR TITLE
fix(distribute): ship Windows otel-helper.cmd/.ps1 in the package

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/distribute.py
+++ b/source/claude_code_with_bedrock/cli/commands/distribute.py
@@ -579,6 +579,8 @@ class DistributeCommand(Command):
             "windows": [
                 ("credential-process-windows.exe", "credential-process-windows.exe"),
                 ("otel-helper-windows.exe", "otel-helper-windows.exe"),
+                ("otel-helper.ps1", "otel-helper.ps1"),
+                ("otel-helper.cmd", "otel-helper.cmd"),
                 ("otelcol-windows.exe", "otelcol-windows.exe"),
                 ("collector-config.yaml", "collector-config.yaml"),
                 ("install.bat", "install.bat"),
@@ -1433,6 +1435,9 @@ class DistributeCommand(Command):
             "otel-helper-linux-arm64",
             "otel-helper-windows.exe",
             "otel-helper.sh",
+            # Windows otel-helper launcher + AV-resilient fallback (required by install.bat)
+            "otel-helper.ps1",
+            "otel-helper.cmd",
             # OTEL Collector sidecar
             "otelcol-macos-arm64",
             "otelcol-macos-intel",
@@ -1474,7 +1479,7 @@ class DistributeCommand(Command):
     PLATFORM_FILES = {
         "windows": {
             "binaries": ["credential-process-windows.exe", "otel-helper-windows.exe"],
-            "installer": ["install.bat", "ccwb-install.ps1"],
+            "installer": ["install.bat", "ccwb-install.ps1", "otel-helper.ps1", "otel-helper.cmd"],
             "label": "Windows",
         },
         "linux-x64": {

--- a/source/tests/test_distribute.py
+++ b/source/tests/test_distribute.py
@@ -43,6 +43,9 @@ def package_dir(tmp_path):
         "otel-helper-windows.exe",
     ]:
         (pkg / platform).write_bytes(b"\x00" * 100)
+    # Windows otel-helper launcher + AV-resilient fallback (required by install.bat)
+    (pkg / "otel-helper.ps1").write_text("# otel-helper.ps1")
+    (pkg / "otel-helper.cmd").write_text("@echo off\nREM otel-helper.cmd")
     return pkg
 
 
@@ -189,6 +192,14 @@ class TestCreateArchive:
             assert "claude-code-package/install.sh" in names
             assert "claude-code-package/credential-process-macos-arm64" in names
 
+    def test_zip_contains_windows_otel_helper_scripts(self, cmd, package_dir):
+        """otel-helper.cmd/.ps1 are required by install.bat and must ship in the zip."""
+        archive = cmd._create_archive(package_dir)
+        with zipfile.ZipFile(archive, "r") as zf:
+            names = zf.namelist()
+            assert "claude-code-package/otel-helper.ps1" in names
+            assert "claude-code-package/otel-helper.cmd" in names
+
     def test_zip_includes_settings_dir(self, cmd, package_dir):
         settings = package_dir / "claude-settings"
         settings.mkdir()
@@ -243,6 +254,9 @@ class TestCreatePerOsArchives:
             names = zf.namelist()
             assert "claude-code-package/install.bat" in names
             assert "claude-code-package/ccwb-install.ps1" in names
+            # AV-resilient otel-helper launcher + fallback (required by install.bat)
+            assert "claude-code-package/otel-helper.ps1" in names
+            assert "claude-code-package/otel-helper.cmd" in names
 
     def test_skips_platform_without_binary(self, cmd, tmp_path):
         """Only Linux x64 binary present → only 1 archive."""


### PR DESCRIPTION
## Why

Windows installs ended up with **no working telemetry**. `install.bat` configures Claude Code's `otelHeadersHelper` to run `otel-helper.cmd` — the AV-resilient wrapper that tries `otel-helper.exe` and falls back to `otel-helper.ps1` if antivirus blocks the binary. But the **distribution manifest never shipped `otel-helper.cmd` or `otel-helper.ps1`**: only `otel-helper.exe` reached the host.

So `settings.json` pointed `otelHeadersHelper` at a file that wasn't present, and Claude Code failed every metric export with:

```
'...\otel-helper.cmd' is not recognized as an internal or external command
```

Because Claude Code treats an `otelHeadersHelper` failure as a hard export error, **all metrics were silently dropped** on Windows.

## What

Add `otel-helper.ps1` and `otel-helper.cmd` to the Windows distribution in all three places `distribute.py` enumerates package contents:
- the per-OS Windows file list,
- the all-files copy list, and
- `PLATFORM_FILES["windows"]["installer"]`.

## Tests

- `test_zip_contains_windows_otel_helper_scripts` — the full-package zip includes `otel-helper.cmd`/`.ps1`.
- `test_create_per_os_archives` — the Windows per-OS archive includes them.
- The `package_dir` fixture now seeds both files so the assertions are meaningful.

All 31 `test_distribute.py` tests pass.

## Related
This is the distribution-side half of the Windows telemetry fix; the installer/settings side (pointing `otelHeadersHelper` at a cmd-safe path and failing loudly if the helper is missing) is in a separate PR. A third PR covers the Route53 CNAME callback fix that was found alongside this.