### PR TITLE
fix(package): configure localhost OTEL endpoint in sidecar mode

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -3772,10 +3772,25 @@ Available metrics include:
 
             # If monitoring is enabled, add telemetry configuration
             if profile.monitoring_enabled:
-                # Try profile first (saved by ccwb deploy), fall back to CloudFormation query
-                endpoint = getattr(profile, "otel_collector_endpoint", None)
+                _monitoring_mode = getattr(profile, "monitoring_mode", "central")
 
-                if not endpoint:
+                # Sidecar mode: Claude Code always sends to the local otelcol on
+                # localhost:4318. There is no central monitoring stack to read a
+                # CollectorEndpoint from, so resolve the endpoint up front and skip
+                # the profile/CloudFormation/prompt resolution below (which only
+                # applies to central mode). Doing this here — rather than as an
+                # override after resolution — is what actually configures telemetry
+                # for sidecar packages: real sidecar deploys have no saved
+                # otel_collector_endpoint, so the old post-resolution override never
+                # ran and telemetry was silently left unconfigured.
+                if _monitoring_mode == "sidecar":
+                    endpoint = "http://localhost:4318"
+                else:
+                    # Central mode: try profile first (saved by ccwb deploy), then
+                    # fall back to CloudFormation query.
+                    endpoint = getattr(profile, "otel_collector_endpoint", None)
+
+                if not endpoint and _monitoring_mode != "sidecar":
                     # Fall back to reading from CloudFormation stack outputs
                     # Try multiple possible stack name patterns
                     possible_stacks = [
@@ -3863,19 +3878,14 @@ Available metrics include:
                         pass
 
                 if endpoint:
-                    # Add monitoring configuration
+                    # Add monitoring configuration. In sidecar mode `endpoint` was
+                    # already resolved to http://localhost:4318 above; in central
+                    # mode it is the ALB address from the profile/CloudFormation.
                     resource_attrs = otel_resource_attributes or (
                         "department=engineering,team.id=default,"
                         "cost_center=default,organization=default,"
                         "project=default"
                     )
-
-                    # Sidecar mode: Claude Code sends to local otelcol, not directly to the ALB.
-                    # Override whatever endpoint the profile stores (which is the ALB address) so
-                    # users don't have to edit settings.json manually after running ccwb package.
-                    _monitoring_mode = getattr(profile, "monitoring_mode", "central")
-                    if _monitoring_mode == "sidecar":
-                        endpoint = "http://localhost:4318"
 
                     settings["env"].update(
                         {

--- a/source/tests/cli/commands/test_package_oidc_sidecar.py
+++ b/source/tests/cli/commands/test_package_oidc_sidecar.py
@@ -12,7 +12,9 @@ from claude_code_with_bedrock.cli.commands.package import PackageCommand
 from claude_code_with_bedrock.config import Profile
 
 
-def _make_oidc_profile(monitoring_mode="sidecar", monitoring_enabled=True, endpoint="https://alb.example.com"):
+def _make_oidc_profile(
+    monitoring_mode="sidecar", monitoring_enabled=True, endpoint: str | None = "https://alb.example.com"
+):
     return Profile(
         name="test-oidc",
         provider_domain="auth.example.com",
@@ -42,6 +44,25 @@ class TestSidecarEndpointOverride:
             settings_path = output_dir / "claude-settings" / "settings.json"
             settings = json.loads(settings_path.read_text())
             assert settings["env"]["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://localhost:4318"
+
+    def test_sidecar_without_saved_endpoint_still_configures_localhost(self):
+        """Regression: real sidecar deploys have NO saved otel_collector_endpoint
+        (there is no central monitoring stack to read one from). Telemetry must
+        still be configured to http://localhost:4318 — the previous code only
+        applied the localhost override *after* resolving a non-empty endpoint, so
+        a None endpoint fell through to the 'no endpoint found' path and telemetry
+        was silently left unconfigured."""
+        command = PackageCommand()
+        profile = _make_oidc_profile(monitoring_mode="sidecar", endpoint=None)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            command._create_claude_settings(output_dir, profile)
+
+            settings_path = output_dir / "claude-settings" / "settings.json"
+            settings = json.loads(settings_path.read_text())
+            assert settings["env"]["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://localhost:4318"
+            assert settings["env"]["CLAUDE_CODE_ENABLE_TELEMETRY"] == "1"
 
     def test_central_mode_preserves_profile_endpoint(self):
         """Central mode must NOT override the ALB endpoint with localhost."""


### PR DESCRIPTION
## Why
`ccwb package` left telemetry **unconfigured** for sidecar profiles. The sidecar override to `http://localhost:4318` was applied *after* the endpoint was resolved from the profile or CloudFormation — inside an `if endpoint:` block:

```python
endpoint = getattr(profile, "otel_collector_endpoint", None)   # None in sidecar
if not endpoint:
    ... CloudFormation lookup ...                              # no monitoring stack → still None
if not endpoint:
    ... "No OTel collector endpoint found" warning + prompt ...
if endpoint:                                                   # never true in real sidecar
    if monitoring_mode == "sidecar":
        endpoint = "http://localhost:4318"                     # dead code here
```

Real sidecar deploys have no central monitoring stack, so `otel_collector_endpoint` is never saved and the CloudFormation lookup finds nothing. `endpoint` stayed `None`, the code fell into the warning/prompt path, and `settings.json` was written **without** `OTEL_EXPORTER_OTLP_ENDPOINT` or `CLAUDE_CODE_ENABLE_TELEMETRY` → Claude Code emitted no telemetry to the local collector.

The existing sidecar test masked this — its fixture pre-set `otel_collector_endpoint="https://alb.example.com"`, so `endpoint` was non-None and the override ran. That never happens in a real sidecar deployment.

## What
- Resolve the sidecar endpoint to `http://localhost:4318` **up front**, before the profile/CloudFormation/prompt resolution (which only applies to central mode), so it no longer depends on a pre-existing endpoint.
- Skip the CloudFormation stack lookup entirely in sidecar mode (there's no monitoring stack to query).
- Remove the now-redundant post-resolution override.
- Add a regression test with a sidecar profile and **no** saved endpoint (`otel_collector_endpoint=None`) asserting `OTEL_EXPORTER_OTLP_ENDPOINT == http://localhost:4318` and `CLAUDE_CODE_ENABLE_TELEMETRY == "1"`. **Verified it fails without the fix and passes with it.**

## Relationship to #678
#678 restored the otelcol build + collector-config generation and *introduced* the localhost override — but placed it after endpoint resolution, where it can't run for the normal sidecar case. This moves it to where it actually takes effect.

## Testing
- `poetry run pytest tests/cli/commands/test_package_oidc_sidecar.py -q` → 26 passed.
- Package/sidecar suite (117 tests) green. ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)