### PR TITLE
fix(ci): improve coverage, safety, and cost across workflows

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   label:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:

--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -7,9 +7,13 @@ on:
   schedule:
     - cron: '38 6 * * 2'
 permissions: {}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   bandit:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -1,9 +1,9 @@
 name: Bandit
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "beta"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "beta"]
   schedule:
     - cron: '38 6 * * 2'
 permissions: {}
@@ -18,6 +18,9 @@ jobs:
       - name: Bandit Scan
         uses: shundor/python-bandit-scan@ab1d87dfccc5a0ffab88be3aaac6ffe35c10d6cd
         with:
+          # exit_zero keeps Bandit non-blocking: there is an existing backlog of
+          # findings (mostly B404/B603 subprocess + B108/B110) that must be triaged
+          # before this can gate merges. Flipping to blocking is tracked separately.
           exit_zero: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           excluded_paths: tests,.venv

--- a/.github/workflows/cfn_nag.yml
+++ b/.github/workflows/cfn_nag.yml
@@ -6,9 +6,13 @@ on:
     branches: ["main", "beta"]
   workflow_dispatch:
 permissions: {}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   scan:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/cfn_nag.yml
+++ b/.github/workflows/cfn_nag.yml
@@ -1,9 +1,9 @@
 name: cfn_nag
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "beta"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "beta"]
   workflow_dispatch:
 permissions: {}
 jobs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:
@@ -48,6 +49,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: build
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -16,6 +16,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Go Tests (${{ matrix.os }})

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,6 +17,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   integration:
     runs-on: ubuntu-latest
@@ -33,6 +37,17 @@ jobs:
 
       - name: Install Poetry
         run: pip install poetry
+
+      - name: Configure Poetry
+        run: poetry config virtualenvs.in-project true
+
+      - name: Cache Poetry virtualenv
+        uses: actions/cache@v5
+        with:
+          path: source/.venv
+          key: ${{ runner.os }}-poetry-${{ matrix.python-version }}-${{ hashFiles('source/poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-poetry-${{ matrix.python-version }}-
 
       - name: Install dependencies
         working-directory: source

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,10 +1,17 @@
 name: Integration Tests (Tier 2)
 on:
+  push:
+    branches: [main, beta]
+    paths:
+      - 'source/**'
+      - 'deployment/**'
+      - '.github/workflows/integration-tests.yml'
   pull_request:
     branches: [main, beta]
     paths:
       - 'source/**'
       - 'deployment/**'
+      - '.github/workflows/integration-tests.yml'
   workflow_dispatch:
 
 permissions:
@@ -13,6 +20,7 @@ permissions:
 jobs:
   integration:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         python-version: ['3.10', '3.12']

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ruff:
     name: Ruff (lint + format)

--- a/.github/workflows/pytest-ci.yml
+++ b/.github/workflows/pytest-ci.yml
@@ -18,6 +18,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Tests (Python ${{ matrix.python-version }}, ${{ matrix.os }})

--- a/.github/workflows/release-beta.yml
+++ b/.github/workflows/release-beta.yml
@@ -13,6 +13,7 @@ jobs:
   tag-beta:
     name: Create Beta Pre-release Tag
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release-initiate.yml
+++ b/.github/workflows/release-initiate.yml
@@ -23,6 +23,7 @@ jobs:
   initiate-release:
     name: Create Release Branch and PR
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
       pull-requests: write
@@ -217,6 +218,7 @@ jobs:
   close-stale-release-prs:
     name: Close Stale Release PRs
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -16,6 +16,7 @@ jobs:
   release:
     name: Tag and Release
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
     outputs:
@@ -68,6 +69,7 @@ jobs:
     needs: release
     if: always() && needs.release.result != 'failure'
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     permissions:
       contents: write
     strategy:

--- a/.github/workflows/release-merge-tag.yml
+++ b/.github/workflows/release-merge-tag.yml
@@ -21,6 +21,7 @@ jobs:
       github.event.pull_request.merged == true &&
       startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
     steps:
@@ -84,6 +85,7 @@ jobs:
       github.event.pull_request.merged == true &&
       !startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/scanners.yml
+++ b/.github/workflows/scanners.yml
@@ -1,7 +1,9 @@
 name: Scanners
 on:
   push:
+    branches: ["main", "beta"]
   pull_request:
+    branches: ["main", "beta"]
   workflow_dispatch:
 permissions: {}
 jobs:

--- a/.github/workflows/scanners.yml
+++ b/.github/workflows/scanners.yml
@@ -6,9 +6,13 @@ on:
     branches: ["main", "beta"]
   workflow_dispatch:
 permissions: {}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   secrets-scanner:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -7,9 +7,13 @@ on:
   schedule:
     - cron: '15 12 * * *'
 permissions: {}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   semgrep:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,6 +7,7 @@ permissions: {}
 jobs:
   stale:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/validate-regions.yml
+++ b/.github/workflows/validate-regions.yml
@@ -14,9 +14,14 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate-regions:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Why
A specialist audit of all 20 workflows surfaced two dominant issues: **security/test gates that only fired on `main`** (bypassed by the normal `beta` PR flow) and **cost waste from missing concurrency control**. This PR addresses both, plus runaway-job protection and caching.

Supersedes #695 (same work; branch renamed to reflect the full scope — coverage + safety + cost).

## Coverage & safety — run gates on `beta` PRs
- **bandit** (Python SAST) → extend to `beta`. Kept `exit_zero: true` (non-blocking): there's an existing finding backlog (`B404`/`B603` subprocess + `B108`/`B110`) to triage before it can gate. Documented inline.
- **cfn_nag** (CloudFormation security) → extend to `beta`.
- **integration-tests** → add `push` trigger so the release-bound `beta` branch is covered after merge.
- **scanners** (secrets) → scope to `main`/`beta` to cut redundant per-branch runs.

> Deliberately **not** included: `pr-testing-validation` on beta — it scrapes the PR description rather than testing code, adds author friction, and has a known asymmetric-logic bug. Tracked separately.

## Cost & reliability — CI hygiene
- **Concurrency groups** (`cancel-in-progress: true`) on every test/lint/scan workflow. Stale runs on rapid pushes auto-cancel — the biggest avoidable runner-minute drain (worst on the pytest 5-cell and go-tests 3-OS matrices). Release workflows intentionally excluded (cancelling mid-publish is unsafe).
- **`timeout-minutes`** on every job that lacked one (was defaulting to GitHub's 6h cap).
- **Poetry venv cache** in integration-tests, mirroring pytest-ci.

## Notes
- No behavior change on `main`; this only *adds* `beta` coverage and trims waste.
- Follow-up from the same audit: pin all actions to SHAs (starting with `anthropics/claude-code-action`).

## Needs manual verification
Whether bandit/cfn_nag/semgrep are **required status checks** in `beta` branch protection (not API-readable). Extending triggers makes them *run*; making them *block* is a branch-protection setting.