### PR TITLE
docs: add .claude/rules for distribution manifest parity and token endpoint builder

### DIFF
--- a/.claude/rules/distribution-manifest-parity.md
+++ b/.claude/rules/distribution-manifest-parity.md
@@ -1,0 +1,34 @@
+# Distribution Manifest Parity
+
+## Rule
+When adding a new file that ships to end users, update ALL distribution paths:
+1. `package.py` — local package creation (installer, settings)
+2. `distribute.py` — S3/landing page archives (per-OS zips + full archive)
+
+These are independent code paths with no shared manifest. Missing a file
+in one silently breaks end-user deployments.
+
+## Checklist (for any new distributable file)
+- [ ] Added to `_create_archive()` all-files list in distribute.py
+- [ ] Added to per-OS file list in `_upload_landing_page_packages()`
+- [ ] Added to `PLATFORM_FILES[platform]["installer"]` or `["binaries"]`
+- [ ] Added to `package.py` installer copy logic
+- [ ] Added test assertion in `test_distribute.py` confirming zip contains file
+
+## Why
+install.bat/install.sh reference files by name. If the distribution
+archive doesn't include them, the installer configures paths that don't
+exist → silent failures (no error, just missing functionality).
+
+## Anti-Pattern
+```python
+# ❌ Adding to package.py but forgetting distribute.py
+# package.py copies otel-helper.cmd to install dir ✓
+# distribute.py never includes it in the zip ✗
+# Result: install.bat references otel-helper.cmd → "not recognized"
+```
+
+## Related
+- PR #572 (introduced .cmd/.ps1 but missed distribute.py)
+- PR #672 (fix)
+- `binary-distribution.md`, `go-binary-architecture.md`

--- a/.claude/rules/token-endpoint-single-builder.md
+++ b/.claude/rules/token-endpoint-single-builder.md
@@ -1,0 +1,41 @@
+# Token Endpoint Single Builder
+
+## Rule
+Any code that constructs a provider's token endpoint URL MUST use
+`provider.TokenEndpointURL()`. Never inline URL building with
+`providerDomain + provCfg.TokenEndpoint` concatenation.
+
+## Why
+Azure's `provider_domain` is stored WITH a trailing `/v2.0`
+(`login.microsoftonline.com/<tenant>/v2.0`) while its token endpoint
+already carries the version segment (`/oauth2/v2.0/token`). Naive
+concatenation produces `.../v2.0/oauth2/v2.0/token` — a doubled segment
+Azure rejects with HTTP 404.
+
+Google uses absolute URLs (`https://oauth2.googleapis.com/token`) that
+must be returned as-is, not prefixed with a domain.
+
+These quirks are handled in exactly one place: `provider.TokenEndpointURL()`
+(in `internal/provider/endpoints.go`). Using it everywhere guarantees the
+auth flow and refresh flow can never drift apart.
+
+## Anti-Pattern
+```go
+// ❌ Wrong — inline URL building (Azure 404, Google double-prefix)
+provCfg := provider.ConfigFor(providerType, oktaAuthServerID)
+tokenURL = "https://" + providerDomain + provCfg.TokenEndpoint
+
+// ✅ Correct — shared builder handles all provider quirks
+tokenURL = provider.TokenEndpointURL(providerType, oktaAuthServerID, providerDomain)
+```
+
+## Callers (must all use the shared builder)
+- `oidc/flow.go` — browser authorization-code exchange
+- `tryRefreshToken()` in main.go — silent refresh
+- `refreshIDTokenOnly()` — monitoring token refresh (when added)
+- Any future token endpoint caller
+
+## Related
+- PR #666 (introduced `TokenEndpointURL` + `NormalizeDomain`)
+- `issuer-url-format.md` — same class of provider-specific URL quirks
+- `credential-flow.md` — runtime flow showing where refresh happens


### PR DESCRIPTION
## Why

Two recent bugs (#672 and #666) shared a common root cause: silent failures that CI tests can't catch because the failure mode only manifests at runtime on end-user machines.

Adding .claude/rules guardrails ensures AI coding agents (and human reviewers) catch these patterns at PR time.

## New Rules

### 1. `distribution-manifest-parity.md`

**Prevents:** PR #572-style bugs where a new file is added to `package.py` (installer) but forgotten in `distribute.py` (archive). The installer then references files that don't exist.

**Checklist:** Any new distributable file must be added to all 4 locations in distribute.py + package.py + a test assertion.

### 2. `token-endpoint-single-builder.md`

**Prevents:** PR #666-style bugs where token endpoint URLs are built inline in multiple places. Azure's trailing `/v2.0` was stripped in the auth flow but not in the refresh flow → HTTP 404 → valid refresh_token deleted.

**Enforcement:** All token URL construction must go through `provider.TokenEndpointURL()` — the single shared builder introduced in #666.

## Risk

Zero — docs-only change (.claude/rules/ files).