### PR TITLE
fix(quota): resolve route-key conflict on in-place stack update

### DIFF
--- a/deployment/infrastructure/quota-monitoring.yaml
+++ b/deployment/infrastructure/quota-monitoring.yaml
@@ -482,25 +482,17 @@ Resources:
       IntegrationUri: !GetAtt QuotaCheckFunction.Arn
       PayloadFormatVersion: '2.0'
 
-  # Route for GET /check — JWT when OIDC configured, IAM auth when IDC/none
-  QuotaCheckRouteWithAuth:
+  # Route for GET /check — single resource to avoid route-key conflict on
+  # in-place updates (two resources sharing the same RouteKey causes CFN 409).
+  # Uses !If to switch between JWT auth (OIDC) and IAM auth (IDC/none).
+  QuotaCheckRoute:
     Type: AWS::ApiGatewayV2::Route
-    Condition: HasJwtAuth
     Properties:
       ApiId: !Ref QuotaCheckApi
       RouteKey: 'GET /check'
       Target: !Sub 'integrations/${QuotaCheckIntegration}'
-      AuthorizerId: !Ref QuotaCheckAuthorizer
-      AuthorizationType: JWT
-
-  QuotaCheckRouteIAM:
-    Type: AWS::ApiGatewayV2::Route
-    Condition: NoJwtAuth
-    Properties:
-      ApiId: !Ref QuotaCheckApi
-      RouteKey: 'GET /check'
-      Target: !Sub 'integrations/${QuotaCheckIntegration}'
-      AuthorizationType: AWS_IAM
+      AuthorizerId: !If [HasJwtAuth, !Ref QuotaCheckAuthorizer, !Ref 'AWS::NoValue']
+      AuthorizationType: !If [HasJwtAuth, 'JWT', 'AWS_IAM']
 
   # Default stage with auto-deploy
   QuotaCheckStage:


### PR DESCRIPTION
## Summary
Fixes the CFN 409 route-key conflict that blocks in-place quota stack upgrades (Bug 1 from #682).

## Problem
When upgrading an existing quota stack from a pre-split template version, CloudFormation creates the new logical route resource **before** deleting the old one. Since both `QuotaCheckRouteWithAuth` and `QuotaCheckRouteIAM` declare the same `RouteKey: 'GET /check'`, the API Gateway returns a 409 ConflictException. The stack rolls back cleanly (no outage), but the upgrade is permanently blocked.

## Fix
Merge the two conditional resources into a **single** `QuotaCheckRoute` resource that uses `!If` to switch between JWT auth (OIDC) and IAM auth (IDC/none):

```yaml
QuotaCheckRoute:
  Type: AWS::ApiGatewayV2::Route
  Properties:
    ApiId: !Ref QuotaCheckApi
    RouteKey: 'GET /check'
    Target: !Sub 'integrations/${QuotaCheckIntegration}'
    AuthorizerId: !If [HasJwtAuth, !Ref QuotaCheckAuthorizer, !Ref 'AWS::NoValue']
    AuthorizationType: !If [HasJwtAuth, 'JWT', 'AWS_IAM']
```

This eliminates the transient duplicate route entirely, making in-place upgrades seamless.

## Impact
- **Risk:** Low — single route resource with `!If` is functionally equivalent to the conditional pair
- **Backward compat:** Existing stacks will transition cleanly on next deploy (old logical IDs get deleted, new one gets created)
- **Note:** Stacks currently in `UPDATE_ROLLBACK_COMPLETE` state from this bug will need one more deploy after this fix lands

## Testing
- CFN template validates successfully
- Verified no other references to old logical IDs (`QuotaCheckRouteWithAuth`, `QuotaCheckRouteIAM`)

Partially addresses #682
cc @scouturier for review