### PR TITLE
fix(go): keep quota notification server alive until browser connects

### DIFF
--- a/source/go/cmd/credential-process/main.go
+++ b/source/go/cmd/credential-process/main.go
@@ -102,11 +102,11 @@ func main() {
 
 	// Auth dispatch: IDC > legacy passthrough > OIDC
 	if cfg.IsIDC() {
-		os.Exit(app.runIDC())
+		exitAfterNotifications(app.runIDC())
 	}
 	if !cfg.IsSsoEnabled() {
 		// Legacy passthrough: no IDC fields, just ambient credential chain.
-		os.Exit(app.runPassthrough())
+		exitAfterNotifications(app.runPassthrough())
 	}
 
 	// OIDC path — resolve provider type and redirect port
@@ -138,7 +138,18 @@ func main() {
 		// Fall through to normal auth flow
 	}
 
-	os.Exit(app.run())
+	exitAfterNotifications(app.run())
+}
+
+// exitAfterNotifications waits for any pending quota browser notification to be
+// fetched (or time out) before terminating. Credentials are already written to
+// stdout by the time run()/runIDC()/runPassthrough() return, so this only holds
+// the process open long enough for the browser to connect — it never delays the
+// AWS SDK. Without it, os.Exit kills the notification server goroutine before
+// the browser connects (ERR_CONNECTION_REFUSED).
+func exitAfterNotifications(code int) {
+	waitForQuotaNotification()
+	os.Exit(code)
 }
 
 type credentialApp struct {
@@ -735,7 +746,6 @@ func (a *credentialApp) saveMonitoringTokenAndHeaders(idToken string, claims map
 		}
 	}
 }
