### PR TITLE
fix(credential-process): add --set-client-secret to Go binary

### DIFF
--- a/source/go/cmd/credential-process/main.go
+++ b/source/go/cmd/credential-process/main.go
@@ -12,6 +12,7 @@ import (
 
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"golang.org/x/term"
 
 	"ccwb-go/internal/config"
 	"ccwb-go/internal/federation"
@@ -51,6 +52,7 @@ func main() {
 	showTags := flag.Bool("show-tags", false, "Print the https://aws.amazon.com/tags claim from the cached ID token (debug)")
 	getTag := flag.String("get-tag", "", "Print the value of a single principal tag from the cached ID token (e.g. --get-tag Zone). Exit codes: 0 hit, 2 absent, 4 expired.")
 	login := flag.Bool("login", false, "Interactively sign in (IDC: run device authorization and cache the SSO token), then exit. Use this once on headless/SSH hosts before Claude Code runs.")
+	setClientSecret := flag.Bool("set-client-secret", false, "Store Azure AD client secret in OS secure storage. Set CCWB_CLIENT_SECRET env var for non-interactive use, or enter it at the prompt.")
 	flag.Parse()
 
 	if *versionFlag || *shortVersion {
@@ -67,6 +69,12 @@ func main() {
 		if detected := config.AutoDetectProfile(); detected != "" {
 			profile = detected
 		}
+	}
+
+	// --set-client-secret runs before config load so it works on fresh machines
+	// where config.json may not yet exist.
+	if *setClientSecret {
+		os.Exit(runSetClientSecret(profile))
 	}
 
 	debug = os.Getenv("COGNITO_AUTH_DEBUG") == "1" || os.Getenv("COGNITO_AUTH_DEBUG") == "true" || os.Getenv("COGNITO_AUTH_DEBUG") == "yes"
@@ -628,7 +636,7 @@ func (a *credentialApp) resolveConfidentialAuth() (*oidc.ConfidentialAuth, error
 		if secret == "" {
 			return nil, fmt.Errorf(
 				"azure_auth_mode is 'secret' but no client secret is stored.\n"+
-					"Run: ccwb init --profile %s (re-run the Azure step) to store one in the OS keyring.",
+					"Run: credential-process --set-client-secret --profile %s",
 				a.profile)
 		}
 		return &oidc.ConfidentialAuth{ClientSecret: secret}, nil
@@ -1112,4 +1120,37 @@ func printQuotaBlocked(qr *quota.Result) {
 func outputJSON(v interface{}) {
 	data, _ := json.Marshal(v)
 	fmt.Println(string(data))
+}
+
+// runSetClientSecret stores an Azure confidential-client secret in the OS keyring.
+// Mirrors the Python credential-process --set-client-secret behaviour:
+//   - Read secret from CCWB_CLIENT_SECRET env var (non-interactive / automation), or
+//   - Prompt via terminal (interactive). Blank input clears the stored secret.
+func runSetClientSecret(profile string) int {
+	var secret string
+
+	if env := os.Getenv("CCWB_CLIENT_SECRET"); env != "" {
+		secret = env
+	} else {
+		fmt.Fprintf(os.Stderr, "Enter client secret for profile '%s' (press Enter to clear): ", profile)
+		raw, err := term.ReadPassword(int(os.Stdin.Fd()))
+		fmt.Fprintln(os.Stderr) // newline after hidden input
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error reading secret: %v\n", err)
+			return 1
+		}
+		secret = string(raw)
+	}
+
+	if err := storage.SaveClientSecret(profile, secret); err != nil {
+		fmt.Fprintf(os.Stderr, "Error storing client secret: %v\n", err)
+		return 1
+	}
+
+	if secret == "" {
+		fmt.Fprintf(os.Stderr, "✓ Client secret cleared for profile '%s'\n", profile)
+	} else {
+		fmt.Fprintf(os.Stderr, "✓ Client secret stored for profile '%s'\n", profile)
+	}
+	return 0
 }

--- a/source/go/cmd/credential-process/main.go
+++ b/source/go/cmd/credential-process/main.go
@@ -1130,7 +1130,7 @@ func runSetClientSecret(profile string) int {
 	var secret string
 
 	if env := os.Getenv("CCWB_CLIENT_SECRET"); env != "" {
-		secret = env
+		secret = env // pragma: allowlist secret
 	} else {
 		fmt.Fprintf(os.Stderr, "Enter client secret for profile '%s' (press Enter to clear): ", profile)
 		raw, err := term.ReadPassword(int(os.Stdin.Fd()))

--- a/source/go/internal/storage/client_secret_test.go
+++ b/source/go/internal/storage/client_secret_test.go
@@ -7,16 +7,15 @@ import (
 // TestSaveReadClientSecret is the regression guard for the --set-client-secret
 // parity gap: the Go binary had ReadClientSecret but no SaveClientSecret, so
 // users on Go-packaged installs could not store a secret without running ccwb init.
+//
+// Driven through the in-memory mockKeyring so it runs on Linux CI, where
+// 99designs/keyring has no Secret Service backend.
 func TestSaveReadClientSecret(t *testing.T) {
+	kr := newMockKeyring()
 	profile := "test-client-secret-profile"
 
-	// Ensure clean state.
-	if err := SaveClientSecret(profile, ""); err != nil {
-		t.Fatalf("clear before test: %v", err)
-	}
-
 	// Absent secret must return empty string, not an error.
-	got, err := ReadClientSecret(profile)
+	got, err := readClientSecretImpl(kr, profile)
 	if err != nil {
 		t.Fatalf("ReadClientSecret on absent key: %v", err)
 	}
@@ -25,11 +24,11 @@ func TestSaveReadClientSecret(t *testing.T) {
 	}
 
 	// Store a secret and read it back.
-	const want = "super-secret-value"
-	if err := SaveClientSecret(profile, want); err != nil {
+	const want = "placeholder-not-a-real-secret"
+	if err := saveClientSecretImpl(kr, profile, want); err != nil {
 		t.Fatalf("SaveClientSecret: %v", err)
 	}
-	got, err = ReadClientSecret(profile)
+	got, err = readClientSecretImpl(kr, profile)
 	if err != nil {
 		t.Fatalf("ReadClientSecret after save: %v", err)
 	}
@@ -37,15 +36,21 @@ func TestSaveReadClientSecret(t *testing.T) {
 		t.Fatalf("round-trip mismatch: got %q, want %q", got, want)
 	}
 
-	// Clear the secret and confirm it is gone.
-	if err := SaveClientSecret(profile, ""); err != nil {
+	// Clear the secret (empty input) and confirm it is gone.
+	if err := saveClientSecretImpl(kr, profile, ""); err != nil {
 		t.Fatalf("SaveClientSecret clear: %v", err)
 	}
-	got, err = ReadClientSecret(profile)
+	got, err = readClientSecretImpl(kr, profile)
 	if err != nil {
 		t.Fatalf("ReadClientSecret after clear: %v", err)
 	}
 	if got != "" {
 		t.Fatalf("expected empty string after clear, got %q", got)
+	}
+
+	// Clearing an already-absent secret must be a no-op, not an error
+	// (ErrKeyNotFound from Remove must be swallowed).
+	if err := saveClientSecretImpl(kr, profile, ""); err != nil {
+		t.Fatalf("SaveClientSecret clear on absent key should be no-op, got: %v", err)
 	}
 }

--- a/source/go/internal/storage/client_secret_test.go
+++ b/source/go/internal/storage/client_secret_test.go
@@ -1,0 +1,51 @@
+package storage
+
+import (
+	"testing"
+)
+
+// TestSaveReadClientSecret is the regression guard for the --set-client-secret
+// parity gap: the Go binary had ReadClientSecret but no SaveClientSecret, so
+// users on Go-packaged installs could not store a secret without running ccwb init.
+func TestSaveReadClientSecret(t *testing.T) {
+	profile := "test-client-secret-profile"
+
+	// Ensure clean state.
+	if err := SaveClientSecret(profile, ""); err != nil {
+		t.Fatalf("clear before test: %v", err)
+	}
+
+	// Absent secret must return empty string, not an error.
+	got, err := ReadClientSecret(profile)
+	if err != nil {
+		t.Fatalf("ReadClientSecret on absent key: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("expected empty string for absent secret, got %q", got)
+	}
+
+	// Store a secret and read it back.
+	const want = "super-secret-value"
+	if err := SaveClientSecret(profile, want); err != nil {
+		t.Fatalf("SaveClientSecret: %v", err)
+	}
+	got, err = ReadClientSecret(profile)
+	if err != nil {
+		t.Fatalf("ReadClientSecret after save: %v", err)
+	}
+	if got != want {
+		t.Fatalf("round-trip mismatch: got %q, want %q", got, want)
+	}
+
+	// Clear the secret and confirm it is gone.
+	if err := SaveClientSecret(profile, ""); err != nil {
+		t.Fatalf("SaveClientSecret clear: %v", err)
+	}
+	got, err = ReadClientSecret(profile)
+	if err != nil {
+		t.Fatalf("ReadClientSecret after clear: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("expected empty string after clear, got %q", got)
+	}
+}

--- a/source/go/internal/storage/keyring.go
+++ b/source/go/internal/storage/keyring.go
@@ -91,6 +91,13 @@ func ReadClientSecret(profile string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	return readClientSecretImpl(kr, profile)
+}
+
+// readClientSecretImpl is the testable core of ReadClientSecret. Taking the
+// keyringRW interface lets unit tests drive it with a mock so they run on Linux
+// CI, where 99designs/keyring has no Secret Service backend.
+func readClientSecretImpl(kr keyringRW, profile string) (string, error) {
 	item, err := kr.Get(profile + "-client-secret")
 	if err != nil {
 		if errors.Is(err, keyring.ErrKeyNotFound) {
@@ -109,6 +116,12 @@ func SaveClientSecret(profile, secret string) error {
 	if err != nil {
 		return err
 	}
+	return saveClientSecretImpl(kr, profile, secret)
+}
+
+// saveClientSecretImpl is the testable core of SaveClientSecret (see
+// readClientSecretImpl for why the interface is threaded through).
+func saveClientSecretImpl(kr keyringRW, profile, secret string) error {
 	if secret == "" {
 		if err := kr.Remove(profile + "-client-secret"); err != nil && !errors.Is(err, keyring.ErrKeyNotFound) {
 			return err

--- a/source/go/internal/storage/keyring.go
+++ b/source/go/internal/storage/keyring.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"runtime"
 
-	"github.com/99designs/keyring"
 	"ccwb-go/internal/federation"
+	"github.com/99designs/keyring"
 )
 
 const serviceName = "claude-code-with-bedrock"
@@ -99,6 +99,26 @@ func ReadClientSecret(profile string) (string, error) {
 		return "", err
 	}
 	return string(item.Data), nil
+}
+
+// SaveClientSecret stores an Azure confidential-client secret in the OS keyring.
+// Key matches what ReadClientSecret and the Python ccwb init wizard use.
+// Pass an empty secret to delete the entry.
+func SaveClientSecret(profile, secret string) error {
+	kr, err := openKeyring()
+	if err != nil {
+		return err
+	}
+	if secret == "" {
+		if err := kr.Remove(profile + "-client-secret"); err != nil && !errors.Is(err, keyring.ErrKeyNotFound) {
+			return err
+		}
+		return nil
+	}
+	return kr.Set(keyring.Item{
+		Key:  profile + "-client-secret",
+		Data: []byte(secret),
+	})
 }
 
 // ReadMonitoringTokenFromKeyring reads the monitoring token from keyring.

--- a/source/go/internal/storage/keyring_split.go
+++ b/source/go/internal/storage/keyring_split.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/99designs/keyring"
 	"ccwb-go/internal/federation"
+	"github.com/99designs/keyring"
 )
 
 // Windows Credential Manager has a ~2560 byte UTF-16LE limit.
@@ -18,6 +18,7 @@ import (
 type keyringRW interface {
 	Get(key string) (keyring.Item, error)
 	Set(item keyring.Item) error
+	Remove(key string) error
 }
 
 func readFromKeyringWindows(kr keyring.Keyring, profile string) (*federation.AWSCredentials, error) {

--- a/source/go/internal/storage/keyring_split_test.go
+++ b/source/go/internal/storage/keyring_split_test.go
@@ -5,18 +5,18 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/99designs/keyring"
 	"ccwb-go/internal/federation"
+	"github.com/99designs/keyring"
 )
 
 // mockKeyring is a keyringRW implementation backed by an in-memory map.
 // It records every Set call so tests can assert on upconvert writes, and
 // returns keyring.ErrKeyNotFound for missing keys (matching the real library).
 type mockKeyring struct {
-	store       map[string][]byte
-	setCalls    []keyring.Item
-	failSet     bool
-	failSetKey  string
+	store          map[string][]byte
+	setCalls       []keyring.Item
+	failSet        bool
+	failSetKey     string
 	getErrOverride map[string]error
 }
 
@@ -41,6 +41,14 @@ func (m *mockKeyring) Set(item keyring.Item) error {
 	}
 	m.store[item.Key] = item.Data
 	m.setCalls = append(m.setCalls, item)
+	return nil
+}
+
+func (m *mockKeyring) Remove(key string) error {
+	if _, ok := m.store[key]; !ok {
+		return keyring.ErrKeyNotFound
+	}
+	delete(m.store, key)
 	return nil
 }
 


### PR DESCRIPTION
## Why

A user on a Go-packaged install using Azure EntraID with `azure_auth_mode=secret` was blocked: the credential-process told them to run `credential-process --set-client-secret --profile <name>`, but that flag **only existed in the Python provider**. Running it against the Go binary produced an unknown-flag error — the binary's own error message pointed at a command it didn't implement.

This is a Python→Go parity gap of the same class called out in `.claude/rules/credential-helper-parity.md` (provider detection, browser notifications). It's the second such gap found recently.

## What

- Add `storage.SaveClientSecret()` — writes the **same** keyring key `ReadClientSecret` already reads (`{profile}-client-secret` under service `claude-code-with-bedrock`), so it interoperates with secrets stored by `ccwb init`.
- Add the `--set-client-secret` flag to the Go credential-process:
  - Reads `CCWB_CLIENT_SECRET` for non-interactive/automation use, or prompts via terminal with hidden input.
  - Blank input clears the stored entry.
  - Runs **before** config load, so it works on a fresh machine where `config.json` doesn't exist yet.
- Update the "no client secret is stored" error message to point at the now-working Go command instead of the `ccwb init` hint.
- Add a regression test covering the save → read → clear round-trip.

## Testing

- `go test ./internal/storage/` and `./cmd/credential-process/` pass.
- `gofmt` / `go vet` clean.

## Notes

Scoped to one concern per `.claude/rules/pr-standards.md`. A broader Python↔Go parity audit surfaced additional gaps (Windows keyring chunking for the monitoring token, OTEL cache `schema_version` mismatch, monitoring-token expiry buffer); those will be addressed in separate follow-up PRs.