### PR TITLE
fix(okta): accept Okta custom URL domains in OktaDomain validation

### DIFF
--- a/deployment/infrastructure/bedrock-auth-okta.yaml
+++ b/deployment/infrastructure/bedrock-auth-okta.yaml
@@ -12,9 +12,19 @@ Parameters:
 
   OktaDomain:
     Type: String
-    Description: Your Okta domain (e.g., company.okta.com)
-    AllowedPattern: '^[a-zA-Z0-9][a-zA-Z0-9-]*\.okta(-emea)?\.com$'
-    ConstraintDescription: Must be a valid Okta domain
+    Description: >-
+      Your Okta domain — an Okta org domain (e.g., company.okta.com,
+      company.okta-emea.com, company.oktapreview.com, company.okta-gov.com) or an
+      Okta custom URL domain hosted on your own domain (e.g., login.company.com).
+    # Validate as a fully-qualified domain name rather than hard-coding okta.com.
+    # Okta supports custom URL domains (CNAME'd to the org) and government orgs
+    # (okta-gov.com), so the previous '.okta(-emea).com' pattern rejected valid
+    # issuers. This still substitutes safely into https://${OktaDomain}: it forbids
+    # a scheme, path, port, whitespace, or empty labels. (Issue: custom Okta domains.)
+    AllowedPattern: '^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$'
+    ConstraintDescription: >-
+      Must be a valid fully-qualified domain name with no scheme, path, or port
+      (e.g., company.okta.com or login.company.com)
 
   OktaClientId:
     Type: String

--- a/source/tests/test_okta_domain_pattern.py
+++ b/source/tests/test_okta_domain_pattern.py
@@ -1,0 +1,86 @@
+"""Regression test: OktaDomain AllowedPattern must accept Okta custom URL domains.
+
+The original pattern '^[a-zA-Z0-9][a-zA-Z0-9-]*\\.okta(-emea)?\\.com$' only allowed
+*.okta.com / *.okta-emea.com, which blocked:
+  - Okta custom URL domains hosted on the customer's own domain (login.company.com)
+  - Okta preview orgs (*.oktapreview.com)
+  - Okta for Government orgs (*.okta-gov.com) — relevant for GovCloud
+The domain is substituted into `https://${OktaDomain}` for the IAM OIDC provider,
+so it must be a valid FQDN with no scheme/path/port, but need not be on okta.com.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+INFRA_DIR = Path(__file__).resolve().parents[2] / "deployment" / "infrastructure"
+
+
+class CfnLoader(yaml.SafeLoader):
+    pass
+
+
+def _cfn_tag_constructor(loader, tag_suffix, node):
+    if isinstance(node, yaml.ScalarNode):
+        return loader.construct_scalar(node)
+    elif isinstance(node, yaml.SequenceNode):
+        return loader.construct_sequence(node)
+    elif isinstance(node, yaml.MappingNode):
+        return loader.construct_mapping(node)
+
+
+CfnLoader.add_multi_constructor("!", _cfn_tag_constructor)
+
+
+def _okta_domain_pattern() -> str:
+    template_path = INFRA_DIR / "bedrock-auth-okta.yaml"
+    with open(template_path, encoding="utf-8") as f:
+        template = yaml.load(f, Loader=CfnLoader)
+    return template["Parameters"]["OktaDomain"]["AllowedPattern"]
+
+
+class TestOktaDomainPattern:
+    """OktaDomain must accept org domains AND custom URL domains, reject malformed input."""
+
+    @pytest.mark.parametrize(
+        "domain",
+        [
+            "company.okta.com",
+            "company.okta-emea.com",
+            "company.oktapreview.com",
+            "company.okta-gov.com",  # Okta for Government
+            "login.company.com",  # custom URL domain
+            "id.acme.io",
+            "sso.enterprise.co.uk",
+            "auth.example.com",
+        ],
+    )
+    def test_pattern_accepts_valid_domains(self, domain):
+        pattern = _okta_domain_pattern()
+        assert re.match(pattern, domain), f"Pattern {pattern!r} should accept {domain!r}"
+
+    @pytest.mark.parametrize(
+        "domain",
+        [
+            "https://company.okta.com",  # scheme
+            "company.okta.com/oauth2/default",  # path
+            "company.okta.com:443",  # port
+            "company.okta.com.",  # trailing dot
+            "company..com",  # empty label
+            "-bad.okta.com",  # label starts with hyphen
+            "localhost",  # no dot / no TLD
+            "company.c",  # single-char TLD
+            "company.okta.com ",  # trailing whitespace
+            "",  # empty
+        ],
+    )
+    def test_pattern_rejects_invalid_domains(self, domain):
+        pattern = _okta_domain_pattern()
+        assert not re.match(pattern, domain), f"Pattern {pattern!r} should reject {domain!r}"
+
+    def test_pattern_no_longer_hardcodes_okta_com(self):
+        """Guard against re-introducing an okta.com-only constraint."""
+        pattern = _okta_domain_pattern()
+        assert "okta" not in pattern.lower(), "OktaDomain pattern must not hard-code 'okta' (blocks custom domains)"


### PR DESCRIPTION
## Why
`bedrock-auth-okta.yaml` validated `OktaDomain` with `^[a-zA-Z0-9][a-zA-Z0-9-]*\.okta(-emea)?\.com$`, accepting only `*.okta.com` / `*.okta-emea.com`. That **rejects valid Okta issuers**, and blocked a real deployment:

- **Okta custom URL domains** — enterprises CNAME their Okta org to their own domain (e.g. `login.company.com`). This is a first-class, supported Okta feature.
- **Okta preview orgs** (`*.oktapreview.com`).
- **Okta for Government** orgs (`*.okta-gov.com`) — relevant for GovCloud.

The value is only substituted into `https://${OktaDomain}` for the IAM OIDC provider URL, so it needs to be a valid hostname — it does not need to be on `okta.com`.

## What
- Replace the okta.com-specific pattern with a fully-qualified-domain-name check:
  `^(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$`
  Accepts org **and** custom domains while still forbidding a scheme, path, port, whitespace, or empty labels — so it stays safe when substituted into the `!Sub` URL.
- Clarify the parameter `Description` and `ConstraintDescription`.
- Add a regression test (`test_okta_domain_pattern.py`) asserting the pattern accepts org + custom + `okta-gov` domains and rejects `https://`, paths, ports, trailing dots, empty labels, and single-char TLDs.

The CLI-side validator (`validate_oidc_provider_domain`) is already a generic FQDN check, so no Python change is needed — the template was the only blocker.

## Testing
- `cd source && poetry run pytest tests/ -q` → 1353 passed, 22 skipped, 0 failures.
- `cfn-lint deployment/infrastructure/bedrock-auth-okta.yaml` → clean (exit 0).
- ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)