### PR TITLE
feat(cli): ccwb doctor — one-command troubleshooting for installation and configuration issues

### DIFF
--- a/.claude/rules/doctor-checks.md
+++ b/.claude/rules/doctor-checks.md
@@ -1,0 +1,18 @@
+# Doctor Checks Rule
+
+When adding new install artifacts (binaries, config files, settings):
+
+1. Add a health check in `source/claude_code_with_bedrock/cli/commands/doctor.py`
+2. Add a test in `source/tests/cli/commands/test_doctor.py`
+3. Update `assets/docs/CLI_REFERENCE.md` doctor section
+
+When adding new flags to credential-process or otel-helper:
+
+1. Update `--explain` or `--status` output if the flag affects resolved config
+2. Update `explain_test.go` with the new field assertion
+3. If the flag is user-facing, add it to `credential-process --help` description
+
+The diagnostic flags are:
+- `credential-process --explain` → resolved config JSON (auth mode, provider, quota, storage, paths)
+- `otel-helper --status` → proxy health + cached headers
+- `ccwb doctor` → calls both + static file checks

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The architecture is modular — start with authentication, then optionally add [
 | **Quota enforcement** (optional) | Quota check API + DynamoDB policies + per-user/team limits | `ccwb deploy --stack quota` |
 | **Analytics** (optional) | S3 data lake + Athena for historical SQL queries on usage data | `ccwb deploy --stack analytics` |
 | **Distribution** (optional) | S3 presigned URLs or self-service landing page with IdP auth | `ccwb deploy --stack distribution` |
+| **Diagnostics** | Installation health checks + resolved config dump | `ccwb doctor` |
 
 See [Monitoring Guide](assets/docs/MONITORING.md), [Quota Guide](assets/docs/QUOTA_MONITORING.md), [Analytics Guide](assets/docs/ANALYTICS.md), and [Distribution Comparison](assets/docs/distribution/comparison.md) for detailed setup.
 ### Authentication Modes

--- a/assets/docs/CLI_REFERENCE.md
+++ b/assets/docs/CLI_REFERENCE.md
@@ -1187,3 +1187,51 @@ poetry run ccwb destroy [stack] [options]
 - Warns about manual cleanup requirements (e.g., CloudWatch LogGroups)
 
 **Note:** Some resources like CloudWatch LogGroups may require manual deletion.
+
+### `doctor` - Validate Installation Health
+
+Runs health checks on the local machine to catch misconfigurations and aid troubleshooting.
+
+```bash
+poetry run ccwb doctor [options]
+```
+
+**Options:**
+
+- `--verbose` / `-v` - Show raw JSON from `credential-process --explain` and `otel-helper --status`
+- `--live` / `-l` - Also attempt authentication and check proxy connectivity
+- `--json` - Machine-readable JSON output (for CI or support)
+- `--profile <name>` - Check a specific profile
+
+**Health Checks:**
+
+| Check | What it validates |
+|-------|-------------------|
+| `credential-process` | Binary exists in install dir (.exe/.cmd/.ps1 on Windows) |
+| `config.json` | Present, valid JSON, lists profiles |
+| `aws-profile` | `~/.aws/config` references credential-process |
+| `settings.json` | Claude Code settings file with env/hooks |
+| `explain` | Calls `credential-process --explain` — shows resolved auth mode, provider, quota |
+| `otel-helper` | Telemetry binary exists (only FAIL if monitoring configured) |
+| `otel-status` | Calls `otel-helper --status` — proxy running? headers cached? |
+| `auth-test` | (--live only) Attempts credential check |
+| `proxy-health` | (--live only) TCP connect to OTEL proxy port |
+
+**On failure:** Generates a pre-filled GitHub issue URL with diagnostics, environment, and auth mode.
+
+### Go Binary Diagnostic Flags
+
+These flags are available on the installed Go binaries (v2.5.0+):
+
+```bash
+# Print resolved configuration (no auth, no network)
+credential-process --explain
+
+# Print proxy and cache status
+otel-helper --status
+
+# Show version with commit SHA
+credential-process --version   # → credential-process v2.5.0-beta.91 (62a232f)
+```
+
+`--explain` output includes: auth mode (oidc/idc/passthrough), provider type, federation type, quota config, storage mode, and file paths. Useful for verifying the binary detected the correct configuration before debugging auth failures.

--- a/source/claude_code_with_bedrock/cli/__init__.py
+++ b/source/claude_code_with_bedrock/cli/__init__.py
@@ -22,6 +22,7 @@ from .commands.cowork import CoworkGenerateCommand
 from .commands.deploy import DeployCommand
 from .commands.destroy import DestroyCommand
 from .commands.distribute import DistributeCommand
+from .commands.doctor import DoctorCommand
 from .commands.init import InitCommand
 from .commands.package import PackageCommand
 from .commands.package_cb import PackageCbCommand
@@ -59,6 +60,7 @@ def create_application() -> Application:
     application.add(BuildsCommand())
     application.add(DistributeCommand())
     application.add(DestroyCommand())
+    application.add(DoctorCommand())
     application.add(CleanupCommand())
     application.add(CoworkGenerateCommand())
     # application.add(TokenCommand())  # Temporarily disabled

--- a/source/claude_code_with_bedrock/cli/commands/doctor.py
+++ b/source/claude_code_with_bedrock/cli/commands/doctor.py
@@ -305,6 +305,7 @@ def run_doctor(home: Path = None, live: bool = False) -> list:
         # ─── Check 9 (live only): proxy port health ───────────────────────────
         check = HealthCheck("proxy-health", "OTEL proxy accepting connections")
         import socket
+
         for port in [4318, 4319]:
             try:
                 with socket.create_connection(("127.0.0.1", port), timeout=1):
@@ -412,11 +413,13 @@ def _print_issue_link(checks: list, console: Console):
             if monitoring.get("bootstrap_endpoint"):
                 issue_body += f"- **Bootstrap endpoint:** {monitoring['bootstrap_endpoint']}\n"
 
-    params = urllib.parse.urlencode({
-        "title": f"ccwb doctor: {', '.join(c.name for c in failed_checks)} failed",
-        "body": issue_body,
-        "labels": "bug",
-    })
+    params = urllib.parse.urlencode(
+        {
+            "title": f"ccwb doctor: {', '.join(c.name for c in failed_checks)} failed",
+            "body": issue_body,
+            "labels": "bug",
+        }
+    )
     issue_url = f"https://github.com/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock/issues/new?{params}"
     console.print("\n[dim]Report this issue (pre-filled):[/dim]")
     console.print(f"  {issue_url}")

--- a/source/claude_code_with_bedrock/cli/commands/doctor.py
+++ b/source/claude_code_with_bedrock/cli/commands/doctor.py
@@ -182,11 +182,19 @@ def run_doctor(home: Path = None, live: bool = False) -> list:
             provider_type = ""
             if explain_data.get("provider"):
                 provider_type = f", provider={explain_data['provider'].get('type', '?')}"
+            monitoring = explain_data.get("monitoring", {})
+            monitoring_str = ""
+            if monitoring.get("enabled"):
+                mon_mode = monitoring.get("mode", "?")
+                delivery = monitoring.get("config_delivery", "static")
+                monitoring_str = f", monitoring={mon_mode}"
+                if delivery == "bootstrap":
+                    monitoring_str += " (bootstrap)"
             quota_str = ""
             if explain_data.get("quota", {}).get("enabled"):
                 quota_str = ", quota=enabled"
             check.pass_(
-                f"mode={mode}{provider_type}{quota_str} (v{ver} @{commit})",
+                f"mode={mode}{provider_type}{monitoring_str}{quota_str} (v{ver} @{commit})",
                 detail=explain_data,
             )
         else:
@@ -396,6 +404,13 @@ def _print_issue_link(checks: list, console: Console):
         issue_body += f"- **Commit:** {explain_check.detail.get('commit', 'unknown')}\n"
         if explain_check.detail.get("provider"):
             issue_body += f"- **Provider:** {explain_check.detail['provider'].get('type', 'unknown')}\n"
+        monitoring = explain_check.detail.get("monitoring", {})
+        if monitoring.get("enabled"):
+            issue_body += f"- **Monitoring:** {monitoring.get('mode', 'unknown')} ({monitoring.get('config_delivery', 'static')})\n"
+            if monitoring.get("endpoint"):
+                issue_body += f"- **OTEL endpoint:** {monitoring['endpoint']}\n"
+            if monitoring.get("bootstrap_endpoint"):
+                issue_body += f"- **Bootstrap endpoint:** {monitoring['bootstrap_endpoint']}\n"
 
     params = urllib.parse.urlencode({
         "title": f"ccwb doctor: {', '.join(c.name for c in failed_checks)} failed",

--- a/source/claude_code_with_bedrock/cli/commands/doctor.py
+++ b/source/claude_code_with_bedrock/cli/commands/doctor.py
@@ -89,12 +89,13 @@ def _run_binary_json(binary_path: Path, args: list, timeout: int = 10) -> dict |
     return None
 
 
-def run_doctor(home: Path = None, live: bool = False) -> list:
+def run_doctor(home: Path = None, live: bool = False, profile: str = None) -> list:
     """Run all health checks and return list of HealthCheck results.
 
     Args:
         home: Override home directory (for testing).
         live: If True, also perform network-dependent checks (auth, proxy health).
+        profile: If set, check only this profile (passed to --explain/--status).
     """
     checks = []
 
@@ -174,7 +175,10 @@ def run_doctor(home: Path = None, live: bool = False) -> list:
     # ─── Check 5: credential-process --explain (resolved config) ──────────────
     check = HealthCheck("explain", "Resolved auth mode and configuration")
     if binary_path:
-        explain_data = _run_binary_json(binary_path, ["--explain"])
+        explain_args = ["--explain"]
+        if profile:
+            explain_args.extend(["--profile", profile])
+        explain_data = _run_binary_json(binary_path, explain_args)
         if explain_data:
             mode = explain_data.get("auth", {}).get("mode", "unknown")
             ver = explain_data.get("version", "unknown")
@@ -235,7 +239,10 @@ def run_doctor(home: Path = None, live: bool = False) -> list:
     # ─── Check 7: otel-helper --status (proxy health) ─────────────────────────
     check = HealthCheck("otel-status", "Telemetry proxy status")
     if otel_path:
-        status_data = _run_binary_json(otel_path, ["--status"])
+        status_args = ["--status"]
+        if profile:
+            status_args.extend(["--profile", profile])
+        status_data = _run_binary_json(otel_path, status_args)
         if status_data:
             proxy = status_data.get("proxy", {})
             cache = status_data.get("cache", {})
@@ -474,7 +481,8 @@ Machine-readable output (pipe to scripts or support):
         """Execute the doctor command."""
         console = Console()
         live = self.option("live")
-        checks = run_doctor(live=live)
+        profile = self.option("profile")
+        checks = run_doctor(live=live, profile=profile)
 
         if self.option("json"):
             output = {

--- a/source/claude_code_with_bedrock/cli/commands/doctor.py
+++ b/source/claude_code_with_bedrock/cli/commands/doctor.py
@@ -1,0 +1,482 @@
+# ABOUTME: Doctor command to validate installation health and catch common misconfigurations.
+# ABOUTME: Integrates credential-process --explain and otel-helper --status for deep diagnostics.
+
+"""Doctor command — validate installation health and catch common misconfigurations.
+
+Two diagnostic layers:
+  1. ccwb doctor         → static checks + --explain/--status integration (no auth)
+  2. ccwb doctor --live  → actually attempts authentication and telemetry
+
+This consolidates what would otherwise be 3 separate tools into one command
+that progressively reveals more detail (plain → --verbose → --live → --json).
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from cleo.commands.command import Command
+from cleo.helpers import option
+from rich.console import Console
+from rich.table import Table
+
+
+class HealthCheck:
+    """A single health check with name, runner, and result."""
+
+    def __init__(self, name: str, description: str):
+        self.name = name
+        self.description = description
+        self.status = "skipped"  # pass, fail, warn, skipped
+        self.message = ""
+        self.fix = ""
+        self.detail = None  # optional structured data (e.g. --explain output)
+
+    def pass_(self, msg="", detail=None):
+        self.status = "pass"
+        self.message = msg
+        self.detail = detail
+
+    def fail(self, msg, fix="", detail=None):
+        self.status = "fail"
+        self.message = msg
+        self.fix = fix
+        self.detail = detail
+
+    def warn(self, msg, fix="", detail=None):
+        self.status = "warn"
+        self.message = msg
+        self.fix = fix
+        self.detail = detail
+
+
+def _find_binary(install_dir: Path, name: str) -> Path | None:
+    """Find a binary, checking platform-appropriate extensions."""
+    if sys.platform == "win32":
+        # Check .exe, .cmd, .ps1 in order
+        for ext in [".exe", ".cmd", ".ps1"]:
+            p = install_dir / f"{name}{ext}"
+            if p.exists():
+                return p
+    else:
+        p = install_dir / name
+        if p.exists():
+            return p
+    return None
+
+
+def _run_binary_json(binary_path: Path, args: list, timeout: int = 10) -> dict | None:
+    """Run a binary with args, parse JSON stdout. Returns None on failure."""
+    try:
+        cmd = [str(binary_path)] + args
+        # On Windows, .cmd/.ps1 need shell or explicit interpreter
+        if binary_path.suffix == ".ps1":
+            cmd = ["powershell", "-ExecutionPolicy", "Bypass", "-File"] + cmd
+        elif binary_path.suffix == ".cmd":
+            cmd = ["cmd", "/c"] + cmd
+
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return json.loads(result.stdout)
+    except (subprocess.TimeoutExpired, subprocess.SubprocessError, json.JSONDecodeError, OSError):
+        pass
+    return None
+
+
+def run_doctor(home: Path = None, live: bool = False) -> list:
+    """Run all health checks and return list of HealthCheck results.
+
+    Args:
+        home: Override home directory (for testing).
+        live: If True, also perform network-dependent checks (auth, proxy health).
+    """
+    checks = []
+
+    if home is None:
+        home = Path.home()
+    install_dir = home / "claude-code-with-bedrock"
+
+    # ─── Check 1: credential-process binary ───────────────────────────────────
+    check = HealthCheck("credential-process", "Credential helper binary exists")
+    binary_path = _find_binary(install_dir, "credential-process")
+    if binary_path:
+        check.pass_(str(binary_path))
+    else:
+        check.fail(
+            f"Not found in {install_dir}",
+            "Run 'ccwb package' and execute the installer",
+        )
+    checks.append(check)
+
+    # ─── Check 2: config.json ─────────────────────────────────────────────────
+    check = HealthCheck("config.json", "Configuration file present and valid")
+    config_path = install_dir / "config.json"
+    config_data = None
+    if config_path.exists():
+        try:
+            with open(config_path) as f:
+                config_data = json.load(f)
+            profiles = config_data.get("profiles", config_data)
+            profile_names = [p for p in profiles if isinstance(profiles.get(p), dict)]
+            check.pass_(f"Profiles: {', '.join(profile_names[:5])}")
+        except json.JSONDecodeError as e:
+            check.fail(f"Invalid JSON: {e}", "Re-run the installer or re-package")
+    else:
+        check.fail(f"Not found at {config_path}", "Run the installer from 'ccwb package' output")
+    checks.append(check)
+
+    # ─── Check 3: AWS config profile ──────────────────────────────────────────
+    check = HealthCheck("aws-profile", "AWS config references credential-process")
+    aws_config = home / ".aws" / "config"
+    if aws_config.exists():
+        content = aws_config.read_text()
+        if "credential_process" in content and "claude-code-with-bedrock" in content:
+            check.pass_("credential_process configured in ~/.aws/config")
+        else:
+            check.warn(
+                "~/.aws/config exists but no credential_process entry found",
+                "Re-run the installer or manually add credential_process to your AWS profile",
+            )
+    else:
+        check.fail("~/.aws/config not found", "Run the installer")
+    checks.append(check)
+
+    # ─── Check 4: Claude Code settings.json ────────────────────────────────────
+    check = HealthCheck("settings.json", "Claude Code settings configured")
+    settings_paths = [
+        home / ".claude" / "settings.json",
+        home / ".claude" / "managed-settings.json",
+    ]
+    found_settings = None
+    for sp in settings_paths:
+        if sp.exists():
+            found_settings = sp
+            break
+    if found_settings:
+        try:
+            settings = json.loads(found_settings.read_text())
+            has_env = "env" in settings
+            has_hooks = "hooks" in settings
+            msg = f"{found_settings.name} (env={'✓' if has_env else '✗'}, hooks={'✓' if has_hooks else '✗'})"
+            check.pass_(msg)
+        except Exception as e:
+            check.fail(f"Cannot parse {found_settings}: {e}")
+    else:
+        check.fail("No settings.json or managed-settings.json in ~/.claude/", "Run the installer")
+    checks.append(check)
+
+    # ─── Check 5: credential-process --explain (resolved config) ──────────────
+    check = HealthCheck("explain", "Resolved auth mode and configuration")
+    if binary_path:
+        explain_data = _run_binary_json(binary_path, ["--explain"])
+        if explain_data:
+            mode = explain_data.get("auth", {}).get("mode", "unknown")
+            ver = explain_data.get("version", "unknown")
+            commit = explain_data.get("commit", "unknown")
+            provider_type = ""
+            if explain_data.get("provider"):
+                provider_type = f", provider={explain_data['provider'].get('type', '?')}"
+            quota_str = ""
+            if explain_data.get("quota", {}).get("enabled"):
+                quota_str = ", quota=enabled"
+            check.pass_(
+                f"mode={mode}{provider_type}{quota_str} (v{ver} @{commit})",
+                detail=explain_data,
+            )
+        else:
+            check.warn(
+                "credential-process --explain failed or not supported",
+                "Update to latest version (v2.5.0+) for --explain support",
+            )
+    else:
+        check.status = "skipped"
+        check.message = "Binary not available"
+    checks.append(check)
+
+    # ─── Check 6: otel-helper ──────────────────────────────────────────────────
+    check = HealthCheck("otel-helper", "Telemetry helper binary exists")
+    otel_path = _find_binary(install_dir, "otel-helper")
+    if otel_path:
+        check.pass_(str(otel_path))
+    elif config_data:
+        # Only fail if monitoring is actually configured
+        profiles_data = config_data.get("profiles", config_data)
+        any_monitoring = any(
+            isinstance(profiles_data.get(p), dict) and profiles_data[p].get("otel_collector_endpoint")
+            for p in profiles_data
+        )
+        if any_monitoring:
+            check.fail(
+                "Monitoring configured but otel-helper not found",
+                "Re-run 'ccwb package' with Go installed, then re-install",
+            )
+        else:
+            check.status = "skipped"
+            check.message = "Monitoring not configured"
+    else:
+        check.status = "skipped"
+        check.message = "Config not available"
+    checks.append(check)
+
+    # ─── Check 7: otel-helper --status (proxy health) ─────────────────────────
+    check = HealthCheck("otel-status", "Telemetry proxy status")
+    if otel_path:
+        status_data = _run_binary_json(otel_path, ["--status"])
+        if status_data:
+            proxy = status_data.get("proxy", {})
+            cache = status_data.get("cache", {})
+            if proxy.get("listening"):
+                check.pass_(
+                    f"Proxy listening on port {proxy.get('port')}, cache={'✓' if cache.get('has_headers') else '✗'}",
+                    detail=status_data,
+                )
+            else:
+                # Proxy not running is only a problem if monitoring is configured
+                if config_data:
+                    profiles_data = config_data.get("profiles", config_data)
+                    any_monitoring = any(
+                        isinstance(profiles_data.get(p), dict) and profiles_data[p].get("otel_collector_endpoint")
+                        for p in profiles_data
+                    )
+                    if any_monitoring:
+                        check.warn(
+                            f"Proxy not running (port {proxy.get('port')})",
+                            "Proxy starts automatically when credential-process runs",
+                        )
+                    else:
+                        check.status = "skipped"
+                        check.message = "Monitoring not configured"
+                else:
+                    check.pass_("Proxy not running (no monitoring configured)", detail=status_data)
+        else:
+            check.warn(
+                "otel-helper --status failed or not supported",
+                "Update to latest version (v2.5.0+) for --status support",
+            )
+    else:
+        check.status = "skipped"
+        check.message = "otel-helper not available"
+    checks.append(check)
+
+    # ─── Check 8 (live only): credential-process auth test ─────────────────────
+    if live:
+        check = HealthCheck("auth-test", "Credential helper can authenticate")
+        if binary_path and config_data:
+            # Try credential-process with a short timeout
+            try:
+                result = subprocess.run(
+                    [str(binary_path), "--check-expiration"],
+                    capture_output=True,
+                    text=True,
+                    timeout=15,
+                )
+                if result.returncode == 0:
+                    check.pass_("Credentials valid (not expired)")
+                elif result.returncode == 1:
+                    check.warn(
+                        "Credentials expired (needs browser auth or refresh)",
+                        "Run 'credential-process' manually to re-authenticate",
+                    )
+                else:
+                    check.fail(f"Exit code {result.returncode}: {result.stderr.strip()[:100]}")
+            except subprocess.TimeoutExpired:
+                check.warn("Timed out — may need interactive authentication")
+            except Exception as e:
+                check.fail(f"Cannot execute: {e}")
+        else:
+            check.status = "skipped"
+            check.message = "Binary or config not available"
+        checks.append(check)
+
+        # ─── Check 9 (live only): proxy port health ───────────────────────────
+        check = HealthCheck("proxy-health", "OTEL proxy accepting connections")
+        import socket
+        for port in [4318, 4319]:
+            try:
+                with socket.create_connection(("127.0.0.1", port), timeout=1):
+                    check.pass_(f"Port {port} accepting connections")
+                    break
+            except (TimeoutError, OSError):
+                continue
+        else:
+            if config_data:
+                profiles_data = config_data.get("profiles", config_data)
+                any_monitoring = any(
+                    isinstance(profiles_data.get(p), dict) and profiles_data[p].get("otel_collector_endpoint")
+                    for p in profiles_data
+                )
+                if any_monitoring:
+                    check.warn(
+                        "No OTEL proxy listening on 4318 or 4319",
+                        "Run credential-process to spawn the proxy, or start otel-helper manually",
+                    )
+                else:
+                    check.status = "skipped"
+                    check.message = "Monitoring not configured"
+            else:
+                check.status = "skipped"
+                check.message = "Config not available"
+        checks.append(check)
+
+    return checks
+
+
+def print_results(checks: list, console: Console = None) -> int:
+    """Print health check results as a rich table. Returns exit code (0=ok, 1=failures)."""
+    if console is None:
+        console = Console()
+
+    console.print("\n[bold]ccwb doctor[/bold] — Installation Health Check\n")
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Check", style="cyan", min_width=18)
+    table.add_column("Status", width=6)
+    table.add_column("Details")
+
+    for c in checks:
+        if c.status == "pass":
+            status = "[green]PASS[/green]"
+        elif c.status == "fail":
+            status = "[red]FAIL[/red]"
+        elif c.status == "warn":
+            status = "[yellow]WARN[/yellow]"
+        else:
+            status = "[dim]SKIP[/dim]"
+
+        details = c.message
+        if c.fix:
+            details += f"\n[dim]  Fix: {c.fix}[/dim]"
+
+        table.add_row(c.name, status, details)
+
+    console.print(table)
+
+    # Summary
+    fails = sum(1 for c in checks if c.status == "fail")
+    warns = sum(1 for c in checks if c.status == "warn")
+    passes = sum(1 for c in checks if c.status == "pass")
+
+    console.print()
+    if fails == 0:
+        console.print(f"[green]✓ All checks passed[/green] ({passes} pass, {warns} warnings)")
+        return 0
+    else:
+        console.print(f"[red]✗ {fails} check(s) failed[/red] ({passes} pass, {warns} warnings)")
+        _print_issue_link(checks, console)
+        return 1
+
+
+def _print_issue_link(checks: list, console: Console):
+    """Generate a pre-filled GitHub issue URL from failed checks."""
+    import platform
+    import urllib.parse
+
+    failed_checks = [c for c in checks if c.status == "fail"]
+
+    issue_body = "## ccwb doctor output\n\n"
+    issue_body += "| Check | Status | Details |\n|-------|--------|---------|\n"
+    for c in checks:
+        issue_body += f"| {c.name} | {c.status.upper()} | {c.message} |\n"
+
+    issue_body += "\n## Environment\n"
+    issue_body += f"- **OS:** {platform.system()} {platform.release()} ({platform.machine()})\n"
+    issue_body += f"- **Python:** {platform.python_version()}\n"
+
+    # Include --explain output if available
+    explain_check = next((c for c in checks if c.name == "explain" and c.detail), None)
+    if explain_check:
+        issue_body += f"- **Auth mode:** {explain_check.detail.get('auth', {}).get('mode', 'unknown')}\n"
+        issue_body += f"- **Version:** {explain_check.detail.get('version', 'unknown')}\n"
+        issue_body += f"- **Commit:** {explain_check.detail.get('commit', 'unknown')}\n"
+        if explain_check.detail.get("provider"):
+            issue_body += f"- **Provider:** {explain_check.detail['provider'].get('type', 'unknown')}\n"
+
+    params = urllib.parse.urlencode({
+        "title": f"ccwb doctor: {', '.join(c.name for c in failed_checks)} failed",
+        "body": issue_body,
+        "labels": "bug",
+    })
+    issue_url = f"https://github.com/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock/issues/new?{params}"
+    console.print("\n[dim]Report this issue (pre-filled):[/dim]")
+    console.print(f"  {issue_url}")
+
+
+def print_verbose(checks: list, console: Console):
+    """Print detailed --explain and --status output for troubleshooting."""
+    console.print("\n[bold]Detailed Diagnostics[/bold] (--verbose)\n")
+
+    explain_check = next((c for c in checks if c.name == "explain" and c.detail), None)
+    if explain_check:
+        console.print("[cyan]credential-process --explain:[/cyan]")
+        console.print_json(json.dumps(explain_check.detail, indent=2))
+        console.print()
+
+    status_check = next((c for c in checks if c.name == "otel-status" and c.detail), None)
+    if status_check:
+        console.print("[cyan]otel-helper --status:[/cyan]")
+        console.print_json(json.dumps(status_check.detail, indent=2))
+        console.print()
+
+
+class DoctorCommand(Command):
+    name = "doctor"
+    description = "Validate installation health and catch common misconfigurations"
+    help = """Run post-installation health checks on the local machine.
+
+Checks credential-process binary, config.json, AWS profile, Claude Code
+settings, resolved auth mode (via --explain), and telemetry proxy status.
+
+Use after running the installer to verify everything is working:
+  <info>poetry run ccwb doctor</info>
+
+Live checks (actually attempts auth + proxy connectivity):
+  <info>poetry run ccwb doctor --live</info>
+
+Detailed config dump for troubleshooting:
+  <info>poetry run ccwb doctor --verbose</info>
+
+Machine-readable output (pipe to scripts or support):
+  <info>poetry run ccwb doctor --json</info>
+"""
+
+    options = [
+        option("profile", description="Configuration profile to check", flag=False),
+        option("verbose", "v", description="Show detailed --explain and --status JSON output"),
+        option("live", "l", description="Perform live checks (auth test, proxy connectivity)"),
+        option("json", description="Output results as JSON (for automation)"),
+    ]
+
+    def handle(self) -> int:
+        """Execute the doctor command."""
+        console = Console()
+        live = self.option("live")
+        checks = run_doctor(live=live)
+
+        if self.option("json"):
+            output = {
+                "checks": [
+                    {
+                        "name": c.name,
+                        "status": c.status,
+                        "message": c.message,
+                        "fix": c.fix,
+                        "detail": c.detail,
+                    }
+                    for c in checks
+                ],
+            }
+            console.print_json(json.dumps(output))
+            return 0 if not any(c.status == "fail" for c in checks) else 1
+
+        exit_code = print_results(checks, console)
+
+        if self.option("verbose"):
+            print_verbose(checks, console)
+
+        return exit_code

--- a/source/claude_code_with_bedrock/cli/commands/doctor.py
+++ b/source/claude_code_with_bedrock/cli/commands/doctor.py
@@ -120,7 +120,7 @@ def run_doctor(home: Path = None, live: bool = False) -> list:
     config_data = None
     if config_path.exists():
         try:
-            with open(config_path) as f:
+            with open(config_path, encoding="utf-8") as f:
                 config_data = json.load(f)
             profiles = config_data.get("profiles", config_data)
             profile_names = [p for p in profiles if isinstance(profiles.get(p), dict)]

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -843,6 +843,7 @@ class PackageCommand(Command):
 
         # Show next steps
         console.print("\n[bold]Next steps:[/bold]")
+        console.print("After installation, verify with: [cyan]poetry run ccwb doctor[/cyan]")
 
         # Only show distribute command if distribution is enabled
         if profile.enable_distribution:

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -60,8 +60,33 @@ def _go_ldflags(goos: str) -> str:
     stripped Go binaries in subprocess/non-interactive contexts. Everywhere else we
     strip (-s -w) for size. This rule applies identically to credential-process,
     otel-helper, and the otelcol sidecar — hence one shared helper.
+
+    Always injects version and commit via -X flags so --version and --explain
+    report the build origin (critical for beta vs release troubleshooting).
     """
-    return "" if goos == "windows" else "-s -w"
+    import subprocess
+
+    # Resolve version from git tags
+    try:
+        ver = subprocess.check_output(
+            ["git", "describe", "--tags", "--always", "--dirty"],
+            stderr=subprocess.DEVNULL, text=True,
+        ).strip()
+    except (subprocess.SubprocessError, FileNotFoundError):
+        ver = "dev"
+
+    # Resolve commit SHA
+    try:
+        commit = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            stderr=subprocess.DEVNULL, text=True,
+        ).strip()
+    except (subprocess.SubprocessError, FileNotFoundError):
+        commit = "unknown"
+
+    version_flags = f"-X ccwb-go/internal/version.Version={ver} -X ccwb-go/internal/version.Commit={commit}"
+    strip_flags = "" if goos == "windows" else "-s -w"
+    return f"{strip_flags} {version_flags}".strip()
 
 
 def _find_universal2_python() -> Path | None:

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -70,7 +70,8 @@ def _go_ldflags(goos: str) -> str:
     try:
         ver = subprocess.check_output(
             ["git", "describe", "--tags", "--always", "--dirty"],
-            stderr=subprocess.DEVNULL, text=True,
+            stderr=subprocess.DEVNULL,
+            text=True,
         ).strip()
     except (subprocess.SubprocessError, FileNotFoundError):
         ver = "dev"
@@ -79,7 +80,8 @@ def _go_ldflags(goos: str) -> str:
     try:
         commit = subprocess.check_output(
             ["git", "rev-parse", "--short", "HEAD"],
-            stderr=subprocess.DEVNULL, text=True,
+            stderr=subprocess.DEVNULL,
+            text=True,
         ).strip()
     except (subprocess.SubprocessError, FileNotFoundError):
         commit = "unknown"

--- a/source/go/Makefile
+++ b/source/go/Makefile
@@ -1,9 +1,10 @@
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
-LDFLAGS := -s -w -X ccwb-go/internal/version.Version=$(VERSION)
+COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+LDFLAGS := -s -w -X ccwb-go/internal/version.Version=$(VERSION) -X ccwb-go/internal/version.Commit=$(COMMIT)
 # Windows: do NOT strip (-s -w). Defender cloud ML (Wacatac.B!ml) flags
 # stripped Go binaries and blocks them in subprocess/non-interactive contexts.
 # The .syso PE version-info files help but are not sufficient alone.
-LDFLAGS_WIN := -X ccwb-go/internal/version.Version=$(VERSION)
+LDFLAGS_WIN := -X ccwb-go/internal/version.Version=$(VERSION) -X ccwb-go/internal/version.Commit=$(COMMIT)
 OUT ?= bin
 
 .PHONY: all test clean fmt vet macos-arm64 macos-intel linux-x64 linux-arm64 windows

--- a/source/go/cmd/credential-process/explain.go
+++ b/source/go/cmd/credential-process/explain.go
@@ -27,6 +27,8 @@ type ExplainOutput struct {
 	Monitoring MonitoringInfo  `json:"monitoring"`
 	Quota      QuotaInfo       `json:"quota"`
 	Storage    StorageInfo     `json:"storage"`
+	Session    SessionInfo     `json:"session"`
+	Env        EnvInfo         `json:"env"`
 	Paths      PathsInfo       `json:"paths"`
 }
 
@@ -70,6 +72,27 @@ type MonitoringInfo struct {
 // StorageInfo describes credential storage configuration.
 type StorageInfo struct {
 	Mode string `json:"mode"` // "keyring" | "file" | "session"
+}
+
+// SessionInfo describes session parameters that affect credential behavior.
+type SessionInfo struct {
+	MaxDurationSec int    `json:"max_duration_sec,omitempty"` // STS session length
+	RedirectPort   int    `json:"redirect_port"`              // OAuth callback port (default 8400)
+	AzureAuthMode  string `json:"azure_auth_mode,omitempty"`  // "" | "secret" | "certificate"
+	HelperContext  string `json:"helper_context,omitempty"`   // CLAUDE_HELPER_CONTEXT env value
+}
+
+// EnvInfo captures relevant environment variables that override behavior.
+type EnvInfo struct {
+	CCWBProfile       string `json:"ccwb_profile,omitempty"`        // CCWB_PROFILE override
+	AWSProfile        string `json:"aws_profile,omitempty"`         // AWS_PROFILE
+	RedirectPort      string `json:"redirect_port,omitempty"`       // REDIRECT_PORT override
+	DebugEnabled      bool   `json:"debug_enabled"`                 // COGNITO_AUTH_DEBUG=1
+	NoBrowserNotify   bool   `json:"no_browser_notification"`       // CCWB_NO_BROWSER_NOTIFICATION=1
+	IsSSH             bool   `json:"is_ssh"`                        // SSH_CONNECTION detected
+	IsHeadless        bool   `json:"is_headless"`                   // No DISPLAY/WAYLAND_DISPLAY
+	BrowserOverride   string `json:"browser_override,omitempty"`    // $BROWSER env
+	MonitoringToken   bool   `json:"has_monitoring_token"`          // CLAUDE_CODE_MONITORING_TOKEN set
 }
 
 // PathsInfo shows resolved file paths for troubleshooting.
@@ -159,6 +182,12 @@ func buildExplainOutput(profile string, cfg *config.ProfileConfig) ExplainOutput
 
 	// Resolve monitoring configuration
 	output.Monitoring = resolveMonitoring(cfg)
+
+	// Resolve session parameters
+	output.Session = resolveSession(cfg)
+
+	// Resolve environment detection
+	output.Env = resolveEnv()
 
 	return output
 }
@@ -263,5 +292,63 @@ func resolvePaths(profile string) PathsInfo {
 			info.ConfigFile = filepath.Join(home, "claude-code-with-bedrock", "config.json")
 		}
 	}
+	return info
+}
+
+// resolveSession returns session parameters from the config.
+func resolveSession(cfg *config.ProfileConfig) SessionInfo {
+	info := SessionInfo{
+		RedirectPort: 8400, // default
+	}
+	if cfg.MaxSessionDuration > 0 {
+		info.MaxDurationSec = cfg.MaxSessionDuration
+	}
+	if cfg.RedirectPort > 0 {
+		info.RedirectPort = cfg.RedirectPort
+	}
+	// Env override for redirect port
+	if envPort := os.Getenv("REDIRECT_PORT"); envPort != "" {
+		info.RedirectPort = 0 // will be overridden at runtime
+	}
+	if cfg.AzureAuthMode != "" {
+		info.AzureAuthMode = cfg.AzureAuthMode
+	}
+	// Claude Desktop helper context
+	if ctx := os.Getenv("CLAUDE_HELPER_CONTEXT"); ctx != "" {
+		info.HelperContext = ctx
+	}
+	return info
+}
+
+// resolveEnv captures environment variables that affect runtime behavior.
+func resolveEnv() EnvInfo {
+	info := EnvInfo{}
+
+	// Profile overrides
+	info.CCWBProfile = os.Getenv("CCWB_PROFILE")
+	info.AWSProfile = os.Getenv("AWS_PROFILE")
+	info.RedirectPort = os.Getenv("REDIRECT_PORT")
+
+	// Debug mode
+	debugVal := os.Getenv("COGNITO_AUTH_DEBUG")
+	info.DebugEnabled = debugVal == "1" || debugVal == "true" || debugVal == "yes"
+
+	// Browser notification suppression
+	info.NoBrowserNotify = os.Getenv("CCWB_NO_BROWSER_NOTIFICATION") == "1"
+
+	// SSH detection (affects browser-based auth)
+	info.IsSSH = os.Getenv("SSH_CONNECTION") != "" || os.Getenv("SSH_TTY") != "" || os.Getenv("SSH_CLIENT") != ""
+
+	// Headless detection (no display server)
+	if runtime.GOOS == "linux" {
+		info.IsHeadless = os.Getenv("DISPLAY") == "" && os.Getenv("WAYLAND_DISPLAY") == ""
+	}
+
+	// Browser override
+	info.BrowserOverride = os.Getenv("BROWSER")
+
+	// Monitoring token presence (not the value — sensitive)
+	info.MonitoringToken = os.Getenv("CLAUDE_CODE_MONITORING_TOKEN") != ""
+
 	return info
 }

--- a/source/go/cmd/credential-process/explain.go
+++ b/source/go/cmd/credential-process/explain.go
@@ -18,15 +18,16 @@ import (
 
 // ExplainOutput is the structured JSON output for --explain.
 type ExplainOutput struct {
-	Version  string        `json:"version"`
-	Commit   string        `json:"commit"`
-	Profile  string        `json:"profile"`
-	Platform PlatformInfo  `json:"platform"`
-	Auth     AuthInfo      `json:"auth"`
-	Provider *ProviderInfo `json:"provider,omitempty"`
-	Quota    QuotaInfo     `json:"quota"`
-	Storage  StorageInfo   `json:"storage"`
-	Paths    PathsInfo     `json:"paths"`
+	Version    string          `json:"version"`
+	Commit     string          `json:"commit"`
+	Profile    string          `json:"profile"`
+	Platform   PlatformInfo    `json:"platform"`
+	Auth       AuthInfo        `json:"auth"`
+	Provider   *ProviderInfo   `json:"provider,omitempty"`
+	Monitoring MonitoringInfo  `json:"monitoring"`
+	Quota      QuotaInfo       `json:"quota"`
+	Storage    StorageInfo     `json:"storage"`
+	Paths      PathsInfo       `json:"paths"`
 }
 
 // PlatformInfo describes the runtime environment.
@@ -55,6 +56,15 @@ type QuotaInfo struct {
 	Endpoint   string `json:"endpoint,omitempty"`
 	FailMode   string `json:"fail_mode,omitempty"`   // "open" | "closed"
 	AuthMethod string `json:"auth_method,omitempty"` // "bearer" | "sigv4"
+}
+
+// MonitoringInfo describes telemetry collection configuration.
+type MonitoringInfo struct {
+	Enabled          bool   `json:"enabled"`
+	Mode             string `json:"mode"`                        // "central" | "sidecar" | "none"
+	Endpoint         string `json:"endpoint,omitempty"`          // OTEL collector endpoint
+	ConfigDelivery   string `json:"config_delivery"`             // "static" | "bootstrap"
+	BootstrapEndpoint string `json:"bootstrap_endpoint,omitempty"` // Lambda URL (if bootstrap)
 }
 
 // StorageInfo describes credential storage configuration.
@@ -147,7 +157,48 @@ func buildExplainOutput(profile string, cfg *config.ProfileConfig) ExplainOutput
 		}
 	}
 
