### PR TITLE
feat: config schema validation at package time

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -20,6 +20,7 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 from claude_code_with_bedrock.cli.utils.aws import get_stack_outputs
 from claude_code_with_bedrock.cli.utils.display import display_configuration_info
 from claude_code_with_bedrock.cli.utils.helpers import get_codebuild_region
+from claude_code_with_bedrock.cli.validators import validate_profile_for_packaging
 from claude_code_with_bedrock.config import Config
 from claude_code_with_bedrock.models import (
     get_source_region_for_profile,
@@ -210,6 +211,11 @@ class PackageCommand(Command):
             description="Use legacy PyInstaller/Nuitka build instead of Go (deprecated)",
             flag=True,
         ),
+        option(
+            "skip-validation",
+            description="Skip configuration validation checks",
+            flag=True,
+        ),
     ]
 
     def handle(self) -> int:
@@ -238,6 +244,25 @@ class PackageCommand(Command):
         if not profile:
             console.print("[red]No deployment found. Run 'poetry run ccwb init' first.[/red]")
             return 1
+
+        # Run configuration validation (unless skipped)
+        if not self.option("skip-validation"):
+            validation_errors = validate_profile_for_packaging(profile)
+            if validation_errors:
+                has_errors = False
+                for err in validation_errors:
+                    if err.severity == "error":
+                        console.print(f"[red]✗ [{err.field}] {err.message}[/red]")
+                        has_errors = True
+                    else:
+                        console.print(f"[yellow]⚠ [{err.field}] {err.message}[/yellow]")
+                if has_errors:
+                    console.print(
+                        "\n[red]Configuration validation failed. "
+                        "Fix the errors above or re-run with --skip-validation to bypass.[/red]"
+                    )
+                    return 1
+                console.print()  # blank line after warnings
 
         # Regenerate installers from existing binaries (no rebuild needed)
         if self.option("regenerate-installers"):

--- a/source/claude_code_with_bedrock/cli/validators.py
+++ b/source/claude_code_with_bedrock/cli/validators.py
@@ -1,0 +1,79 @@
+# ABOUTME: Configuration validators run at package time to catch misconfigurations early.
+# ABOUTME: Called by the package command before generating any distribution files.
+
+"""Configuration validators run at package time to catch misconfigurations early."""
+
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class ValidationError:
+    field: str
+    message: str
+    severity: str = "error"  # "error" or "warning"
+
+
+def validate_profile_for_packaging(profile) -> List[ValidationError]:
+    """Validate a profile is consistent and ready for packaging."""
+    errors = []
+
+    auth_type = getattr(profile, "effective_auth_type", getattr(profile, "auth_type", "oidc"))
+
+    # IDC requires start URL
+    if auth_type == "idc":
+        if not getattr(profile, "idc_start_url", None):
+            errors.append(ValidationError("idc_start_url", "IDC auth requires idc_start_url"))
+        if not getattr(profile, "idc_account_id", None):
+            errors.append(ValidationError("idc_account_id", "IDC auth requires idc_account_id"))
+        if not getattr(profile, "idc_permission_set_name", None):
+            errors.append(ValidationError("idc_permission_set_name", "IDC auth requires idc_permission_set_name"))
+
+    # OIDC requires provider domain + client ID
+    if auth_type == "oidc":
+        if not getattr(profile, "provider_domain", None) and not getattr(profile, "oidc_issuer_url", None):
+            errors.append(ValidationError("provider_domain", "OIDC auth requires provider_domain or oidc_issuer_url"))
+        if not getattr(profile, "client_id", None):
+            errors.append(ValidationError("client_id", "OIDC auth requires client_id"))
+
+    # Region validation
+    if not getattr(profile, "aws_region", None):
+        errors.append(ValidationError("aws_region", "AWS region is required"))
+
+    allowed_regions = getattr(profile, "allowed_bedrock_regions", None)
+    if allowed_regions and getattr(profile, "aws_region", None):
+        if profile.aws_region not in allowed_regions:
+            errors.append(ValidationError(
+                "aws_region",
+                f"Region '{profile.aws_region}' not in allowed_bedrock_regions: {allowed_regions}",
+                severity="warning"
+            ))
+
+    # Monitoring consistency
+    if getattr(profile, "monitoring_enabled", False):
+        endpoint = getattr(profile, "otel_collector_endpoint", None)
+        config_mode = getattr(profile, "cowork_config_mode", "static")
+        if not endpoint and config_mode != "dynamic":
+            errors.append(ValidationError(
+                "otel_collector_endpoint",
+                "Monitoring enabled but no otel_collector_endpoint configured (and not using bootstrap server). "
+                "Run 'ccwb deploy --stack monitoring' first.",
+                severity="warning"
+            ))
+
+    # Bootstrap server + IDC conflict
+    if getattr(profile, "cowork_config_mode", "static") == "dynamic" and auth_type == "idc":
+        errors.append(ValidationError(
+            "cowork_config_mode",
+            "Bootstrap server (dynamic config) is not supported with IDC auth. Use static MDM profiles."
+        ))
+
+    # Quota enforcement requires quota API endpoint
+    if getattr(profile, "quota_enforcement_mode", "off") != "off":
+        if not getattr(profile, "quota_api_endpoint", None):
+            errors.append(ValidationError(
+                "quota_api_endpoint",
+                f"Quota enforcement mode '{profile.quota_enforcement_mode}' requires quota_api_endpoint"
+            ))
+
+    return errors