-
 
 func (a *credentialApp) shouldRecheckQuota() bool {
 	if a.cfg.QuotaAPIEndpoint == "" {

--- a/source/go/cmd/credential-process/quota_notification.go
+++ b/source/go/cmd/credential-process/quota_notification.go
@@ -12,13 +12,50 @@ import (
 	"os/exec"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"ccwb-go/internal/quota"
 )
 
-// showQuotaBrowserNotification opens a browser window showing quota status.
-// Runs asynchronously (goroutine) to avoid blocking credential output.
+// pendingNotification holds a quota-status server that has been started and had
+// its browser opened, but whose page may not yet have been fetched.
+type pendingNotification struct {
+	server *http.Server
+	served chan struct{}
+	url    string // for tests/diagnostics
+}
+
+var (
+	pendingMu     sync.Mutex
+	pendingNotifs []*pendingNotification
+
+	// notificationWaitTimeout bounds how long the process lingers at exit
+	// waiting for the browser to fetch the quota page. Mirrors the Python
+	// implementation's server.timeout = 5. Var (not const) so tests can shrink it.
+	notificationWaitTimeout = 5 * time.Second
+
+	// openBrowserFunc is the indirection point for opening a browser, so tests
+	// can substitute a no-op instead of launching a real browser.
+	openBrowserFunc = openBrowser
+
+	// isHeadlessFunc is the indirection point for headless detection, so tests
+	// can force a non-headless environment regardless of CI's DISPLAY/SSH vars.
+	isHeadlessFunc = isHeadless
+)
+
+// showQuotaBrowserNotification starts a localhost server showing quota status
+// and opens the browser to it. It does NOT wait for the page to be fetched —
+// the caller must invoke waitForQuotaNotification() before the process exits.
+//
+// Why this split: credential-process exits via os.Exit, which kills every
+// goroutine immediately. A fire-and-forget server raced the process exit, so
+// the browser frequently hit the socket after it was already gone and showed
+// ERR_CONNECTION_REFUSED. By binding the listener synchronously here (the
+// socket accepts connections into the kernel backlog the instant net.Listen
+// returns) and deferring the wait to the exit path — after credentials are
+// already on stdout — the server stays alive until the browser connects,
+// without ever delaying credential delivery.
 //
 // Skipped when:
 // - CCWB_NO_BROWSER_NOTIFICATION=1 is set
@@ -32,7 +69,7 @@ func showQuotaBrowserNotification(qr *quota.Result, isBlocked bool) {
 	}
 
 	// Skip in headless environments
-	if isHeadless() {
+	if isHeadlessFunc() {
 		debugPrint("Browser notification skipped (headless environment detected)")
 		return
 	}
@@ -42,50 +79,64 @@ func showQuotaBrowserNotification(qr *quota.Result, isBlocked bool) {
 		return
 	}
 
-	// Run asynchronously to avoid blocking credential output
-	go func() {
-		html := buildQuotaHTML(usage, qr.Message, isBlocked)
+	html := buildQuotaHTML(usage, qr.Message, isBlocked)
 
-		// Find an available port (8401 preferred, matching Python implementation)
-		listener, err := net.Listen("tcp", "127.0.0.1:8401")
+	// Bind the listener synchronously (8401 preferred, matching Python). Binding
+	// before opening the browser is what closes the connection race: the socket
+	// queues the browser's connection even before Serve() is scheduled.
+	listener, err := net.Listen("tcp", "127.0.0.1:8401")
+	if err != nil {
+		// Try any available port
+		listener, err = net.Listen("tcp", "127.0.0.1:0")
 		if err != nil {
-			// Try any available port
-			listener, err = net.Listen("tcp", "127.0.0.1:0")
-			if err != nil {
-				debugPrint("Could not start quota notification server: %v", err)
-				return
-			}
+			debugPrint("Could not start quota notification server: %v", err)
+			return
 		}
+	}
 
-		port := listener.Addr().(*net.TCPAddr).Port
-		served := make(chan struct{})
+	port := listener.Addr().(*net.TCPAddr).Port
+	served := make(chan struct{})
+	var once sync.Once
 
-		mux := http.NewServeMux()
-		mux.HandleFunc("/quota-status", func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "text/html; charset=utf-8")
-			w.Write([]byte(html))
-			close(served)
-		})
+	mux := http.NewServeMux()
+	mux.HandleFunc("/quota-status", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Write([]byte(html))
+		// once: a browser reload would hit this handler again; closing a
+		// channel twice panics.
+		once.Do(func() { close(served) })
+	})
 
-		server := &http.Server{Handler: mux}
-		go server.Serve(listener)
+	server := &http.Server{Handler: mux}
+	go server.Serve(listener)
 
-		// Open browser
-		url := fmt.Sprintf("http://localhost:%d/quota-status", port)
-		openBrowser(url)
+	// Open browser
+	url := fmt.Sprintf("http://localhost:%d/quota-status", port)
+	openBrowserFunc(url)
 
-		// Wait for page to be served or timeout after 5 seconds
+	pendingMu.Lock()
+	pendingNotifs = append(pendingNotifs, &pendingNotification{server: server, served: served, url: url})
+	pendingMu.Unlock()
+}
+
+// waitForQuotaNotification blocks until any pending quota page has been fetched
+// by the browser (or notificationWaitTimeout elapses), then shuts the server(s)
+// down. Call this immediately before the process exits: credentials are already
+// on stdout by then, so this only delays process teardown, never the AWS SDK.
+func waitForQuotaNotification() {
+	pendingMu.Lock()
+	notifs := pendingNotifs
+	pendingNotifs = nil
+	pendingMu.Unlock()
+
+	for _, n := range notifs {
 		select {
-		case <-served:
-		case <-time.After(5 * time.Second):
+		case <-n.served:
+		case <-time.After(notificationWaitTimeout):
 			debugPrint("Browser notification timed out")
 		}
-
-		server.Close()
-	}()
-
-	// Give the goroutine a moment to start the server before the process might exit
-	time.Sleep(100 * time.Millisecond)
+		n.server.Close()
+	}
 }
 
 // isHeadless returns true if the environment appears to be headless (no GUI).