+	// Resolve monitoring configuration
+	output.Monitoring = resolveMonitoring(cfg)
+
 	return output
+}
+
+// resolveMonitoring returns the monitoring configuration from the profile.
+func resolveMonitoring(cfg *config.ProfileConfig) MonitoringInfo {
+	info := MonitoringInfo{
+		Enabled:        cfg.MonitoringEnabled,
+		Mode:           "none",
+		ConfigDelivery: "static",
+	}
+
+	if !cfg.MonitoringEnabled {
+		return info
+	}
+
+	// Monitoring mode
+	if cfg.MonitoringMode != "" {
+		info.Mode = cfg.MonitoringMode
+	} else {
+		info.Mode = "central" // default
+	}
+
+	// OTEL collector endpoint
+	if cfg.OtelCollectorEndpoint != "" {
+		info.Endpoint = cfg.OtelCollectorEndpoint
+	}
+
+	// Bootstrap server (dynamic config delivery)
+	if cfg.ConfigDeliveryMode != "" {
+		info.ConfigDelivery = cfg.ConfigDeliveryMode
+	}
+	if cfg.BootstrapEndpoint != "" {
+		info.BootstrapEndpoint = cfg.BootstrapEndpoint
+		if info.ConfigDelivery == "static" {
+			info.ConfigDelivery = "bootstrap" // infer from presence of endpoint
+		}
+	}
+
+	return info
 }
 
 // resolveProviderTypeQuiet detects the provider without printing errors.

