### PR TITLE
feat: add ccwb doctor command for installation health checks

### DIFF
--- a/.claude/rules/cli-command-pattern.md
+++ b/.claude/rules/cli-command-pattern.md
@@ -1,0 +1,12 @@
+---
+description: When creating a new CLI command, follow the standard registration pattern
+---
+- New commands go in `source/claude_code_with_bedrock/cli/commands/<name>.py`
+- Subclass `cleo.commands.command.Command` with `name`, `description`, and `help` class attributes
+- Register in `cli/commands/__init__.py` (import + add to `__all__`)
+- Register in `cli/__init__.py` `create_application()` (add to command list)
+- Add entry to `assets/docs/CLI_REFERENCE.md` (section + Table of Contents)
+- Add row to README components table if user-facing
+- Use `rich` for formatted output (already a dependency)
+- Include `# ABOUTME:` comments at file top explaining purpose
+- Add tests in `source/tests/cli/commands/test_<name>.py`

--- a/.claude/rules/doctor-checks.md
+++ b/.claude/rules/doctor-checks.md
@@ -1,0 +1,9 @@
+---
+description: When adding new config fields or install artifacts, update ccwb doctor
+---
+- When adding a new binary to the install directory (e.g., otel-helper, otelcol), add a corresponding health check in `commands/doctor.py`
+- When adding new config.json fields that affect runtime behavior, consider whether `doctor` should validate their presence
+- When adding new settings.json keys, update the settings check to verify them
+- Doctor checks must be graceful: missing optional components → SKIP or WARN, not FAIL
+- Only FAIL for conditions that will definitely break the user experience
+- Keep checks local (no network calls) — doctor runs on user machines without connectivity guarantees