--- a/source/go/cmd/credential-process/quota_notification_test.go
+++ b/source/go/cmd/credential-process/quota_notification_test.go
@@ -1,0 +1,202 @@
+package main
+
+// ABOUTME: Regression tests for the quota browser notification exit race.
+// ABOUTME: The server must outlive credential output and stay reachable until
+// ABOUTME: the browser connects — previously os.Exit killed it first (refused).
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"ccwb-go/internal/quota"
+)
+
+// TestMain installs a no-op browser opener for the whole test binary so that
+// tests touching the quota notification path (e.g. printQuotaWarning in
+// quota_warning_test.go) never launch a real browser on a developer machine
+// where isHeadless() returns false. Individual tests may still override
+// openBrowserFunc via setupNotificationTest; they restore it to this no-op.
+func TestMain(m *testing.M) {
+	openBrowserFunc = func(string) {}
+	os.Exit(m.Run())
+}
+
+// resetPending clears global notification state and installs a no-op browser
+// opener so tests never launch a real browser. It returns a cleanup func.
+func setupNotificationTest(t *testing.T) {
+	t.Helper()
+	pendingMu.Lock()
+	pendingNotifs = nil
+	pendingMu.Unlock()
+
+	origOpen := openBrowserFunc
+	origTimeout := notificationWaitTimeout
+	origHeadless := isHeadlessFunc
+	openBrowserFunc = func(string) {}             // no real browser
+	isHeadlessFunc = func() bool { return false } // force non-headless (CI has no DISPLAY)
+	notificationWaitTimeout = 2 * time.Second
+
+	t.Cleanup(func() {
+		openBrowserFunc = origOpen
+		notificationWaitTimeout = origTimeout
+		isHeadlessFunc = origHeadless
+		pendingMu.Lock()
+		pendingNotifs = nil
+		pendingMu.Unlock()
+	})
+}
+
+func warningResult() *quota.Result {
+	return &quota.Result{
+		Allowed: true,
+		Reason:  "within_limits",
+		Message: "Access granted - enforcement mode is alert-only",
+		Usage: map[string]interface{}{
+			"monthly_percent": float64(22),
+			"daily_percent":   float64(153),
+			"monthly_tokens":  float64(8826347),
+			"monthly_limit":   float64(40000000),
+			"daily_tokens":    float64(8438308),
+			"daily_limit":     float64(5500000),
+		},
+	}
+}
+
+func pendingURL(t *testing.T) string {
+	t.Helper()
+	pendingMu.Lock()
+	defer pendingMu.Unlock()
+	if len(pendingNotifs) != 1 {
+		t.Fatalf("expected exactly 1 pending notification, got %d", len(pendingNotifs))
+	}
+	return pendingNotifs[0].url
+}
+
+// TestNotificationServerReachableAfterReturn is the core regression test:
+// after showQuotaBrowserNotification returns (credentials would already be on
+// stdout at this point), the server must still be reachable. The old
+// fire-and-forget implementation only kept the socket alive for a 100ms sleep
+// and then lost it to os.Exit, producing ERR_CONNECTION_REFUSED.
+func TestNotificationServerReachableAfterReturn(t *testing.T) {
+	setupNotificationTest(t)
+
+	showQuotaBrowserNotification(warningResult(), false)
+	url := pendingURL(t)
+
+	// Simulate the real browser connecting AFTER the function returned. The
+	// server must answer rather than refuse the connection.
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("server should be reachable after return, got: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "Quota Warning") {
+		t.Errorf("expected quota page HTML, got: %q", string(body))
+	}
+
+	// The wait must now return promptly because the page was served.
+	done := make(chan struct{})
+	go func() { waitForQuotaNotification(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(notificationWaitTimeout + time.Second):
+		t.Fatal("waitForQuotaNotification did not return after page was served")
+	}
+}
+
+// TestWaitTimesOutWhenBrowserNeverConnects verifies the exit path does not hang
+// forever when the browser never fetches the page — it must fall back to the
+// timeout and shut down.
+func TestWaitTimesOutWhenBrowserNeverConnects(t *testing.T) {
+	setupNotificationTest(t)
+	notificationWaitTimeout = 200 * time.Millisecond
+
+	showQuotaBrowserNotification(warningResult(), false)
+	_ = pendingURL(t) // server started, but we never connect
+
+	start := time.Now()
+	waitForQuotaNotification()
+	elapsed := time.Since(start)
+
+	if elapsed < notificationWaitTimeout {
+		t.Errorf("wait returned too early (%v), expected to block ~%v", elapsed, notificationWaitTimeout)
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("wait blocked too long (%v), timeout not honored", elapsed)
+	}
+}
+
+// TestReloadDoesNotPanic verifies a browser reload (a second GET to the served
+// page) does not double-close the served channel and panic.
+func TestReloadDoesNotPanic(t *testing.T) {
+	setupNotificationTest(t)
+
+	showQuotaBrowserNotification(warningResult(), false)
+	url := pendingURL(t)
+
+	for i := 0; i < 3; i++ {
+		resp, err := http.Get(url)
+		if err != nil {
+			t.Fatalf("request %d failed: %v", i, err)
+		}
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}
+
+	waitForQuotaNotification() // must not panic
+}
+
+// TestOptOutSkipsServer verifies CCWB_NO_BROWSER_NOTIFICATION=1 starts no server.
+func TestOptOutSkipsServer(t *testing.T) {
+	setupNotificationTest(t)
+	t.Setenv("CCWB_NO_BROWSER_NOTIFICATION", "1")
+
+	showQuotaBrowserNotification(warningResult(), false)
+
+	pendingMu.Lock()
+	n := len(pendingNotifs)
+	pendingMu.Unlock()
+	if n != 0 {
+		t.Errorf("opt-out should start no notification, got %d pending", n)
+	}
+	waitForQuotaNotification() // no-op, must not block or panic
+}
+
+// TestNilUsageSkipsServer verifies a nil usage map starts no server.
+func TestNilUsageSkipsServer(t *testing.T) {
+	setupNotificationTest(t)
+
+	showQuotaBrowserNotification(&quota.Result{Allowed: true, Usage: nil}, false)
+
+	pendingMu.Lock()
+	n := len(pendingNotifs)
+	pendingMu.Unlock()
+	if n != 0 {
+		t.Errorf("nil usage should start no notification, got %d pending", n)
+	}
+}
+
+// TestWaitWithNoPendingIsNoop verifies the exit path is safe when no
+// notification was ever shown (the common case).
+func TestWaitWithNoPendingIsNoop(t *testing.T) {
+	setupNotificationTest(t)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() { defer wg.Done(); waitForQuotaNotification() }()
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("waitForQuotaNotification blocked with nothing pending")
+	}
+}


