### PR TITLE
feat(cowork): use inferenceCredentialHelper for reliable credential refresh

### DIFF
--- a/assets/docs/COWORK_3P.md
+++ b/assets/docs/COWORK_3P.md
@@ -166,13 +166,38 @@ Claude Desktop supports object entries in `inferenceModels` with `anthropicFamil
 
 ### How Credentials Flow
 
+This solution supports two credential modes for CoWork. The **credential helper** mode (default since v2.6.0) is recommended because it gives Claude Desktop direct control over credential lifecycle, eliminating the stale-credential bug that required manual app restarts.
+
+#### Credential Helper Mode (Recommended)
+
 When Claude Cowork starts a session:
+
+1. Claude Desktop reads `inferenceCredentialHelper` from the MDM policy — this points directly at the credential-process binary
+2. Claude Desktop runs the binary and reads temporary AWS credentials from stdout
+3. The output is cached for `inferenceCredentialHelperTtlSec` seconds (default: 3500, just under the 1h STS token lifetime)
+4. When the cache expires, Claude Desktop automatically re-runs the helper — **no restart required**
+5. If credentials are rejected mid-session, Claude Desktop re-runs with `CLAUDE_HELPER_CONTEXT=mid-session-refresh` for seamless recovery (20s timeout)
+
+The credential-process binary handles the `CLAUDE_HELPER_CONTEXT` environment variable:
+- `interactive` → Full browser-based OIDC authentication
+- `mid-session-refresh` → Silent refresh via cached refresh_token (no browser)
+- `background` / `setup-test` → Silent path only, exit non-zero if unavailable
+
+This mode resolves the known issue where CoWork doesn't automatically refresh AWS credentials after token expiry (affecting both IDC and OIDC/Azure AD federated auth users).
+
+Ref: [Claude Desktop Credential Helper documentation](https://claude.com/docs/third-party/claude-desktop/credential-helper)
+
+#### AWS Profile Mode (Legacy)
+
+The legacy flow uses `inferenceBedrockProfile` instead:
 
 1. Claude Desktop reads `inferenceBedrockProfile` from the applied MDM policy (registry on Windows, managed preference on macOS)
 2. It hands that profile name to the AWS SDK, which resolves the corresponding `[profile <name>]` stanza in `~/.aws/config`
 3. The stanza's `credential_process = .../credential-process --profile <name>` entry runs the bundled credential-process binary
 4. The binary authenticates the user via your OIDC provider (Okta, Azure AD, Auth0, etc.) and returns temporary AWS credentials in the standard AWS `credential_process` JSON format
 5. The AWS SDK signs each Bedrock call with those credentials; caching and refresh are handled automatically by the SDK
+
+To use this mode, set `cowork_credential_mode = "profile"` in your deployment profile before running `ccwb cowork generate`.
 
 No wrapper script is required — CoWork reuses the same `credential-process` binary and `~/.aws/config` entry that `install.sh` / `install.bat` already configure for Claude Code CLI.
 

--- a/source/claude_code_with_bedrock/cli/commands/cowork.py
+++ b/source/claude_code_with_bedrock/cli/commands/cowork.py
@@ -118,6 +118,8 @@ class CoworkGenerateCommand(Command):
             model_aliases=model_aliases,
             profile_name=profile_name,
             extra_keys=profile.cowork_3p_extra_keys or None,
+            credential_mode=getattr(profile, "cowork_credential_mode", "helper"),
+            credential_helper_ttl_sec=getattr(profile, "cowork_credential_helper_ttl_sec", 3500),
         )
 
         # Add monitoring OTLP endpoint if available

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -3966,6 +3966,8 @@ Available metrics include:
                 model_aliases=model_aliases,
                 profile_name=profile_name,
                 extra_keys=profile.cowork_3p_extra_keys or None,
+                credential_mode=getattr(profile, "cowork_credential_mode", "helper"),
+                credential_helper_ttl_sec=getattr(profile, "cowork_credential_helper_ttl_sec", 3500),
             )
 
             # Beta features (per-feature managed configuration keys)

--- a/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
+++ b/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
@@ -108,20 +108,46 @@ def _infer_tier_from_model_id(model_id: str) -> str | None:
     return None
 
 
+def _credential_process_path(profile_name: str) -> dict[str, str]:
+    """Return platform-specific credential-process paths for inferenceCredentialHelper.
+
+    The installer places the binary at a predictable location per-platform:
+    - macOS/Linux: ~/claude-code-with-bedrock/credential-process
+    - Windows: %USERPROFILE%\\claude-code-with-bedrock\\credential-process.exe
+
+    For MDM deployment we use the tilde (~) shorthand which Claude Desktop
+    resolves to the user's home directory on all platforms.
+    """
+    return {
+        "unix": f"~/claude-code-with-bedrock/credential-process --profile {profile_name}",
+        "windows": f"%USERPROFILE%\\claude-code-with-bedrock\\credential-process.exe --profile {profile_name}",
+    }
+
+
 def build_mdm_config(
     bedrock_region: str,
     model_aliases: list[str],
     profile_name: str = "ClaudeCode",
     extra_keys: dict[str, str] | None = None,
+    credential_mode: str = "helper",
+    credential_helper_ttl_sec: int = 3500,
 ) -> dict:
     """Build the base CoWork 3P MDM configuration dictionary.
 
-    Uses inferenceBedrockProfile, which points Claude Desktop at an AWS named
-    profile in ~/.aws/config. The installer already configures that profile with
-    credential_process = credential-process --profile <name>, so CoWork reuses
-    the same auth pipeline as Claude Code with zero extra artifacts to ship.
+    Supports two credential modes:
 
-    Ref: https://claude.com/docs/cowork/3p/bedrock
+    - "helper" (default, recommended): Uses inferenceCredentialHelper, which gives
+      Claude Desktop direct control over the credential lifecycle. The app caches
+      the helper's output for `credential_helper_ttl_sec` seconds and automatically
+      re-runs it on expiry — including mid-session silent refresh. This eliminates
+      the stale-credential bug where CoWork requires a restart after token expiry.
+
+    - "profile" (legacy): Uses inferenceBedrockProfile, which delegates credential
+      resolution to the AWS SDK via ~/.aws/config. This works but credential refresh
+      depends on boto3's internal session caching, which doesn't reliably trigger
+      re-authentication in the CoWork process lifecycle.
+
+    Ref: https://claude.com/docs/third-party/claude-desktop/credential-helper
 
     Args:
         bedrock_region: AWS region for Bedrock API calls.
@@ -129,9 +155,10 @@ def build_mdm_config(
         profile_name: AWS named profile (matches ~/.aws/config stanza).
         extra_keys: Optional dictionary of additional MDM keys to merge into the
             configuration. Values should be strings (JSON-encoded for complex types).
-            These are appended after the base keys, allowing administrators to set
-            keys like coworkEgressAllowedHosts, coworkWebSearchEnabled, or
-            managedMcpServers without modifying source code.
+        credential_mode: "helper" or "profile" (default: "helper").
+        credential_helper_ttl_sec: Cache TTL for the credential helper output in
+            seconds (default: 3500, slightly under the 1h STS token lifetime to
+            ensure refresh happens before expiry).
 
     Returns:
         Dictionary of MDM configuration key-value pairs.
@@ -139,7 +166,6 @@ def build_mdm_config(
     config = {
         "inferenceProvider": "bedrock",
         "inferenceBedrockRegion": bedrock_region,
-        "inferenceBedrockProfile": profile_name,
         "inferenceModels": build_inference_models(model_aliases),
         "isClaudeCodeForDesktopEnabled": True,
         "isDesktopExtensionEnabled": True,
@@ -147,6 +173,22 @@ def build_mdm_config(
         "isDesktopExtensionSignatureRequired": True,
         "isLocalDevMcpEnabled": True,
     }
+
+    if credential_mode == "helper":
+        # Direct credential helper — Claude Desktop manages the credential lifecycle.
+        # Uses the same credential-process binary but invoked directly by the app
+        # instead of indirectly via the AWS SDK's credential_process chain.
+        paths = _credential_process_path(profile_name)
+        # Use the Unix path by default; installers for Windows will substitute.
+        # MDM platforms (Jamf, Intune) typically deploy platform-specific configs.
+        config["inferenceCredentialHelper"] = paths["unix"]
+        config["inferenceCredentialHelperTtlSec"] = str(credential_helper_ttl_sec)
+        config["inferenceCredentialHelperSilentRefreshEnabled"] = "true"
+        # Keep the AWS profile as fallback for SDK-level operations (region, etc.)
+        config["inferenceBedrockProfile"] = profile_name
+    else:
+        # Legacy profile mode — rely on AWS SDK credential_process chain.
+        config["inferenceBedrockProfile"] = profile_name
 
     if extra_keys:
         config.update(extra_keys)
@@ -295,13 +337,29 @@ def generate_reg_file(output_dir: Path, mdm_config: dict) -> Path:
     All values are stored as REG_SZ strings — booleans, integers, and arrays
     included — matching what Claude Desktop reads from the registry.
 
+    If inferenceCredentialHelper is present and uses a Unix-style path (~/ prefix),
+    it is rewritten to the Windows equivalent (%USERPROFILE%\\ + .exe suffix).
+
     Returns the path to the generated file.
     """
     reg_key = r"HKEY_CURRENT_USER\SOFTWARE\Policies\Claude"
 
+    # Create a copy with Windows-specific credential helper path
+    config = dict(mdm_config)
+    helper_key = "inferenceCredentialHelper"
+    if helper_key in config and isinstance(config[helper_key], str) and config[helper_key].startswith("~/"):
+        # Convert ~/claude-code-with-bedrock/credential-process --profile X
+        # to %USERPROFILE%\claude-code-with-bedrock\credential-process.exe --profile X
+        unix_path = config[helper_key]
+        parts = unix_path.split(" ", 1)
+        binary_part = parts[0].replace("~/", "%USERPROFILE%\\").replace("/", "\\")
+        if not binary_part.endswith(".exe"):
+            binary_part += ".exe"
+        config[helper_key] = f"{binary_part} {parts[1]}" if len(parts) > 1 else binary_part
+
     lines = ["Windows Registry Editor Version 5.00", "", f"[{reg_key}]"]
 
-    for key, value in _mdm_keys(mdm_config).items():
+    for key, value in _mdm_keys(config).items():
         if isinstance(value, bool):
             string_value = "true" if value else "false"
         elif isinstance(value, (list, dict)):

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -152,6 +152,10 @@ class Profile:
     cowork_3p_enabled: bool = True  # Generate CoWork 3P MDM configs during packaging
     cowork_3p_extra_keys: dict[str, str] = field(default_factory=dict)  # Custom MDM keys merged into CoWork 3P output
     cowork_service_token: str = ""  # Static token for CoWork ALB auth bypass (set during init)
+    cowork_credential_mode: str = (
+        "helper"  # "helper" (inferenceCredentialHelper) or "profile" (inferenceBedrockProfile)
+    )
+    cowork_credential_helper_ttl_sec: int = 3500  # inferenceCredentialHelperTtlSec (refresh before 1h STS expiry)
 
     # Cowork beta features (managed configuration keys)
     cowork_chat_tab_enabled: bool = True  # chatTabEnabled — enables the Chat tab

--- a/source/tests/cli/commands/test_package_manifest.py
+++ b/source/tests/cli/commands/test_package_manifest.py
@@ -17,13 +17,11 @@ For IDC zero-binary:
   - output should contain collector-config.yaml (IDC template)
 """
 
-import inspect
 import json
 from unittest.mock import MagicMock
 
 from claude_code_with_bedrock.cli.commands.package import PackageCommand
 from claude_code_with_bedrock.config import Profile
-
 
 # ---------------------------------------------------------------------------
 # Fixtures: profile factories
@@ -144,8 +142,7 @@ class TestOIDCSidecarManifest:
         profile = _make_oidc_sidecar_profile()
         _run_config_phase(profile, tmp_path)
         assert (tmp_path / "collector-config.yaml").exists(), (
-            "collector-config.yaml missing from OIDC sidecar package — "
-            "local collector will have no configuration."
+            "collector-config.yaml missing from OIDC sidecar package — local collector will have no configuration."
         )
 
     def test_collector_config_has_region(self, tmp_path):
@@ -168,9 +165,7 @@ class TestOIDCSidecarManifest:
         installer = tmp_path / "install.sh"
         assert installer.exists(), "install.sh not generated"
         content = installer.read_text(encoding="utf-8")
-        assert "otelcol" in content, (
-            "Installer does not reference otelcol — sidecar collector will not be installed."
-        )
+        assert "otelcol" in content, "Installer does not reference otelcol — sidecar collector will not be installed."
 
     def test_installer_references_credential_process(self, tmp_path):
         """Installer must reference credential-process binary."""
@@ -183,9 +178,7 @@ class TestOIDCSidecarManifest:
         installer = tmp_path / "install.sh"
         assert installer.exists()
         content = installer.read_text(encoding="utf-8")
-        assert "credential-process" in content, (
-            "Installer does not reference credential-process binary."
-        )
+        assert "credential-process" in content, "Installer does not reference credential-process binary."
 
     def test_claude_settings_has_otel_endpoint(self, tmp_path):
         """Claude settings must configure OTEL endpoint for sidecar (localhost:4318)."""
@@ -220,9 +213,7 @@ class TestOIDCCentralManifest:
         profile = _make_oidc_central_profile()
         _run_config_phase(profile, tmp_path)
         otelcol_files = list(tmp_path.glob("otelcol-*"))
-        assert len(otelcol_files) == 0, (
-            f"Unexpected otelcol binaries in central mode package: {otelcol_files}"
-        )
+        assert len(otelcol_files) == 0, f"Unexpected otelcol binaries in central mode package: {otelcol_files}"
 
     def test_installer_still_valid(self, tmp_path):
         """Central mode must still produce a usable installer."""
@@ -254,12 +245,8 @@ class TestIDCZeroBinaryManifest:
         # No credential-process-* or otel-helper-* files should exist
         cred_binaries = list(tmp_path.glob("credential-process-*"))
         otel_binaries = list(tmp_path.glob("otel-helper-*"))
-        assert len(cred_binaries) == 0, (
-            f"credential-process binaries found in IDC zero-binary package: {cred_binaries}"
-        )
-        assert len(otel_binaries) == 0, (
-            f"otel-helper binaries found in IDC zero-binary package: {otel_binaries}"
-        )
+        assert len(cred_binaries) == 0, f"credential-process binaries found in IDC zero-binary package: {cred_binaries}"
+        assert len(otel_binaries) == 0, f"otel-helper binaries found in IDC zero-binary package: {otel_binaries}"
 
     def test_collector_config_present_with_idc_template(self, tmp_path):
         """IDC zero-binary sidecar MUST produce collector-config.yaml with static identity."""
@@ -274,12 +261,9 @@ class TestIDCZeroBinaryManifest:
         profile = _make_idc_zero_binary_profile()
         _run_config_phase(profile, tmp_path)
         content = (tmp_path / "collector-config.yaml").read_text(encoding="utf-8")
-        assert "test@example.com" in content, (
-            "IDC collector-config.yaml does not contain baked-in user email."
-        )
+        assert "test@example.com" in content, "IDC collector-config.yaml does not contain baked-in user email."
         assert "${USER_EMAIL}" not in content, (
-            "IDC collector-config.yaml still has ${USER_EMAIL} placeholder — "
-            "identity was not substituted."
+            "IDC collector-config.yaml still has ${USER_EMAIL} placeholder — identity was not substituted."
         )
 
     def test_no_otelcol_binaries(self, tmp_path):
@@ -311,8 +295,7 @@ class TestPackageWiringCompleteness:
 
         src = inspect.getsource(PackageCommand.handle)
         assert "_build_go_binaries" in src, (
-            "_build_go_binaries call missing from handle() — "
-            "Go cross-compilation is broken."
+            "_build_go_binaries call missing from handle() — Go cross-compilation is broken."
         )
 
     def test_handle_calls_build_otelcol(self):
@@ -321,8 +304,7 @@ class TestPackageWiringCompleteness:
 
         src = inspect.getsource(PackageCommand.handle)
         assert "_build_otelcol" in src, (
-            "_build_otelcol call missing from handle() — "
-            "sidecar packages will not include the collector binary."
+            "_build_otelcol call missing from handle() — sidecar packages will not include the collector binary."
         )
 
     def test_handle_calls_generate_collector_config(self):
@@ -341,8 +323,7 @@ class TestPackageWiringCompleteness:
 
         src = inspect.getsource(PackageCommand.handle)
         assert "is_idc_zero_binary" in src, (
-            "IDC zero-binary guard missing from handle() — "
-            "would attempt to build binaries on machines without Go."
+            "IDC zero-binary guard missing from handle() — would attempt to build binaries on machines without Go."
         )
 
     def test_sidecar_guard_on_otelcol_build(self):
@@ -353,6 +334,5 @@ class TestPackageWiringCompleteness:
         # Verify both the call and the sidecar guard exist
         assert "_build_otelcol" in src
         assert "sidecar" in src, (
-            "No sidecar guard around _build_otelcol — "
-            "collector would be built unnecessarily for central mode."
+            "No sidecar guard around _build_otelcol — collector would be built unnecessarily for central mode."
         )

--- a/source/tests/test_cowork_credential_helper.py
+++ b/source/tests/test_cowork_credential_helper.py
@@ -1,0 +1,156 @@
+# ABOUTME: Tests for CoWork 3P credential helper mode (inferenceCredentialHelper)
+# ABOUTME: Verifies MDM config generation for both "helper" and "profile" modes
+
+"""Tests for CoWork 3P credential helper mode."""
+
+import json
+
+from claude_code_with_bedrock.cli.utils.cowork_3p import (
+    build_mdm_config,
+    generate_json,
+    generate_reg_file,
+)
+
+
+class TestBuildMdmConfigCredentialHelper:
+    """Test build_mdm_config with credential_mode='helper' (default)."""
+
+    def test_helper_mode_includes_credential_helper_keys(self):
+        """Default mode should produce inferenceCredentialHelper keys."""
+        config = build_mdm_config(
+            bedrock_region="us-west-2",
+            model_aliases=["opus", "sonnet", "haiku"],
+            profile_name="MyProfile",
+        )
+        assert "inferenceCredentialHelper" in config
+        assert "inferenceCredentialHelperTtlSec" in config
+        assert "inferenceCredentialHelperSilentRefreshEnabled" in config
+        assert config["inferenceCredentialHelperSilentRefreshEnabled"] == "true"
+
+    def test_helper_mode_path_includes_profile_name(self):
+        """Credential helper path should include --profile <name>."""
+        config = build_mdm_config(
+            bedrock_region="us-west-2",
+            model_aliases=["sonnet"],
+            profile_name="Production",
+        )
+        assert "--profile Production" in config["inferenceCredentialHelper"]
+        assert "credential-process" in config["inferenceCredentialHelper"]
+
+    def test_helper_mode_ttl_default(self):
+        """Default TTL should be 3500s (under 1h STS expiry)."""
+        config = build_mdm_config(
+            bedrock_region="us-west-2",
+            model_aliases=["sonnet"],
+        )
+        assert config["inferenceCredentialHelperTtlSec"] == "3500"
+
+    def test_helper_mode_custom_ttl(self):
+        """Custom TTL should override default."""
+        config = build_mdm_config(
+            bedrock_region="us-west-2",
+            model_aliases=["sonnet"],
+            credential_helper_ttl_sec=1800,
+        )
+        assert config["inferenceCredentialHelperTtlSec"] == "1800"
+
+    def test_helper_mode_still_includes_bedrock_profile(self):
+        """Helper mode should still include inferenceBedrockProfile for SDK fallback."""
+        config = build_mdm_config(
+            bedrock_region="us-west-2",
+            model_aliases=["sonnet"],
+            profile_name="ClaudeCode",
+        )
+        assert config["inferenceBedrockProfile"] == "ClaudeCode"
+
+    def test_helper_mode_uses_unix_path_by_default(self):
+        """Default path should use ~/ prefix (Unix convention)."""
+        config = build_mdm_config(
+            bedrock_region="us-west-2",
+            model_aliases=["sonnet"],
+            profile_name="Test",
+        )
+        assert config["inferenceCredentialHelper"].startswith("~/")
+
+
+class TestBuildMdmConfigProfileMode:
+    """Test build_mdm_config with credential_mode='profile' (legacy)."""
+
+    def test_profile_mode_uses_bedrock_profile_only(self):
+        """Legacy mode should use inferenceBedrockProfile without credential helper."""
+        config = build_mdm_config(
+            bedrock_region="us-west-2",
+            model_aliases=["opus"],
+            profile_name="LegacyProfile",
+            credential_mode="profile",
+        )
+        assert config["inferenceBedrockProfile"] == "LegacyProfile"
+        assert "inferenceCredentialHelper" not in config
+        assert "inferenceCredentialHelperTtlSec" not in config
+        assert "inferenceCredentialHelperSilentRefreshEnabled" not in config
+
+    def test_profile_mode_backward_compatible(self):
+        """Legacy mode output should match previous behavior exactly."""
+        config = build_mdm_config(
+            bedrock_region="eu-west-1",
+            model_aliases=["opus", "sonnet", "haiku"],
+            profile_name="ClaudeCode",
+            credential_mode="profile",
+        )
+        assert config == {
+            "inferenceProvider": "bedrock",
+            "inferenceBedrockRegion": "eu-west-1",
+            "inferenceBedrockProfile": "ClaudeCode",
+            "inferenceModels": ["opus", "sonnet", "haiku"],
+            "isClaudeCodeForDesktopEnabled": True,
+            "isDesktopExtensionEnabled": True,
+            "isDesktopExtensionDirectoryEnabled": True,
+            "isDesktopExtensionSignatureRequired": True,
+            "isLocalDevMcpEnabled": True,
+        }
+
+
+class TestGenerateRegFileCredentialHelper:
+    """Test Windows .reg generation with credential helper path rewriting."""
+
+    def test_reg_file_rewrites_unix_path_to_windows(self, tmp_path):
+        """Unix ~/... path should become %USERPROFILE%\\... with .exe suffix."""
+        config = build_mdm_config(
+            bedrock_region="us-west-2",
+            model_aliases=["sonnet"],
+            profile_name="Test",
+        )
+        reg_path = generate_reg_file(tmp_path, config)
+        content = reg_path.read_text(encoding="utf-8")
+        # Should contain Windows-style path
+        assert "%USERPROFILE%" in content
+        assert "credential-process.exe" in content
+        assert "--profile Test" in content
+
+    def test_reg_file_no_rewrite_for_profile_mode(self, tmp_path):
+        """Profile mode should not contain credential helper in .reg file."""
+        config = build_mdm_config(
+            bedrock_region="us-west-2",
+            model_aliases=["sonnet"],
+            credential_mode="profile",
+        )
+        reg_path = generate_reg_file(tmp_path, config)
+        content = reg_path.read_text(encoding="utf-8")
+        assert "inferenceCredentialHelper" not in content
+
+
+class TestGenerateJsonCredentialHelper:
+    """Test JSON output includes credential helper keys."""
+
+    def test_json_output_includes_helper_keys(self, tmp_path):
+        """JSON output should include all credential helper keys."""
+        config = build_mdm_config(
+            bedrock_region="us-west-2",
+            model_aliases=["opus", "sonnet"],
+            profile_name="MyProfile",
+        )
+        json_path = generate_json(tmp_path, config)
+        data = json.loads(json_path.read_text(encoding="utf-8"))
+        assert data["inferenceCredentialHelper"] == "~/claude-code-with-bedrock/credential-process --profile MyProfile"
+        assert data["inferenceCredentialHelperTtlSec"] == "3500"
+        assert data["inferenceCredentialHelperSilentRefreshEnabled"] == "true"

--- a/source/tests/test_generic_oidc_distribution.py
+++ b/source/tests/test_generic_oidc_distribution.py
@@ -268,9 +268,5 @@ class TestLandingPageCustomDomainRecord:
     def test_record_remains_conditional_on_hosted_zone(self):
         """DNS is still only created when a Route53 hosted zone is supplied."""
         template = _load_landing_template()
-        record = next(
-            body
-            for body in template["Resources"].values()
-            if body.get("Type") == "AWS::Route53::RecordSet"
-        )
+        record = next(body for body in template["Resources"].values() if body.get("Type") == "AWS::Route53::RecordSet")
         assert record.get("Condition") == "HasRoute53Zone"


### PR DESCRIPTION
## Why

CoWork 3P users report needing to **restart the app when AWS credentials expire** (typically after ~1 hour). This affects both IDC (without credential-helper) and OIDC/Azure AD federated auth modes.

**Root cause:** `inferenceBedrockProfile` delegates credential lifecycle to the AWS SDK (boto3), which doesn't reliably trigger re-authentication within CoWork's process lifecycle. Once the cached STS token expires, CoWork loses Bedrock access until manually restarted.

## Current Workaround (Profile Mode)

```
MDM policy: inferenceBedrockProfile = "ClaudeCode"

