### PR TITLE
fix(ci): trigger Claude Code review on demand only

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,9 +1,7 @@
 ---
 name: Claude Code — PR Review
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-  pull_request_review_comment:
+  issue_comment:
     types: [created]
 
 permissions:
@@ -14,13 +12,11 @@ permissions:
 
 jobs:
   review:
-    # Skip draft PRs, bot PRs, and fork PRs (secrets unavailable)
+    # On-demand only: run when a human comments @claude on a PR (not an issue)
     if: |
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      (
-        (github.event_name == 'pull_request' && !github.event.pull_request.draft && github.event.pull_request.user.login != 'github-actions[bot]') ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
-      )
+      github.event.issue.pull_request != null &&
+      github.event.comment.user.login != 'github-actions[bot]' &&
+      contains(github.event.comment.body, '@claude')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
## Why
The PR review action ran automatically on every PR open/sync, which re-runs Claude on every commit and adds up in cost over time. The action's canonical example uses an on-demand `@claude` trigger as the recommended default.

## What
Switch the trigger from `pull_request` (opened/synchronize/reopened/ready_for_review) to `issue_comment`, gated on a human commenting `@claude` on a PR. Reviews now run only when explicitly requested.