### PR DESCRIPTION
## Why

Users intermittently saw `ERR_CONNECTION_REFUSED` at `localhost:8401/quota-status` instead of the quota warning page when opening Claude Code. The quota data was correct — the local page server was being killed before the browser could connect.

The root cause is a **goroutine-vs-`os.Exit` race** in `quota_notification.go`. The server was started in a fire-and-forget goroutine with only a `time.Sleep(100ms)` before `showQuotaBrowserNotification` returned. The process then exits via `os.Exit`, which terminates every goroutine immediately — including the HTTP server — without honoring the intended 5s `select` wait inside the goroutine. Whether the browser connected in time was a pure race against how fast the OS launched Chrome, which is why it failed randomly and worked on warm runs.

This also diverged from the Python credential-provider, which is synchronous (blocks until the page is served via `server.timeout = 5`), violating `credential-helper-parity.md`. Introduced by PR #658.

## What

**Output-first, wait-at-exit** — credentials hit stdout with zero added latency; only process teardown waits for the browser:

- **Bind the listener synchronously** before opening the browser. The socket queues the browser's connection into the kernel backlog the instant `net.Listen` returns — this closes the connection race.
- `showQuotaBrowserNotification` registers the started server in a pending list and **returns immediately** (non-blocking). Credentials are already written to stdout by `outputJSON()` inside `run()`/`runIDC()`/`runPassthrough()` before those return.
- New `waitForQuotaNotification()` blocks on served-or-timeout (5s), then shuts the server down.
- New `exitAfterNotifications(code)` wrapper calls `waitForQuotaNotification()` then `os.Exit(code)` — used at all three auth entrypoints.
- `sync.Once` guards the `served` channel so a browser reload can't double-close it and panic.
- Test seams `openBrowserFunc` / `isHeadlessFunc` for testability without launching a real browser.

## Tests

New `quota_notification_test.go`:

- `TestNotificationServerReachableAfterReturn` — **the regression**: server is still reachable _after_ `showQuotaBrowserNotification` returns (this test fails on the old fire-and-forget implementation).
- `TestWaitTimesOutWhenBrowserNeverConnects` — exit path falls back to timeout and doesn't hang.
- `TestReloadDoesNotPanic` — browser reload doesn't double-close the channel.
- `TestOptOutSkipsServer`, `TestNilUsageSkipsServer` — skip conditions start no server.
- `TestWaitWithNoPendingIsNoop` — common case (no notification shown) is safe.
- `TestMain` installs a no-op browser opener binary-wide so existing `printQuotaWarning` tests no longer launch a real browser on developer machines.

Verified: `go build ./...`, `go vet`, `go test -race ./...` all clean.