### PR TITLE
fix(deploy): gate central infrastructure on monitoring_mode in sidecar mode

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -122,17 +122,27 @@ class DeployCommand(Command):
                     return 1
                 stacks_to_deploy.append(("auth", "Authentication Stack (Cognito + IAM)"))
             elif stack_arg == "networking":
-                if profile.monitoring_enabled:
-                    stacks_to_deploy.append(("networking", "VPC Networking for OTEL Collector"))
-                else:
+                if not profile.monitoring_enabled:
                     console.print("[yellow]Monitoring is not enabled in your configuration.[/yellow]")
                     return 1
+                if getattr(profile, "monitoring_mode", "central") == "sidecar":
+                    console.print(
+                        "[yellow]Networking stack is not used in sidecar monitoring mode "
+                        "(the local OTEL collector needs no VPC/subnets).[/yellow]"
+                    )
+                    return 1
+                stacks_to_deploy.append(("networking", "VPC Networking for OTEL Collector"))
             elif stack_arg == "monitoring":
-                if profile.monitoring_enabled:
-                    stacks_to_deploy.append(("monitoring", "OpenTelemetry Collector"))
-                else:
+                if not profile.monitoring_enabled:
                     console.print("[yellow]Monitoring is not enabled in your configuration.[/yellow]")
                     return 1
+                if getattr(profile, "monitoring_mode", "central") == "sidecar":
+                    console.print(
+                        "[yellow]The central OTEL collector stack is not used in sidecar mode "
+                        "(telemetry is sent to CloudWatch by the local collector).[/yellow]"
+                    )
+                    return 1
+                stacks_to_deploy.append(("monitoring", "OpenTelemetry Collector"))
             elif stack_arg == "dashboard":
                 if profile.monitoring_enabled:
                     stacks_to_deploy.append(("dashboard", "CloudWatch Dashboard"))
@@ -199,62 +209,7 @@ class DeployCommand(Command):
                 return 1
         else:
             # Deploy all configured stacks in dependency order.
-            #
-            # Ordering constraints:
-            # - auth always comes first (produces the IAM role + OIDC provider
-            #   every other stack may reference). Skipped when auth_type == "none"
-            #   (anonymous mode).
-            # - networking must precede any stack that needs VPC/subnet
-            #   outputs: monitoring (OTel ECS ALB) and landing-page
-            #   distribution (distribution ALB).
-            # - distribution comes after networking to satisfy the
-            #   landing-page variant; the presigned-s3 variant doesn't need
-            #   networking but scheduling it here is harmless.
-            # - dashboard / analytics / quota all follow monitoring.
-            # - codebuild is independent and can trail.
-            if profile.effective_auth_type != "none":
-                stacks_to_deploy.append(("auth", "Authentication Stack (Cognito + IAM)"))
-
-            # Networking first so any downstream stack can read its outputs.
-            need_networking = profile.monitoring_enabled or profile.enable_distribution
-            if need_networking:
-                vpc_config = profile.monitoring_config or {}
-                if vpc_config.get("create_vpc", True):
-                    stacks_to_deploy.append(("networking", "VPC Networking for OTEL Collector"))
-
-            # Distribution (landing-page reads networking outputs; presigned-s3
-            # doesn't, but the scheduling order is a no-op either way).
-            if profile.enable_distribution:
-                stacks_to_deploy.append(("distribution", "Distribution infrastructure (S3 + IAM)"))
-
-            # Monitoring and its dependents.
-            if profile.monitoring_enabled:
-                stacks_to_deploy.append(("s3bucket", "S3 Bucket"))
-                stacks_to_deploy.append(("monitoring", "OpenTelemetry Collector"))
-                stacks_to_deploy.append(("dashboard", "CloudWatch Dashboard"))
-                stacks_to_deploy.append(("cowork-dashboard", "CoWork CloudWatch Dashboard"))
-                # Check if analytics is enabled (default to True for backward compatibility)
-                if getattr(profile, "analytics_enabled", True):
-                    stacks_to_deploy.append(("analytics", "Analytics Pipeline (Kinesis Firehose + Athena)"))
-                # Check if quota monitoring is enabled
-                # Quota enforcement requires SSO — the API Gateway JWT authorizer
-                # has no valid issuer URL otherwise. Skip with a warning rather
-                # than letting CloudFormation fail mid-deploy (issue #454).
-                if getattr(profile, "quota_monitoring_enabled", False):
-                    if profile.effective_auth_type in ("oidc", "idc"):
-                        stacks_to_deploy.append(("quota", "Quota Monitoring (Per-User Token Limits)"))
-                    else:
-                        console.print(
-                            "[yellow]⚠ Skipping quota monitoring stack: quota enforcement requires "
-                            "user authentication (OIDC or IAM Identity Center).[/yellow]"
-                        )
-                        console.print(
-                            "[dim]Re-run 'ccwb init' with OIDC or IDC authentication to deploy quota monitoring.[/dim]"
-                            "[dim]Re-run 'ccwb init' with SSO enabled to deploy quota monitoring. See issue #454.[/dim]"
-                        )
-            # Check if CodeBuild is enabled
-            if getattr(profile, "enable_codebuild", False):
-                stacks_to_deploy.append(("codebuild", "CodeBuild for Windows binary builds"))
+            stacks_to_deploy = self._select_full_deploy_stacks(profile, console)
 
         # Initialize CloudFormation manager
         cf_manager = CloudFormationManager(region=profile.aws_region)
