### PR TITLE
fix(govcloud): use ${AWS::Partition} for all ARNs so GovCloud deploys work

### DIFF
--- a/deployment/infrastructure/analytics-pipeline.yaml
+++ b/deployment/infrastructure/analytics-pipeline.yaml
@@ -166,7 +166,7 @@ Resources:
               Service: lambda.amazonaws.com
             Action: 'sts:AssumeRole'
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
 
   TransformLambda:
     Type: AWS::Lambda::Function

--- a/deployment/infrastructure/bedrock-auth-idc.yaml
+++ b/deployment/infrastructure/bedrock-auth-idc.yaml
@@ -67,7 +67,7 @@ Resources:
                 - 'logs:PutLogEvents'
                 - 'logs:DescribeLogGroups'
                 - 'logs:DescribeLogStreams'
-              Resource: !Sub 'arn:aws:logs:*:${AWS::AccountId}:log-group:/aws/claude-code/*'
+              Resource: !Sub 'arn:${AWS::Partition}:logs:*:${AWS::AccountId}:log-group:/aws/claude-code/*'
             - !Ref 'AWS::NoValue'
   
   # IAM role for IAM Identity Center federation
@@ -87,11 +87,11 @@ Resources:
           # Trust policy for SSO-assumed roles (role chaining from Permission Set)
           - Effect: Allow
             Principal:
-              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
+              AWS: !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:root'
             Action: 'sts:AssumeRole'
             Condition:
               ArnLike:
