### PR TITLE
fix(ci): run security and testing gates on beta PRs, not just main

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -1,9 +1,9 @@
 name: Bandit
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "beta"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "beta"]
   schedule:
     - cron: '38 6 * * 2'
 permissions: {}
@@ -18,6 +18,9 @@ jobs:
       - name: Bandit Scan
         uses: shundor/python-bandit-scan@ab1d87dfccc5a0ffab88be3aaac6ffe35c10d6cd
         with:
+          # exit_zero keeps Bandit non-blocking: there is an existing backlog of
+          # findings (mostly B404/B603 subprocess + B108/B110) that must be triaged
+          # before this can gate merges. Flipping to blocking is tracked separately.
           exit_zero: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           excluded_paths: tests,.venv

--- a/.github/workflows/cfn_nag.yml
+++ b/.github/workflows/cfn_nag.yml
@@ -1,9 +1,9 @@
 name: cfn_nag
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "beta"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "beta"]
   workflow_dispatch:
 permissions: {}
 jobs:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,10 +1,17 @@
 name: Integration Tests (Tier 2)
 on:
+  push:
+    branches: [main, beta]
+    paths:
+      - 'source/**'
+      - 'deployment/**'
+      - '.github/workflows/integration-tests.yml'
   pull_request:
     branches: [main, beta]
     paths:
       - 'source/**'
       - 'deployment/**'
+      - '.github/workflows/integration-tests.yml'
   workflow_dispatch:
 
 permissions:
@@ -13,6 +20,7 @@ permissions:
 jobs:
   integration:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         python-version: ['3.10', '3.12']

--- a/.github/workflows/scanners.yml
+++ b/.github/workflows/scanners.yml
@@ -1,7 +1,9 @@
 name: Scanners
 on:
   push:
+    branches: ["main", "beta"]
   pull_request:
+    branches: ["main", "beta"]
   workflow_dispatch:
 permissions: {}
 jobs:


### PR DESCRIPTION
## Why
The repo's PR target is `beta`, but several CI gates only triggered on `main`. Since code reaches `main` only via release promotion, the normal development flow **bypassed these gates entirely** — they ran too late to be a review gate. Surfaced by a CI audit.

## What
- **bandit** (Python SAST) — extend `pull_request`/`push` to `beta`. Kept `exit_zero: true` (non-blocking) for now: there's an existing backlog of findings (mostly `B404`/`B603` subprocess + `B108`/`B110`) that must be triaged before it can gate merges. Documented inline; flipping to blocking is tracked separately.
- **cfn_nag** (CloudFormation security) — extend to `beta`.
- **integration-tests** — add a `push` trigger so the release-bound `beta` branch is covered after merge, add `timeout-minutes: 15`, and add the workflow to its own path filters.
- **scanners** (secrets) — scope to `main`/`beta` to cut redundant runs on every push to every branch.

## Deliberately NOT included
- **pr-testing-validation** — *not* extended to beta. It scrapes the PR description (regex over checkboxes/prose) rather than testing code, so enforcing it on every beta PR adds author friction for weak signal, and it has a known asymmetric-logic bug (`hasNonEmptyTestResults || cliTestingChecked` lets CLI-checkbox PRs pass with empty results). If wanted on beta, it should go in its own PR after the logic is fixed.

## Notes
- No behavior change for `main`; this only *adds* `beta` coverage (and trims scanner noise).
- Follow-ups from the same audit: (1) concurrency groups fleet-wide, (2) pin actions to SHAs starting with `anthropics/claude-code-action`.

## Needs manual verification
Whether bandit/cfn_nag/semgrep are **required status checks** in `beta` branch protection (not readable via API). Extending the trigger makes them *run*; making them *block* requires the branch-protection setting.