--- a/source/go/cmd/credential-process/explain.go
+++ b/source/go/cmd/credential-process/explain.go
@@ -54,10 +54,15 @@ type ProviderInfo struct {
 
 // QuotaInfo describes quota enforcement configuration.
 type QuotaInfo struct {
-	Enabled    bool   `json:"enabled"`
-	Endpoint   string `json:"endpoint,omitempty"`
-	FailMode   string `json:"fail_mode,omitempty"`   // "open" | "closed"
-	AuthMethod string `json:"auth_method,omitempty"` // "bearer" | "sigv4"
+	Enabled              bool   `json:"enabled"`
+	Endpoint             string `json:"endpoint,omitempty"`
+	FailMode             string `json:"fail_mode"`                         // "open" | "closed"
+	AuthMethod           string `json:"auth_method"`                       // "bearer" | "sigv4"
+	CheckIntervalMin     int    `json:"check_interval_min"`                // Minutes between re-checks
+	CheckTimeoutSec      int    `json:"check_timeout_sec,omitempty"`       // Timeout for quota API call
+	DailyEnforcement     string `json:"daily_enforcement,omitempty"`       // "alert" | "block"
+	MonthlyEnforcement   string `json:"monthly_enforcement,omitempty"`     // "alert" | "block"
+	FineGrained          bool   `json:"fine_grained"`                      // Per-user/group policies in DynamoDB
 }
 
 // MonitoringInfo describes telemetry collection configuration.
@@ -139,22 +144,10 @@ func buildExplainOutput(profile string, cfg *config.ProfileConfig) ExplainOutput
 			Mode:   "idc",
 			Reason: "auth_type=idc or IDC fields present (idc_start_url)",
 		}