CoWork → AWS SDK (boto3) → ~/.aws/config [profile ClaudeCode]
  → credential_process = credential-process --profile ClaudeCode
    → OIDC/IDC auth → STS → 1h temp creds
```

The AWS SDK _should_ re-run `credential_process` when credentials expire, but CoWork's internal caching layer doesn't proactively trigger this — resulting in a dead session until restart.

## New Default (Credential Helper Mode)

```
MDM policy:
  inferenceCredentialHelper = "~/claude-code-with-bedrock/credential-process --profile ClaudeCode"
  inferenceCredentialHelperTtlSec = "3500"
  inferenceCredentialHelperSilentRefreshEnabled = "true"

CoWork (directly) → credential-process → OIDC/IDC auth → STS → 1h temp creds
  └─ Re-runs automatically every 3500s (before 1h expiry)
  └─ Mid-session recovery: CLAUDE_HELPER_CONTEXT=mid-session-refresh (20s)
```

**Key difference:** Claude Desktop itself manages the credential lifecycle instead of delegating to the AWS SDK. It:
1. Caches the helper's output for `inferenceCredentialHelperTtlSec` seconds (default 3500)
2. Automatically re-runs when cache expires — **no restart required**
3. On mid-session rejection, re-runs with `CLAUDE_HELPER_CONTEXT=mid-session-refresh` for silent recovery

Our `credential-process` binary already handles all `CLAUDE_HELPER_CONTEXT` values correctly:
- `interactive` → Full browser OIDC flow
- `mid-session-refresh` → Try cached creds → refresh_token → exit non-zero if both fail
- `background` / `setup-test` → Silent path only

## Availability

Per the [Configuration changelog](https://claude.com/docs/third-party/claude-desktop/configuration-changelog):
- `inferenceCredentialHelper` — **Baseline** (available since initial 3P release)
- `inferenceCredentialHelperTtlSec` — **Baseline**
- `inferenceCredentialHelperTimeoutSec` — Release 1.8089
- `inferenceCredentialHelperSilentRefreshEnabled` — Release 1.10628

All keys are live in shipping Claude Desktop versions.

## Changes

| File | Change |
|------|--------|
| `config.py` | Add `cowork_credential_mode` (helper\|profile) and `cowork_credential_helper_ttl_sec` |
| `cowork_3p.py` | `build_mdm_config()` supports both modes; `_credential_process_path()` helper; `.reg` rewrites ~/→%USERPROFILE% |
| `cowork.py` | Pass credential mode from profile |
| `package.py` | Pass credential mode from profile |
| `COWORK_3P.md` | Document both modes with step-by-step flows |
| `test_cowork_credential_helper.py` | 11 new tests |

## Backward Compatibility

- **Default changes** from profile→helper mode for new deployments
- **Existing deployments** with `cowork_credential_mode` unset will get "helper" mode on next `ccwb cowork generate`
- Set `cowork_credential_mode = "profile"` explicitly to preserve legacy behavior
- Both modes keep `inferenceBedrockProfile` in the MDM config (SDK uses it for region resolution)

## Testing

11 new tests in `test_cowork_credential_helper.py`:
- Helper mode key generation (path, TTL, silent refresh)
- Profile mode backward compatibility (exact match of previous output)
- Windows `.reg` path rewriting (~/→%USERPROFILE%, .exe suffix)
- JSON output validation

Full test suite: 1299 passed, 22 skipped.