--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ See [QUICK_START.md](QUICK_START.md#platform-builds) for build configuration.
 
 - [Quick Start Guide](QUICK_START.md) - Step-by-step deployment walkthrough
 - [CLI Reference](assets/docs/CLI_REFERENCE.md) - Complete command reference for the `ccwb` tool
+- [Troubleshooting](assets/docs/TROUBLESHOOTING.md) - Common issues, `ccwb doctor`, and how to file bugs
 - [Workshop: Claude Code on Amazon Bedrock](https://catalog.workshops.aws/claude-code-on-amazon-bedrock/en-US) - Companion hands-on workshop
 - [Claude Code deployment patterns and best practices with Amazon Bedrock](https://aws.amazon.com/blogs/machine-learning/claude-code-deployment-patterns-and-best-practices-with-amazon-bedrock/) - Blog post covering deployment patterns and best practices
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The architecture is modular — start with authentication, then optionally add [
 | **Quota enforcement** (optional) | Quota check API + DynamoDB policies + per-user/team limits | `ccwb deploy --stack quota` |
 | **Analytics** (optional) | S3 data lake + Athena for historical SQL queries on usage data | `ccwb deploy --stack analytics` |
 | **Distribution** (optional) | S3 presigned URLs or self-service landing page with IdP auth | `ccwb deploy --stack distribution` |
+| **Health check** | Validate installation on user machines (binaries, config, settings) | `ccwb doctor` |
 
 See [Monitoring Guide](assets/docs/MONITORING.md), [Quota Guide](assets/docs/QUOTA_MONITORING.md), [Analytics Guide](assets/docs/ANALYTICS.md), and [Distribution Comparison](assets/docs/distribution/comparison.md) for detailed setup.
 ### Authentication Modes

--- a/assets/docs/CLI_REFERENCE.md
+++ b/assets/docs/CLI_REFERENCE.md
@@ -17,6 +17,7 @@ This document provides a complete reference for all `ccwb` (Claude Code with Bed
     - [`distribute` - Create Distribution URLs](#distribute---create-distribution-urls)
     - [`status` - Check Deployment Status](#status---check-deployment-status)
     - [`cleanup` - Remove Installed Components](#cleanup---remove-installed-components)
+    - [`doctor` - Validate Installation Health](#doctor---validate-installation-health)
   - [Quota Management](#quota-management)
     - [`quota set-user` - Set User Quota](#quota-set-user---set-user-quota)
     - [`quota set-group` - Set Group Quota](#quota-set-group---set-group-quota)
@@ -621,6 +622,35 @@ poetry run ccwb cleanup [options]
 - Clean up after testing
 - Remove failed installations
 - Start fresh with a new configuration
+
+### `doctor` - Validate Installation Health
+
+Runs post-installation health checks on the user's machine and reports PASS/FAIL per check.
+
+```bash
+poetry run ccwb doctor [options]
+```
+
+**Options:**
+
+- `--profile <name>` - Configuration profile to check
+
+**Checks performed:**
+
+| Check | What it validates |
+|-------|-------------------|
+| `credential-process` | Binary exists in install dir |
+| `config.json` | Present, valid JSON, lists profiles |
+| `aws-profile` | `~/.aws/config` references credential-process |
+| `settings.json` | Claude Code settings file exists with env/hooks |
+| `credential-test` | Credential helper responds (graceful timeout) |
+| `otel-helper` | Telemetry binary exists (only FAIL if monitoring configured) |
+
+**Use this to:**
+
+- Validate installation after running the installer
+- Diagnose "telemetry not working" or "auth failing" issues
+- Verify all components are present before contacting support
 
 ## Claude Cowork 3P
 

--- a/assets/docs/TROUBLESHOOTING.md
+++ b/assets/docs/TROUBLESHOOTING.md
@@ -1,18 +1,20 @@
 # Troubleshooting
 
-## Step 1: Run `ccwb doctor`
+Debugging issues remotely is hard — we often can't reproduce problems because we don't know the user's auth type, monitoring mode, OS, or which hooks are configured. `ccwb doctor` solves this by collecting the full environment picture in one command.
+
+## Run `ccwb doctor`
 
 ```bash
 poetry run ccwb doctor           # Quick health check
-poetry run ccwb doctor --verbose # Detailed config dump for support
-poetry run ccwb doctor --json    # Machine-readable output
+poetry run ccwb doctor --verbose # Full config dump (what support needs)
+poetry run ccwb doctor --json    # Machine-readable (pipe to Claude or scripts)
 ```
 
-If checks fail, the command prints a pre-filled GitHub issue URL — just click and submit.
+On failure, the command prints a pre-filled GitHub issue URL with auto-detected OS, auth type, monitoring mode, and all check results. Click the link and submit — no manual environment description needed.
 
 ## Debug Logging
 
-For credential-process issues, enable debug output:
+For credential or auth issues that need deeper investigation:
 
 ```bash
 # Claude Code debug logs
@@ -21,14 +23,6 @@ CLAUDE_CODE_DEBUG_LOGS_DIR=~/.claude/debug claude --debug
 # Direct credential-process test
 ~/claude-code-with-bedrock/credential-process --profile ClaudeCode --debug
 ```
-
-## Filing a Bug
-
-Run `ccwb doctor` — on failure it generates a pre-filled GitHub issue URL with:
-- All check results
-- OS, Python, auth type, monitoring mode (auto-detected)
-
-Click the link, add any extra context, submit. That's it.
 
 ## Getting Help
 

--- a/assets/docs/TROUBLESHOOTING.md
+++ b/assets/docs/TROUBLESHOOTING.md
@@ -4,22 +4,11 @@
 
 ```bash
 poetry run ccwb doctor           # Quick health check
-poetry run ccwb doctor --verbose # Detailed config dump
+poetry run ccwb doctor --verbose # Detailed config dump for support
 poetry run ccwb doctor --json    # Machine-readable output
 ```
 
 If checks fail, the command prints a pre-filled GitHub issue URL — just click and submit.
-
-## Common Issues
-
-| Symptom | Cause | Fix |
-|---------|-------|-----|
-| CloudWatch metrics stuck at 0 | otel-helper not installed or not spawning | Re-run `ccwb package` with Go installed, then re-install |
-| "Cloud authentication" error in Claude Code | Credential refresh expired (IDC) or browser auth failed (OIDC) | Run `credential-process --profile <name>` manually to re-authenticate |
-| Telemetry never reaches dashboard | `otel_collector_endpoint` missing from config | Run `ccwb deploy --stack monitoring` then re-package |
-| `ccwb package` reports "no binaries built" | Go not installed or wrong version | Install Go 1.24+ and re-run |
-| Windows Defender blocks binaries | Unsigned Go executables trigger heuristic detection | Add install directory to exclusions (see [#649](https://github.com/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock/issues/649)) |
-| Region mismatch deployment failure | `aws_region` differs from Cognito/IdP region | Re-run `ccwb init` and verify region selection |
 
 ## Debug Logging
 

--- a/assets/docs/TROUBLESHOOTING.md
+++ b/assets/docs/TROUBLESHOOTING.md
@@ -1,0 +1,48 @@
+# Troubleshooting
+
+## Step 1: Run `ccwb doctor`
+
+```bash
+poetry run ccwb doctor           # Quick health check
+poetry run ccwb doctor --verbose # Detailed config dump
+poetry run ccwb doctor --json    # Machine-readable output
+```
+
+If checks fail, the command prints a pre-filled GitHub issue URL — just click and submit.
+
+## Common Issues
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| CloudWatch metrics stuck at 0 | otel-helper not installed or not spawning | Re-run `ccwb package` with Go installed, then re-install |
+| "Cloud authentication" error in Claude Code | Credential refresh expired (IDC) or browser auth failed (OIDC) | Run `credential-process --profile <name>` manually to re-authenticate |
+| Telemetry never reaches dashboard | `otel_collector_endpoint` missing from config | Run `ccwb deploy --stack monitoring` then re-package |
+| `ccwb package` reports "no binaries built" | Go not installed or wrong version | Install Go 1.24+ and re-run |
+| Windows Defender blocks binaries | Unsigned Go executables trigger heuristic detection | Add install directory to exclusions (see [#649](https://github.com/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock/issues/649)) |
+| Region mismatch deployment failure | `aws_region` differs from Cognito/IdP region | Re-run `ccwb init` and verify region selection |
+
+## Debug Logging
+
+For credential-process issues, enable debug output:
+
+```bash
+# Claude Code debug logs
+CLAUDE_CODE_DEBUG_LOGS_DIR=~/.claude/debug claude --debug
+
+# Direct credential-process test
+~/claude-code-with-bedrock/credential-process --profile ClaudeCode --debug
+```
+
+## Filing a Bug
+
+Run `ccwb doctor` — on failure it generates a pre-filled GitHub issue URL with:
+- All check results
+- OS, Python, auth type, monitoring mode (auto-detected)
+
+Click the link, add any extra context, submit. That's it.
+
+## Getting Help
+
+- [CLI Reference](CLI_REFERENCE.md) — full command documentation
+- [GitHub Issues](https://github.com/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock/issues) — search existing issues
+- [Monitoring Guide](MONITORING.md) — telemetry setup and dashboards

--- a/source/claude_code_with_bedrock/cli/__init__.py
+++ b/source/claude_code_with_bedrock/cli/__init__.py
@@ -22,6 +22,7 @@ from .commands.cowork import CoworkGenerateCommand
 from .commands.deploy import DeployCommand
 from .commands.destroy import DestroyCommand
 from .commands.distribute import DistributeCommand
+from .commands.doctor import DoctorCommand
 from .commands.init import InitCommand
 from .commands.package import PackageCommand
 from .commands.package_cb import PackageCbCommand
@@ -61,6 +62,7 @@ def create_application() -> Application:
     application.add(DestroyCommand())
     application.add(CleanupCommand())
     application.add(CoworkGenerateCommand())
+    application.add(DoctorCommand())
     # application.add(TokenCommand())  # Temporarily disabled
 
     # Context management commands

--- a/source/claude_code_with_bedrock/cli/commands/__init__.py
+++ b/source/claude_code_with_bedrock/cli/commands/__init__.py
@@ -7,6 +7,7 @@ from .builds import BuildsCommand
 from .cowork import CoworkGenerateCommand
 from .deploy import DeployCommand
 from .destroy import DestroyCommand
+from .doctor import DoctorCommand
 from .init import InitCommand
 from .package import PackageCommand
 from .quota import QuotaCommand
@@ -22,5 +23,6 @@ __all__ = [
     "BuildsCommand",
     "DestroyCommand",
     "CoworkGenerateCommand",
+    "DoctorCommand",
     "QuotaCommand",
 ]

--- a/source/claude_code_with_bedrock/cli/commands/doctor.py
+++ b/source/claude_code_with_bedrock/cli/commands/doctor.py
@@ -225,7 +225,28 @@ def print_results(checks: list, console: Console = None):
         issue_body += "| Check | Status | Details |\n|-------|--------|---------|\n"
         for c in checks:
             issue_body += f"| {c.name} | {c.status.upper()} | {c.message} |\n"
-        issue_body += "\n## Environment\n- OS: \n- Python: \n- ccwb version: \n"
+        # Auto-detect environment for easier diagnosis
+        import platform
+        issue_body += "\n## Environment\n"
+        issue_body += f"- **OS:** {platform.system()} {platform.release()} ({platform.machine()})\n"
+        issue_body += f"- **Python:** {platform.python_version()}\n"
+        # Read auth type and monitoring mode from config.json
+        _home = Path.home()
+        _config_path = _home / "claude-code-with-bedrock" / "config.json"
+        _auth_type = "unknown"
+        _monitoring_mode = "none"
+        if _config_path.exists():
+            try:
+                with open(_config_path) as _cf:
+                    _cfg = json.load(_cf)
+                _profiles = _cfg.get("profiles", _cfg)
+                _first = next((v for k, v in _profiles.items() if isinstance(v, dict)), {})
+                _auth_type = _first.get("auth_type", "oidc")
+                _monitoring_mode = _first.get("monitoring_mode", "none")
+            except Exception:
+                pass
+        issue_body += f"- **Auth type:** {_auth_type}\n"
+        issue_body += f"- **Monitoring mode:** {_monitoring_mode}\n"
         import urllib.parse
         params = urllib.parse.urlencode({
             "title": f"ccwb doctor: {', '.join(c.name for c in failed_checks)} failed",

--- a/source/claude_code_with_bedrock/cli/commands/doctor.py
+++ b/source/claude_code_with_bedrock/cli/commands/doctor.py
@@ -259,6 +259,101 @@ def print_results(checks: list, console: Console = None):
         return 1
 
 
+def _collect_environment():
+    """Collect environment info for diagnostics."""
+    import platform
+    home = Path.home()
+    config_path = home / "claude-code-with-bedrock" / "config.json"
+    env = {
+        "os": f"{platform.system()} {platform.release()} ({platform.machine()})",
+        "python": platform.python_version(),
+        "auth_type": "unknown",
+        "monitoring_mode": "none",
+        "profiles": [],
+        "region": "unknown",
+    }
+    if config_path.exists():
+        try:
+            with open(config_path) as f:
+                cfg = json.load(f)
+            profiles = cfg.get("profiles", cfg)
+            for name, data in profiles.items():
+                if not isinstance(data, dict):
+                    continue
+                env["profiles"].append(name)
+                env["auth_type"] = data.get("auth_type", "oidc")
+                env["monitoring_mode"] = data.get("monitoring_mode", "none")
+                env["region"] = data.get("aws_region", "unknown")
+        except Exception:
+            pass
+    return env
+
+
+def print_verbose_config(console: Console):
+    """Print sanitized configuration details for troubleshooting."""
+    console.print("\n[bold]Configuration Details[/bold] (--verbose)\n")
+    home = Path.home()
+    config_path = home / "claude-code-with-bedrock" / "config.json"
+
+    if not config_path.exists():
+        console.print("[dim]No config.json found — skipping verbose output[/dim]")
+        return
+
+    try:
+        with open(config_path) as f:
+            cfg = json.load(f)
+    except Exception as e:
+        console.print(f"[red]Cannot read config.json: {e}[/red]")
+        return
+
+    profiles = cfg.get("profiles", cfg)
+    for name, data in profiles.items():
+        if not isinstance(data, dict):
+            continue
+        console.print(f"[cyan]Profile: {name}[/cyan]")
+        console.print(f"  Auth type: {data.get('auth_type', 'oidc')}")
+        console.print(f"  Region: {data.get('aws_region', 'not set')}")
+        console.print(f"  Provider: {data.get('provider_type', data.get('provider_domain', 'not set'))}")
+        if data.get("auth_type") == "idc":
+            console.print(f"  IDC Start URL: {data.get('idc_start_url', 'not set')}")
+            console.print(f"  IDC Account: {data.get('idc_account_id', 'not set')}")
+            console.print(f"  IDC Permission Set: {data.get('idc_permission_set_name', 'not set')}")
+        else:
+            domain = data.get("provider_domain", data.get("oidc_issuer_url", "not set"))
+            console.print(f"  Provider domain: {domain}")
+            console.print(f"  Client ID: {data.get('client_id', 'not set')[:8]}..." if data.get('client_id') else "  Client ID: not set")
+        if data.get("monitoring_mode"):
+            console.print(f"  Monitoring: {data.get('monitoring_mode')}")
+        if data.get("otel_collector_endpoint"):
+            console.print(f"  OTEL endpoint: {data.get('otel_collector_endpoint')}")
+        if data.get("quota_api_endpoint"):
+            console.print(f"  Quota API: {data.get('quota_api_endpoint')}")
+        console.print()
+
+    # Check settings.json hooks
+    for settings_name in ["settings.json", "managed-settings.json"]:
+        settings_path = home / ".claude" / settings_name
+        if settings_path.exists():
+            try:
+                settings = json.loads(settings_path.read_text())
+                console.print(f"[cyan]{settings_name}[/cyan]")
+                env = settings.get("env", {})
+                if env.get("AWS_PROFILE"):
+                    console.print(f"  AWS_PROFILE: {env['AWS_PROFILE']}")
+                hooks = settings.get("hooks", {})
+                for hook_name in ["awsCredentialExport", "awsAuthRefresh", "otelHeadersHelper"]:
+                    val = hooks.get(hook_name)
+                    if val:
+                        # Show just the command basename for readability
+                        cmd = val if isinstance(val, str) else str(val)
+                        console.print(f"  {hook_name}: [green]✓[/green] {cmd[:60]}")
+                    else:
+                        console.print(f"  {hook_name}: [dim]not set[/dim]")
+                console.print()
+            except Exception:
+                pass
+
+
 class DoctorCommand(Command):
     name = "doctor"
     description = "Validate installation health and catch common misconfigurations"
@@ -276,10 +371,25 @@ To check a specific profile:
 
     options = [
         option("profile", description="Configuration profile to check", flag=False),
+        option("verbose", "v", description="Show detailed configuration for troubleshooting"),
+        option("json", description="Output results as JSON (for automation)"),
     ]
 
     def handle(self) -> int:
         """Execute the doctor command."""
         console = Console()
         checks = run_doctor()
-        return print_results(checks, console)
+        exit_code = print_results(checks, console)
+
+        if self.option("verbose"):
+            print_verbose_config(console)
+
+        if self.option("json"):
+            import json as json_mod
+            output = {
+                "checks": [{"name": c.name, "status": c.status, "message": c.message, "fix": c.fix} for c in checks],
+                "environment": _collect_environment(),
+            }
+            console.print_json(json_mod.dumps(output))
+
+        return exit_code

--- a/source/claude_code_with_bedrock/cli/commands/doctor.py
+++ b/source/claude_code_with_bedrock/cli/commands/doctor.py
@@ -219,6 +219,22 @@ def print_results(checks: list, console: Console = None):
         return 0
     else:
         console.print(f"[red]✗ {fails} check(s) failed[/red] ({passes} pass, {warns} warnings)")
+        # Generate pre-filled GitHub issue URL to reduce filing burden
+        failed_checks = [c for c in checks if c.status == "fail"]
+        issue_body = "## ccwb doctor output\n\n"
+        issue_body += "| Check | Status | Details |\n|-------|--------|---------|\n"
+        for c in checks:
+            issue_body += f"| {c.name} | {c.status.upper()} | {c.message} |\n"
+        issue_body += "\n## Environment\n- OS: \n- Python: \n- ccwb version: \n"
+        import urllib.parse
+        params = urllib.parse.urlencode({
+            "title": f"ccwb doctor: {', '.join(c.name for c in failed_checks)} failed",
+            "body": issue_body,
+            "labels": "bug",
+        })
+        issue_url = f"https://github.com/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock/issues/new?{params}"
+        console.print(f"\n[dim]Report this issue (pre-filled):[/dim]")
+        console.print(f"  {issue_url}")
         return 1
 
 

--- a/source/claude_code_with_bedrock/cli/commands/doctor.py
+++ b/source/claude_code_with_bedrock/cli/commands/doctor.py
@@ -1,0 +1,237 @@
+# ABOUTME: Doctor command to validate installation health and catch common misconfigurations
+# ABOUTME: Checks credential-process binary, config, AWS profile, settings, and telemetry helper
+
+"""Doctor command — validate installation health and catch common misconfigurations."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from cleo.commands.command import Command
+from cleo.helpers import option
+from rich.console import Console
+from rich.table import Table
+
+
+class HealthCheck:
+    """A single health check with name, runner, and result."""
+
+    def __init__(self, name: str, description: str):
+        self.name = name
+        self.description = description
+        self.status = "skipped"  # pass, fail, warn, skipped
+        self.message = ""
+        self.fix = ""
+
+    def pass_(self, msg=""):
+        self.status = "pass"
+        self.message = msg
+
+    def fail(self, msg, fix=""):
+        self.status = "fail"
+        self.message = msg
+        self.fix = fix
+
+    def warn(self, msg, fix=""):
+        self.status = "warn"
+        self.message = msg
+        self.fix = fix
+
+
+def run_doctor(home: Path = None):
+    """Run all health checks and return list of HealthCheck results."""
+    checks = []
+
+    if home is None:
+        home = Path.home()
+    install_dir = home / "claude-code-with-bedrock"
+
+    # 1. Binary presence
+    check = HealthCheck("credential-process", "Credential helper binary exists")
+    binary_name = "credential-process.exe" if sys.platform == "win32" else "credential-process"
+    binary_path = install_dir / binary_name
+    if binary_path.exists():
+        check.pass_(str(binary_path))
+    else:
+        check.fail(f"Not found at {binary_path}", "Run 'ccwb package' and execute the installer")
+    checks.append(check)
+
+    # 2. Config.json
+    check = HealthCheck("config.json", "Configuration file present and valid")
+    config_path = install_dir / "config.json"
+    config_data = None
+    if config_path.exists():
+        try:
+            with open(config_path) as f:
+                config_data = json.load(f)
+            profiles = list(config_data.get("profiles", config_data).keys())
+            profiles = [p for p in profiles if p != "profiles"]
+            check.pass_(f"Profiles: {', '.join(profiles[:5])}")
+        except json.JSONDecodeError as e:
+            check.fail(f"Invalid JSON: {e}", "Re-run the installer or re-package")
+    else:
+        check.fail(f"Not found at {config_path}", "Run the installer from 'ccwb package' output")
+    checks.append(check)
+
+    # 3. AWS config profile
+    check = HealthCheck("aws-profile", "AWS config references credential-process")
+    aws_config = home / ".aws" / "config"
+    if aws_config.exists():
+        content = aws_config.read_text()
+        if "credential_process" in content and "claude-code-with-bedrock" in content:
+            check.pass_("credential_process configured in ~/.aws/config")
+        else:
+            check.warn(
+                "~/.aws/config exists but no credential_process entry found",
+                "Re-run the installer or manually add credential_process to your AWS profile",
+            )
+    else:
+        check.fail("~/.aws/config not found", "Run the installer")
+    checks.append(check)
+
+    # 4. Settings.json
+    check = HealthCheck("settings.json", "Claude Code settings configured")
+    settings_paths = [
+        home / ".claude" / "settings.json",
+        home / ".claude" / "managed-settings.json",
+    ]
+    found_settings = None
+    for sp in settings_paths:
+        if sp.exists():
+            found_settings = sp
+            break
+    if found_settings:
+        try:
+            settings = json.loads(found_settings.read_text())
+            has_env = "env" in settings
+            has_hooks = "hooks" in settings
+            check.pass_(f"{found_settings.name} (env={'✓' if has_env else '✗'}, hooks={'✓' if has_hooks else '✗'})")
+        except Exception as e:
+            check.fail(f"Cannot parse {found_settings}: {e}")
+    else:
+        check.fail("No settings.json or managed-settings.json in ~/.claude/", "Run the installer")
+    checks.append(check)
+
+    # 5. Credential test (non-blocking — just tries to invoke credential-process)
+    check = HealthCheck("credential-test", "Credential helper responds")
+    if binary_path.exists() and config_data:
+        # Find first profile name
+        if "profiles" in config_data:
+            first_profile = next(iter(config_data["profiles"]), None)
+        else:
+            first_profile = next((k for k in config_data if k != "profiles"), None)
+
+        if first_profile:
+            try:
+                result = subprocess.run(
+                    [str(binary_path), "--profile", first_profile, "--health-check"],
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+                if result.returncode == 0:
+                    check.pass_(f"Profile '{first_profile}' responds")
+                else:
+                    check.warn(
+                        f"credential-process exited {result.returncode} (may need auth)",
+                        "Run credential-process manually to authenticate",
+                    )
+            except subprocess.TimeoutExpired:
+                check.warn("credential-process timed out (may need interactive auth)")
+            except Exception as e:
+                check.fail(f"Cannot execute: {e}")
+        else:
+            check.warn("No profiles found in config.json")
+    else:
+        check.status = "skipped"
+        check.message = "Binary or config not available"
+    checks.append(check)
+
+    # 6. OTEL helper
+    check = HealthCheck("otel-helper", "Telemetry helper binary exists")
+    otel_name = "otel-helper.exe" if sys.platform == "win32" else "otel-helper"
+    otel_path = install_dir / otel_name
+    if otel_path.exists():
+        check.pass_(str(otel_path))
+    elif config_data:
+        # Check if monitoring is even configured
+        profiles_data = config_data.get("profiles", config_data)
+        any_monitoring = any(
+            "otel_collector_endpoint" in (profiles_data.get(p, {}) if isinstance(profiles_data.get(p), dict) else {})
+            for p in profiles_data
+            if p != "profiles"
+        )
+        if any_monitoring:
+            check.fail(
+                f"Monitoring configured but {otel_name} not found",
+                "Re-run 'ccwb package' with Go installed, then re-install",
+            )
+        else:
+            check.status = "skipped"
+            check.message = "Monitoring not configured"
+    else:
+        check.status = "skipped"
+        check.message = "Config not available"
+    checks.append(check)
+
+    return checks
+
+
+def print_results(checks: list, console: Console = None):
+    """Print health check results as a rich table. Returns exit code (0=ok, 1=failures)."""
+    if console is None:
+        console = Console()
+
+    console.print("\n[bold]ccwb doctor[/bold] — Installation Health Check\n")
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Check", style="cyan")
+    table.add_column("Status", width=6)
+    table.add_column("Details")
+
+    for c in checks:
+        if c.status == "pass":
+            status = "[green]PASS[/green]"
+        elif c.status == "fail":
+            status = "[red]FAIL[/red]"
+        elif c.status == "warn":
+            status = "[yellow]WARN[/yellow]"
+        else:
+            status = "[dim]SKIP[/dim]"
+
+        details = c.message
+        if c.fix:
+            details += f"\n[dim]  Fix: {c.fix}[/dim]"
+
+        table.add_row(c.name, status, details)
+
+    console.print(table)
+
+    # Summary
+    fails = sum(1 for c in checks if c.status == "fail")
+    warns = sum(1 for c in checks if c.status == "warn")
+    passes = sum(1 for c in checks if c.status == "pass")
+
+    console.print()
+    if fails == 0:
+        console.print(f"[green]✓ All checks passed[/green] ({passes} pass, {warns} warnings)")
+        return 0
+    else:
+        console.print(f"[red]✗ {fails} check(s) failed[/red] ({passes} pass, {warns} warnings)")
+        return 1
+
+
+class DoctorCommand(Command):
+    name = "doctor"
+    description = "Validate installation health and catch common misconfigurations"
+
+    options = [
+        option("profile", description="Configuration profile to check", flag=False),
+    ]
+
+    def handle(self) -> int:
+        """Execute the doctor command."""
+        console = Console()
+        checks = run_doctor()
+        return print_results(checks, console)

--- a/source/claude_code_with_bedrock/cli/commands/doctor.py
+++ b/source/claude_code_with_bedrock/cli/commands/doctor.py
@@ -225,6 +225,17 @@ def print_results(checks: list, console: Console = None):
 class DoctorCommand(Command):
     name = "doctor"
     description = "Validate installation health and catch common misconfigurations"
+    help = """Run post-installation health checks on the local machine.
+
+Checks credential-process binary, config.json, AWS profile, Claude Code
+settings, credential helper responsiveness, and otel-helper presence.
+
+Use after running the installer to verify everything is working:
+  <info>poetry run ccwb doctor</info>
+
+To check a specific profile:
+  <info>poetry run ccwb doctor --profile MyProfile</info>
+"""
 
     options = [
         option("profile", description="Configuration profile to check", flag=False),

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -786,6 +786,8 @@ class PackageCommand(Command):
             console.print("\n[yellow]⚠ Package generated without binaries. Fix the build issue and re-run.[/yellow]")
             return 1
 
+        console.print("After installation, validate with: [cyan]poetry run ccwb doctor[/cyan]")
+
         return 0
 
     def _check_build_status(self, build_id: str, console: Console) -> int:

--- a/source/tests/cli/commands/test_doctor.py
+++ b/source/tests/cli/commands/test_doctor.py
@@ -1,0 +1,153 @@
+# ABOUTME: Unit tests for the doctor command
+# ABOUTME: Tests health check logic with mocked install directories
+
+"""Tests for the doctor command."""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+from claude_code_with_bedrock.cli.commands.doctor import run_doctor
+
+
+class TestDoctorAllPass:
+    """Test that all checks pass with a fully mocked install directory."""
+
+    def test_all_checks_pass(self, tmp_path):
+        """All checks pass when all files and binaries are present."""
+        home = tmp_path
+
+        # Create install directory with binary and config
+        install_dir = home / "claude-code-with-bedrock"
+        install_dir.mkdir()
+
+        binary_name = "credential-process.exe" if sys.platform == "win32" else "credential-process"
+        binary_path = install_dir / binary_name
+        binary_path.touch()
+        binary_path.chmod(0o755)
+
+        # Config with a profile
+        config = {"profiles": {"default": {"provider_domain": "example.okta.com", "client_id": "abc123"}}}
+        (install_dir / "config.json").write_text(json.dumps(config))
+
+        # AWS config
+        aws_dir = home / ".aws"
+        aws_dir.mkdir()
+        (aws_dir / "config").write_text(
+            "[profile ClaudeCode]\n"
+            "credential_process = /home/user/claude-code-with-bedrock/credential-process --profile default\n"
+        )
+
+        # Claude settings
+        claude_dir = home / ".claude"
+        claude_dir.mkdir()
+        settings = {"env": {"AWS_PROFILE": "ClaudeCode"}, "hooks": {"preToolUse": []}}
+        (claude_dir / "settings.json").write_text(json.dumps(settings))
+
+        # Mock subprocess for credential-test
+        with patch("claude_code_with_bedrock.cli.commands.doctor.subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            checks = run_doctor(home=home)
+
+        statuses = {c.name: c.status for c in checks}
+        assert statuses["credential-process"] == "pass"
+        assert statuses["config.json"] == "pass"
+        assert statuses["aws-profile"] == "pass"
+        assert statuses["settings.json"] == "pass"
+        assert statuses["credential-test"] == "pass"
+        assert statuses["otel-helper"] == "skipped"  # Monitoring not configured
+
+
+class TestDoctorMissingBinary:
+    """Test that missing binary results in FAIL."""
+
+    def test_missing_binary_fails(self, tmp_path):
+        """Missing credential-process binary → FAIL."""
+        home = tmp_path
+
+        # Create install dir without the binary
+        install_dir = home / "claude-code-with-bedrock"
+        install_dir.mkdir()
+
+        checks = run_doctor(home=home)
+
+        statuses = {c.name: c.status for c in checks}
+        assert statuses["credential-process"] == "fail"
+        assert "Not found" in next(c.message for c in checks if c.name == "credential-process")
+
+
+class TestDoctorInvalidConfig:
+    """Test that invalid config.json results in FAIL."""
+
+    def test_invalid_config_json_fails(self, tmp_path):
+        """Malformed config.json → FAIL."""
+        home = tmp_path
+
+        install_dir = home / "claude-code-with-bedrock"
+        install_dir.mkdir()
+
+        # Create binary so that check passes
+        binary_name = "credential-process.exe" if sys.platform == "win32" else "credential-process"
+        (install_dir / binary_name).touch()
+
+        # Write invalid JSON
+        (install_dir / "config.json").write_text("{ invalid json !!!")
+
+        checks = run_doctor(home=home)
+
+        statuses = {c.name: c.status for c in checks}
+        assert statuses["config.json"] == "fail"
+        assert "Invalid JSON" in next(c.message for c in checks if c.name == "config.json")
+
+
+class TestDoctorOtelSkip:
+    """Test that otel-helper is SKIP when monitoring is not configured."""
+
+    def test_no_monitoring_no_otel_skips(self, tmp_path):
+        """No monitoring configured + no otel-helper → SKIP (not FAIL)."""
+        home = tmp_path
+
+        install_dir = home / "claude-code-with-bedrock"
+        install_dir.mkdir()
+
+        # Config without otel_collector_endpoint
+        config = {"profiles": {"default": {"provider_domain": "example.okta.com"}}}
+        (install_dir / "config.json").write_text(json.dumps(config))
+
+        # Binary present so config loads
+        binary_name = "credential-process.exe" if sys.platform == "win32" else "credential-process"
+        (install_dir / binary_name).touch()
+
+        checks = run_doctor(home=home)
+
+        statuses = {c.name: c.status for c in checks}
+        assert statuses["otel-helper"] == "skipped"
+        assert "Monitoring not configured" in next(c.message for c in checks if c.name == "otel-helper")
+
+    def test_monitoring_configured_but_otel_missing_fails(self, tmp_path):
+        """Monitoring configured but otel-helper missing → FAIL."""
+        home = tmp_path
+
+        install_dir = home / "claude-code-with-bedrock"
+        install_dir.mkdir()
+
+        # Config WITH otel_collector_endpoint
+        config = {
+            "profiles": {
+                "default": {
+                    "provider_domain": "example.okta.com",
+                    "otel_collector_endpoint": "http://localhost:4318",
+                }
+            }
+        }
+        (install_dir / "config.json").write_text(json.dumps(config))
+
+        binary_name = "credential-process.exe" if sys.platform == "win32" else "credential-process"
+        (install_dir / binary_name).touch()
+
+        checks = run_doctor(home=home)
+
+        statuses = {c.name: c.status for c in checks}
+        assert statuses["otel-helper"] == "fail"
+        assert "Monitoring configured" in next(c.message for c in checks if c.name == "otel-helper")


### PR DESCRIPTION
## Summary

Adds `ccwb doctor` — a troubleshooting command that validates the installation, dumps configuration details, and generates pre-filled GitHub issues for frictionless bug reporting. The first thing support asks you to run.

### Usage

```bash
# Quick health check
poetry run ccwb doctor

# Detailed config dump for troubleshooting
poetry run ccwb doctor --verbose

# Machine-readable output (pipe to Claude or scripts)
poetry run ccwb doctor --json
```

### Issues this would have caught (or surfaced faster)
- #583 — CloudWatch metrics stuck at 0 (otel-helper missing → immediate FAIL)
- #541 — CoWork telemetry never reaches dashboard (missing OTEL env vars)
- #592 — AWS CLI dependency + incorrect success (broken binary)
- #520 — "No binaries built" exits 1 (binary existence check)
- #664 — Credential refresh fails silently (credential-test surfaces it)
- #546 — Secrets Manager not found (config/credential-process broken)

### Health Checks (6)
| Check | What it validates |
|-------|-------------------|
| `credential-process` | Binary exists in install dir |
| `config.json` | Present + valid JSON + lists profiles |
| `aws-profile` | `~/.aws/config` references credential-process |
| `settings.json` | Claude Code settings file exists with env/hooks |
| `credential-test` | credential-process responds (graceful timeout) |
| `otel-helper` | Telemetry binary exists (only FAIL if monitoring configured) |

### `--verbose` mode (troubleshooting config dump)
Shows sanitized configuration for support diagnosis:
- Auth type (oidc/idc), region, provider domain
- IDC-specific: start URL, account, permission set
- Monitoring mode + OTEL endpoint
- settings.json hooks: awsCredentialExport, awsAuthRefresh, otelHeadersHelper (✓/not set)

### On failure: pre-filled GitHub issue
Clickable URL with auto-detected:
- OS, Python version, auth type, monitoring mode
- Full doctor output table
- Auto-labeled as `bug`

### Changes
- `source/claude_code_with_bedrock/cli/commands/doctor.py` — command with `--verbose`, `--json`, `--profile`, issue URL
- `source/claude_code_with_bedrock/cli/__init__.py` — registration
- `source/claude_code_with_bedrock/cli/commands/__init__.py` — export
- `source/claude_code_with_bedrock/cli/commands/package.py` — post-package hint
- `source/tests/cli/commands/test_doctor.py` — 5 tests
- `assets/docs/CLI_REFERENCE.md` — full doctor section + ToC
- `README.md` — components table row
- `.claude/rules/doctor-checks.md` — update doctor when adding install artifacts
- `.claude/rules/cli-command-pattern.md` — standard new command pattern

### Risk: NONE
- New command, no existing logic modified
- `package.py` change is a single print (post-success hint)
- Only 2-line imports in `__init__` files
- All 5 tests pass | No network calls