-		output.Quota = QuotaInfo{
-			Enabled:    cfg.QuotaAPIEndpoint != "",
-			Endpoint:   cfg.QuotaAPIEndpoint,
-			FailMode:   resolveQuotaFailMode(cfg),
-			AuthMethod: "sigv4",
-		}
 	case !cfg.IsSsoEnabled():
 		output.Auth = AuthInfo{
 			Mode:   "passthrough",
 			Reason: "sso_enabled=false and no IDC fields — using ambient AWS credential chain",
-		}
-		output.Quota = QuotaInfo{
-			Enabled:    cfg.QuotaAPIEndpoint != "",
-			Endpoint:   cfg.QuotaAPIEndpoint,
-			FailMode:   resolveQuotaFailMode(cfg),
-			AuthMethod: "sigv4",
 		}
 	default:
 		provType := resolveProviderTypeQuiet(cfg)
@@ -172,12 +165,6 @@ func buildExplainOutput(profile string, cfg *config.ProfileConfig) ExplainOutput
 			Domain: cfg.ProviderDomain,
 			Prompt: prompt,
 		}
-		output.Quota = QuotaInfo{
-			Enabled:    cfg.QuotaAPIEndpoint != "",
-			Endpoint:   cfg.QuotaAPIEndpoint,
-			FailMode:   resolveQuotaFailMode(cfg),
-			AuthMethod: "bearer",
-		}
 	}
 
 	// Resolve monitoring configuration
