### PR TITLE
fix(cli): honor non-interactive mode in package and distribute + fix generic linux binary naming

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/distribute.py
+++ b/source/claude_code_with_bedrock/cli/commands/distribute.py
@@ -217,6 +217,13 @@ class DistributeCommand(Command):
             console.print("\n[green]Auto-selecting only available build[/green]")
             return build_map[choices[0]]
 
+        # Non-interactive: auto-select latest build
+        import sys as _sys
+
+        if not _sys.stdin.isatty():
+            console.print("\n[dim]Non-interactive mode: selecting latest build[/dim]")
+            return build_map[choices[0]]
+
         # Show selection
         console.print()
         selected = questionary.select(
@@ -593,8 +600,11 @@ class DistributeCommand(Command):
             "linux": [
                 ("credential-process-linux-x64", "credential-process-linux-x64"),
                 ("credential-process-linux-arm64", "credential-process-linux-arm64"),
+                # Accept generic linux binary (maps to x64 for compat with install.sh)
+                ("credential-process-linux", "credential-process-linux-x64"),
                 ("otel-helper-linux-x64", "otel-helper-linux-x64"),
                 ("otel-helper-linux-arm64", "otel-helper-linux-arm64"),
+                ("otel-helper-linux", "otel-helper-linux-x64"),
                 ("otelcol-linux-x64", "otelcol-linux-x64"),
                 ("otelcol-linux-arm64", "otelcol-linux-arm64"),
                 ("otel-helper.sh", "otel-helper.sh"),
@@ -949,12 +959,18 @@ class DistributeCommand(Command):
 
         if "windows" not in found_platforms:
             console.print("\n[yellow]Warning: Windows support not included in this distribution[/yellow]")
-            from questionary import confirm
+            import sys as _sys
 
-            proceed = confirm("Continue without Windows support?", default=False).ask()
-            if not proceed:
-                console.print("Distribution cancelled.")
-                return 0
+            if _sys.stdin.isatty():
+                from questionary import confirm
+
+                proceed = confirm("Continue without Windows support?", default=False).ask()
+                if not proceed:
+                    console.print("Distribution cancelled.")
+                    return 0
+            else:
+                # Non-interactive: proceed with default (skip Windows)
+                console.print("[dim]Non-interactive mode: proceeding without Windows support[/dim]")
 
         console.print(f"\n[green]Ready to distribute for: {', '.join(found_platforms)}[/green]")
 

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -14,13 +14,6 @@ from pathlib import Path
 import questionary
 from cleo.commands.command import Command
 from cleo.helpers import option
-
-
-def _is_interactive() -> bool:
-    """Return True when stdin is a TTY and prompts can be displayed."""
-    return sys.stdin.isatty()
-
-
 from rich.console import Console
 from rich.panel import Panel
 from rich.progress import Progress, SpinnerColumn, TextColumn
@@ -32,6 +25,12 @@ from claude_code_with_bedrock.config import Config
 from claude_code_with_bedrock.models import (
     get_source_region_for_profile,
 )
+
+
+def _is_interactive() -> bool:
+    """Return True when stdin is a TTY and prompts can be displayed."""
+    return sys.stdin.isatty()
+
 
 # Runtime packages bundled into the credential provider binary.
 _CREDENTIAL_PROVIDER_RUNTIME_DEPS = ["boto3", "requests", "PyJWT", "keyring", "cryptography"]

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -19,6 +19,8 @@ from cleo.helpers import option
 def _is_interactive() -> bool:
     """Return True when stdin is a TTY and prompts can be displayed."""
     return sys.stdin.isatty()
+
+
 from rich.console import Console
 from rich.panel import Panel
 from rich.progress import Progress, SpinnerColumn, TextColumn
@@ -312,7 +314,9 @@ class PackageCommand(Command):
             else:
                 # Non-interactive: build all available platforms
                 selected_platforms = platform_choices
-                console.print(f"[dim]Non-interactive mode: building all platforms ({', '.join(selected_platforms)})[/dim]")
+                console.print(
+                    f"[dim]Non-interactive mode: building all platforms ({', '.join(selected_platforms)})[/dim]"
+                )
 
             # Use the selected platforms (guaranteed to have at least one due to validation)
             target_platform = selected_platforms if len(selected_platforms) > 1 else selected_platforms[0]

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -7,12 +7,18 @@ import json
 import os
 import platform
 import subprocess
+import sys
 from datetime import datetime
 from pathlib import Path
 
 import questionary
 from cleo.commands.command import Command
 from cleo.helpers import option
+
+
+def _is_interactive() -> bool:
+    """Return True when stdin is a TTY and prompts can be displayed."""
+    return sys.stdin.isatty()
 from rich.console import Console
 from rich.panel import Panel
 from rich.progress import Progress, SpinnerColumn, TextColumn
@@ -297,28 +303,39 @@ class PackageCommand(Command):
                 platform_choices.append("windows")
 
             # Use checkbox for multiple selection (require at least one)
-            selected_platforms = questionary.checkbox(
-                "Which platform(s) do you want to build for? (Use space to select, enter to confirm)",
-                choices=platform_choices,
-                validate=lambda x: len(x) > 0 or "You must select at least one platform",
-            ).ask()
+            if _is_interactive():
+                selected_platforms = questionary.checkbox(
+                    "Which platform(s) do you want to build for? (Use space to select, enter to confirm)",
+                    choices=platform_choices,
+                    validate=lambda x: len(x) > 0 or "You must select at least one platform",
+                ).ask()
+            else:
+                # Non-interactive: build all available platforms
+                selected_platforms = platform_choices
+                console.print(f"[dim]Non-interactive mode: building all platforms ({', '.join(selected_platforms)})[/dim]")
 
             # Use the selected platforms (guaranteed to have at least one due to validation)
             target_platform = selected_platforms if len(selected_platforms) > 1 else selected_platforms[0]
 
         # Prompt for co-authorship preference (default to No - opt-in approach)
-        include_coauthored_by = questionary.confirm(
-            "Include 'Co-Authored-By: Claude' in git commits?",
-            default=False,
-        ).ask()
+        if _is_interactive():
+            include_coauthored_by = questionary.confirm(
+                "Include 'Co-Authored-By: Claude' in git commits?",
+                default=False,
+            ).ask()
+        else:
+            include_coauthored_by = False
 
         # Prompt for custom OTel resource attributes (only when monitoring is enabled)
         otel_resource_attributes = None
         if profile.monitoring_enabled:
-            customize_otel = questionary.confirm(
-                "Customize telemetry resource attributes? (department, team, cost center)",
-                default=False,
-            ).ask()
+            if _is_interactive():
+                customize_otel = questionary.confirm(
+                    "Customize telemetry resource attributes? (department, team, cost center)",
+                    default=False,
+                ).ask()
+            else:
+                customize_otel = False
 
             if customize_otel:
                 console.print(
@@ -347,6 +364,24 @@ class PackageCommand(Command):
                 f"[red]Invalid platform: {target_platform}. Valid options: {', '.join(valid_platforms)}[/red]"
             )
             return 1
+
+        # Normalize generic platform tokens to their arch-specific canonical names.
+        # This ensures binary naming is consistent with what distribute and install.sh expect.
+        # See #682 Bug 4: generic 'linux' produces 'credential-process-linux' which
+        # distribute silently drops and install.sh can't find.
+        _PLATFORM_CANONICAL = {
+            "linux": "linux-x64",
+            "macos": "macos-arm64",
+        }
+        if use_go:
+            if isinstance(target_platform, list):
+                target_platform = [_PLATFORM_CANONICAL.get(p, p) for p in target_platform]
+            elif target_platform in _PLATFORM_CANONICAL:
+                canonical = _PLATFORM_CANONICAL[target_platform]
+                console.print(
+                    f"[dim]Normalizing platform '{target_platform}' → '{canonical}' for consistent binary naming[/dim]"
+                )
+                target_platform = canonical
 
         # Get federation identifier — try profile first, fall back to CloudFormation
         federation_type = profile.federation_type
@@ -463,17 +498,22 @@ class PackageCommand(Command):
                 if "@" in session_name:
                     idc_user_email = session_name
                     console.print(f"[dim]Detected user email from IDC: {idc_user_email}[/dim]")
-                else:
+                elif _is_interactive():
                     # Prompt if we can't auto-detect
                     idc_user_email = questionary.text(
                         "User email for OTEL attribution (IDC session name):",
                         default=session_name or "",
                     ).ask()
+                else:
+                    idc_user_email = session_name or ""
             except Exception:
-                idc_user_email = questionary.text(
-                    "User email for OTEL attribution:",
-                    default="",
-                ).ask()
+                if _is_interactive():
+                    idc_user_email = questionary.text(
+                        "User email for OTEL attribution:",
+                        default="",
+                    ).ask()
+                else:
+                    idc_user_email = ""
 
             if not idc_user_email:
                 console.print("[yellow]Warning: No user email — OTEL attribution will be anonymous[/yellow]")
@@ -2438,13 +2478,19 @@ RUN pyinstaller \
             return 1
 
         # Prompt for co-authorship and OTEL attributes
-        include_coauthored_by = questionary.confirm(
-            "Include 'Co-Authored-By: Claude' in git commits?", default=False
-        ).ask()
+        if _is_interactive():
+            include_coauthored_by = questionary.confirm(
+                "Include 'Co-Authored-By: Claude' in git commits?", default=False
+            ).ask()
+        else:
+            include_coauthored_by = False
 
         otel_resource_attributes = None
         if profile.monitoring_enabled:
-            customize_otel = questionary.confirm("Customize telemetry resource attributes?", default=False).ask()
+            if _is_interactive():
+                customize_otel = questionary.confirm("Customize telemetry resource attributes?", default=False).ask()
+            else:
+                customize_otel = False
             if customize_otel:
                 department = questionary.text("Department:", default="engineering").ask()
                 team_id = questionary.text("Team ID:", default="default").ask()


### PR DESCRIPTION
## Summary
Fixes Bugs 2, 3, and 4 from #682 — all related to non-interactive/CI-driven deployment flows.

## Bug 2 & 3 — `package` and `distribute` ignore non-interactive mode

**Problem:** Both commands call `questionary` prompts unconditionally. When stdin is not a TTY (CI pipelines, agent-driven automation, piped commands), they crash with:
- `EOFError` (from prompt_toolkit under a PTY)
- `[Errno 22] Invalid argument` (non-TTY fd)

**Fix:** Added `_is_interactive()` helper (`sys.stdin.isatty()`) and guarded all questionary calls:
- Platform selection: defaults to all available platforms
- Co-authorship: defaults to `False` (opt-in)
- OTel customization: defaults to `False` (skip)
- IDC user email: uses auto-detected value or empty string
- Windows warning: proceeds without Windows (prints info message)
- Build selection wizard: auto-selects latest build

**Impact:** Unblocks all CI/scripted/agent-driven `ccwb package` and `ccwb distribute` flows.

## Bug 4 — Generic `--target-platform linux` silently drops binaries

**Problem:** `ccwb package --target-platform linux --go` produces `credential-process-linux` (no arch suffix), but `distribute` only recognizes `credential-process-linux-x64` / `credential-process-linux-arm64`, so:
1. `distribute` silently ships a config-only zip (no warning)
2. `install.sh` fails on target machines

**Fix (two-layer defense):**
1. **Normalize early:** In Go mode, `linux` → `linux-x64` and `macos` → `macos-arm64` before the build runs. Binary gets named correctly from the start.
2. **Accept generic names:** Added fallback entries in distribute's `platform_files` map that accept `credential-process-linux` and rename it to `credential-process-linux-x64` in the zip. This handles existing builds that used the old naming.

## Risk Assessment
- **Risk:** Low
- **Backward compat:** ✅ Existing interactive workflows unchanged (prompts still appear when TTY detected)
- **Test coverage:** All existing tests pass (31 distribute tests, 17 manifest tests)
- **Blast radius:** Only affects non-TTY execution paths (previously broken) and generic platform token resolution

## Testing
```bash
python3 -m pytest source/tests/cli/commands/test_package_manifest.py -x -q  # 17 passed
python3 -m pytest source/tests/test_distribute.py -x -q                      # 31 passed
```

Partially addresses #682
cc @scouturier for review