--- a/source/claude_code_with_bedrock/cli/validators.py
+++ b/source/claude_code_with_bedrock/cli/validators.py
@@ -43,37 +43,45 @@ def validate_profile_for_packaging(profile) -> List[ValidationError]:
     allowed_regions = getattr(profile, "allowed_bedrock_regions", None)
     if allowed_regions and getattr(profile, "aws_region", None):
         if profile.aws_region not in allowed_regions:
-            errors.append(ValidationError(
-                "aws_region",
-                f"Region '{profile.aws_region}' not in allowed_bedrock_regions: {allowed_regions}",
-                severity="warning"
-            ))
+            errors.append(
+                ValidationError(
+                    "aws_region",
+                    f"Region '{profile.aws_region}' not in allowed_bedrock_regions: {allowed_regions}",
+                    severity="warning",
+                )
+            )
 
     # Monitoring consistency
     if getattr(profile, "monitoring_enabled", False):
         endpoint = getattr(profile, "otel_collector_endpoint", None)
         config_mode = getattr(profile, "cowork_config_mode", "static")
         if not endpoint and config_mode != "dynamic":
-            errors.append(ValidationError(
-                "otel_collector_endpoint",
-                "Monitoring enabled but no otel_collector_endpoint configured (and not using bootstrap server). "
-                "Run 'ccwb deploy --stack monitoring' first.",
-                severity="warning"
-            ))
+            errors.append(
+                ValidationError(
+                    "otel_collector_endpoint",
+                    "Monitoring enabled but no otel_collector_endpoint configured (and not using bootstrap server). "
+                    "Run 'ccwb deploy --stack monitoring' first.",
+                    severity="warning",
+                )
+            )
 
     # Bootstrap server + IDC conflict
     if getattr(profile, "cowork_config_mode", "static") == "dynamic" and auth_type == "idc":
-        errors.append(ValidationError(
-            "cowork_config_mode",
-            "Bootstrap server (dynamic config) is not supported with IDC auth. Use static MDM profiles."
-        ))
+        errors.append(
+            ValidationError(
+                "cowork_config_mode",
+                "Bootstrap server (dynamic config) is not supported with IDC auth. Use static MDM profiles.",
+            )
+        )
 
     # Quota enforcement requires quota API endpoint
     if getattr(profile, "quota_enforcement_mode", "off") != "off":
         if not getattr(profile, "quota_api_endpoint", None):
-            errors.append(ValidationError(
-                "quota_api_endpoint",
-                f"Quota enforcement mode '{profile.quota_enforcement_mode}' requires quota_api_endpoint"
-            ))
+            errors.append(
+                ValidationError(
+                    "quota_api_endpoint",
+                    f"Quota enforcement mode '{profile.quota_enforcement_mode}' requires quota_api_endpoint",
+                )
+            )
 
     return errors