@@ -188,6 +175,13 @@ func buildExplainOutput(profile string, cfg *config.ProfileConfig) ExplainOutput
 
 	// Resolve environment detection
 	output.Env = resolveEnv()
+
+	// Resolve quota (same logic for all auth modes, just auth_method differs)
+	quotaAuthMethod := "sigv4"
+	if output.Auth.Mode == "oidc" {
+		quotaAuthMethod = "bearer"
+	}
+	output.Quota = resolveQuota(cfg, quotaAuthMethod)
 
 	return output
 }
@@ -263,6 +257,21 @@ func resolveStorageMode(cfg *config.ProfileConfig) string {
 		return cfg.CredentialStorage
 	}
 	return "keyring" // default
+}
+
+// resolveQuota returns the full quota configuration.
+func resolveQuota(cfg *config.ProfileConfig, authMethod string) QuotaInfo {
+	return QuotaInfo{
+		Enabled:            cfg.QuotaAPIEndpoint != "",
+		Endpoint:           cfg.QuotaAPIEndpoint,
+		FailMode:           resolveQuotaFailMode(cfg),
+		AuthMethod:         authMethod,
+		CheckIntervalMin:   cfg.QuotaCheckInterval,
+		CheckTimeoutSec:    cfg.QuotaCheckTimeout,
+		DailyEnforcement:   cfg.DailyEnforcementMode,
+		MonthlyEnforcement: cfg.MonthlyEnforcementMode,
+		FineGrained:        cfg.EnableFineGrained,
+	}
 }
 
 // resolveQuotaFailMode returns the quota fail mode (default: open).

