### PR TITLE
fix(distribution): use CNAME for custom-domain landing page (OIDC callback mismatch)

### DIFF
--- a/deployment/infrastructure/landing-page-distribution.yaml
+++ b/deployment/infrastructure/landing-page-distribution.yaml
@@ -1009,18 +1009,29 @@ Resources:
           Order: 2
           TargetGroupArn: !Ref LambdaTargetGroup
 
-  # Route53 A Record (if custom domain with Route53)
-  DomainARecord:
+  # Route53 record for the custom domain (if custom domain with Route53).
+  # Use a CNAME (not an A alias) so the host resolves through the custom
+  # domain name rather than the ALB's IP addresses. With an A alias, OIDC
+  # callbacks can be sent to/from the resolved IP instead of the configured
+  # custom domain, producing a "Callback URL mismatch" error at the IdP.
+  #
+  # UPGRADE NOTE: earlier versions created an A-alias record named DomainARecord.
+  # Renaming the logical ID here makes CloudFormation create this CNAME before
+  # deleting the old A record, and Route53 rejects a CNAME that coexists with a
+  # same-name A record ("conflicting RRSet"). Existing custom-domain deployments
+  # must therefore delete the old Route53 A record for CustomDomainName (or
+  # delete/recreate the landing-page stack) before applying this update. Fresh
+  # deployments are unaffected. See the PR / docs for the migration steps.
+  CustomDomainRecord:
     Type: AWS::Route53::RecordSet
     Condition: HasRoute53Zone
     Properties:
       HostedZoneId: !Ref HostedZoneId
       Name: !Ref CustomDomainName
-      Type: A
-      AliasTarget:
-        HostedZoneId: !GetAtt DistributionALB.CanonicalHostedZoneID
-        DNSName: !GetAtt DistributionALB.DNSName
-        EvaluateTargetHealth: false
+      Type: CNAME
+      TTL: '300'
+      ResourceRecords:
+        - !GetAtt DistributionALB.DNSName
 
   # Lambda function to update Cognito User Pool Client callback URLs
   CognitoCallbackUpdaterRole:

--- a/source/tests/test_generic_oidc_distribution.py
+++ b/source/tests/test_generic_oidc_distribution.py
@@ -11,6 +11,7 @@ ForgeRock, etc.) through the validator, config round-trip, deploy params, and CF
 from pathlib import Path
 
 import pytest
+import yaml
 
 from claude_code_with_bedrock.config import Profile
 from claude_code_with_bedrock.validators import validate_profile
@@ -20,6 +21,32 @@ REPO_ROOT = SOURCE_ROOT.parents[0]
 DEPLOY_PY = SOURCE_ROOT / "claude_code_with_bedrock" / "cli" / "commands" / "deploy.py"
 INIT_PY = SOURCE_ROOT / "claude_code_with_bedrock" / "cli" / "commands" / "init.py"
 LANDING_TEMPLATE = REPO_ROOT / "deployment" / "infrastructure" / "landing-page-distribution.yaml"
+
+
+# --- CFN-aware YAML loader (handles !Ref, !Sub, !GetAtt, etc.) ---
+
+
+class _CfnLoader(yaml.SafeLoader):
+    pass
+
+
+def _cfn_tag_constructor(loader, tag_suffix, node):
+    """Resolve any !Tag to its scalar/sequence/mapping payload (value only)."""
+    if isinstance(node, yaml.ScalarNode):
+        return loader.construct_scalar(node)
+    if isinstance(node, yaml.SequenceNode):
+        return loader.construct_sequence(node)
+    if isinstance(node, yaml.MappingNode):
+        return loader.construct_mapping(node)
+    return None
+
+
+_CfnLoader.add_multi_constructor("!", _cfn_tag_constructor)
+
+
+def _load_landing_template() -> dict:
+    with open(LANDING_TEMPLATE, encoding="utf-8") as f:
+        return yaml.load(f, Loader=_CfnLoader)
 
 
 class TestGenericDistributionValidator:
@@ -198,3 +225,52 @@ class TestGenericDistributionTemplate:
         assert "!Ref GenericUserInfoEndpoint" in text
         assert "!Ref GenericClientId" in text
         assert "resolve:secretsmanager:${GenericClientSecretArn}" in text
