### PR TITLE
fix(ci): post Claude Code review findings as PR comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           use_bedrock: "true"
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          track_progress: "true"
           claude_args: |
             --model global.anthropic.claude-sonnet-4-6
           prompt: |


### PR DESCRIPTION
## Why
The Claude Code review action was running in agent mode (triggered by `prompt:` on `pull_request` events), which processes the diff and generates output but never posts it anywhere. Reviews ran successfully but silently — no comments appeared on PRs.

## What
Add `track_progress: "true"` to force tag mode on PR events. In tag mode, the action creates a comment thread and posts Claude's findings directly to the PR.