--- a/source/go/cmd/credential-process/explain.go
+++ b/source/go/cmd/credential-process/explain.go
@@ -1,0 +1,214 @@
+// ABOUTME: --explain flag implementation for credential-process.
+// ABOUTME: Prints resolved configuration as JSON without performing auth.
+// ABOUTME: Used for troubleshooting (what mode was detected?) and E2E test oracles.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"ccwb-go/internal/config"
+	"ccwb-go/internal/provider"
+	"ccwb-go/internal/version"
+)
+
+// ExplainOutput is the structured JSON output for --explain.
+type ExplainOutput struct {
+	Version  string        `json:"version"`
+	Profile  string        `json:"profile"`
+	Platform PlatformInfo  `json:"platform"`
+	Auth     AuthInfo      `json:"auth"`
+	Provider *ProviderInfo `json:"provider,omitempty"`
+	Quota    QuotaInfo     `json:"quota"`
+	Storage  StorageInfo   `json:"storage"`
+	Paths    PathsInfo     `json:"paths"`
+}
+
+// PlatformInfo describes the runtime environment.
+type PlatformInfo struct {
+	OS   string `json:"os"`
+	Arch string `json:"arch"`
+}
+
+// AuthInfo describes the resolved authentication mode.
+type AuthInfo struct {
+	Mode         string `json:"mode"`          // "oidc" | "idc" | "passthrough"
+	Reason       string `json:"reason"`        // human-readable explanation of why this mode was chosen
+	FederationType string `json:"federation_type,omitempty"` // "cognito" | "direct_sts" | ""
+}
+
+// ProviderInfo describes the OIDC identity provider (only for OIDC mode).
+type ProviderInfo struct {
+	Type   string `json:"type"`             // "okta" | "azure" | "cognito" | "auth0" | "google" | "generic"
+	Domain string `json:"domain"`
+	Prompt string `json:"prompt,omitempty"` // OIDC prompt parameter
+}
+
+// QuotaInfo describes quota enforcement configuration.
+type QuotaInfo struct {
+	Enabled    bool   `json:"enabled"`
+	Endpoint   string `json:"endpoint,omitempty"`
+	FailMode   string `json:"fail_mode,omitempty"`   // "open" | "closed"
+	AuthMethod string `json:"auth_method,omitempty"` // "bearer" | "sigv4"
+}
+
+// StorageInfo describes credential storage configuration.
+type StorageInfo struct {
+	Mode string `json:"mode"` // "keyring" | "file" | "session"
+}
+
+// PathsInfo shows resolved file paths for troubleshooting.
+type PathsInfo struct {
+	ConfigDir  string `json:"config_dir"`
+	ConfigFile string `json:"config_file"`
+	InstallDir string `json:"install_dir,omitempty"`
+}
+
+// runExplain prints the resolved configuration as JSON and exits 0.
+// It never performs authentication or network calls.
+func runExplain(profile string, cfg *config.ProfileConfig) {
+	output := buildExplainOutput(profile, cfg)
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(output); err != nil {
+		fmt.Fprintf(os.Stderr, "Error encoding explain output: %v\n", err)
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+// buildExplainOutput constructs the explain output without side effects.
+func buildExplainOutput(profile string, cfg *config.ProfileConfig) ExplainOutput {
+	output := ExplainOutput{
+		Version: version.Version,
+		Profile: profile,
+		Platform: PlatformInfo{
+			OS:   runtime.GOOS,
+			Arch: runtime.GOARCH,
+		},
+		Storage: StorageInfo{
+			Mode: resolveStorageMode(cfg),
+		},
+		Paths: resolvePaths(profile),
+	}
+
+	// Determine auth mode
+	switch {
+	case cfg.IsIDC():
+		output.Auth = AuthInfo{
+			Mode:   "idc",
+			Reason: "auth_type=idc or IDC fields present (idc_start_url)",
+		}
+		output.Quota = QuotaInfo{
+			Enabled:    cfg.QuotaAPIEndpoint != "",
+			Endpoint:   cfg.QuotaAPIEndpoint,
+			FailMode:   resolveQuotaFailMode(cfg),
+			AuthMethod: "sigv4",
+		}
+	case !cfg.IsSsoEnabled():
+		output.Auth = AuthInfo{
+			Mode:   "passthrough",
+			Reason: "sso_enabled=false and no IDC fields — using ambient AWS credential chain",
+		}
+		output.Quota = QuotaInfo{
+			Enabled:    cfg.QuotaAPIEndpoint != "",
+			Endpoint:   cfg.QuotaAPIEndpoint,
+			FailMode:   resolveQuotaFailMode(cfg),
+			AuthMethod: "sigv4",
+		}
+	default:
+		provType := resolveProviderTypeQuiet(cfg)
+		output.Auth = AuthInfo{
+			Mode:           "oidc",
+			Reason:         "sso_enabled=true (default) with provider_domain configured",
+			FederationType: resolveFederationType(cfg),
+		}
+		prompt := ""
+		if cfg.OIDCPrompt != nil {
+			prompt = *cfg.OIDCPrompt
+		}
+		output.Provider = &ProviderInfo{
+			Type:   provType,
+			Domain: cfg.ProviderDomain,
+			Prompt: prompt,
+		}
+		output.Quota = QuotaInfo{
+			Enabled:    cfg.QuotaAPIEndpoint != "",
+			Endpoint:   cfg.QuotaAPIEndpoint,
+			FailMode:   resolveQuotaFailMode(cfg),
+			AuthMethod: "bearer",
+		}
+	}
+
+	return output
+}
+
+// resolveProviderTypeQuiet detects the provider without printing errors.
+func resolveProviderTypeQuiet(cfg *config.ProfileConfig) string {
+	if provider.IsKnown(cfg.ProviderType) {
+		return cfg.ProviderType
+	}
+	detected := provider.Detect(cfg.ProviderDomain)
+	if detected == "oidc" {
+		return "unknown"
+	}
+	return detected
+}
+
+// resolveFederationType returns "cognito" or "direct_sts" based on config.
+func resolveFederationType(cfg *config.ProfileConfig) string {
+	if cfg.IdentityPoolID != "" || cfg.IdentityPoolName != "" {
+		return "cognito"
+	}
+	if cfg.FederatedRoleARN != "" {
+		return "direct_sts"
+	}
+	// Legacy: check for cognito markers
+	if cfg.CognitoUserPoolID != "" {
+		return "cognito"
+	}
+	return ""
+}
+
+// resolveStorageMode returns the credential storage mode.
+func resolveStorageMode(cfg *config.ProfileConfig) string {
+	if cfg.CredentialStorage != "" {
+		return cfg.CredentialStorage
+	}
+	return "keyring" // default
+}
+
+// resolveQuotaFailMode returns the quota fail mode (default: open).
+func resolveQuotaFailMode(cfg *config.ProfileConfig) string {
+	if cfg.QuotaFailMode != "" {
+		return cfg.QuotaFailMode
+	}
+	return "open"
+}
+
+// resolvePaths returns the file paths credential-process uses.
+func resolvePaths(profile string) PathsInfo {
+	info := PathsInfo{}
+
+	// Check for install dir (where binaries live)
+	exe, err := os.Executable()
+	if err == nil {
+		info.InstallDir = filepath.Dir(exe)
+		info.ConfigFile = filepath.Join(filepath.Dir(exe), "config.json")
+		info.ConfigDir = filepath.Dir(exe)
+	}
+
+	// Fallback to ~/claude-code-with-bedrock/
+	if info.ConfigFile == "" {
+		if home, err := os.UserHomeDir(); err == nil {
+			info.ConfigDir = filepath.Join(home, "claude-code-with-bedrock")
+			info.ConfigFile = filepath.Join(home, "claude-code-with-bedrock", "config.json")
+		}
+	}
+	return info
+}

--- a/source/go/cmd/credential-process/explain.go
+++ b/source/go/cmd/credential-process/explain.go
@@ -19,6 +19,7 @@ import (
 // ExplainOutput is the structured JSON output for --explain.
 type ExplainOutput struct {
 	Version  string        `json:"version"`
+	Commit   string        `json:"commit"`
 	Profile  string        `json:"profile"`
 	Platform PlatformInfo  `json:"platform"`
 	Auth     AuthInfo      `json:"auth"`
@@ -86,6 +87,7 @@ func runExplain(profile string, cfg *config.ProfileConfig) {
 func buildExplainOutput(profile string, cfg *config.ProfileConfig) ExplainOutput {
 	output := ExplainOutput{
 		Version: version.Version,
+		Commit:  version.Commit,
 		Profile: profile,
 		Platform: PlatformInfo{
 			OS:   runtime.GOOS,

--- a/source/go/cmd/credential-process/explain_test.go
+++ b/source/go/cmd/credential-process/explain_test.go
@@ -44,6 +44,10 @@ func TestExplainOutputOIDC(t *testing.T) {
 	if !output.Quota.Enabled {
 		t.Error("expected quota to be enabled when endpoint is set")
 	}
+	if output.Quota.CheckIntervalMin != 0 {
+		// Default is set by config loader, not by explain
+		// When not set in struct, it's 0
+	}
 }
 
 func TestExplainOutputIDC(t *testing.T) {

--- a/source/go/cmd/credential-process/explain_test.go
+++ b/source/go/cmd/credential-process/explain_test.go
@@ -1,0 +1,159 @@
+// ABOUTME: Tests for credential-process --explain flag.
+// ABOUTME: Verifies JSON output structure and mode detection for OIDC, IDC, passthrough.
+
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"ccwb-go/internal/config"
+)
+
+func TestExplainOutputOIDC(t *testing.T) {
+	cfg := &config.ProfileConfig{
+		ProviderDomain:    "company.okta.com",
+		ClientID:          "0oatest123",
+		ProviderType:      "okta",
+		AWSRegion:         "us-west-2",
+		CredentialStorage: "keyring",
+		IdentityPoolName:  "claude-code-pool",
+		QuotaAPIEndpoint:  "https://quota.example.com/check",
+	}
+
+	output := buildExplainOutput("TestProfile", cfg)
+
+	if output.Auth.Mode != "oidc" {
+		t.Errorf("expected auth mode 'oidc', got '%s'", output.Auth.Mode)
+	}
+	if output.Provider == nil {
+		t.Fatal("expected provider info for OIDC mode")
+	}
+	if output.Provider.Type != "okta" {
+		t.Errorf("expected provider type 'okta', got '%s'", output.Provider.Type)
+	}
+	if output.Provider.Domain != "company.okta.com" {
+		t.Errorf("expected provider domain 'company.okta.com', got '%s'", output.Provider.Domain)
+	}
+	if output.Quota.AuthMethod != "bearer" {
+		t.Errorf("expected quota auth method 'bearer', got '%s'", output.Quota.AuthMethod)
+	}
+	if output.Auth.FederationType != "cognito" {
+		t.Errorf("expected federation type 'cognito', got '%s'", output.Auth.FederationType)
+	}
+	if !output.Quota.Enabled {
+		t.Error("expected quota to be enabled when endpoint is set")
+	}
+}
+
+func TestExplainOutputIDC(t *testing.T) {
+	cfg := &config.ProfileConfig{
+		AuthType:             "idc",
+		IDCStartURL:          "https://d-123456.awsapps.com/start",
+		IDCAccountID:         "123456789012",
+		IDCPermissionSetName: "AdministratorAccess",
+		AWSRegion:            "us-east-1",
+		QuotaAPIEndpoint:     "https://quota.example.com/check",
+	}
+
+	output := buildExplainOutput("IDCProfile", cfg)
+
+	if output.Auth.Mode != "idc" {
+		t.Errorf("expected auth mode 'idc', got '%s'", output.Auth.Mode)
+	}
+	if output.Provider != nil {
+		t.Error("expected no provider info for IDC mode")
+	}
+	if output.Quota.AuthMethod != "sigv4" {
+		t.Errorf("expected quota auth method 'sigv4', got '%s'", output.Quota.AuthMethod)
+	}
+	if output.Profile != "IDCProfile" {
+		t.Errorf("expected profile 'IDCProfile', got '%s'", output.Profile)
+	}
+}
+
+func TestExplainOutputPassthrough(t *testing.T) {
+	ssoDisabled := false
+	cfg := &config.ProfileConfig{
+		SsoEnabled: &ssoDisabled,
+		AWSRegion:  "eu-west-1",
+	}
+
+	output := buildExplainOutput("PassthroughProfile", cfg)
+
+	if output.Auth.Mode != "passthrough" {
+		t.Errorf("expected auth mode 'passthrough', got '%s'", output.Auth.Mode)
+	}
+	if output.Provider != nil {
+		t.Error("expected no provider info for passthrough mode")
+	}
+	if output.Storage.Mode != "keyring" {
+		t.Errorf("expected default storage mode 'keyring', got '%s'", output.Storage.Mode)
+	}
+}
+
+func TestExplainOutputDirectSTS(t *testing.T) {
+	cfg := &config.ProfileConfig{
+		ProviderDomain:   "login.microsoftonline.com",
+		ProviderType:     "azure",
+		AWSRegion:        "us-east-1",
+		FederatedRoleARN: "arn:aws:iam::123456789012:role/test",
+	}
+
+	output := buildExplainOutput("AzureProfile", cfg)
+
+	if output.Auth.FederationType != "direct_sts" {
+		t.Errorf("expected federation type 'direct_sts', got '%s'", output.Auth.FederationType)
+	}
+	if output.Provider.Type != "azure" {
+		t.Errorf("expected provider type 'azure', got '%s'", output.Provider.Type)
+	}
+}
+
+func TestExplainOutputJSONRoundTrip(t *testing.T) {
+	cfg := &config.ProfileConfig{
+		ProviderDomain:    "auth.example.com",
+		ProviderType:      "generic",
+		AWSRegion:         "ap-southeast-2",
+		CredentialStorage: "file",
+		FederatedRoleARN:  "arn:aws:iam::123456789012:role/test",
+	}
+
+	output := buildExplainOutput("RoundTrip", cfg)
+
+	data, err := json.Marshal(output)
+	if err != nil {
+		t.Fatalf("failed to marshal explain output: %v", err)
+	}
+
+	var decoded ExplainOutput
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("failed to unmarshal explain output: %v", err)
+	}
+	if decoded.Auth.Mode != "oidc" {
+		t.Errorf("expected auth mode 'oidc' after round-trip, got '%s'", decoded.Auth.Mode)
+	}
+	if decoded.Storage.Mode != "file" {
+		t.Errorf("expected storage mode 'file', got '%s'", decoded.Storage.Mode)
+	}
+	if decoded.Platform.OS == "" {
+		t.Error("expected platform OS to be set")
+	}
+}
+
+func TestExplainQuotaDisabled(t *testing.T) {
+	cfg := &config.ProfileConfig{
+		ProviderDomain: "company.okta.com",
+		ProviderType:   "okta",
+		// No QuotaAPIEndpoint
+	}
+
+	output := buildExplainOutput("NoQuota", cfg)
+
+	if output.Quota.Enabled {
+		t.Error("expected quota to be disabled when no endpoint configured")
+	}
+	if output.Quota.Endpoint != "" {
+		t.Errorf("expected empty endpoint, got '%s'", output.Quota.Endpoint)
+	}
+}

--- a/source/go/cmd/credential-process/main.go
+++ b/source/go/cmd/credential-process/main.go
@@ -53,6 +53,7 @@ func main() {
 	getTag := flag.String("get-tag", "", "Print the value of a single principal tag from the cached ID token (e.g. --get-tag Zone). Exit codes: 0 hit, 2 absent, 4 expired.")
 	login := flag.Bool("login", false, "Interactively sign in (IDC: run device authorization and cache the SSO token), then exit. Use this once on headless/SSH hosts before Claude Code runs.")
 	setClientSecret := flag.Bool("set-client-secret", false, "Store Azure AD client secret in OS secure storage. Set CCWB_CLIENT_SECRET env var for non-interactive use, or enter it at the prompt.")
+	explain := flag.Bool("explain", false, "Print resolved configuration as JSON and exit (no auth, no network calls)")
 	flag.Parse()
 
 	if *versionFlag || *shortVersion {
@@ -89,6 +90,11 @@ func main() {
 	app := &credentialApp{
 		profile: profile,
 		cfg:     cfg,
+	}
+
+	// --explain: print resolved config as JSON and exit (no auth, no network).
+	if *explain {
+		runExplain(profile, cfg)
 	}
 
 	// Flag dispatch — must run before auth-type branching so IDC users

--- a/source/go/cmd/credential-process/main.go
+++ b/source/go/cmd/credential-process/main.go
@@ -57,7 +57,7 @@ func main() {
 	flag.Parse()
 
 	if *versionFlag || *shortVersion {
-		fmt.Printf("credential-process %s\n", version.Version)
+		fmt.Printf("credential-process %s (%s)\n", version.Version, version.Commit)
 		os.Exit(0)
 	}
 

--- a/source/go/cmd/otel-helper/main.go
+++ b/source/go/cmd/otel-helper/main.go
@@ -59,6 +59,7 @@ func main() {
 	testMode := flag.Bool("test", false, "Run in test mode with verbose output")
 	verboseFlag := flag.Bool("verbose", false, "Show verbose output")
 	versionFlag := flag.Bool("version", false, "Show version")
+	statusFlag := flag.Bool("status", false, "Print current otel-helper status as JSON and exit (proxy running? port? mode?)")
 	proxyMode := flag.Bool("proxy", false, "Run as SigV4 signing proxy for CoWork OTLP logs")
 	proxyPort := flag.Int("proxy-port", defaultProxyPort, "Port for the signing proxy (default 4318)")
 	proxyRegion := flag.String("proxy-region", "", "AWS region for CloudWatch OTLP (default: AWS_REGION env)")
@@ -67,6 +68,10 @@ func main() {
 	if *versionFlag {
 		fmt.Printf("otel-helper %s\n", version.Version)
 		os.Exit(0)
+	}
+
+	if *statusFlag {
+		os.Exit(runStatus(*proxyPort))
 	}
 
 	verbose = *verboseFlag || *testMode

--- a/source/go/cmd/otel-helper/main.go
+++ b/source/go/cmd/otel-helper/main.go
@@ -66,7 +66,7 @@ func main() {
 	flag.Parse()
 
 	if *versionFlag {
-		fmt.Printf("otel-helper %s\n", version.Version)
+		fmt.Printf("otel-helper %s (%s)\n", version.Version, version.Commit)
 		os.Exit(0)
 	}
 

--- a/source/go/cmd/otel-helper/status.go
+++ b/source/go/cmd/otel-helper/status.go
@@ -1,0 +1,97 @@
+// ABOUTME: --status flag implementation for otel-helper.
+// ABOUTME: Prints current otel-helper state (proxy running? port? cached headers?)
+// ABOUTME: without starting any services. Used for troubleshooting and ccwb doctor.
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"runtime"
+	"time"
+
+	"ccwb-go/internal/otel"
+	"ccwb-go/internal/version"
+)
+
+// StatusOutput is the structured JSON output for --status.
+type StatusOutput struct {
+	Version  string          `json:"version"`
+	Platform string          `json:"platform"`
+	Profile  string          `json:"profile"`
+	Proxy    ProxyStatus     `json:"proxy"`
+	Cache    CacheStatus     `json:"cache"`
+}
+
+// ProxyStatus reports whether the otel-helper proxy is running.
+type ProxyStatus struct {
+	Listening bool   `json:"listening"`
+	Port      int    `json:"port"`
+	Mode      string `json:"mode,omitempty"` // "sigv4" | "passthrough" | "" (not running)
+}
+
+// CacheStatus reports the state of the otel-headers cache.
+type CacheStatus struct {
+	HasHeaders bool     `json:"has_headers"`
+	Headers    []string `json:"header_keys,omitempty"` // e.g. ["x-user-email", "Authorization"]
+}
+
+// runStatus prints otel-helper status as JSON and returns exit code.
+func runStatus(proxyPort int) int {
+	profile := os.Getenv("AWS_PROFILE")
+	if profile == "" {
+		profile = "ClaudeCode"
+	}
+
+	output := StatusOutput{
+		Version:  version.Version,
+		Platform: runtime.GOOS + "/" + runtime.GOARCH,
+		Profile:  profile,
+		Proxy: ProxyStatus{
+			Port: proxyPort,
+		},
+		Cache: CacheStatus{},
+	}
+
+	// Check if proxy is listening
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", proxyPort), 500*time.Millisecond)
+	if err == nil {
+		conn.Close()
+		output.Proxy.Listening = true
+		output.Proxy.Mode = "sigv4" // Default; passthrough mode detection would need process inspection
+	}
+
+	// Also check alternate port (4319 for sidecar)
+	if proxyPort == defaultProxyPort {
+		altConn, altErr := net.DialTimeout("tcp", "127.0.0.1:4319", 500*time.Millisecond)
+		if altErr == nil {
+			altConn.Close()
+			if !output.Proxy.Listening {
+				output.Proxy.Listening = true
+				output.Proxy.Port = 4319
+				output.Proxy.Mode = "sigv4"
+			}
+		}
+	}
+
+	// Check cached headers
+	headers, err := otel.ReadCachedHeaders(profile)
+	if err == nil && len(headers) > 0 {
+		output.Cache.HasHeaders = true
+		keys := make([]string, 0, len(headers))
+		for k := range headers {
+			keys = append(keys, k)
+		}
+		output.Cache.Headers = keys
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(output); err != nil {
+		fmt.Fprintf(os.Stderr, "Error encoding status output: %v\n", err)
+		return 1
+	}
+	return 0
+}

--- a/source/go/internal/config/config.go
+++ b/source/go/internal/config/config.go
@@ -30,10 +30,13 @@ type ProfileConfig struct {
 	MaxSessionDuration int `json:"max_session_duration"`
 
 	// Quota
-	QuotaAPIEndpoint   string `json:"quota_api_endpoint"`
-	QuotaFailMode      string `json:"quota_fail_mode"`
-	QuotaCheckInterval int    `json:"quota_check_interval"`
-	QuotaCheckTimeout  int    `json:"quota_check_timeout"`
+	QuotaAPIEndpoint       string `json:"quota_api_endpoint"`
+	QuotaFailMode          string `json:"quota_fail_mode"`
+	QuotaCheckInterval     int    `json:"quota_check_interval"`
+	QuotaCheckTimeout      int    `json:"quota_check_timeout"`
+	DailyEnforcementMode   string `json:"daily_enforcement_mode,omitempty"`   // "alert" | "block"
+	MonthlyEnforcementMode string `json:"monthly_enforcement_mode,omitempty"` // "alert" | "block"
+	EnableFineGrained      bool   `json:"enable_finegrained_quotas,omitempty"`
 
 	// Okta Custom Authorization Server id. Absent / empty / "default" all
 	// mean "use the default CAS" -- the Go code normalizes these equivalently.

--- a/source/go/internal/config/config.go
+++ b/source/go/internal/config/config.go
@@ -98,6 +98,15 @@ type ProfileConfig struct {
 	IDCPermissionSetName string `json:"idc_permission_set_name,omitempty"` // IAM role name / permission set
 	IDCRegion            string `json:"idc_region,omitempty"`              // SSO endpoint region (defaults to aws_region)
 
+	// Monitoring
+	MonitoringEnabled      bool   `json:"monitoring_enabled,omitempty"`       // Whether telemetry collection is active
+	MonitoringMode         string `json:"monitoring_mode,omitempty"`          // "central" (ECS Fargate) | "sidecar" (local collector)
+	OtelCollectorEndpoint  string `json:"otel_collector_endpoint,omitempty"` // ALB/collector URL for OTLP export
+
+	// Bootstrap server (dynamic config delivery for CoWork)
+	BootstrapEndpoint      string `json:"bootstrap_endpoint,omitempty"`      // Lambda URL for per-user config at sign-in
+	ConfigDeliveryMode     string `json:"config_delivery_mode,omitempty"`    // "static" | "bootstrap"
+
 	// Legacy field names
 	OktaDomain   string `json:"okta_domain"`
 	OktaClientID string `json:"okta_client_id"`

--- a/source/go/internal/version/version.go
+++ b/source/go/internal/version/version.go
@@ -2,3 +2,6 @@ package version
 
 // Version is set via -ldflags at build time.
 var Version = "dev"
+
+// Commit is set via -ldflags at build time (short SHA).
+var Commit = "unknown"

--- a/source/tests/cli/commands/test_doctor.py
+++ b/source/tests/cli/commands/test_doctor.py
@@ -21,6 +21,7 @@ from claude_code_with_bedrock.cli.commands.doctor import (
 class TestDoctorBinaryDetection:
     """Test binary detection across platforms."""
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="Unix-only test")
     def test_find_binary_unix(self, tmp_path):
         """Unix: finds binary without extension."""
         (tmp_path / "credential-process").write_text("#!/bin/sh")

--- a/source/tests/cli/commands/test_doctor.py
+++ b/source/tests/cli/commands/test_doctor.py
@@ -6,17 +6,15 @@
 import json
 import sys
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
 
 from claude_code_with_bedrock.cli.commands.doctor import (
-    run_doctor,
-    HealthCheck,
     _find_binary,
-    _run_binary_json,
+    run_doctor,
 )
 
 
@@ -86,7 +84,9 @@ class TestDoctorHealthChecks:
         # AWS config
         aws_dir = tmp_path / ".aws"
         aws_dir.mkdir()
-        (aws_dir / "config").write_text("[profile ClaudeCode]\ncredential_process = ~/claude-code-with-bedrock/credential-process\n")
+        (aws_dir / "config").write_text(
+            "[profile ClaudeCode]\ncredential_process = ~/claude-code-with-bedrock/credential-process\n"
+        )
 
         # Claude settings
         claude_dir = tmp_path / ".claude"
@@ -94,22 +94,26 @@ class TestDoctorHealthChecks:
         (claude_dir / "settings.json").write_text(json.dumps({"env": {"AWS_PROFILE": "ClaudeCode"}, "hooks": {}}))
 
         # Mock subprocess calls for --explain and --status
-        explain_output = json.dumps({
-            "version": "2.5.0",
-            "commit": "abc1234",
-            "profile": "default",
-            "auth": {"mode": "oidc", "reason": "sso_enabled=true"},
-            "provider": {"type": "okta", "domain": "company.okta.com"},
-            "quota": {"enabled": False},
-            "storage": {"mode": "keyring"},
-            "paths": {},
-            "platform": {"os": "linux", "arch": "amd64"},
-        })
-        status_output = json.dumps({
-            "version": "2.5.0",
-            "proxy": {"listening": False, "port": 4318},
-            "cache": {"has_headers": False},
-        })
+        explain_output = json.dumps(
+            {
+                "version": "2.5.0",
+                "commit": "abc1234",
+                "profile": "default",
+                "auth": {"mode": "oidc", "reason": "sso_enabled=true"},
+                "provider": {"type": "okta", "domain": "company.okta.com"},
+                "quota": {"enabled": False},
+                "storage": {"mode": "keyring"},
+                "paths": {},
+                "platform": {"os": "linux", "arch": "amd64"},
+            }
+        )
+        status_output = json.dumps(
+            {
+                "version": "2.5.0",
+                "proxy": {"listening": False, "port": 4318},
+                "cache": {"has_headers": False},
+            }
+        )
 
         def mock_run(cmd, **kwargs):
             mock_result = MagicMock()

--- a/source/tests/cli/commands/test_doctor.py
+++ b/source/tests/cli/commands/test_doctor.py
@@ -1,0 +1,214 @@
+# ABOUTME: Tests for ccwb doctor command — validates health checks work correctly.
+# ABOUTME: Covers binary detection, --explain integration, Windows path handling.
+
+"""Tests for doctor command."""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+from claude_code_with_bedrock.cli.commands.doctor import (
+    run_doctor,
+    HealthCheck,
+    _find_binary,
+    _run_binary_json,
+)
+
+
+class TestDoctorBinaryDetection:
+    """Test binary detection across platforms."""
+
+    def test_find_binary_unix(self, tmp_path):
+        """Unix: finds binary without extension."""
+        (tmp_path / "credential-process").write_text("#!/bin/sh")
+        result = _find_binary(tmp_path, "credential-process")
+        assert result is not None
+        assert result.name == "credential-process"
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only test")
+    def test_find_binary_windows_exe(self, tmp_path):
+        """Windows: prefers .exe over .cmd/.ps1."""
+        (tmp_path / "credential-process.exe").write_text("")
+        (tmp_path / "credential-process.cmd").write_text("")
+        result = _find_binary(tmp_path, "credential-process")
+        assert result.suffix == ".exe"
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only test")
+    def test_find_binary_windows_cmd_fallback(self, tmp_path):
+        """Windows: falls back to .cmd when .exe missing."""
+        (tmp_path / "credential-process.cmd").write_text("")
+        result = _find_binary(tmp_path, "credential-process")
+        assert result.suffix == ".cmd"
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="Windows-only test")
+    def test_find_binary_windows_ps1_fallback(self, tmp_path):
+        """Windows: falls back to .ps1 when .exe and .cmd missing."""
+        (tmp_path / "otel-helper.ps1").write_text("")
+        result = _find_binary(tmp_path, "otel-helper")
+        assert result.suffix == ".ps1"
+
+    def test_find_binary_missing(self, tmp_path):
+        """Returns None when binary not found."""
+        result = _find_binary(tmp_path, "nonexistent")
+        assert result is None
+
+
+class TestDoctorHealthChecks:
+    """Test the full doctor run with mocked filesystem."""
+
+    def test_all_pass_with_complete_install(self, tmp_path):
+        """All static checks pass with correct installation."""
+        # Set up mock installation
+        install_dir = tmp_path / "claude-code-with-bedrock"
+        install_dir.mkdir()
+
+        binary_name = "credential-process.exe" if sys.platform == "win32" else "credential-process"
+        (install_dir / binary_name).write_text("binary")
+
+        otel_name = "otel-helper.exe" if sys.platform == "win32" else "otel-helper"
+        (install_dir / otel_name).write_text("binary")
+
+        config = {
+            "profiles": {
+                "default": {
+                    "provider_domain": "company.okta.com",
+                    "aws_region": "us-west-2",
+                }
+            }
+        }
+        (install_dir / "config.json").write_text(json.dumps(config))
+
+        # AWS config
+        aws_dir = tmp_path / ".aws"
+        aws_dir.mkdir()
+        (aws_dir / "config").write_text("[profile ClaudeCode]\ncredential_process = ~/claude-code-with-bedrock/credential-process\n")
+
+        # Claude settings
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "settings.json").write_text(json.dumps({"env": {"AWS_PROFILE": "ClaudeCode"}, "hooks": {}}))
+
+        # Mock subprocess calls for --explain and --status
+        explain_output = json.dumps({
+            "version": "2.5.0",
+            "commit": "abc1234",
+            "profile": "default",
+            "auth": {"mode": "oidc", "reason": "sso_enabled=true"},
+            "provider": {"type": "okta", "domain": "company.okta.com"},
+            "quota": {"enabled": False},
+            "storage": {"mode": "keyring"},
+            "paths": {},
+            "platform": {"os": "linux", "arch": "amd64"},
+        })
+        status_output = json.dumps({
+            "version": "2.5.0",
+            "proxy": {"listening": False, "port": 4318},
+            "cache": {"has_headers": False},
+        })
+
+        def mock_run(cmd, **kwargs):
+            mock_result = MagicMock()
+            if "--explain" in cmd:
+                mock_result.returncode = 0
+                mock_result.stdout = explain_output
+            elif "--status" in cmd:
+                mock_result.returncode = 0
+                mock_result.stdout = status_output
+            else:
+                mock_result.returncode = 1
+                mock_result.stdout = ""
+            return mock_result
+
+        with patch("claude_code_with_bedrock.cli.commands.doctor.subprocess.run", side_effect=mock_run):
+            checks = run_doctor(home=tmp_path)
+
+        # All static checks should pass (no monitoring configured, so otel is skipped)
+        fails = [c for c in checks if c.status == "fail"]
+        assert len(fails) == 0, f"Unexpected failures: {[(c.name, c.message) for c in fails]}"
+
+    def test_missing_binary_fails(self, tmp_path):
+        """Missing credential-process binary causes failure."""
+        install_dir = tmp_path / "claude-code-with-bedrock"
+        install_dir.mkdir()
+        (install_dir / "config.json").write_text('{"profiles":{}}')
+
+        checks = run_doctor(home=tmp_path)
+        binary_check = next(c for c in checks if c.name == "credential-process")
+        assert binary_check.status == "fail"
+
+    def test_invalid_config_json_fails(self, tmp_path):
+        """Invalid JSON in config.json causes failure."""
+        install_dir = tmp_path / "claude-code-with-bedrock"
+        install_dir.mkdir()
+        (install_dir / "config.json").write_text("not valid json{{{")
+
+        binary_name = "credential-process.exe" if sys.platform == "win32" else "credential-process"
+        (install_dir / binary_name).write_text("binary")
+
+        checks = run_doctor(home=tmp_path)
+        config_check = next(c for c in checks if c.name == "config.json")
+        assert config_check.status == "fail"
+        assert "Invalid JSON" in config_check.message
+
+    def test_explain_populates_detail(self, tmp_path):
+        """--explain output is captured in check detail field."""
+        install_dir = tmp_path / "claude-code-with-bedrock"
+        install_dir.mkdir()
+
+        binary_name = "credential-process.exe" if sys.platform == "win32" else "credential-process"
+        (install_dir / binary_name).write_text("binary")
+        (install_dir / "config.json").write_text('{"profiles":{"default":{}}}')
+
+        explain_data = {
+            "version": "2.5.0",
+            "commit": "abc1234",
+            "auth": {"mode": "idc", "reason": "auth_type=idc"},
+            "profile": "default",
+            "platform": {"os": "linux", "arch": "arm64"},
+            "quota": {"enabled": True, "auth_method": "sigv4"},
+            "storage": {"mode": "file"},
+            "paths": {},
+        }
+
+        def mock_run(cmd, **kwargs):
+            mock_result = MagicMock()
+            if "--explain" in cmd:
+                mock_result.returncode = 0
+                mock_result.stdout = json.dumps(explain_data)
+            else:
+                mock_result.returncode = 1
+                mock_result.stdout = ""
+            return mock_result
+
+        with patch("claude_code_with_bedrock.cli.commands.doctor.subprocess.run", side_effect=mock_run):
+            checks = run_doctor(home=tmp_path)
+
+        explain_check = next(c for c in checks if c.name == "explain")
+        assert explain_check.status == "pass"
+        assert explain_check.detail is not None
+        assert explain_check.detail["auth"]["mode"] == "idc"
+        assert "mode=idc" in explain_check.message
+
+    def test_json_output_format(self, tmp_path):
+        """--json output is valid JSON with expected structure."""
+        install_dir = tmp_path / "claude-code-with-bedrock"
+        install_dir.mkdir()
+        (install_dir / "config.json").write_text('{"profiles":{}}')
+
+        checks = run_doctor(home=tmp_path)
+        output = {
+            "checks": [
+                {"name": c.name, "status": c.status, "message": c.message, "fix": c.fix, "detail": c.detail}
+                for c in checks
+            ],
+        }
+        # Should be valid JSON
+        serialized = json.dumps(output)
+        parsed = json.loads(serialized)
+        assert "checks" in parsed
+        assert all("name" in c for c in parsed["checks"])

--- a/source/tests/cli/commands/test_package_oidc_sidecar.py
+++ b/source/tests/cli/commands/test_package_oidc_sidecar.py
@@ -250,14 +250,23 @@ class TestBuildOtelcolTargets:
         """Windows binaries must NOT be stripped (Defender Wacatac.B!ml on stripped Go)."""
         from claude_code_with_bedrock.cli.commands.package import _go_ldflags
 
-        assert _go_ldflags("windows") == ""
+        flags = _go_ldflags("windows")
+        assert "-s" not in flags.split()
+        assert "-w" not in flags.split()
+        # Version injection must still be present
+        assert "-X" in flags
 
     def test_non_windows_ldflags_stripped(self):
         """macOS/Linux binaries are stripped (-s -w) for size."""
         from claude_code_with_bedrock.cli.commands.package import _go_ldflags
 
-        assert _go_ldflags("darwin") == "-s -w"
-        assert _go_ldflags("linux") == "-s -w"
+        darwin_flags = _go_ldflags("darwin")
+        linux_flags = _go_ldflags("linux")
+        assert "-s" in darwin_flags and "-w" in darwin_flags
+        assert "-s" in linux_flags and "-w" in linux_flags
+        # Version injection must also be present
+        assert "-X" in darwin_flags
+        assert "-X" in linux_flags
 
     def test_build_otelcol_method_exists(self):
         """_build_otelcol must be restored on PackageCommand (regression for PR #338 removal)."""


### PR DESCRIPTION
## Why

Support requests follow a pattern: user hits a silent failure, we ask "what auth mode?", "monitoring configured?", "what version?" — and the user doesn't know. Issues #664, #428, #427, #520, #583, #541 would have been diagnosed in seconds with one command.

## Usage

```bash
# Quick self-check (instant, no network calls)
ccwb doctor

# Full diagnostic export (includes live auth + proxy probes)
ccwb doctor --json > diagnostics.json
```

## What It Checks

| Check | What | Mode |
|-------|------|------|
| `credential-process` | Binary exists (.exe/.cmd/.ps1 on Windows) | both |
| `config.json` | Valid JSON, lists profiles | both |
| `aws-profile` | ~/.aws/config references credential-process | both |
| `settings.json` | Claude Code hooks configured | both |
| `explain` | Full resolved config via `credential-process --explain` | both |
| `otel-helper` | Telemetry binary present (if monitoring configured) | both |
| `otel-status` | Proxy running? Headers cached? via `otel-helper --status` | both |
| `auth-test` | Attempts credential check | --json only |
| `proxy-health` | TCP connect to OTEL proxy port | --json only |

## `credential-process --explain` (Go)

The diagnostic backbone. Outputs every configuration dimension as JSON — no auth, no network calls:

```json
{
  "version": "v2.5.0-beta.91",
  "commit": "62a232f",
  "profile": "ClaudeCode",
  "auth": { "mode": "oidc", "reason": "sso_enabled=true with provider_domain configured" },
  "provider": { "type": "okta", "domain": "company.okta.com" },
  "monitoring": { "enabled": true, "mode": "central", "endpoint": "https://otel.example.com" },
  "quota": { "enabled": true, "fail_mode": "open", "auth_method": "bearer" },
  "storage": { "mode": "keyring" },
  "paths": { "config_dir": "~/claude-code-with-bedrock", "config_file": "config.json" },
  "platform": { "os": "windows", "arch": "amd64" }
}
```

## Troubleshooting workflow

1. Run `ccwb doctor` — fix any FAIL items
2. If issues persist: `ccwb doctor --json > diagnostics.json`
3. Ask Claude to file an issue: *"Create a GitHub issue on aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock with the diagnostics from diagnostics.json. Use gh api."*

## Testing

- 7 unit tests (binary detection, health checks, explain integration, JSON output format)
- 6 Go tests for `--explain` (OIDC, IDC, passthrough, direct-STS, quota, JSON roundtrip)
- All 1306 tests pass

## Backwards compatible

- New optional command — no impact on existing workflows
- Go `--explain` and `--status` flags are additive (no behavior change to existing flags)