+
+
+class TestLandingPageCustomDomainRecord:
+    """The custom-domain DNS record must be a CNAME, not an A alias.
+
+    Regression: an A alias to the ALB resolves the host to the ALB's IP
+    addresses. OIDC callbacks then carry the resolved IP instead of the
+    configured custom domain, so the IdP rejects them with a
+    "Callback URL mismatch" error. A CNAME keeps the custom domain name in
+    the request, so callback URLs match what is registered at the IdP.
+    """
+
+    def _record_set(self) -> dict:
+        """Return the single Route53::RecordSet resource for the custom domain."""
+        template = _load_landing_template()
+        record_sets = [
+            (name, body)
+            for name, body in template["Resources"].items()
+            if body.get("Type") == "AWS::Route53::RecordSet"
+        ]
+        assert len(record_sets) == 1, f"expected exactly one RecordSet, got {[n for n, _ in record_sets]}"
+        return record_sets[0][1]
+
+    def test_custom_domain_record_is_cname(self):
+        """The record Type is CNAME (not A)."""
+        props = self._record_set()["Properties"]
+        assert props["Type"] == "CNAME", f"expected CNAME, got {props['Type']!r}"
+
+    def test_cname_uses_resource_records_not_alias_target(self):
+        """A CNAME points via ResourceRecords; AliasTarget is A/AAAA-only and invalid here."""
+        props = self._record_set()["Properties"]
+        assert "AliasTarget" not in props, "CNAME records must not use AliasTarget"
+        assert props.get("ResourceRecords"), "CNAME must declare ResourceRecords"
+        assert "TTL" in props, "CNAME ResourceRecords require a TTL"
+
+    def test_cname_points_at_alb_dns_name(self):
+        """The CNAME target is the ALB's DNS name (the !GetAtt value, resolved by the loader)."""
+        props = self._record_set()["Properties"]
+        assert props["ResourceRecords"] == ["DistributionALB.DNSName"]
+
+    def test_record_remains_conditional_on_hosted_zone(self):
+        """DNS is still only created when a Route53 hosted zone is supplied."""
+        template = _load_landing_template()
+        record = next(
+            body
+            for body in template["Resources"].values()
+            if body.get("Type") == "AWS::Route53::RecordSet"
+        )
+        assert record.get("Condition") == "HasRoute53Zone"


### PR DESCRIPTION
## Why

When the landing-page distribution is deployed with a **custom domain backed by Route53**, it created an **A-alias** record pointing at the ALB. An A alias resolves the hostname to the ALB's IP addresses, so OIDC callbacks ended up carrying the resolved IP instead of the configured custom domain. The IdP then rejected sign-in with a **"Callback URL mismatch"** error, because the callback didn't match the custom-domain URL registered with the provider.

## What

Change the Route53 record from an **A alias** to a **CNAME** pointing at the ALB's DNS name, so the custom domain name (which matches the registered callback URL) stays in the request:

```diff
-      Type: A
-      AliasTarget:
-        HostedZoneId: !GetAtt DistributionALB.CanonicalHostedZoneID
-        DNSName: !GetAtt DistributionALB.DNSName
-        EvaluateTargetHealth: false
+      Type: CNAME
+      TTL: '300'
+      ResourceRecords:
+        - !GetAtt DistributionALB.DNSName
```

Also renamed the logical ID `DomainARecord` → `CustomDomainRecord` so the resource name no longer misrepresents its type. Still conditional on `HasRoute53Zone`.

## ⚠️ Upgrade impact (existing custom-domain deployments)

Renaming the logical ID makes CloudFormation **create the new CNAME before deleting the old A record**. Route53 rejects a CNAME that coexists with a same-name A record (`conflicting RRSet`), so an in-place stack update would fail and roll back.

**Before upgrading an existing custom-domain deployment**, do one of:
- Delete the existing Route53 **A record** for the custom domain, then run the update; or
- Delete and recreate the landing-page stack.

**Fresh deployments are unaffected.** (Per the `AWS::Route53::RecordSet` spec, keeping the logical ID would have allowed an in-place A→CNAME UPSERT — "No interruption" — but it would leave the resource misleadingly named `DomainARecord` while holding a CNAME. We chose the accurate name + documented migration over the wrong name.)

This caveat is also documented in a comment on the resource in the template.

## Tests

New `TestLandingPageCustomDomainRecord` (parses the template with a CFN-aware YAML loader; asserts by resource Type, not logical-ID name):
- the record `Type` is `CNAME`, not `A`
- it uses `ResourceRecords` + `TTL`, not `AliasTarget`
- the target is the ALB DNS name
- it remains conditional on `HasRoute53Zone`

`cfn-lint`: no new findings — warning count identical to `beta`, none touch the changed `RecordSet`.

## Compatibility
Subdomain custom domains only (e.g. `claude.example.com`); a CNAME at the zone apex is not permitted by DNS. This matches the documented setup.

## Related
Found alongside the Windows distribution fix (#672) and the IDC reliability fixes (#671); kept as a separate PR per one-concern-per-PR.