@@ -350,6 +305,92 @@ class DeployCommand(Command):
         self._show_stack_outputs(profile, console, config)
 
         return 0
+
+    def _select_full_deploy_stacks(self, profile, console: Console) -> list:
+        """Return the ordered ``(stack_type, description)`` list for a full ``ccwb deploy``.
+
+        Pure selection logic with no AWS calls so it can be unit-tested. The only
+        side effect is a warning printed via ``console`` when quota is enabled but
+        the auth type cannot support it.
+
+        Ordering constraints:
+        - auth always comes first (produces the IAM role + OIDC provider every
+          other stack may reference). Skipped when auth_type == "none".
+        - networking must precede any stack that reads its VPC/subnet outputs:
+          central monitoring (OTel ECS ALB) and landing-page distribution.
+        - distribution follows networking for the landing-page variant; the
+          presigned-s3 variant doesn't need networking but the order is harmless.
+        - dashboard / analytics / quota all follow monitoring.
+        - codebuild is independent and can trail.
+
+        Monitoring mode is the key gate: sidecar runs a local OTEL collector that
+        ships metrics straight to CloudWatch, so it needs no VPC/ECS/ALB and no
+        Athena pipeline — only the CloudWatch dashboard. The #338 Go-rewrite
+        refactor dropped this gate, so sidecar profiles were deploying the entire
+        central stack (VPC + ECS + ALB + Athena), which fails in accounts that
+        disallow new VPCs.
+        """
+        stacks_to_deploy = []
+
+        if profile.effective_auth_type != "none":
+            stacks_to_deploy.append(("auth", "Authentication Stack (Cognito + IAM)"))
+
+        monitoring_mode = getattr(profile, "monitoring_mode", "central")
+        central_monitoring = profile.monitoring_enabled and monitoring_mode == "central"
+
+        # Networking first so any downstream stack can read its outputs.
+        need_networking = central_monitoring or profile.enable_distribution
+        if need_networking:
+            vpc_config = profile.monitoring_config or {}
+            if vpc_config.get("create_vpc", True):
+                stacks_to_deploy.append(("networking", "VPC Networking for OTEL Collector"))
+
+        # Distribution (landing-page reads networking outputs; presigned-s3
+        # doesn't, but the scheduling order is a no-op either way).
+        if profile.enable_distribution:
+            stacks_to_deploy.append(("distribution", "Distribution infrastructure (S3 + IAM)"))
+
+        # Monitoring and its dependents.
+        if profile.monitoring_enabled:
+            if central_monitoring:
+                stacks_to_deploy.append(("s3bucket", "S3 Bucket"))
+                stacks_to_deploy.append(("monitoring", "OpenTelemetry Collector"))
+                stacks_to_deploy.append(("dashboard", "CloudWatch Dashboard"))
+                stacks_to_deploy.append(("cowork-dashboard", "CoWork CloudWatch Dashboard"))
+                # Analytics defaults to True for backward compatibility.
+                if getattr(profile, "analytics_enabled", True):
+                    stacks_to_deploy.append(("analytics", "Analytics Pipeline (Kinesis Firehose + Athena)"))
+            else:
+                # Sidecar mode: metrics reach CloudWatch via the local collector,
+                # so the only server-side stack is the CloudWatch dashboard
+                # (PromQL). No networking/ECS, no Athena pipeline, and CoWork
+                # cannot export telemetry in this mode.
+                stacks_to_deploy.append(("dashboard", "CloudWatch Dashboard"))
+
+            # Quota enforcement works in both monitoring modes. It needs the
+            # s3bucket stack for Lambda packaging; central scheduled it above, so
+            # add it here for sidecar before the quota stack. Quota requires OIDC
+            # or IDC (per-user identity); skip with a warning rather than letting
+            # CloudFormation fail mid-deploy (issue #454).
+            if getattr(profile, "quota_monitoring_enabled", False):
+                if profile.effective_auth_type in ("oidc", "idc"):
+                    if not central_monitoring:
+                        stacks_to_deploy.append(("s3bucket", "S3 Bucket"))
+                    stacks_to_deploy.append(("quota", "Quota Monitoring (Per-User Token Limits)"))
+                else:
+                    console.print(
+                        "[yellow]⚠ Skipping quota monitoring stack: quota enforcement requires "
+                        "user authentication (OIDC or IAM Identity Center).[/yellow]"
+                    )
+                    console.print(
+                        "[dim]Re-run 'ccwb init' with OIDC or IDC authentication to deploy "
+                        "quota monitoring. See issue #454.[/dim]"
+                    )
+
+        if getattr(profile, "enable_codebuild", False):
+            stacks_to_deploy.append(("codebuild", "CodeBuild for Windows binary builds"))
+
+        return stacks_to_deploy
 
     def _convert_params_to_boto3(self, params: list) -> list:
         """Convert CLI parameter format to boto3 format.

--- a/source/tests/cli/commands/test_deploy_matrix.py
+++ b/source/tests/cli/commands/test_deploy_matrix.py
@@ -145,3 +145,115 @@ class TestDeployParameterMatrix:
         if pool_id and "_" in pool_id:
             pool_region = pool_id.split("_")[0]
             assert pool_region in issuer, f"Issuer should contain pool region '{pool_region}'"
+
+
+class _NullConsole:
+    """Minimal console stub — captures nothing, just satisfies .print()."""
+
+    def print(self, *args, **kwargs):  # noqa: D401 - test stub
+        pass
+
+
+# Server-side stacks that must NEVER be scheduled in sidecar monitoring mode.
+# Sidecar runs a local OTEL collector → no VPC/ECS/ALB and no Athena pipeline,
+# and CoWork cannot export telemetry in sidecar mode.
+_CENTRAL_ONLY_STACKS = {"networking", "monitoring", "cowork-dashboard", "analytics"}
+
+
+class TestSidecarStackSelection:
+    """Regression tests for the sidecar deploy gate (#438 / #338 regression).
+
+    PR #338 (Go rewrite) refactored deploy.py's stack selection and dropped the
+    ``monitoring_mode == "central"`` gate, so `ccwb deploy` scheduled the entire
+    central stack (VPC + ECS + ALB + Athena) even for sidecar profiles. That
+    fails in accounts that disallow new VPCs. These tests pin the correct stacks
+    for each mode so the gate can't silently disappear again.
+    """
+
+    @pytest.fixture
+    def command(self):
+        return DeployCommand()
+
+    def _stack_types(self, command, profile):
+        return [s[0] for s in command._select_full_deploy_stacks(profile, _NullConsole())]
+
+    def test_sidecar_excludes_central_infrastructure(self, command):
+        """Sidecar mode must not schedule networking/monitoring/cowork/analytics."""
+        profile = _base_profile(monitoring_mode="sidecar")
+        stacks = self._stack_types(command, profile)
+        assert _CENTRAL_ONLY_STACKS.isdisjoint(stacks), (
+            f"Sidecar mode scheduled central-only stacks: {sorted(_CENTRAL_ONLY_STACKS.intersection(stacks))}"
+        )
+
+    def test_sidecar_includes_dashboard(self, command):
+        """The CloudWatch dashboard works in both modes and must be deployed."""
+        profile = _base_profile(monitoring_mode="sidecar")
+        assert "dashboard" in self._stack_types(command, profile)
+
+    def test_sidecar_with_quota_includes_s3bucket_and_quota(self, command):
+        """Quota works in sidecar; it needs s3bucket (Lambda packaging) before quota."""
+        profile = _base_profile(monitoring_mode="sidecar", quota_monitoring_enabled=True)
+        stacks = self._stack_types(command, profile)
+        assert "quota" in stacks
+        assert "s3bucket" in stacks
+        assert stacks.index("s3bucket") < stacks.index("quota"), "s3bucket must precede quota"
+
+    def test_sidecar_without_quota_omits_s3bucket(self, command):
+        """No quota in sidecar → no s3bucket (it's only needed for Lambda packaging)."""
+        profile = _base_profile(monitoring_mode="sidecar", quota_monitoring_enabled=False)
+        stacks = self._stack_types(command, profile)
+        assert "s3bucket" not in stacks
+        assert "quota" not in stacks
+
+    def test_sidecar_idc_quota_still_scheduled(self, command):
+        """IDC sidecar (zero-binary) supports quota via SigV4 — must still deploy it."""
+        profile = _base_profile(
+            monitoring_mode="sidecar",
+            sso_enabled=False,  # effective_auth_type resolves to idc/none
+            auth_type="idc",
+            quota_monitoring_enabled=True,
+        )
+        if profile.effective_auth_type != "idc":
+            pytest.skip("profile did not resolve to IDC auth")
+        stacks = self._stack_types(command, profile)
+        assert "quota" in stacks
+        assert _CENTRAL_ONLY_STACKS.isdisjoint(stacks)
+
+    def test_central_includes_full_stack(self, command):
+        """Central mode must still schedule the full server-side stack (no over-correction)."""
+        profile = _base_profile(monitoring_mode="central", quota_monitoring_enabled=True)
+        stacks = self._stack_types(command, profile)
+        for expected in ("networking", "s3bucket", "monitoring", "dashboard", "cowork-dashboard", "analytics", "quota"):
+            assert expected in stacks, f"central mode missing '{expected}'"
+
+    def test_central_existing_vpc_skips_networking(self, command):
+        """Central mode with create_vpc=False reuses an existing VPC — no networking stack."""
+        profile = _base_profile(
+            monitoring_mode="central",
+            monitoring_config={"create_vpc": False},
+        )
+        assert "networking" not in self._stack_types(command, profile)
+
+    def test_missing_monitoring_mode_defaults_to_central(self, command):
+        """Backward compat: a profile lacking monitoring_mode behaves as central."""
+        profile = _base_profile(quota_monitoring_enabled=True)
+        # Simulate an old loaded object with no monitoring_mode attribute at all.
+        delattr(profile, "monitoring_mode")
+        stacks = self._stack_types(command, profile)
+        assert "networking" in stacks
+        assert "monitoring" in stacks
+
+    def test_sidecar_none_auth_omits_auth_and_quota(self, command):
+        """Sidecar + 'none' auth: anonymous telemetry, no auth stack, no quota."""
+        profile = _base_profile(
+            monitoring_mode="sidecar",
+            sso_enabled=False,
+            auth_type="none",
+            quota_monitoring_enabled=True,  # requested, but 'none' can't support it
+        )
+        assert profile.effective_auth_type == "none"
+        stacks = self._stack_types(command, profile)
+        assert "auth" not in stacks
+        assert "quota" not in stacks
+        assert "dashboard" in stacks
+        assert _CENTRAL_ONLY_STACKS.isdisjoint(stacks)


### PR DESCRIPTION
## Why
In sidecar monitoring mode the OTEL collector runs locally and ships metrics straight to CloudWatch, so no VPC/ECS/ALB or Athena pipeline is needed. But `ccwb deploy` scheduled the entire central stack regardless of mode, so **sidecar deployments attempted to create a VPC + ECS + ALB**. That fails outright in accounts that disallow new VPCs/subnets, and needlessly provisions costly infrastructure for everyone else running sidecar mode.

## Root cause
PR #338 (the Go rewrite) refactored deploy.py's "deploy all" stack selection and dropped the `monitoring_mode == "central"` gate that the original sidecar feature carried. PR #391 only restored the guard for the `cowork-dashboard` path, leaving `networking`/`monitoring`/`analytics` ungated — so the regression stayed live.

## What
- Extract full-deploy selection into a pure, unit-testable `_select_full_deploy_stacks()`.
- **Sidecar mode** now schedules only `auth`, `dashboard`, and (for OIDC/IDC quota) `s3bucket` + `quota` — never `networking`, `monitoring`, `cowork-dashboard`, or `analytics`. **Central mode** keeps the full stack unchanged.
- `ccwb deploy networking` and `ccwb deploy monitoring` now refuse in sidecar mode with a clear message (mirrors the existing `cowork-dashboard` guard).
- Add 9 regression tests pinning stack selection per mode: sidecar exclusions, dashboard-always, quota+s3bucket ordering, IDC sidecar quota, central full stack, existing-VPC skip, missing-`monitoring_mode` backward-compat, and sidecar + `none` auth.

## Pairs with
#678 (already on `beta`) restored the `otelcol` build and sidecar `collector-config` generation in `ccwb package` that the same #338 refactor dropped. This PR is the deploy-side half of that same regression.

## Testing
- `cd source && poetry run pytest tests/ -q` → 1308 passed, 22 skipped, 0 failures.
- `ruff check` clean; `ruff format` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)