### PR TITLE
fix(monitoring): raise OTEL collector ALB idle timeout to 300s

### DIFF
--- a/deployment/infrastructure/otel-collector.yaml
+++ b/deployment/infrastructure/otel-collector.yaml
@@ -257,6 +257,17 @@ Resources:
       Type: application
       IpAddressType: ipv4
       Scheme: !Ref ALBScheme
+      LoadBalancerAttributes:
+        # Raise the idle timeout above the AWS default of 60s. Claude Code
+        # reuses a pooled keep-alive connection for OTLP metric exports, which
+        # only happen after activity (e.g. a model response). At 60s the ALB
+        # reaps the connection during idle gaps between turns, so the next
+        # export reuses a dead socket and logs a benign but noisy "socket hang
+        # up". 300s covers typical in-session pauses. (Reduces, but cannot fully
+        # eliminate — arbitrarily long idle gaps still reap the connection; the
+        # root cause is client-side connection reuse.)
+        - Key: idle_timeout.timeout_seconds
+          Value: '300'
       SecurityGroups:
         - !Ref ALBSecurityGroup
       Subnets: !Ref SubnetIds

--- a/source/tests/e2e/test_cfn_contracts.py
+++ b/source/tests/e2e/test_cfn_contracts.py
@@ -341,3 +341,45 @@ class TestCoWorkLogGroupContract:
         created = self._log_group_names(_load_template("otel-collector.yaml"))
         missing = dash_groups - created
         assert not missing, f"cowork-dashboard filters target log groups nobody creates: {missing}"
+
+
+class TestOtelCollectorAlbIdleTimeout:
+    """The OTEL collector ALB must raise its idle timeout above the AWS default
+    of 60s.
+
+    Claude Code reuses a pooled keep-alive connection for OTLP metric exports,
+    which only happen after activity. At the 60s default the ALB reaps the
+    connection during idle gaps between turns, so the next export reuses a dead
+    socket and logs a benign-but-noisy "socket hang up". Raising the idle
+    timeout keeps the connection alive across normal in-session pauses.
+    """
+
+    def _load_balancer(self) -> dict:
+        otel = _load_template("otel-collector.yaml")
+        lbs = [
+            body
+            for body in otel["Resources"].values()
+            if body.get("Type") == "AWS::ElasticLoadBalancingV2::LoadBalancer"
+        ]
+        assert len(lbs) == 1, f"expected exactly one ALB, found {len(lbs)}"
+        return lbs[0]
+
+    def _idle_timeout(self) -> int:
+        attrs = self._load_balancer()["Properties"].get("LoadBalancerAttributes", [])
+        for attr in attrs:
+            if attr.get("Key") == "idle_timeout.timeout_seconds":
+                return int(attr["Value"])
+        raise AssertionError("idle_timeout.timeout_seconds not set on the collector ALB")
+
+    def test_idle_timeout_is_set(self):
+        # Raises AssertionError if the attribute is missing.
+        self._idle_timeout()
+
+    def test_idle_timeout_above_default(self):
+        """Must exceed the 60s AWS default (that default is what causes the
+        socket-hang-up reaping)."""
+        assert self._idle_timeout() > 60
+
+    def test_idle_timeout_within_alb_max(self):
+        """ALB idle timeout is capped at 4000s by the service."""
+        assert 1 <= self._idle_timeout() <= 4000


### PR DESCRIPTION
## Why

Claude Code reuses a pooled keep-alive connection for OTLP metric exports, and those exports only happen **after activity** (e.g. a model response). With the ALB's default idle timeout of **60s**, the connection is reaped during the idle gaps between turns, so the next export reuses a dead socket and Claude Code logs:

```
PeriodicExportingMetricReader: metrics export failed (error Error: socket hang up)
```

It's **benign and self-recovering** — the next export reconnects and metrics still land in the dashboard — but it's noisy and confusing. It reliably appears right after a response (the first export following an idle gap), so users reasonably suspect something is broken. Observed on both Linux and Windows clients against the same collector; empirically, raising the ALB idle timeout makes it stop.

## What

Set `idle_timeout.timeout_seconds: '300'` via `LoadBalancerAttributes` on the collector ALB (was the AWS default of 60s). 300s comfortably covers normal in-session pauses (reading, thinking, typing) while keeping idle connections from lingering excessively — which matters at fleet scale (hundreds of developers each holding a keep-alive connection).

```yaml
LoadBalancer:
  Type: AWS::ElasticLoadBalancingV2::LoadBalancer
  Properties:
    ...
    LoadBalancerAttributes:
      - Key: idle_timeout.timeout_seconds
        Value: '300'
```

## Honest scope

This **reduces but cannot fully eliminate** the error: an idle gap longer than the timeout still reaps the connection. The root cause is client-side connection reuse in Claude Code's OTLP exporter (it would need to validate/retry a pooled socket before reuse), which can't be fixed from the collector side. 300s is a pragmatic mitigation, not a cure.

I started to add this as a tunable CloudFormation parameter, but kept it a hardcoded value to keep the change minimal — happy to parameterize if reviewers prefer.

## Tests

`TestOtelCollectorAlbIdleTimeout` (test_cfn_contracts.py): the collector ALB sets `idle_timeout.timeout_seconds`, it exceeds the 60s default, and it's within the ALB's 1–4000s range. Full `test_cfn_contracts.py` (102 tests) passes.

`cfn-lint`: no new findings — warning count identical to `beta`, none touch the LoadBalancer.

## Note
Rebased on latest `beta`; the LoadBalancer there was recently updated by #635 (internal-ALB scheme) — this change layers cleanly on top (adds `LoadBalancerAttributes`, no conflict with `Scheme`).