-                'aws:PrincipalArn': !Sub 'arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/*'
+                'aws:PrincipalArn': !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/*'
       ManagedPolicyArns:
         - !Ref BedrockAccessPolicy
       # Optional CloudWatch access for monitoring

--- a/deployment/infrastructure/codebuild-windows.yaml
+++ b/deployment/infrastructure/codebuild-windows.yaml
@@ -74,7 +74,7 @@ Resources:
               Service: codebuild.amazonaws.com
             Action: sts:AssumeRole
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/CloudWatchLogsFullAccess
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/CloudWatchLogsFullAccess'
       Policies:
         - PolicyName: CodeBuildS3Policy
           PolicyDocument:

--- a/deployment/infrastructure/cognito-user-pool-setup.yaml
+++ b/deployment/infrastructure/cognito-user-pool-setup.yaml
@@ -357,7 +357,7 @@ Resources:
               Service: lambda.amazonaws.com
             Action: sts:AssumeRole
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
       Policies:
         - PolicyName: UpdateCognitoClient
           PolicyDocument:
@@ -448,7 +448,7 @@ Resources:
               Service: lambda.amazonaws.com
             Action: sts:AssumeRole
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
       Policies:
         - PolicyName: CognitoAndSecretsAccess
           PolicyDocument:
@@ -466,7 +466,7 @@ Resources:
                   - secretsmanager:DescribeSecret
                   - secretsmanager:TagResource
                 Resource:
-                  - !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:*'
+                  - !Sub 'arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:*'
 
   # Custom Resource to automatically store distribution web client secret
   DistributionWebClientSecret:
@@ -493,7 +493,7 @@ Resources:
               Service: lambda.amazonaws.com
             Action: sts:AssumeRole
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
 
   PreTokenGenerationFunction:
     Type: AWS::Lambda::Function

--- a/deployment/infrastructure/landing-page-distribution.yaml
+++ b/deployment/infrastructure/landing-page-distribution.yaml
@@ -31,6 +31,11 @@ Mappings:
     ap-south-1:     { AccountId: '718504428378' }
     me-south-1:     { AccountId: '076674570225' }
     sa-east-1:      { AccountId: '507241528517' }
+    # GovCloud uses the regional ELB account-ID model (not the service principal).
+    # Without these keys the unconditional !FindInMap below fails to resolve and
+    # the whole stack errors out in GovCloud.
+    us-gov-west-1:  { AccountId: '048591011584' }
+    us-gov-east-1:  { AccountId: '190560391635' }
 
 Parameters:
   IdentityPoolName:
@@ -280,7 +285,7 @@ Resources:
               Service: lambda.amazonaws.com
             Action: sts:AssumeRole
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole'
       Policies:
         - PolicyName: S3ReadAccess
           PolicyDocument:
@@ -893,7 +898,7 @@ Resources:
       FunctionName: !Ref LandingPageFunction
       Action: lambda:InvokeFunction
       Principal: elasticloadbalancing.amazonaws.com
-      SourceArn: !Sub 'arn:aws:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:targetgroup/*'
+      SourceArn: !Sub 'arn:${AWS::Partition}:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:targetgroup/*'
 
   # ACM Certificate (required for HTTPS/OIDC)
   Certificate:
@@ -1046,7 +1051,7 @@ Resources:
               Service: lambda.amazonaws.com
             Action: sts:AssumeRole
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
       Policies:
         - PolicyName: UpdateCognitoClient
           PolicyDocument:
@@ -1057,7 +1062,7 @@ Resources:
                   - cognito-idp:UpdateUserPoolClient
                   - cognito-idp:DescribeUserPoolClient
                 Resource:
-                  - !Sub 'arn:aws:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/${CognitoUserPoolId}'
+                  - !Sub 'arn:${AWS::Partition}:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/${CognitoUserPoolId}'
 
   CognitoCallbackUpdaterFunction:
     Type: AWS::Lambda::Function

--- a/deployment/infrastructure/otel-collector.yaml
+++ b/deployment/infrastructure/otel-collector.yaml
@@ -382,7 +382,7 @@ Resources:
               Service: ecs-tasks.amazonaws.com
             Action: sts:AssumeRole
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy'
       Policies:
         - PolicyName: CloudWatchLogs
           PolicyDocument:

--- a/deployment/infrastructure/quota-monitoring.yaml
+++ b/deployment/infrastructure/quota-monitoring.yaml
@@ -202,7 +202,7 @@ Resources:
               Service: lambda.amazonaws.com
             Action: sts:AssumeRole
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
       Policies:
         - PolicyName: QuotaMonitorPolicy
           PolicyDocument:
@@ -308,7 +308,7 @@ Resources:
               Service: lambda.amazonaws.com
             Action: sts:AssumeRole
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
       Policies:
         - PolicyName: BypassDetectionPolicy
           PolicyDocument:
@@ -403,7 +403,7 @@ Resources:
               Service: lambda.amazonaws.com
             Action: sts:AssumeRole
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
       Policies:
         - PolicyName: QuotaCheckPolicy
           PolicyDocument:
@@ -517,7 +517,7 @@ Resources:
       FunctionName: !Ref QuotaCheckFunction
       Action: lambda:InvokeFunction
       Principal: apigateway.amazonaws.com
-      SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${QuotaCheckApi}/*'
+      SourceArn: !Sub 'arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${QuotaCheckApi}/*'
 
   # ============================================
   # End Quota Check API
@@ -540,7 +540,7 @@ Resources:
           - Sid: AllowQuotaApiInvoke
             Effect: Allow
             Action: 'execute-api:Invoke'
-            Resource: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${QuotaCheckApi}/*'
+            Resource: !Sub 'arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${QuotaCheckApi}/*'
 
 Outputs:
   QuotaTableName:

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1813,9 +1813,12 @@ class InitCommand(Command):
                     try:
                         secret_arn = secrets_client.describe_secret(SecretId=secret_name)["ARN"]
                     except Exception:
-                        secret_arn = (
-                            f"arn:aws:secretsmanager:{region}:{account_id}:secret:{secret_name}"  # allow-handbuilt-arn
-                        )
+                        # Partition-aware so the fallback ARN is valid in GovCloud
+                        # (aws-us-gov) and China (aws-cn), not just commercial AWS.
+                        from claude_code_with_bedrock.utils.partition import aws_partition_for_region
+
+                        partition = aws_partition_for_region(region)
+                        secret_arn = f"arn:{partition}:secretsmanager:{region}:{account_id}:secret:{secret_name}"  # allow-handbuilt-arn
 
             # Custom domain (REQUIRED for authenticated landing page)
             console.print("\n[bold]Custom Domain Configuration (REQUIRED)[/bold]")

--- a/source/claude_code_with_bedrock/utils/partition.py
+++ b/source/claude_code_with_bedrock/utils/partition.py
@@ -1,0 +1,19 @@
+# ABOUTME: Maps an AWS region to its ARN partition (commercial, GovCloud, China).
+# ABOUTME: Python-side mirror of the ${AWS::Partition} pseudo-parameter used in templates.
+
+
+def aws_partition_for_region(region: str) -> str:
+    """Return the ARN partition for an AWS region.
+
+    GovCloud regions (``us-gov-*``) use ``aws-us-gov``, China regions (``cn-*``)
+    use ``aws-cn``, and everything else uses ``aws``. This mirrors the
+    ``${AWS::Partition}`` pseudo-parameter that CloudFormation templates rely on,
+    so any ARN we have to build by hand in Python stays partition-correct outside
+    commercial AWS (e.g. GovCloud deployments).
+    """
+    r = (region or "").lower()
+    if r.startswith("us-gov-"):
+        return "aws-us-gov"
+    if r.startswith("cn-"):
+        return "aws-cn"
+    return "aws"

--- a/source/tests/e2e/test_cfn_contracts.py
+++ b/source/tests/e2e/test_cfn_contracts.py
@@ -383,3 +383,38 @@ class TestOtelCollectorAlbIdleTimeout:
     def test_idle_timeout_within_alb_max(self):
         """ALB idle timeout is capped at 4000s by the service."""
         assert 1 <= self._idle_timeout() <= 4000
+
+
+class TestArnPartitionPortability:
+    """ARNs must use ${AWS::Partition}, never a hardcoded partition.
+
+    GovCloud uses the `aws-us-gov` partition and China uses `aws-cn`. A literal
+    `arn:aws:` in a template either fails outright (e.g. an IAM trust principal
+    that can't resolve) or silently never matches in those partitions. The repo
+    already uses `${AWS::Partition}` widely; this guard stops new `arn:aws:`
+    literals from creeping back in (regression: GovCloud deploy support).
+    """
+
+    # The only legitimate literal `aws` that is NOT a partition: the AWS-owned
+    # account alias in managed-policy ARNs, e.g. `arn:${AWS::Partition}:iam::aws:policy/...`.
+    # We strip those before scanning so the check targets the partition position only.
+    @pytest.mark.parametrize("template_path", _get_all_templates(), ids=lambda p: p.name)
+    def test_no_hardcoded_arn_partition(self, template_path):
+        raw = template_path.read_text(encoding="utf-8")
+        offenders = [
+            f"{template_path.name}:{i}: {line.strip()}"
+            for i, line in enumerate(raw.splitlines(), start=1)
+            if "arn:aws:" in line
+        ]
+        assert not offenders, (
+            "Hardcoded ARN partition found — use 'arn:${AWS::Partition}:' so the "
+            "template works in GovCloud (aws-us-gov) and China (aws-cn):\n" + "\n".join(offenders)
+        )
+
+    def test_govcloud_regions_in_elb_account_map(self):
+        """ALB access logging uses an unconditional !FindInMap on the ELB account
+        map, so GovCloud regions must be present or the stack fails to deploy."""
+        template = _load_template("landing-page-distribution.yaml")
+        elb_map = template.get("Mappings", {}).get("ELBServiceAccounts", {})
+        for region in ("us-gov-west-1", "us-gov-east-1"):
+            assert region in elb_map, f"ELBServiceAccounts mapping missing GovCloud region {region}"

--- a/source/tests/test_partition.py
+++ b/source/tests/test_partition.py
@@ -1,0 +1,25 @@
+# ABOUTME: Unit tests for aws_partition_for_region (Python mirror of ${AWS::Partition}).
+
+import pytest
+
+from claude_code_with_bedrock.utils.partition import aws_partition_for_region
+
+
+@pytest.mark.parametrize(
+    "region,expected",
+    [
+        ("us-east-1", "aws"),
+        ("us-west-2", "aws"),
+        ("eu-west-1", "aws"),
+        ("US-EAST-1", "aws"),  # case-insensitive
+        ("us-gov-west-1", "aws-us-gov"),
+        ("us-gov-east-1", "aws-us-gov"),
+        ("US-GOV-WEST-1", "aws-us-gov"),
+        ("cn-north-1", "aws-cn"),
+        ("cn-northwest-1", "aws-cn"),
+        ("", "aws"),
+        (None, "aws"),
+    ],
+)
+def test_partition_for_region(region, expected):
+    assert aws_partition_for_region(region) == expected


### PR DESCRIPTION
## Why
GovCloud uses the `aws-us-gov` ARN partition (China uses `aws-cn`). **19 ARNs** across the CloudFormation templates hardcoded the commercial `aws` partition, so in GovCloud they either fail outright or silently never match:

- IAM roles referencing `arn:aws:iam::aws:policy/...` **cannot attach** the managed policy.
- The IDC trust-policy principals in `bedrock-auth-idc.yaml` (`...:root`, SSO `PrincipalArn`) **cannot resolve** → broken auth.
- `execute-api`, `secretsmanager`, `cognito-idp`, `elasticloadbalancing`, and `logs` resource ARNs silently never match → access denied at runtime.

The repo already uses `${AWS::Partition}` in 46 places; these were stragglers (three templates had zero partition substitution).

## What
- Replace every hardcoded `arn:aws:` with `arn:${AWS::Partition}:` across **7 templates** — 11 AWS managed-policy ARNs + 8 `!Sub` service/principal ARNs. The AWS-owned account alias in `::aws:policy/...` is intentionally left unchanged (it is not the partition).
- **`landing-page-distribution.yaml`**: add GovCloud ELB log-delivery account IDs (`us-gov-west-1`, `us-gov-east-1`). The ALB access-log bucket policy does an **unconditional `!FindInMap`** on the ELB account map, so without these keys the whole stack fails to deploy in GovCloud — despite the dual-principal design that intended to cover it.
- **`init.py`**: make the last-resort hand-built Secrets Manager ARN partition-aware via a new `utils.partition.aws_partition_for_region()` helper (Python mirror of `${AWS::Partition}`).
- **Regression guards**: a parametrized contract test that fails on any `arn:aws:` literal in any template, a GovCloud-region-presence check on the ELB account map, and unit tests for the partition helper.

## Not changed (intentionally)
- Service principals (`*.amazonaws.com`, e.g. `ecs-tasks.amazonaws.com`) — these do **not** change in GovCloud.
- The Go/Python STS credential path — it uses AWS SDK v2 `NewFromConfig`, which resolves the partition from the configured region automatically.

## Testing
- `cd source && poetry run pytest tests/ -q` → **1334 passed, 22 skipped, 0 failures**.
- `cfn-lint` on all 7 changed templates: **zero new findings** (identical warning counts before/after).
- `ruff check` + `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)