--- a/source/claude_code_with_bedrock/cli/validators.py
+++ b/source/claude_code_with_bedrock/cli/validators.py
@@ -4,7 +4,6 @@
 """Configuration validators run at package time to catch misconfigurations early."""
 
 from dataclasses import dataclass
-from typing import List
 
 
 @dataclass
@@ -14,7 +13,7 @@ class ValidationError:
     severity: str = "error"  # "error" or "warning"
 
 
-def validate_profile_for_packaging(profile) -> List[ValidationError]:
+def validate_profile_for_packaging(profile) -> list[ValidationError]:
     """Validate a profile is consistent and ready for packaging."""
     errors = []
 

--- a/source/tests/cli/test_validators.py
+++ b/source/tests/cli/test_validators.py
@@ -5,7 +5,7 @@
 
 from types import SimpleNamespace
 
-from claude_code_with_bedrock.cli.validators import ValidationError, validate_profile_for_packaging
+from claude_code_with_bedrock.cli.validators import validate_profile_for_packaging
 
 
 def _make_profile(**kwargs):

--- a/source/tests/cli/test_validators.py
+++ b/source/tests/cli/test_validators.py
@@ -1,0 +1,238 @@
+# ABOUTME: Unit tests for configuration validators (validators.py)
+# ABOUTME: Ensures packaging-time validation catches misconfigurations early
+
+"""Tests for the configuration validators."""
+
+from types import SimpleNamespace
+
+from claude_code_with_bedrock.cli.validators import ValidationError, validate_profile_for_packaging
+
+
+def _make_profile(**kwargs):
+    """Create a minimal profile-like object with sensible defaults."""
+    defaults = {
+        "effective_auth_type": "oidc",
+        "auth_type": "oidc",
+        "provider_domain": "test.okta.com",
+        "oidc_issuer_url": None,
+        "client_id": "test-client-id",
+        "aws_region": "us-east-1",
+        "allowed_bedrock_regions": None,
+        "monitoring_enabled": False,
+        "otel_collector_endpoint": None,
+        "cowork_config_mode": "static",
+        "quota_enforcement_mode": "off",
+        "quota_api_endpoint": None,
+        "idc_start_url": None,
+        "idc_account_id": None,
+        "idc_permission_set_name": None,
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+class TestValidateOIDCProfile:
+    """Tests for OIDC profile validation."""
+
+    def test_valid_oidc_profile_no_errors(self):
+        """A valid OIDC profile should produce no errors."""
+        profile = _make_profile()
+        errors = validate_profile_for_packaging(profile)
+        assert errors == []
+
+    def test_oidc_missing_client_id(self):
+        """OIDC without client_id should produce an error."""
+        profile = _make_profile(client_id=None)
+        errors = validate_profile_for_packaging(profile)
+        error_fields = [e.field for e in errors if e.severity == "error"]
+        assert "client_id" in error_fields
+
+    def test_oidc_missing_provider_domain_and_issuer_url(self):
+        """OIDC without provider_domain or oidc_issuer_url should produce an error."""
+        profile = _make_profile(provider_domain=None, oidc_issuer_url=None)
+        errors = validate_profile_for_packaging(profile)
+        error_fields = [e.field for e in errors if e.severity == "error"]
+        assert "provider_domain" in error_fields
+
+    def test_oidc_with_issuer_url_instead_of_domain(self):
+        """OIDC with oidc_issuer_url (no provider_domain) should be valid."""
+        profile = _make_profile(provider_domain=None, oidc_issuer_url="https://issuer.example.com")
+        errors = validate_profile_for_packaging(profile)
+        assert errors == []
+
+
+class TestValidateIDCProfile:
+    """Tests for IDC profile validation."""
+
+    def test_valid_idc_profile_no_errors(self):
+        """A valid IDC profile should produce no errors."""
+        profile = _make_profile(
+            effective_auth_type="idc",
+            auth_type="idc",
+            idc_start_url="https://d-12345.awsapps.com/start",
+            idc_account_id="123456789012",
+            idc_permission_set_name="AdministratorAccess",
+        )
+        errors = validate_profile_for_packaging(profile)
+        assert errors == []
+
+    def test_idc_missing_start_url(self):
+        """IDC without idc_start_url should produce an error."""
+        profile = _make_profile(
+            effective_auth_type="idc",
+            auth_type="idc",
+            idc_start_url=None,
+            idc_account_id="123456789012",
+            idc_permission_set_name="AdministratorAccess",
+        )
+        errors = validate_profile_for_packaging(profile)
+        error_fields = [e.field for e in errors if e.severity == "error"]
+        assert "idc_start_url" in error_fields
+
+    def test_idc_missing_account_id(self):
+        """IDC without idc_account_id should produce an error."""
+        profile = _make_profile(
+            effective_auth_type="idc",
+            auth_type="idc",
+            idc_start_url="https://d-12345.awsapps.com/start",
+            idc_account_id=None,
+            idc_permission_set_name="AdministratorAccess",
+        )
+        errors = validate_profile_for_packaging(profile)
+        error_fields = [e.field for e in errors if e.severity == "error"]
+        assert "idc_account_id" in error_fields
+
+    def test_idc_missing_permission_set(self):
+        """IDC without idc_permission_set_name should produce an error."""
+        profile = _make_profile(
+            effective_auth_type="idc",
+            auth_type="idc",
+            idc_start_url="https://d-12345.awsapps.com/start",
+            idc_account_id="123456789012",
+            idc_permission_set_name=None,
+        )
+        errors = validate_profile_for_packaging(profile)
+        error_fields = [e.field for e in errors if e.severity == "error"]
+        assert "idc_permission_set_name" in error_fields
+
+
+class TestValidateRegion:
+    """Tests for region validation."""
+
+    def test_missing_region(self):
+        """Missing aws_region should produce an error."""
+        profile = _make_profile(aws_region=None)
+        errors = validate_profile_for_packaging(profile)
+        error_fields = [e.field for e in errors if e.severity == "error"]
+        assert "aws_region" in error_fields
+
+    def test_region_not_in_allowed_list_is_warning(self):
+        """Region not in allowed_bedrock_regions should produce a warning (not error)."""
+        profile = _make_profile(
+            aws_region="eu-west-1",
+            allowed_bedrock_regions=["us-east-1", "us-west-2"],
+        )
+        errors = validate_profile_for_packaging(profile)
+        warnings = [e for e in errors if e.severity == "warning"]
+        error_only = [e for e in errors if e.severity == "error"]
+        assert len(warnings) == 1
+        assert warnings[0].field == "aws_region"
+        assert error_only == []
+
+
+class TestValidateMonitoring:
+    """Tests for monitoring configuration validation."""
+
+    def test_monitoring_enabled_no_endpoint_static_is_warning(self):
+        """Monitoring enabled + no endpoint + static config mode should produce a warning."""
+        profile = _make_profile(
+            monitoring_enabled=True,
+            otel_collector_endpoint=None,
+            cowork_config_mode="static",
+        )
+        errors = validate_profile_for_packaging(profile)
+        warnings = [e for e in errors if e.severity == "warning"]
+        assert any(e.field == "otel_collector_endpoint" for e in warnings)
+
+    def test_monitoring_enabled_no_endpoint_dynamic_no_warning(self):
+        """Monitoring enabled + no endpoint + dynamic config mode should NOT produce a warning."""
+        profile = _make_profile(
+            monitoring_enabled=True,
+            otel_collector_endpoint=None,
+            cowork_config_mode="dynamic",
+        )
+        errors = validate_profile_for_packaging(profile)
+        otel_issues = [e for e in errors if e.field == "otel_collector_endpoint"]
+        assert otel_issues == []
+
+    def test_monitoring_enabled_with_endpoint_no_warning(self):
+        """Monitoring enabled with endpoint should produce no monitoring warning."""
+        profile = _make_profile(
+            monitoring_enabled=True,
+            otel_collector_endpoint="http://localhost:4318",
+            cowork_config_mode="static",
+        )
+        errors = validate_profile_for_packaging(profile)
+        otel_issues = [e for e in errors if e.field == "otel_collector_endpoint"]
+        assert otel_issues == []
+
+
+class TestValidateBootstrapIDCConflict:
+    """Tests for bootstrap server + IDC conflict."""
+
+    def test_dynamic_config_with_idc_is_error(self):
+        """Dynamic config mode + IDC auth should produce an error."""
+        profile = _make_profile(
+            effective_auth_type="idc",
+            auth_type="idc",
+            cowork_config_mode="dynamic",
+            idc_start_url="https://d-12345.awsapps.com/start",
+            idc_account_id="123456789012",
+            idc_permission_set_name="AdministratorAccess",
+        )
+        errors = validate_profile_for_packaging(profile)
+        error_fields = [e.field for e in errors if e.severity == "error"]
+        assert "cowork_config_mode" in error_fields
+
+    def test_dynamic_config_with_oidc_no_error(self):
+        """Dynamic config mode + OIDC auth should NOT produce this error."""
+        profile = _make_profile(
+            cowork_config_mode="dynamic",
+        )
+        errors = validate_profile_for_packaging(profile)
+        config_issues = [e for e in errors if e.field == "cowork_config_mode"]
+        assert config_issues == []
+
+
+class TestValidateQuotaEnforcement:
+    """Tests for quota enforcement validation."""
+
+    def test_quota_enforcement_without_endpoint_is_error(self):
+        """Quota enforcement enabled without quota_api_endpoint should produce an error."""
+        profile = _make_profile(
+            quota_enforcement_mode="strict",
+            quota_api_endpoint=None,
+        )
+        errors = validate_profile_for_packaging(profile)
+        error_fields = [e.field for e in errors if e.severity == "error"]
+        assert "quota_api_endpoint" in error_fields
+
+    def test_quota_enforcement_with_endpoint_no_error(self):
+        """Quota enforcement enabled with endpoint should produce no error."""
+        profile = _make_profile(
+            quota_enforcement_mode="strict",
+            quota_api_endpoint="https://quota.example.com/api",
+        )
+        errors = validate_profile_for_packaging(profile)
+        quota_issues = [e for e in errors if e.field == "quota_api_endpoint"]
+        assert quota_issues == []
+
+    def test_quota_enforcement_off_no_error(self):
+        """Quota enforcement off should produce no quota-related error."""
+        profile = _make_profile(
+            quota_enforcement_mode="off",
+            quota_api_endpoint=None,
+        )
+        errors = validate_profile_for_packaging(profile)
+        quota_issues = [e for e in errors if e.field == "quota_api_endpoint"]
+        assert quota_issues == []


### PR DESCRIPTION
## Summary

Adds validation at `ccwb package` time to catch misconfigurations before they reach user machines.

### Issues this would have caught
- #596 — Cognito region mismatch (region not in allowed_bedrock_regions → warning)
- #592 — AWS CLI dependency + incorrect success output (missing required fields flagged)
- #606 — Quota "block" mode silent failure (enforcement mode without endpoint → error)
- #541 — CoWork telemetry never reaches dashboard (monitoring enabled, no endpoint → warning)
- #555 — Deploy fails on cowork-dashboard (config inconsistency caught early)
- #520 — Windows "no binaries built" (profile misconfiguration detected before build)

### Validations
- IDC: requires `idc_start_url`, `idc_account_id`, `idc_permission_set_name`
- OIDC: requires `provider_domain` or `oidc_issuer_url` + `client_id`
- Region: `aws_region` required, warns if not in `allowed_bedrock_regions`
- Monitoring: warns if enabled without endpoint (and not using bootstrap server)
- Bootstrap + IDC conflict: errors if `cowork_config_mode=dynamic` with IDC
- Quota: errors if enforcement enabled without endpoint

### Changes
- `source/claude_code_with_bedrock/cli/validators.py` — new validation module (79 lines)
- `source/claude_code_with_bedrock/cli/commands/package.py` — integration + `--skip-validation` flag
- `source/tests/cli/test_validators.py` — 18 tests

### Risk: NONE
- Validation is additive, runs before existing logic
- `--skip-validation` escape hatch for edge cases
- Existing valid profiles continue to pass (validators only flag genuinely invalid states)
- 21/21 tests pass (18 new + 3 existing package tests)