### PR TITLE
refactor: IDC reliability hardening (portlock offset, launcher gating, lint fixes)

### DIFF
--- a/source/tests/cli/commands/test_installer_launcher.py
+++ b/source/tests/cli/commands/test_installer_launcher.py
@@ -63,7 +63,7 @@ class TestBashInstallerLauncher:
         assert "exec claude" in content
         assert "|| exit 1" in content
 
-    @pytest.mark.skipif(sys.platform == 'win32', reason='bash heredoc validation not meaningful on Windows')
+    @pytest.mark.skipif(sys.platform == "win32", reason="bash heredoc validation not meaningful on Windows")
     def test_installer_is_valid_bash(self):
         if shutil.which("bash") is None:
             pytest.skip("bash not available")
@@ -73,7 +73,7 @@ class TestBashInstallerLauncher:
             result = subprocess.run(["bash", "-n", str(script)], capture_output=True, text=True)
             assert result.returncode == 0, f"install.sh has bash syntax errors: {result.stderr}"
 
-    @pytest.mark.skipif(sys.platform == 'win32', reason='bash heredoc validation not meaningful on Windows')
+    @pytest.mark.skipif(sys.platform == "win32", reason="bash heredoc validation not meaningful on Windows")
     def test_generated_launcher_is_valid_bash(self):
         """Execute just the heredoc that writes the launcher, then syntax-check
         the launcher it produces — this is where escaping bugs would surface."""
@@ -170,7 +170,7 @@ class TestWindowsInstallerLauncher:
         is what corrupted the quotes in the first place."""
         content = self._generate()
         launcher_section = content[content.index("Creating launcher") : content.index("Installation complete")]
-        assert "> \"%LAUNCHER%\" echo @echo off" in launcher_section
+        assert '> "%LAUNCHER%" echo @echo off' in launcher_section
         # No PowerShell invocation should be building the launcher lines.
         assert "$lines" not in launcher_section
 


### PR DESCRIPTION
## Summary

Follow-up to #671. Addresses reliability issues and CI failures introduced by the IDC launcher and portlock changes.

## Changes

1. **Offset IDC portlock to port 8402** — avoids collision with `quota_notification.go`'s HTTP server which tries port 8401 first. The IDC refresh lock now uses 8402, distinct from both the OIDC redirect port (8400) and the quota notification server (8401).

2. **Gate launcher generation on IDC auth only** — the `claude-bedrock` launcher is only meaningful for IDC (where interactive sign-in must be shown before Claude starts). OIDC users get a simplified 'use claude directly' message instead. This prevents confusion when `--login` exits 1 for non-IDC profiles.

3. **Fix Ruff C408 lint error** — `test_package_idc_otel_helper.py` had `dict()` call that Ruff wants as a dict literal.

4. **Fix Windows bash test failures** — `test_installer_is_valid_bash` and `test_generated_launcher_is_valid_bash` are skipped on Windows (`sys.platform == 'win32'`) since bash heredoc validation isn't meaningful there.

## Dependencies

Builds on #671 which is already merged to beta. No other dependencies.

## Testing

- `ruff check source/tests/` passes
- `go build ./...` succeeds
- `go test ./cmd/credential-process/...` passes
- Python AST parse of package.py succeeds