### PR TITLE
feat(bootstrap): add IAM auth for IDC users [depends on #706]

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,15 @@ poetry run ccwb cowork generate
 
 This generates MDM configuration files (JSON, macOS .mobileconfig, Windows .reg) using your existing deployment profile. See the [CoWork 3P Guide](assets/docs/COWORK_3P.md) for setup and deployment details.
 
+**Configuration Delivery Methods:**
+
+| Method | Auth Type | Description |
+|--------|-----------|-------------|
+| **Static (MDM)** | OIDC, IDC | Full config baked into MDM profile — inference region, models, OTEL endpoint |
+| **Dynamic (Bootstrap Server)** | OIDC only | Lightweight API validates user's OIDC token and returns per-user config at sign-in |
+
+The bootstrap server enables central config changes without MDM re-deployment and injects per-user OTLP identity headers (`x-user-id`, `x-user-email`) for telemetry attribution. See [Bootstrap Server](assets/docs/BOOTSTRAP_SERVER.md) for details.
+
 ## Architecture Overview
 
 The architecture is modular — start with authentication, then optionally add [monitoring, quota enforcement, analytics, or distribution](#what-gets-deployed) independently as requirements grow. This guidance supports three authentication paths (see [Authentication Modes](#authentication-modes) for details). The recommended path is Direct IAM Federation:

--- a/assets/docs/BOOTSTRAP_SERVER.md
+++ b/assets/docs/BOOTSTRAP_SERVER.md
@@ -1,0 +1,128 @@
+# Bootstrap Server
+
+The CoWork Bootstrap Server delivers per-user configuration to Claude Desktop (CoWork) clients dynamically at sign-in. Instead of baking full configuration into static MDM profiles, administrators deploy a lightweight API endpoint that validates the user's OIDC token and returns their personalized settings — inference region, allowed models, OTEL endpoint, and session lifetime.
+
+This enables organizations to change configuration centrally without re-deploying MDM profiles, support different config per user/group (future v2), and ensure configuration is only delivered to authenticated users with valid OIDC tokens.
+
+## How It Works
+
+```
+┌─────────────┐     1. Sign in (OIDC)      ┌──────────────┐
+│  CoWork     │ ──────────────────────────► │  OIDC IdP    │
+│  (Client)   │ ◄────────────────────────── │  (Okta/Azure)│
+│             │     2. Receive token        └──────────────┘
+│             │
+│             │     3. GET /config           ┌──────────────┐
+│             │        Authorization:        │  Bootstrap   │
+│             │        Bearer <token>        │  Server      │
+│             │ ──────────────────────────► │  (Lambda)    │
+│             │                              │              │
+│             │     4. Validate JWT          │  - Verify    │
+│             │        against JWKS          │    signature │
+│             │                              │  - Check iss │
+│             │     5. Return config JSON    │  - Check aud │
+│             │ ◄────────────────────────── │  - Check exp │
+└─────────────┘                              └──────────────┘
+```
+
+1. User signs into CoWork via OIDC (standard flow)
+2. CoWork receives an access/ID token from the IdP
+3. CoWork calls the bootstrap URL with the Bearer token
+4. Lambda validates the JWT signature against the IdP's JWKS
+5. Lambda returns per-user configuration JSON
+
+## Configuration Options
+
+The bootstrap server is configured during `ccwb init` and deployed with `ccwb deploy bootstrap`.
+
+### Init Wizard
+
+During `ccwb init`, after the CoWork 3P section:
+
+```
+CoWork configuration delivery:
+  ❯ Static (default — MDM profile with inline config)
+    Dynamic (bootstrap server — per-user config at sign-in)
+```
+
+### CloudFormation Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `OidcIssuerUrl` | OIDC issuer URL for token validation | (from profile) |
+| `OidcClientId` | Client ID for audience validation | (from profile) |
+| `OidcJwksEndpoint` | JWKS endpoint for signature verification | (auto-derived) |
+| `DefaultInferenceRegion` | AWS region for Bedrock inference | `us-east-1` |
+| `DefaultInferenceModels` | Comma-separated allowed model IDs | Sonnet |
+| `OtlpEndpoint` | OpenTelemetry collector endpoint | (optional) |
+| `InferenceSessionLifetimeSec` | Session lifetime before re-auth | `28800` (8h) |
+
+### Response Format
+
+```json
+{
+  "inferenceProvider": "bedrock",
+  "inferenceRegion": "us-east-1",
+  "inferenceModels": ["us.anthropic.claude-sonnet-4-20250514-v1:0"],
+  "inferenceSessionLifetimeSec": 28800,
+  "otlpEndpoint": "https://otel.example.com",
+  "otlpHeaders": {
+    "x-user-id": "user-sub-claim",
+    "x-user-email": "user@example.com"
+  },
+  "expiresAt": 1719352800,
+  "user": {
+    "sub": "user-sub-claim",
+    "email": "user@example.com"
+  }
+}
+```
+
+## Security Considerations
+
+- **Token validation**: Every request must include a valid JWT Bearer token. The Lambda validates the signature against the IdP's JWKS, checks issuer (`iss`), audience (`aud`), and expiration (`exp`) claims.
+- **No caching**: Responses include `Cache-Control: no-store` to prevent stale configuration.
+- **HTTPS only**: API Gateway enforces HTTPS. The JWKS endpoint must also be HTTPS.
+- **Short-lived config**: The `expiresAt` field (1 hour) tells clients when to re-fetch. This limits exposure if a config response is somehow captured.
+- **No secrets in response**: The config response contains no credentials — only configuration directives. Authentication for Bedrock remains handled by the credential helper.
+
+## How Clients Connect (MDM Anchor Profile)
+
+When using dynamic configuration, deploy a minimal MDM "anchor" profile that only contains the bootstrap URL. The client fetches full configuration from the server at sign-in:
+
+```json
+{
+  "coworkOAuthClientId": "your-oidc-client-id",
+  "coworkOAuthIssuer": "https://your-idp.example.com/oauth2/default",
+  "bootstrapUrl": "https://abc123.execute-api.us-east-1.amazonaws.com/config"
+}
+```
+
+This replaces the need for a full static MDM profile with all inference settings inlined. The client authenticates, receives its token, calls the bootstrap URL, and receives its full configuration.
+
+## Deployment
+
+```bash
+# Initialize with dynamic config mode
+poetry run ccwb init
+# Select "Dynamic" when prompted for CoWork configuration delivery
+
+# Deploy the bootstrap server stack
+poetry run ccwb deploy bootstrap
+
+# Or deploy all stacks (bootstrap is included when dynamic mode is configured)
+poetry run ccwb deploy
+```
+
+## Supported Identity Providers
+
+The bootstrap server works with any OIDC-compatible IdP:
+
+- **Okta** — JWKS at `{issuer}/v1/keys`
+- **Azure AD / Entra ID** — JWKS at `login.microsoftonline.com/{tenant}/discovery/v2.0/keys`
+- **Google Workspace** — JWKS at `googleapis.com/oauth2/v3/certs`
+- **Amazon Cognito** — JWKS at `{user-pool-url}/.well-known/jwks.json`
+- **Auth0** — JWKS at `{issuer}/.well-known/jwks.json`
+- **Generic OIDC** — Any provider with a standard JWKS endpoint
+
+> **Note**: IAM Identity Center (IDC) is not supported for bootstrap server in v1. Use static MDM profiles for IDC deployments.

--- a/assets/docs/BOOTSTRAP_SERVER.md
+++ b/assets/docs/BOOTSTRAP_SERVER.md
@@ -54,8 +54,18 @@ Claude Desktop configuration delivery:
 | `OidcJwksEndpoint` | JWKS endpoint for signature verification | (auto-derived) |
 | `DefaultInferenceRegion` | AWS region for Bedrock inference | `us-east-1` |
 | `DefaultInferenceModels` | Comma-separated allowed model IDs | Sonnet |
-| `OtlpEndpoint` | OpenTelemetry collector endpoint | (optional) |
+| `OtlpEndpoint` | OpenTelemetry collector endpoint (HTTPS) | (optional) |
 | `InferenceSessionLifetimeSec` | Session lifetime before re-auth | `28800` (8h) |
+
+### OTLP Telemetry Output
+
+When `OtlpEndpoint` is configured, the bootstrap server response includes:
+- **`otlpEndpoint`** — The HTTPS collector URL that Claude Desktop will send traces/metrics to
+- **`otlpHeaders`** — Per-user identity headers injected into every OTLP export:
+  - `x-user-id`: The user's `sub` claim from the OIDC token
+  - `x-user-email`: The user's `email` claim (when available)
+
+This gives CloudWatch dashboards per-user attribution without requiring a local proxy — the headers are delivered at sign-in and applied for the session lifetime.
 
 ### Response Format
 

--- a/assets/docs/BOOTSTRAP_SERVER.md
+++ b/assets/docs/BOOTSTRAP_SERVER.md
@@ -1,6 +1,6 @@
 # Bootstrap Server
 
-The CoWork Bootstrap Server delivers per-user configuration to Claude Desktop (CoWork) clients dynamically at sign-in. Instead of baking full configuration into static MDM profiles, administrators deploy a lightweight API endpoint that validates the user's OIDC token and returns their personalized settings — inference region, allowed models, OTEL endpoint, and session lifetime.
+The Claude Desktop Bootstrap Server delivers per-user configuration to Claude Desktop clients dynamically at sign-in. Instead of baking full configuration into static MDM profiles, administrators deploy a lightweight API endpoint that validates the user's OIDC token and returns their personalized settings — inference region, allowed models, OTEL endpoint, and session lifetime.
 
 This enables organizations to change configuration centrally without re-deploying MDM profiles, support different config per user/group (future v2), and ensure configuration is only delivered to authenticated users with valid OIDC tokens.
 
@@ -8,7 +8,7 @@ This enables organizations to change configuration centrally without re-deployin
 
 ```
 ┌─────────────┐     1. Sign in (OIDC)      ┌──────────────┐
-│  CoWork     │ ──────────────────────────► │  OIDC IdP    │
+│Claude Desktop│ ──────────────────────────► │  OIDC IdP    │
 │  (Client)   │ ◄────────────────────────── │  (Okta/Azure)│
 │             │     2. Receive token        └──────────────┘
 │             │
@@ -25,9 +25,9 @@ This enables organizations to change configuration centrally without re-deployin
 └─────────────┘                              └──────────────┘
 ```
 
-1. User signs into CoWork via OIDC (standard flow)
-2. CoWork receives an access/ID token from the IdP
-3. CoWork calls the bootstrap URL with the Bearer token
+1. User signs into Claude Desktop via OIDC (standard flow)
+2. Claude Desktop receives an access/ID token from the IdP
+3. Claude Desktop calls the bootstrap URL with the Bearer token
 4. Lambda validates the JWT signature against the IdP's JWKS
 5. Lambda returns per-user configuration JSON
 
@@ -37,10 +37,10 @@ The bootstrap server is configured during `ccwb init` and deployed with `ccwb de
 
 ### Init Wizard
 
-During `ccwb init`, after the CoWork 3P section:
+During `ccwb init`, after the Claude Desktop 3P section:
 
 ```
-CoWork configuration delivery:
+Claude Desktop configuration delivery:
   ❯ Static (default — MDM profile with inline config)
     Dynamic (bootstrap server — per-user config at sign-in)
 ```
@@ -105,7 +105,7 @@ This replaces the need for a full static MDM profile with all inference settings
 ```bash
 # Initialize with dynamic config mode
 poetry run ccwb init
-# Select "Dynamic" when prompted for CoWork configuration delivery
+# Select "Dynamic" when prompted for Claude Desktop configuration delivery
 
 # Deploy the bootstrap server stack
 poetry run ccwb deploy bootstrap

--- a/deployment/infrastructure/bootstrap-server.yaml
+++ b/deployment/infrastructure/bootstrap-server.yaml
@@ -1,0 +1,154 @@
+# ABOUTME: CloudFormation template for the CoWork Bootstrap Server
+# ABOUTME: Deploys an API Gateway HTTP API + Lambda that validates OIDC tokens
+# ABOUTME: and returns per-user configuration for Claude Desktop (CoWork) at sign-in
+
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  CoWork Bootstrap Server — delivers per-user configuration dynamically at sign-in
+  as an alternative to static MDM profiles. Validates OIDC Bearer tokens and returns
+  configuration JSON including inference provider, region, models, and OTEL settings.
+
+Parameters:
+  OidcIssuerUrl:
+    Type: String
+    Description: "OIDC issuer URL (e.g. https://company.okta.com/oauth2/default)"
+    AllowedPattern: "^https://.*"
+    ConstraintDescription: "Must be a valid HTTPS URL"
+
+  OidcClientId:
+    Type: String
+    Description: "OIDC client ID for token audience validation"
+    MinLength: 1
+
+  OidcJwksEndpoint:
+    Type: String
+    Description: "JWKS endpoint URL for JWT signature verification"
+    AllowedPattern: "^https://.*"
+    ConstraintDescription: "Must be a valid HTTPS URL"
+
+  DefaultInferenceRegion:
+    Type: String
+    Description: "Default AWS region for Bedrock inference"
+    Default: "us-east-1"
+
+  DefaultInferenceModels:
+    Type: String
+    Description: "Comma-separated list of allowed model IDs"
+    Default: "us.anthropic.claude-sonnet-4-20250514-v1:0"
+
+  OtlpEndpoint:
+    Type: String
+    Description: "OpenTelemetry collector endpoint URL (optional)"
+    Default: ""
+
+  InferenceSessionLifetimeSec:
+    Type: Number
+    Description: "Session lifetime in seconds before re-authentication reminder"
+    Default: 28800
+    MinValue: 3600
+    MaxValue: 86400
+
+Resources:
+  BootstrapFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub "${AWS::StackName}-bootstrap"
+      Runtime: python3.12
+      Handler: index.lambda_handler
+      Timeout: 10
+      MemorySize: 256
+      Code:
+        ZipFile: |
+          # Inline placeholder — real code deployed via package command
+          def lambda_handler(event, context):
+              return {"statusCode": 500, "body": "Not deployed"}
+      Environment:
+        Variables:
+          OIDC_ISSUER_URL: !Ref OidcIssuerUrl
+          OIDC_CLIENT_ID: !Ref OidcClientId
+          OIDC_JWKS_ENDPOINT: !Ref OidcJwksEndpoint
+          DEFAULT_INFERENCE_REGION: !Ref DefaultInferenceRegion
+          DEFAULT_INFERENCE_MODELS: !Ref DefaultInferenceModels
+          OTLP_ENDPOINT: !Ref OtlpEndpoint
+          INFERENCE_SESSION_LIFETIME_SEC: !Ref InferenceSessionLifetimeSec
+      Role: !GetAtt BootstrapFunctionRole.Arn
+      Tags:
+        - Key: Application
+          Value: "claude-code-with-bedrock"
+        - Key: Component
+          Value: "bootstrap-server"
+
+  BootstrapFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "${AWS::StackName}-bootstrap-role"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: "sts:AssumeRole"
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+
+  BootstrapApi:
+    Type: AWS::ApiGatewayV2::Api
+    Properties:
+      Name: !Sub "${AWS::StackName}-api"
+      ProtocolType: HTTP
+      Description: "CoWork Bootstrap Server API"
+      CorsConfiguration:
+        AllowOrigins:
+          - "*"
+        AllowMethods:
+          - GET
+        AllowHeaders:
+          - Authorization
+          - Content-Type
+        MaxAge: 3600
+
+  BootstrapApiStage:
+    Type: AWS::ApiGatewayV2::Stage
+    Properties:
+      ApiId: !Ref BootstrapApi
+      StageName: "$default"
+      AutoDeploy: true
+
+  BootstrapApiIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    Properties:
+      ApiId: !Ref BootstrapApi
+      IntegrationType: AWS_PROXY
+      IntegrationUri: !GetAtt BootstrapFunction.Arn
+      PayloadFormatVersion: "2.0"
+
+  BootstrapApiRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref BootstrapApi
+      RouteKey: "GET /config"
+      Target: !Sub "integrations/${BootstrapApiIntegration}"
+
+  BootstrapApiPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref BootstrapFunction
+      Action: "lambda:InvokeFunction"
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${BootstrapApi}/*"
+
+Outputs:
+  BootstrapUrl:
+    Description: "Bootstrap server endpoint URL for MDM bootstrapUrl key"
+    Value: !Sub "https://${BootstrapApi}.execute-api.${AWS::Region}.amazonaws.com/config"
+    Export:
+      Name: !Sub "${AWS::StackName}-BootstrapUrl"
+
+  BootstrapFunctionArn:
+    Description: "Bootstrap Lambda function ARN"
+    Value: !GetAtt BootstrapFunction.Arn
+
+  BootstrapApiId:
+    Description: "API Gateway HTTP API ID"
+    Value: !Ref BootstrapApi

--- a/deployment/infrastructure/bootstrap-server.yaml
+++ b/deployment/infrastructure/bootstrap-server.yaml
@@ -1,24 +1,23 @@
 # ABOUTME: CloudFormation template for the Claude Desktop Bootstrap Server
 # ABOUTME: Deploys an API Gateway HTTP API + Lambda that validates OIDC tokens
-# ABOUTME: and returns per-user configuration for Claude Desktop at sign-in
+# ABOUTME: or IAM (SigV4) auth and returns per-user configuration for Claude Desktop
 
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
-  Claude Desktop Bootstrap Server — delivers per-user configuration dynamically at sign-in
-  as an alternative to static MDM profiles. Validates OIDC Bearer tokens and returns
-  configuration JSON including inference provider, region, models, and OTEL settings.
+  Claude Desktop Bootstrap Server — delivers per-user configuration dynamically at sign-in.
+  Supports OIDC Bearer auth (JWT validation) and IAM auth (SigV4 for IDC users).
+  Returns configuration JSON including inference provider, region, models, and OTEL settings.
 
 Parameters:
   OidcIssuerUrl:
     Type: String
-    Description: "OIDC issuer URL (e.g. https://company.okta.com/oauth2/default)"
-    AllowedPattern: "^https://.*"
-    ConstraintDescription: "Must be a valid HTTPS URL"
+    Description: "OIDC issuer URL (e.g. https://company.okta.com/oauth2/default). Leave empty for IDC-only mode."
+    Default: ""
 
   OidcClientId:
     Type: String
-    Description: "OIDC client ID for token audience validation"
-    MinLength: 1
+    Description: "OIDC client ID for token audience validation. Leave empty for IDC-only mode."
+    Default: ""
 
   OidcJwksEndpoint:
     Type: String
@@ -46,6 +45,10 @@ Parameters:
     Default: 28800
     MinValue: 3600
     MaxValue: 86400
+
+Conditions:
+  HasOidcAuth: !Not [!Equals [!Ref OidcIssuerUrl, ""]]
+  HasIamAuth: !Equals [!Ref OidcIssuerUrl, ""]
 
 Resources:
   BootstrapFunction:
@@ -131,6 +134,25 @@ Resources:
       ApiId: !Ref BootstrapApi
       RouteKey: "GET /config"
       Target: !Sub "integrations/${BootstrapApiIntegration}"
+      # OIDC mode: no API-level auth (Lambda validates Bearer token itself)
+      # IDC mode: AWS_IAM auth (SigV4 — API Gateway validates the signature)
+      AuthorizationType: !If [HasOidcAuth, "NONE", "AWS_IAM"]
+
+  # IAM Managed Policy for IDC callers (only created when using IAM auth).
+  # IDC permission sets must include this policy to call the bootstrap API.
+  BootstrapApiInvokePolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Condition: HasIamAuth
+    Properties:
+      ManagedPolicyName: !Sub "${AWS::StackName}-BootstrapApiInvoke"
+      Description: "Allows invoke on the bootstrap API Gateway (required for IDC/IAM-auth callers)"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: AllowBootstrapApiInvoke
+            Effect: Allow
+            Action: "execute-api:Invoke"
+            Resource: !Sub "arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${BootstrapApi}/*"
 
   BootstrapApiPermission:
     Type: AWS::Lambda::Permission
@@ -154,3 +176,10 @@ Outputs:
   BootstrapApiId:
     Description: "API Gateway HTTP API ID"
     Value: !Ref BootstrapApi
+
+  BootstrapApiInvokePolicyArn:
+    Condition: HasIamAuth
+    Description: "ARN of the managed policy granting execute-api:Invoke (attach to IDC permission sets)"
+    Value: !Ref BootstrapApiInvokePolicy
+    Export:
+      Name: !Sub "${AWS::StackName}-BootstrapApiInvokePolicyArn"

--- a/deployment/infrastructure/bootstrap-server.yaml
+++ b/deployment/infrastructure/bootstrap-server.yaml
@@ -1,10 +1,10 @@
-# ABOUTME: CloudFormation template for the CoWork Bootstrap Server
+# ABOUTME: CloudFormation template for the Claude Desktop Bootstrap Server
 # ABOUTME: Deploys an API Gateway HTTP API + Lambda that validates OIDC tokens
-# ABOUTME: and returns per-user configuration for Claude Desktop (CoWork) at sign-in
+# ABOUTME: and returns per-user configuration for Claude Desktop at sign-in
 
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >
-  CoWork Bootstrap Server — delivers per-user configuration dynamically at sign-in
+  Claude Desktop Bootstrap Server — delivers per-user configuration dynamically at sign-in
   as an alternative to static MDM profiles. Validates OIDC Bearer tokens and returns
   configuration JSON including inference provider, region, models, and OTEL settings.
 
@@ -97,7 +97,7 @@ Resources:
     Properties:
       Name: !Sub "${AWS::StackName}-api"
       ProtocolType: HTTP
-      Description: "CoWork Bootstrap Server API"
+      Description: "Claude Desktop Bootstrap Server API"
       CorsConfiguration:
         AllowOrigins:
           - "*"

--- a/deployment/infrastructure/bootstrap-server.yaml
+++ b/deployment/infrastructure/bootstrap-server.yaml
@@ -22,9 +22,8 @@ Parameters:
 
   OidcJwksEndpoint:
     Type: String
-    Description: "JWKS endpoint URL for JWT signature verification"
-    AllowedPattern: "^https://.*"
-    ConstraintDescription: "Must be a valid HTTPS URL"
+    Description: "JWKS endpoint URL (optional — auto-discovered from issuer if empty)"
+    Default: ""
 
   DefaultInferenceRegion:
     Type: String
@@ -90,7 +89,7 @@ Resources:
               Service: lambda.amazonaws.com
             Action: "sts:AssumeRole"
       ManagedPolicyArns:
-        - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 
   BootstrapApi:
     Type: AWS::ApiGatewayV2::Api
@@ -114,6 +113,9 @@ Resources:
       ApiId: !Ref BootstrapApi
       StageName: "$default"
       AutoDeploy: true
+      DefaultRouteSettings:
+        ThrottlingBurstLimit: 50
+        ThrottlingRateLimit: 10
 
   BootstrapApiIntegration:
     Type: AWS::ApiGatewayV2::Integration
@@ -136,7 +138,7 @@ Resources:
       FunctionName: !Ref BootstrapFunction
       Action: "lambda:InvokeFunction"
       Principal: apigateway.amazonaws.com
-      SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${BootstrapApi}/*"
+      SourceArn: !Sub "arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${BootstrapApi}/*"
 
 Outputs:
   BootstrapUrl:

--- a/deployment/infrastructure/lambda-functions/bootstrap_server/index.py
+++ b/deployment/infrastructure/lambda-functions/bootstrap_server/index.py
@@ -40,31 +40,65 @@ _jwks_cache = None
 _jwks_cache_time = 0
 JWKS_CACHE_TTL = 3600  # Cache JWKS for 1 hour
 
+# Resolved JWKS endpoint (auto-discovered if not explicitly configured)
+_resolved_jwks_endpoint = None
+
+
+def _resolve_jwks_endpoint():
+    """Resolve JWKS endpoint — use explicit config or discover from issuer."""
+    global _resolved_jwks_endpoint
+    if _resolved_jwks_endpoint:
+        return _resolved_jwks_endpoint
+
+    if OIDC_JWKS_ENDPOINT:
+        _resolved_jwks_endpoint = OIDC_JWKS_ENDPOINT
+        return _resolved_jwks_endpoint
+
+    # Auto-discover from OIDC issuer's well-known configuration
+    if OIDC_ISSUER_URL:
+        discovery_url = OIDC_ISSUER_URL.rstrip("/") + "/.well-known/openid-configuration"
+        try:
+            req = urllib.request.Request(discovery_url)
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                oidc_config = json.loads(resp.read())
+                _resolved_jwks_endpoint = oidc_config.get("jwks_uri", "")
+                return _resolved_jwks_endpoint
+        except Exception:
+            pass
+
+    return ""
+
 
 def _get_jwks_client():
     """Get or create a cached PyJWKClient instance."""
     global _jwks_client
     if _jwks_client is None and HAS_PYJWT:
-        _jwks_client = PyJWKClient(OIDC_JWKS_ENDPOINT, cache_keys=True)
+        endpoint = _resolve_jwks_endpoint()
+        if endpoint:
+            _jwks_client = PyJWKClient(endpoint, cache_keys=True)
     return _jwks_client
 
 
 def _fetch_jwks():
-    """Fetch JWKS from the configured endpoint with caching."""
+    """Fetch JWKS from the resolved endpoint with caching."""
     global _jwks_cache, _jwks_cache_time
+
+    endpoint = _resolve_jwks_endpoint()
+    if not endpoint:
+        raise ValueError("No JWKS endpoint configured or discoverable from issuer")
 
     now = time.time()
     if _jwks_cache and (now - _jwks_cache_time) < JWKS_CACHE_TTL:
         return _jwks_cache
 
     try:
-        req = urllib.request.Request(OIDC_JWKS_ENDPOINT)
+        req = urllib.request.Request(endpoint)
         with urllib.request.urlopen(req, timeout=5) as resp:
             _jwks_cache = json.loads(resp.read())
             _jwks_cache_time = now
             return _jwks_cache
     except Exception as e:
-        raise ValueError(f"Failed to fetch JWKS: {str(e)}")
+        raise ValueError(f"Failed to fetch JWKS from {endpoint}: {str(e)}")
 
 
 def _validate_token(token: str) -> dict:

--- a/deployment/infrastructure/lambda-functions/bootstrap_server/index.py
+++ b/deployment/infrastructure/lambda-functions/bootstrap_server/index.py
@@ -1,0 +1,260 @@
+# ABOUTME: Lambda handler for the CoWork Bootstrap Server
+# ABOUTME: Validates OIDC Bearer tokens (JWT) against JWKS and returns per-user
+# ABOUTME: configuration JSON for Claude Desktop (CoWork) dynamic provisioning
+
+"""CoWork Bootstrap Server Lambda handler.
+
+Validates incoming JWT Bearer tokens against the configured OIDC provider's JWKS
+endpoint, extracts user identity, and returns personalized configuration for
+Claude Desktop (CoWork) clients.
+"""
+
+import json
+import os
+import time
+import urllib.request
+from datetime import datetime, timezone
+
+# Optional: PyJWT with cryptography for RS256 verification
+# Falls back to manual verification if not available in Lambda layer
+try:
+    import jwt
+    from jwt import PyJWKClient
+
+    HAS_PYJWT = True
+except ImportError:
+    HAS_PYJWT = False
+
+# Configuration from environment variables
+OIDC_ISSUER_URL = os.environ.get("OIDC_ISSUER_URL", "")
+OIDC_CLIENT_ID = os.environ.get("OIDC_CLIENT_ID", "")
+OIDC_JWKS_ENDPOINT = os.environ.get("OIDC_JWKS_ENDPOINT", "")
+DEFAULT_INFERENCE_REGION = os.environ.get("DEFAULT_INFERENCE_REGION", "us-east-1")
+DEFAULT_INFERENCE_MODELS = os.environ.get("DEFAULT_INFERENCE_MODELS", "")
+OTLP_ENDPOINT = os.environ.get("OTLP_ENDPOINT", "")
+INFERENCE_SESSION_LIFETIME_SEC = int(os.environ.get("INFERENCE_SESSION_LIFETIME_SEC", "28800"))
+
+# JWKS cache (module-level for Lambda container reuse)
+_jwks_client = None
+_jwks_cache = None
+_jwks_cache_time = 0
+JWKS_CACHE_TTL = 3600  # Cache JWKS for 1 hour
+
+
+def _get_jwks_client():
+    """Get or create a cached PyJWKClient instance."""
+    global _jwks_client
+    if _jwks_client is None and HAS_PYJWT:
+        _jwks_client = PyJWKClient(OIDC_JWKS_ENDPOINT, cache_keys=True)
+    return _jwks_client
+
+
+def _fetch_jwks():
+    """Fetch JWKS from the configured endpoint with caching."""
+    global _jwks_cache, _jwks_cache_time
+
+    now = time.time()
+    if _jwks_cache and (now - _jwks_cache_time) < JWKS_CACHE_TTL:
+        return _jwks_cache
+
+    try:
+        req = urllib.request.Request(OIDC_JWKS_ENDPOINT)
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            _jwks_cache = json.loads(resp.read())
+            _jwks_cache_time = now
+            return _jwks_cache
+    except Exception as e:
+        raise ValueError(f"Failed to fetch JWKS: {str(e)}")
+
+
+def _validate_token(token: str) -> dict:
+    """Validate JWT token and return decoded claims.
+
+    Args:
+        token: Raw JWT Bearer token string
+
+    Returns:
+        Decoded token claims dict
+
+    Raises:
+        ValueError: If token is invalid, expired, or signature verification fails
+    """
+    if not token:
+        raise ValueError("No token provided")
+
+    if not HAS_PYJWT:
+        raise ValueError("PyJWT library not available — cannot validate tokens")
+
+    try:
+        # Get the signing key from JWKS
+        jwks_client = _get_jwks_client()
+        signing_key = jwks_client.get_signing_key_from_jwt(token)
+
+        # Decode and validate the token
+        decoded = jwt.decode(
+            token,
+            signing_key.key,
+            algorithms=["RS256", "RS384", "RS512", "ES256", "ES384", "ES512"],
+            issuer=OIDC_ISSUER_URL,
+            audience=OIDC_CLIENT_ID,
+            options={
+                "verify_exp": True,
+                "verify_iss": True,
+                "verify_aud": True,
+                "require": ["exp", "iss", "sub"],
+            },
+        )
+        return decoded
+
+    except jwt.ExpiredSignatureError:
+        raise ValueError("Token has expired")
+    except jwt.InvalidIssuerError:
+        raise ValueError("Invalid token issuer")
+    except jwt.InvalidAudienceError:
+        raise ValueError("Invalid token audience")
+    except jwt.InvalidSignatureError:
+        raise ValueError("Invalid token signature")
+    except jwt.DecodeError as e:
+        raise ValueError(f"Token decode error: {str(e)}")
+    except Exception as e:
+        raise ValueError(f"Token validation failed: {str(e)}")
+
+
+def _build_config_response(claims: dict) -> dict:
+    """Build the configuration response for a validated user.
+
+    Args:
+        claims: Decoded JWT claims
+
+    Returns:
+        Configuration dict for the CoWork client
+    """
+    user_sub = claims.get("sub", "unknown")
+    user_email = claims.get("email", claims.get("preferred_username", user_sub))
+
+    # Calculate expiration (1 hour from now)
+    expires_at = int(time.time()) + 3600
+
+    # Build OTLP headers with user identity
+    otlp_headers = {}
+    if OTLP_ENDPOINT:
+        otlp_headers = {
+            "x-user-id": user_sub,
+            "x-user-email": user_email,
+        }
+
+    # Parse models list
+    models = [m.strip() for m in DEFAULT_INFERENCE_MODELS.split(",") if m.strip()]
+
+    config = {
+        "inferenceProvider": "bedrock",
+        "inferenceRegion": DEFAULT_INFERENCE_REGION,
+        "inferenceModels": models,
+        "inferenceSessionLifetimeSec": INFERENCE_SESSION_LIFETIME_SEC,
+        "expiresAt": expires_at,
+        "user": {
+            "sub": user_sub,
+            "email": user_email,
+        },
+    }
+
+    # Add OTEL configuration if endpoint is set
+    if OTLP_ENDPOINT:
+        config["otlpEndpoint"] = OTLP_ENDPOINT
+        config["otlpHeaders"] = otlp_headers
+
+    return config
+
+
+def _response(status_code: int, body: dict, extra_headers: dict = None) -> dict:
+    """Build a standard API Gateway v2 response.
+
+    Args:
+        status_code: HTTP status code
+        body: Response body dict
+        extra_headers: Additional headers to include
+
+    Returns:
+        API Gateway v2 response dict
+    """
+    headers = {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-store",
+        "X-Content-Type-Options": "nosniff",
+    }
+    if extra_headers:
+        headers.update(extra_headers)
+
+    return {
+        "statusCode": status_code,
+        "headers": headers,
+        "body": json.dumps(body),
+    }
+
+
+def lambda_handler(event, context):
+    """Main Lambda handler for the Bootstrap Server.
+
+    Expects:
+        - GET /config with Authorization: Bearer <token> header
+
+    Returns:
+        - 200: Configuration JSON on success
+        - 401: Invalid or missing token
+        - 403: User not authorized
+        - 500: Internal server error
+    """
+    try:
+        # Extract Authorization header
+        headers = event.get("headers", {})
+        auth_header = headers.get("authorization", headers.get("Authorization", ""))
+
+        if not auth_header:
+            return _response(401, {
+                "error": "unauthorized",
+                "message": "Missing Authorization header",
+            })
+
+        # Extract Bearer token
+        if not auth_header.startswith("Bearer "):
+            return _response(401, {
+                "error": "unauthorized",
+                "message": "Invalid authorization scheme — expected Bearer token",
+            })
+
+        token = auth_header[7:]  # Strip "Bearer " prefix
+
+        # Validate token
+        try:
+            claims = _validate_token(token)
+        except ValueError as e:
+            error_msg = str(e)
+            # Distinguish between auth errors
+            if "expired" in error_msg.lower():
+                return _response(401, {
+                    "error": "token_expired",
+                    "message": "Token has expired — please re-authenticate",
+                })
+            elif "issuer" in error_msg.lower() or "audience" in error_msg.lower():
+                return _response(403, {
+                    "error": "forbidden",
+                    "message": f"Token validation failed: {error_msg}",
+                })
+            else:
+                return _response(401, {
+                    "error": "unauthorized",
+                    "message": f"Token validation failed: {error_msg}",
+                })
+
+        # Build and return configuration
+        config = _build_config_response(claims)
+
+        return _response(200, config)
+
+    except Exception as e:
+        # Log the error for CloudWatch but don't leak details to client
+        print(f"ERROR: Unhandled exception in bootstrap handler: {str(e)}")
+        return _response(500, {
+            "error": "internal_error",
+            "message": "An internal error occurred",
+        })

--- a/deployment/infrastructure/lambda-functions/bootstrap_server/index.py
+++ b/deployment/infrastructure/lambda-functions/bootstrap_server/index.py
@@ -1,12 +1,12 @@
-# ABOUTME: Lambda handler for the CoWork Bootstrap Server
+# ABOUTME: Lambda handler for the Claude Desktop Bootstrap Server
 # ABOUTME: Validates OIDC Bearer tokens (JWT) against JWKS and returns per-user
-# ABOUTME: configuration JSON for Claude Desktop (CoWork) dynamic provisioning
+# ABOUTME: configuration JSON for Claude Desktop dynamic provisioning
 
-"""CoWork Bootstrap Server Lambda handler.
+"""Claude Desktop Bootstrap Server Lambda handler.
 
 Validates incoming JWT Bearer tokens against the configured OIDC provider's JWKS
 endpoint, extracts user identity, and returns personalized configuration for
-Claude Desktop (CoWork) clients.
+Claude Desktop clients.
 """
 
 import json
@@ -127,7 +127,7 @@ def _build_config_response(claims: dict) -> dict:
         claims: Decoded JWT claims
 
     Returns:
-        Configuration dict for the CoWork client
+        Configuration dict for the Claude Desktop client
     """
     user_sub = claims.get("sub", "unknown")
     user_email = claims.get("email", claims.get("preferred_username", user_sub))

--- a/deployment/infrastructure/lambda-functions/bootstrap_server/index.py
+++ b/deployment/infrastructure/lambda-functions/bootstrap_server/index.py
@@ -230,61 +230,30 @@ def _response(status_code: int, body: dict, extra_headers: dict = None) -> dict:
 def lambda_handler(event, context):
     """Main Lambda handler for the Bootstrap Server.
 
-    Expects:
-        - GET /config with Authorization: Bearer <token> header
+    Supports two authentication modes:
+    1. OIDC (Bearer token): Client sends Authorization: Bearer <jwt>
+       Lambda validates JWT signature against JWKS.
+    2. IAM (SigV4): Client signs request with STS credentials.
+       API Gateway validates SigV4; Lambda extracts identity from request context.
 
     Returns:
         - 200: Configuration JSON on success
-        - 401: Invalid or missing token
+        - 401: Invalid or missing token (OIDC mode)
         - 403: User not authorized
         - 500: Internal server error
     """
     try:
-        # Extract Authorization header
-        headers = event.get("headers", {})
-        auth_header = headers.get("authorization", headers.get("Authorization", ""))
+        # Check if this is an IAM-authenticated request (SigV4)
+        # API Gateway populates requestContext.authorizer.iam for AWS_IAM routes
+        request_context = event.get("requestContext", {})
+        iam_context = request_context.get("authorizer", {}).get("iam", {})
 
-        if not auth_header:
-            return _response(401, {
-                "error": "unauthorized",
-                "message": "Missing Authorization header",
-            })
+        if iam_context:
+            # IAM auth mode (IDC users) — identity comes from SigV4 context
+            return _handle_iam_auth(iam_context)
 
-        # Extract Bearer token
-        if not auth_header.startswith("Bearer "):
-            return _response(401, {
-                "error": "unauthorized",
-                "message": "Invalid authorization scheme — expected Bearer token",
-            })
-
-        token = auth_header[7:]  # Strip "Bearer " prefix
-
-        # Validate token
-        try:
-            claims = _validate_token(token)
-        except ValueError as e:
-            error_msg = str(e)
-            # Distinguish between auth errors
-            if "expired" in error_msg.lower():
-                return _response(401, {
-                    "error": "token_expired",
-                    "message": "Token has expired — please re-authenticate",
-                })
-            elif "issuer" in error_msg.lower() or "audience" in error_msg.lower():
-                return _response(403, {
-                    "error": "forbidden",
-                    "message": f"Token validation failed: {error_msg}",
-                })
-            else:
-                return _response(401, {
-                    "error": "unauthorized",
-                    "message": f"Token validation failed: {error_msg}",
-                })
-
-        # Build and return configuration
-        config = _build_config_response(claims)
-
-        return _response(200, config)
+        # OIDC Bearer token mode
+        return _handle_oidc_auth(event)
 
     except Exception as e:
         # Log the error for CloudWatch but don't leak details to client
@@ -293,3 +262,81 @@ def lambda_handler(event, context):
             "error": "internal_error",
             "message": "An internal error occurred",
         })
+
+
+def _handle_iam_auth(iam_context: dict) -> dict:
+    """Handle IAM-authenticated requests (IDC users with SigV4).
+
+    API Gateway has already validated the SigV4 signature. We extract the
+    user identity from the IAM context (caller ARN).
+
+    IDC ARN format: arn:aws:sts::ACCOUNT:assumed-role/RoleName/user@company.com
+    The session name (last segment after /) is typically the user's email.
+    """
+    user_arn = iam_context.get("userArn", "")
+    account_id = iam_context.get("accountId", "")
+
+    # Extract user identity from ARN session name
+    # IDC format: arn:aws:sts::123456:assumed-role/AWSReservedSSO_PermSet_xxx/user@company.com
+    session_name = user_arn.rsplit("/", 1)[-1] if "/" in user_arn else ""
+    user_email = session_name if "@" in session_name else ""
+    user_sub = session_name or user_arn  # Use session name as sub, fall back to full ARN
+
+    # Build claims-like dict for _build_config_response
+    claims = {
+        "sub": user_sub,
+        "email": user_email,
+        "arn": user_arn,
+        "account_id": account_id,
+    }
+
+    config = _build_config_response(claims)
+    return _response(200, config)
+
+
+def _handle_oidc_auth(event: dict) -> dict:
+    """Handle OIDC Bearer token authentication."""
+    # Extract Authorization header
+    headers = event.get("headers", {})
+    auth_header = headers.get("authorization", headers.get("Authorization", ""))
+
+    if not auth_header:
+        return _response(401, {
+            "error": "unauthorized",
+            "message": "Missing Authorization header",
+        })
+
+    # Extract Bearer token
+    if not auth_header.startswith("Bearer "):
+        return _response(401, {
+            "error": "unauthorized",
+            "message": "Invalid authorization scheme — expected Bearer token",
+        })
+
+    token = auth_header[7:]  # Strip "Bearer " prefix
+
+    # Validate token
+    try:
+        claims = _validate_token(token)
+    except ValueError as e:
+        error_msg = str(e)
+        # Distinguish between auth errors
+        if "expired" in error_msg.lower():
+            return _response(401, {
+                "error": "token_expired",
+                "message": "Token has expired — please re-authenticate",
+            })
+        elif "issuer" in error_msg.lower() or "audience" in error_msg.lower():
+            return _response(403, {
+                "error": "forbidden",
+                "message": f"Token validation failed: {error_msg}",
+            })
+        else:
+            return _response(401, {
+                "error": "unauthorized",
+                "message": f"Token validation failed: {error_msg}",
+            })
+
+    # Build and return configuration
+    config = _build_config_response(claims)
+    return _response(200, config)

--- a/deployment/infrastructure/lambda-functions/bootstrap_server/index.py
+++ b/deployment/infrastructure/lambda-functions/bootstrap_server/index.py
@@ -15,8 +15,9 @@ import time
 import urllib.request
 from datetime import datetime, timezone
 
-# Optional: PyJWT with cryptography for RS256 verification
-# Falls back to manual verification if not available in Lambda layer
+# PyJWT with cryptography for RS256/ES256 signature verification.
+# Bundled via requirements.txt at deploy time. The try/except is a safety net
+# in case the function is deployed without dependencies (e.g. inline ZipFile).
 try:
     import jwt
     from jwt import PyJWKClient

--- a/deployment/infrastructure/lambda-functions/bootstrap_server/requirements.txt
+++ b/deployment/infrastructure/lambda-functions/bootstrap_server/requirements.txt
@@ -1,0 +1,1 @@
+PyJWT[crypto]>=2.8.0

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -48,6 +48,83 @@ def _extract_azure_tenant_id(domain: str) -> str:
     return match.group(0) if match else domain
 
 
+def _deploy_bootstrap_lambda_code(
+    stack_name: str,
+    region: str,
+    project_root,
+    console=None,
+):
+    """Package and deploy bootstrap Lambda with bundled PyJWT dependencies.
+
+    Installs PyJWT[crypto] into a temp directory, zips with the handler,
+    and updates the Lambda function code via update-function-code.
+    """
+    import shutil
+    import subprocess
+    import tempfile
+    import zipfile
+    from pathlib import Path
+
+    lambda_dir = project_root / "deployment" / "infrastructure" / "lambda-functions" / "bootstrap_server"
+    handler_file = lambda_dir / "index.py"
+    requirements_file = lambda_dir / "requirements.txt"
+
+    if not handler_file.exists():
+        if console:
+            console.print("[yellow]Warning: bootstrap Lambda handler not found, skipping code deploy[/yellow]")
+        return
+
+    function_name = f"{stack_name}-bootstrap"
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        package_dir = tmp_path / "package"
+        package_dir.mkdir()
+
+        # Install dependencies
+        if requirements_file.exists():
+            subprocess.run(
+                [
+                    "pip", "install",
+                    "-r", str(requirements_file),
+                    "-t", str(package_dir),
+                    "--quiet",
+                    "--platform", "manylinux2014_x86_64",
+                    "--only-binary=:all:",
+                    "--python-version", "3.12",
+                ],
+                check=False,
+                capture_output=True,
+            )
+
+        # Copy handler
+        shutil.copy2(handler_file, package_dir / "index.py")
+
+        # Create zip
+        zip_path = tmp_path / "bootstrap.zip"
+        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            for file in package_dir.rglob("*"):
+                if file.is_file() and "__pycache__" not in str(file):
+                    zf.write(file, file.relative_to(package_dir))
+
+        # Update Lambda function code
+        import boto3
+
+        client = boto3.client("lambda", region_name=region)
+        try:
+            with open(zip_path, "rb") as f:
+                client.update_function_code(
+                    FunctionName=function_name,
+                    ZipFile=f.read(),
+                )
+            if console:
+                console.print(f"[green]✓ Bootstrap Lambda code deployed ({zip_path.stat().st_size // 1024}KB)[/green]")
+        except Exception as e:
+            if console:
+                console.print(f"[yellow]Warning: Could not update Lambda code: {e}[/yellow]")
+                console.print("[dim]  Run 'aws lambda update-function-code' manually if needed.[/dim]")
+
+
 class DeployCommand(Command):
     name = "deploy"
     description = "Deploy AWS infrastructure (auth, monitoring, dashboards)"
@@ -1098,26 +1175,9 @@ class DeployCommand(Command):
                 elif not oidc_issuer_url and profile.provider_type == "google":
                     oidc_issuer_url = "https://accounts.google.com"
 
-                # Build JWKS endpoint from issuer
+                # JWKS endpoint — pass explicit URI if configured, otherwise Lambda
+                # auto-discovers via {issuer}/.well-known/openid-configuration
                 jwks_endpoint = getattr(profile, "oidc_jwks_uri", None) or ""
-                if not jwks_endpoint and oidc_issuer_url:
-                    # Standard OIDC discovery: issuer + /.well-known/openid-configuration
-                    # Most providers put JWKS at issuer/keys or /protocol/openid-connect/certs
-                    # For simplicity, use well-known pattern
-                    jwks_endpoint = oidc_issuer_url.rstrip("/") + "/.well-known/jwks.json"
-                    if profile.provider_type == "okta":
-                        jwks_endpoint = oidc_issuer_url.rstrip("/") + "/v1/keys"
-                    elif profile.provider_type == "azure":
-                        tenant_id = _extract_azure_tenant_id(profile.provider_domain)
-                        jwks_endpoint = (
-                            f"https://login.microsoftonline.com/{tenant_id}/discovery/v2.0/keys"
-                        )
-                    elif profile.provider_type == "cognito":
-                        jwks_endpoint = oidc_issuer_url.rstrip("/") + "/.well-known/jwks.json"
-                    elif profile.provider_type == "google":
-                        jwks_endpoint = "https://www.googleapis.com/oauth2/v3/certs"
-                    elif profile.provider_type == "auth0":
-                        jwks_endpoint = oidc_issuer_url.rstrip("/") + "/.well-known/jwks.json"
 
                 # Get OTEL endpoint from monitoring config if available
                 otlp_endpoint = getattr(profile, "otel_collector_endpoint", "") or ""
@@ -1141,6 +1201,16 @@ class DeployCommand(Command):
                     ["CAPABILITY_NAMED_IAM"],
                     task_description="Deploying Claude Desktop Bootstrap Server...",
                 )
+
+                # Deploy Lambda code with bundled dependencies
+                if result == 0:
+                    console.print("[cyan]Packaging bootstrap Lambda with dependencies...[/cyan]")
+                    _deploy_bootstrap_lambda_code(
+                        stack_name=stack_name,
+                        region=profile.aws_region,
+                        project_root=project_root,
+                        console=console,
+                    )
 
                 # Display bootstrap URL on success
                 if result == 0:

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -1146,7 +1146,7 @@ class DeployCommand(Command):
                 if result == 0:
                     outputs = get_stack_outputs(stack_name, profile.aws_region)
                     bootstrap_url = outputs.get("BootstrapUrl", "N/A")
-                    console.print(f"\n[bold green]\u2713 Bootstrap server deployed![/bold green]")
+                    console.print("\n[bold green]\u2713 Bootstrap server deployed![/bold green]")
                     console.print(f"\n[bold]Bootstrap URL:[/bold] {bootstrap_url}")
                     console.print(
                         "\n[dim]Add this URL as 'bootstrapUrl' in your MDM anchor profile.[/dim]"
@@ -1355,9 +1355,9 @@ class DeployCommand(Command):
             template = project_root / "deployment" / "infrastructure" / "bootstrap-server.yaml"
             stack_name = profile.stack_names.get("bootstrap", f"{profile.identity_pool_name}-bootstrap")
             params = [
-                f"OidcIssuerUrl=<from-oidc-config>",
+                "OidcIssuerUrl=<from-oidc-config>",
                 f"OidcClientId={profile.client_id}",
-                f"OidcJwksEndpoint=<from-oidc-config>",
+                "OidcJwksEndpoint=<from-oidc-config>",
                 f"DefaultInferenceRegion={profile.aws_region}",
                 f"DefaultInferenceModels={getattr(profile, 'selected_model', '') or 'us.anthropic.claude-sonnet-4-20250514-v1:0'}",
                 f"OtlpEndpoint={getattr(profile, 'otel_collector_endpoint', '') or ''}",

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -189,10 +189,25 @@ class DeployCommand(Command):
                 else:
                     console.print("[yellow]CodeBuild is not enabled in your configuration.[/yellow]")
                     return 1
+            elif stack_arg == "bootstrap":
+                # Bootstrap server for dynamic CoWork configuration delivery
+                cowork_config_mode = getattr(profile, "cowork_config_mode", "static")
+                if cowork_config_mode != "dynamic":
+                    console.print("[yellow]Bootstrap server requires dynamic config mode.[/yellow]")
+                    console.print(
+                        "Run 'poetry run ccwb init' and select 'Dynamic' for CoWork configuration delivery."
+                    )
+                    return 1
+                if profile.effective_auth_type != "oidc":
+                    console.print(
+                        "[yellow]Bootstrap server requires OIDC authentication.[/yellow]"
+                    )
+                    return 1
+                stacks_to_deploy.append(("bootstrap", "CoWork Bootstrap Server"))
             else:
                 console.print(f"[red]Unknown stack: {stack_arg}[/red]")
                 console.print(
-                    "Valid stacks: auth, distribution, networking, monitoring, dashboard, cowork-dashboard, analytics, quota, codebuild\n"
+                    "Valid stacks: auth, distribution, networking, monitoring, dashboard, cowork-dashboard, analytics, quota, codebuild, bootstrap\n"
                 )
                 console.print("[dim]Tip: Use 'ccwb deploy' without arguments to deploy all enabled stacks.[/dim]")
                 console.print("[dim]Use 'ccwb deploy quota' for quota-specific updates or late enablement.[/dim]")
@@ -255,6 +270,11 @@ class DeployCommand(Command):
             # Check if CodeBuild is enabled
             if getattr(profile, "enable_codebuild", False):
                 stacks_to_deploy.append(("codebuild", "CodeBuild for Windows binary builds"))
+
+            # Check if bootstrap server is enabled (dynamic CoWork config delivery)
+            if getattr(profile, "cowork_config_mode", "static") == "dynamic":
+                if profile.effective_auth_type == "oidc":
+                    stacks_to_deploy.append(("bootstrap", "CoWork Bootstrap Server"))
 
         # Initialize CloudFormation manager
         cf_manager = CloudFormationManager(region=profile.aws_region)
@@ -1047,6 +1067,93 @@ class DeployCommand(Command):
                     cf=cf,
                 )
 
+            elif stack_type == "bootstrap":
+                # CoWork Bootstrap Server for dynamic configuration delivery
+                template = project_root / "deployment" / "infrastructure" / "bootstrap-server.yaml"
+                stack_name = profile.stack_names.get(
+                    "bootstrap", f"{profile.identity_pool_name}-bootstrap"
+                )
+
+                # Build OIDC issuer URL from provider config
+                oidc_issuer_url = getattr(profile, "oidc_issuer_url", None) or ""
+                if not oidc_issuer_url and profile.provider_type == "okta":
+                    okta_auth_server = getattr(profile, "okta_auth_server", "default")
+                    if okta_auth_server:
+                        oidc_issuer_url = f"https://{profile.provider_domain}/oauth2/{okta_auth_server}"
+                    else:
+                        oidc_issuer_url = f"https://{profile.provider_domain}"
+                elif not oidc_issuer_url and profile.provider_type == "auth0":
+                    oidc_issuer_url = f"https://{profile.provider_domain}/"
+                elif not oidc_issuer_url and profile.provider_type == "azure":
+                    tenant_id = _extract_azure_tenant_id(profile.provider_domain)
+                    oidc_issuer_url = (
+                        f"https://login.microsoftonline.com/{tenant_id}/v2.0"
+                    )
+                elif not oidc_issuer_url and profile.provider_type == "cognito":
+                    # Cognito issuer is the user pool URL
+                    pool_id = getattr(profile, "cognito_user_pool_id", "")
+                    if pool_id:
+                        pool_region = pool_id.split("_")[0] if "_" in pool_id else profile.aws_region
+                        oidc_issuer_url = f"https://cognito-idp.{pool_region}.amazonaws.com/{pool_id}"
+                elif not oidc_issuer_url and profile.provider_type == "google":
+                    oidc_issuer_url = "https://accounts.google.com"
+
+                # Build JWKS endpoint from issuer
+                jwks_endpoint = getattr(profile, "oidc_jwks_uri", None) or ""
+                if not jwks_endpoint and oidc_issuer_url:
+                    # Standard OIDC discovery: issuer + /.well-known/openid-configuration
+                    # Most providers put JWKS at issuer/keys or /protocol/openid-connect/certs
+                    # For simplicity, use well-known pattern
+                    jwks_endpoint = oidc_issuer_url.rstrip("/") + "/.well-known/jwks.json"
+                    if profile.provider_type == "okta":
+                        jwks_endpoint = oidc_issuer_url.rstrip("/") + "/v1/keys"
+                    elif profile.provider_type == "azure":
+                        tenant_id = _extract_azure_tenant_id(profile.provider_domain)
+                        jwks_endpoint = (
+                            f"https://login.microsoftonline.com/{tenant_id}/discovery/v2.0/keys"
+                        )
+                    elif profile.provider_type == "cognito":
+                        jwks_endpoint = oidc_issuer_url.rstrip("/") + "/.well-known/jwks.json"
+                    elif profile.provider_type == "google":
+                        jwks_endpoint = "https://www.googleapis.com/oauth2/v3/certs"
+                    elif profile.provider_type == "auth0":
+                        jwks_endpoint = oidc_issuer_url.rstrip("/") + "/.well-known/jwks.json"
+
+                # Get OTEL endpoint from monitoring config if available
+                otlp_endpoint = getattr(profile, "otel_collector_endpoint", "") or ""
+
+                # Get inference models
+                inference_models = getattr(profile, "selected_model", "") or "us.anthropic.claude-sonnet-4-20250514-v1:0"
+
+                params = [
+                    f"OidcIssuerUrl={oidc_issuer_url}",
+                    f"OidcClientId={profile.client_id}",
+                    f"OidcJwksEndpoint={jwks_endpoint}",
+                    f"DefaultInferenceRegion={profile.aws_region}",
+                    f"DefaultInferenceModels={inference_models}",
+                    f"OtlpEndpoint={otlp_endpoint}",
+                ]
+
+                result = deploy_with_cf(
+                    template,
+                    stack_name,
+                    params,
+                    ["CAPABILITY_NAMED_IAM"],
+                    task_description="Deploying CoWork Bootstrap Server...",
+                )
+
+                # Display bootstrap URL on success
+                if result == 0:
+                    outputs = get_stack_outputs(stack_name, profile.aws_region)
+                    bootstrap_url = outputs.get("BootstrapUrl", "N/A")
+                    console.print(f"\n[bold green]\u2713 Bootstrap server deployed![/bold green]")
+                    console.print(f"\n[bold]Bootstrap URL:[/bold] {bootstrap_url}")
+                    console.print(
+                        "\n[dim]Add this URL as 'bootstrapUrl' in your MDM anchor profile.[/dim]"
+                    )
+
+                return result
+
             else:
                 console.print(f"[red]Unknown stack type: {stack_type}[/red]")
                 return 1
@@ -1242,6 +1349,19 @@ class DeployCommand(Command):
             template = project_root / "deployment" / "infrastructure" / "codebuild-windows.yaml"
             stack_name = profile.stack_names.get("codebuild", f"{profile.identity_pool_name}-codebuild")
             params = [f"ProjectNamePrefix={profile.identity_pool_name}"]
+            print_deploy_cmd(template, stack_name, params)
+
+        elif stack_type == "bootstrap":
+            template = project_root / "deployment" / "infrastructure" / "bootstrap-server.yaml"
+            stack_name = profile.stack_names.get("bootstrap", f"{profile.identity_pool_name}-bootstrap")
+            params = [
+                f"OidcIssuerUrl=<from-oidc-config>",
+                f"OidcClientId={profile.client_id}",
+                f"OidcJwksEndpoint=<from-oidc-config>",
+                f"DefaultInferenceRegion={profile.aws_region}",
+                f"DefaultInferenceModels={getattr(profile, 'selected_model', '') or 'us.anthropic.claude-sonnet-4-20250514-v1:0'}",
+                f"OtlpEndpoint={getattr(profile, 'otel_collector_endpoint', '') or ''}",
+            ]
             print_deploy_cmd(template, stack_name, params)
 
         elif stack_type == "distribution":

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -85,13 +85,18 @@ def _deploy_bootstrap_lambda_code(
         if requirements_file.exists():
             subprocess.run(
                 [
-                    "pip", "install",
-                    "-r", str(requirements_file),
-                    "-t", str(package_dir),
+                    "pip",
+                    "install",
+                    "-r",
+                    str(requirements_file),
+                    "-t",
+                    str(package_dir),
                     "--quiet",
-                    "--platform", "manylinux2014_x86_64",
+                    "--platform",
+                    "manylinux2014_x86_64",
                     "--only-binary=:all:",
-                    "--python-version", "3.12",
+                    "--python-version",
+                    "3.12",
                 ],
                 check=False,
                 capture_output=True,
@@ -325,14 +330,10 @@ class DeployCommand(Command):
                 cowork_config_mode = getattr(profile, "cowork_config_mode", "static")
                 if cowork_config_mode != "dynamic":
                     console.print("[yellow]Bootstrap server requires dynamic config mode.[/yellow]")
-                    console.print(
-                        "Run 'poetry run ccwb init' and select 'Dynamic' for CoWork configuration delivery."
-                    )
+                    console.print("Run 'poetry run ccwb init' and select 'Dynamic' for CoWork configuration delivery.")
                     return 1
                 if profile.effective_auth_type != "oidc":
-                    console.print(
-                        "[yellow]Bootstrap server requires OIDC authentication.[/yellow]"
-                    )
+                    console.print("[yellow]Bootstrap server requires OIDC authentication.[/yellow]")
                     return 1
                 stacks_to_deploy.append(("bootstrap", "Claude Desktop Bootstrap Server"))
             else:
@@ -1201,9 +1202,7 @@ class DeployCommand(Command):
             elif stack_type == "bootstrap":
                 # Claude Desktop Bootstrap Server for dynamic configuration delivery
                 template = project_root / "deployment" / "infrastructure" / "bootstrap-server.yaml"
-                stack_name = profile.stack_names.get(
-                    "bootstrap", f"{profile.identity_pool_name}-bootstrap"
-                )
+                stack_name = profile.stack_names.get("bootstrap", f"{profile.identity_pool_name}-bootstrap")
 
                 params = _resolve_bootstrap_params(profile)
 
@@ -1231,9 +1230,7 @@ class DeployCommand(Command):
                     bootstrap_url = outputs.get("BootstrapUrl", "N/A")
                     console.print("\n[bold green]\u2713 Bootstrap server deployed![/bold green]")
                     console.print(f"\n[bold]Bootstrap URL:[/bold] {bootstrap_url}")
-                    console.print(
-                        "\n[dim]Add this URL as 'bootstrapUrl' in your MDM anchor profile.[/dim]"
-                    )
+                    console.print("\n[dim]Add this URL as 'bootstrapUrl' in your MDM anchor profile.[/dim]")
 
                 return result
 

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -125,6 +125,60 @@ def _deploy_bootstrap_lambda_code(
                 console.print("[dim]  Run 'aws lambda update-function-code' manually if needed.[/dim]")
 
 
+def _resolve_oidc_issuer(profile) -> str:
+    """Resolve the OIDC issuer URL from profile configuration.
+
+    Checks explicit oidc_issuer_url first, then builds from provider_domain
+    based on the provider type. Used by bootstrap deploy and dry-run paths.
+    """
+    issuer = getattr(profile, "oidc_issuer_url", None) or ""
+    if issuer:
+        return issuer
+
+    provider_type = getattr(profile, "provider_type", "")
+    domain = getattr(profile, "provider_domain", "")
+
+    if provider_type == "okta":
+        okta_auth_server = getattr(profile, "okta_auth_server", "default")
+        if okta_auth_server:
+            return f"https://{domain}/oauth2/{okta_auth_server}"
+        return f"https://{domain}"
+    elif provider_type == "auth0":
+        return f"https://{domain}/"
+    elif provider_type == "azure":
+        tenant_id = _extract_azure_tenant_id(domain)
+        return f"https://login.microsoftonline.com/{tenant_id}/v2.0"
+    elif provider_type == "cognito":
+        pool_id = getattr(profile, "cognito_user_pool_id", "")
+        if pool_id:
+            pool_region = pool_id.split("_")[0] if "_" in pool_id else getattr(profile, "aws_region", "us-east-1")
+            return f"https://cognito-idp.{pool_region}.amazonaws.com/{pool_id}"
+    elif provider_type == "google":
+        return "https://accounts.google.com"
+
+    return ""
+
+
+def _resolve_bootstrap_params(profile) -> list:
+    """Resolve all CFN parameters for the bootstrap server stack.
+
+    Shared between the real deploy path and the dry-run/print path.
+    """
+    oidc_issuer_url = _resolve_oidc_issuer(profile)
+    jwks_endpoint = getattr(profile, "oidc_jwks_uri", None) or ""
+    otlp_endpoint = getattr(profile, "otel_collector_endpoint", "") or ""
+    inference_models = getattr(profile, "selected_model", "") or "us.anthropic.claude-sonnet-4-20250514-v1:0"
+
+    return [
+        f"OidcIssuerUrl={oidc_issuer_url}",
+        f"OidcClientId={profile.client_id}",
+        f"OidcJwksEndpoint={jwks_endpoint}",
+        f"DefaultInferenceRegion={profile.aws_region}",
+        f"DefaultInferenceModels={inference_models}",
+        f"OtlpEndpoint={otlp_endpoint}",
+    ]
+
+
 class DeployCommand(Command):
     name = "deploy"
     description = "Deploy AWS infrastructure (auth, monitoring, dashboards)"
@@ -1151,48 +1205,7 @@ class DeployCommand(Command):
                     "bootstrap", f"{profile.identity_pool_name}-bootstrap"
                 )
 
-                # Build OIDC issuer URL from provider config
-                oidc_issuer_url = getattr(profile, "oidc_issuer_url", None) or ""
-                if not oidc_issuer_url and profile.provider_type == "okta":
-                    okta_auth_server = getattr(profile, "okta_auth_server", "default")
-                    if okta_auth_server:
-                        oidc_issuer_url = f"https://{profile.provider_domain}/oauth2/{okta_auth_server}"
-                    else:
-                        oidc_issuer_url = f"https://{profile.provider_domain}"
-                elif not oidc_issuer_url and profile.provider_type == "auth0":
-                    oidc_issuer_url = f"https://{profile.provider_domain}/"
-                elif not oidc_issuer_url and profile.provider_type == "azure":
-                    tenant_id = _extract_azure_tenant_id(profile.provider_domain)
-                    oidc_issuer_url = (
-                        f"https://login.microsoftonline.com/{tenant_id}/v2.0"
-                    )
-                elif not oidc_issuer_url and profile.provider_type == "cognito":
-                    # Cognito issuer is the user pool URL
-                    pool_id = getattr(profile, "cognito_user_pool_id", "")
-                    if pool_id:
-                        pool_region = pool_id.split("_")[0] if "_" in pool_id else profile.aws_region
-                        oidc_issuer_url = f"https://cognito-idp.{pool_region}.amazonaws.com/{pool_id}"
-                elif not oidc_issuer_url and profile.provider_type == "google":
-                    oidc_issuer_url = "https://accounts.google.com"
-
-                # JWKS endpoint — pass explicit URI if configured, otherwise Lambda
-                # auto-discovers via {issuer}/.well-known/openid-configuration
-                jwks_endpoint = getattr(profile, "oidc_jwks_uri", None) or ""
-
-                # Get OTEL endpoint from monitoring config if available
-                otlp_endpoint = getattr(profile, "otel_collector_endpoint", "") or ""
-
-                # Get inference models
-                inference_models = getattr(profile, "selected_model", "") or "us.anthropic.claude-sonnet-4-20250514-v1:0"
-
-                params = [
-                    f"OidcIssuerUrl={oidc_issuer_url}",
-                    f"OidcClientId={profile.client_id}",
-                    f"OidcJwksEndpoint={jwks_endpoint}",
-                    f"DefaultInferenceRegion={profile.aws_region}",
-                    f"DefaultInferenceModels={inference_models}",
-                    f"OtlpEndpoint={otlp_endpoint}",
-                ]
+                params = _resolve_bootstrap_params(profile)
 
                 result = deploy_with_cf(
                     template,
@@ -1424,14 +1437,7 @@ class DeployCommand(Command):
         elif stack_type == "bootstrap":
             template = project_root / "deployment" / "infrastructure" / "bootstrap-server.yaml"
             stack_name = profile.stack_names.get("bootstrap", f"{profile.identity_pool_name}-bootstrap")
-            params = [
-                "OidcIssuerUrl=<from-oidc-config>",
-                f"OidcClientId={profile.client_id}",
-                "OidcJwksEndpoint=<from-oidc-config>",
-                f"DefaultInferenceRegion={profile.aws_region}",
-                f"DefaultInferenceModels={getattr(profile, 'selected_model', '') or 'us.anthropic.claude-sonnet-4-20250514-v1:0'}",
-                f"OtlpEndpoint={getattr(profile, 'otel_collector_endpoint', '') or ''}",
-            ]
+            params = _resolve_bootstrap_params(profile)
             print_deploy_cmd(template, stack_name, params)
 
         elif stack_type == "distribution":

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -190,7 +190,7 @@ class DeployCommand(Command):
                     console.print("[yellow]CodeBuild is not enabled in your configuration.[/yellow]")
                     return 1
             elif stack_arg == "bootstrap":
-                # Bootstrap server for dynamic CoWork configuration delivery
+                # Bootstrap server for dynamic Claude Desktop configuration delivery
                 cowork_config_mode = getattr(profile, "cowork_config_mode", "static")
                 if cowork_config_mode != "dynamic":
                     console.print("[yellow]Bootstrap server requires dynamic config mode.[/yellow]")
@@ -203,7 +203,7 @@ class DeployCommand(Command):
                         "[yellow]Bootstrap server requires OIDC authentication.[/yellow]"
                     )
                     return 1
-                stacks_to_deploy.append(("bootstrap", "CoWork Bootstrap Server"))
+                stacks_to_deploy.append(("bootstrap", "Claude Desktop Bootstrap Server"))
             else:
                 console.print(f"[red]Unknown stack: {stack_arg}[/red]")
                 console.print(
@@ -271,10 +271,10 @@ class DeployCommand(Command):
             if getattr(profile, "enable_codebuild", False):
                 stacks_to_deploy.append(("codebuild", "CodeBuild for Windows binary builds"))
 
-            # Check if bootstrap server is enabled (dynamic CoWork config delivery)
+            # Check if bootstrap server is enabled (dynamic Claude Desktop config delivery)
             if getattr(profile, "cowork_config_mode", "static") == "dynamic":
                 if profile.effective_auth_type == "oidc":
-                    stacks_to_deploy.append(("bootstrap", "CoWork Bootstrap Server"))
+                    stacks_to_deploy.append(("bootstrap", "Claude Desktop Bootstrap Server"))
 
         # Initialize CloudFormation manager
         cf_manager = CloudFormationManager(region=profile.aws_region)
@@ -1068,7 +1068,7 @@ class DeployCommand(Command):
                 )
 
             elif stack_type == "bootstrap":
-                # CoWork Bootstrap Server for dynamic configuration delivery
+                # Claude Desktop Bootstrap Server for dynamic configuration delivery
                 template = project_root / "deployment" / "infrastructure" / "bootstrap-server.yaml"
                 stack_name = profile.stack_names.get(
                     "bootstrap", f"{profile.identity_pool_name}-bootstrap"
@@ -1139,7 +1139,7 @@ class DeployCommand(Command):
                     stack_name,
                     params,
                     ["CAPABILITY_NAMED_IAM"],
-                    task_description="Deploying CoWork Bootstrap Server...",
+                    task_description="Deploying Claude Desktop Bootstrap Server...",
                 )
 
                 # Display bootstrap URL on success

--- a/source/claude_code_with_bedrock/cli/commands/destroy.py
+++ b/source/claude_code_with_bedrock/cli/commands/destroy.py
@@ -18,6 +18,7 @@ from claude_code_with_bedrock.config import Config
 # Keep in sync with deploy.py's stack types when adding new stacks.
 DESTROYABLE_STACKS = [
     "codebuild",
+    "bootstrap",
     "analytics",
     "quota",
     "cowork-dashboard",

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1509,6 +1509,42 @@ class InitCommand(Command):
                 else:
                     console.print("[dim]CoWork service token already configured[/dim]")
 
+            # CoWork configuration delivery mode (OIDC only)
+            if config.get("auth_type", "oidc") == "oidc":
+                console.print("\n[bold]CoWork Configuration Delivery[/bold]")
+                console.print("How should CoWork clients receive their configuration?")
+                console.print("  • Static: MDM profile with inline config (default)")
+                console.print("  • Dynamic: Bootstrap server delivers per-user config at sign-in")
+
+                config_mode_choices = [
+                    questionary.Choice(
+                        "Static (default \u2014 MDM profile with inline config)", value="static"
+                    ),
+                    questionary.Choice(
+                        "Dynamic (bootstrap server \u2014 per-user config at sign-in)", value="dynamic"
+                    ),
+                ]
+                saved_config_mode = config.get("cowork", {}).get("config_mode", "static")
+                config_mode = questionary.select(
+                    "CoWork configuration delivery:",
+                    choices=config_mode_choices,
+                    default=saved_config_mode,
+                ).ask()
+
+                if "cowork" not in config:
+                    config["cowork"] = {}
+                config["cowork"]["config_mode"] = config_mode
+
+                if config_mode == "dynamic":
+                    console.print(
+                        "[green]\u2713[/green] Bootstrap server will be deployed with [cyan]ccwb deploy bootstrap[/cyan]"
+                    )
+                    console.print(
+                        "[dim]  Clients receive per-user config dynamically at sign-in via OIDC token exchange[/dim]"
+                    )
+                else:
+                    console.print("[green]\u2713[/green] Static MDM configuration (default)")
+
         # Settings deployment target
         console.print("\n[bold]Settings Deployment Target[/bold]")
         console.print("Choose where Claude Code settings are installed on user machines:")
@@ -2596,6 +2632,7 @@ class InitCommand(Command):
             "cowork_3p_enabled": config_data.get("cowork_3p", {}).get("enabled", True),
             "cowork_3p_extra_keys": config_data.get("cowork_3p", {}).get("extra_keys", {}),
             "cowork_service_token": config_data.get("cowork_3p", {}).get("service_token", ""),
+            "cowork_config_mode": config_data.get("cowork", {}).get("config_mode", "static"),
             "cowork_chat_tab_enabled": config_data.get("cowork_3p", {}).get("chat_tab_enabled", True),
             "cowork_chat_advanced_file_analysis": config_data.get("cowork_3p", {}).get(
                 "chat_advanced_file_analysis", True
@@ -2973,6 +3010,12 @@ class InitCommand(Command):
             if profile.cowork_chat_advanced_file_analysis:
                 cowork_3p_config["chat_advanced_file_analysis"] = True
             existing_config["cowork_3p"] = cowork_3p_config
+
+            # Add CoWork dynamic config mode
+            if profile.cowork_config_mode and profile.cowork_config_mode != "static":
+                if "cowork" not in existing_config:
+                    existing_config["cowork"] = {}
+                existing_config["cowork"]["config_mode"] = profile.cowork_config_mode
 
             # Add distribution configuration if present
             if hasattr(profile, "enable_distribution"):

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1509,10 +1509,10 @@ class InitCommand(Command):
                 else:
                     console.print("[dim]CoWork service token already configured[/dim]")
 
-            # CoWork configuration delivery mode (OIDC only)
+            # Claude Desktop configuration delivery mode (OIDC only)
             if config.get("auth_type", "oidc") == "oidc":
-                console.print("\n[bold]CoWork Configuration Delivery[/bold]")
-                console.print("How should CoWork clients receive their configuration?")
+                console.print("\n[bold]Claude Desktop Configuration Delivery[/bold]")
+                console.print("How should Claude Desktop clients receive their configuration?")
                 console.print("  • Static: MDM profile with inline config (default)")
                 console.print("  • Dynamic: Bootstrap server delivers per-user config at sign-in")
 
@@ -1526,7 +1526,7 @@ class InitCommand(Command):
                 ]
                 saved_config_mode = config.get("cowork", {}).get("config_mode", "static")
                 config_mode = questionary.select(
-                    "CoWork configuration delivery:",
+                    "Claude Desktop configuration delivery:",
                     choices=config_mode_choices,
                     default=saved_config_mode,
                 ).ask()
@@ -3011,7 +3011,7 @@ class InitCommand(Command):
                 cowork_3p_config["chat_advanced_file_analysis"] = True
             existing_config["cowork_3p"] = cowork_3p_config
 
-            # Add CoWork dynamic config mode
+            # Add Claude Desktop dynamic config mode
             if profile.cowork_config_mode and profile.cowork_config_mode != "static":
                 if "cowork" not in existing_config:
                     existing_config["cowork"] = {}

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1509,7 +1509,9 @@ class InitCommand(Command):
                 else:
                     console.print("[dim]CoWork service token already configured[/dim]")
 
-            # Claude Desktop configuration delivery mode (OIDC only)
+            # Claude Desktop configuration delivery mode (OIDC only).
+            # IDC deployments use static MDM profiles — bootstrap server requires
+            # OIDC Bearer tokens for user validation (IDC has no standard JWT flow).
             if config.get("auth_type", "oidc") == "oidc":
                 console.print("\n[bold]Claude Desktop Configuration Delivery[/bold]")
                 console.print("How should Claude Desktop clients receive their configuration?")

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1519,12 +1519,8 @@ class InitCommand(Command):
                 console.print("  • Dynamic: Bootstrap server delivers per-user config at sign-in")
 
                 config_mode_choices = [
-                    questionary.Choice(
-                        "Static (default \u2014 MDM profile with inline config)", value="static"
-                    ),
-                    questionary.Choice(
-                        "Dynamic (bootstrap server \u2014 per-user config at sign-in)", value="dynamic"
-                    ),
+                    questionary.Choice("Static (default \u2014 MDM profile with inline config)", value="static"),
+                    questionary.Choice("Dynamic (bootstrap server \u2014 per-user config at sign-in)", value="dynamic"),
                 ]
                 saved_config_mode = config.get("cowork", {}).get("config_mode", "static")
                 config_mode = questionary.select(

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1509,10 +1509,10 @@ class InitCommand(Command):
                 else:
                     console.print("[dim]CoWork service token already configured[/dim]")
 
-            # Claude Desktop configuration delivery mode (OIDC only).
-            # IDC deployments use static MDM profiles — bootstrap server requires
-            # OIDC Bearer tokens for user validation (IDC has no standard JWT flow).
-            if config.get("auth_type", "oidc") == "oidc":
+            # Claude Desktop configuration delivery mode.
+            # OIDC: Bootstrap server validates Bearer JWT.
+            # IDC: Bootstrap server uses IAM auth (SigV4) — no Cognito required.
+            if config.get("auth_type", "oidc") in ("oidc", "idc"):
                 console.print("\n[bold]Claude Desktop Configuration Delivery[/bold]")
                 console.print("How should Claude Desktop clients receive their configuration?")
                 console.print("  • Static: MDM profile with inline config (default)")

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -156,6 +156,7 @@ class Profile:
         "helper"  # "helper" (inferenceCredentialHelper) or "profile" (inferenceBedrockProfile)
     )
     cowork_credential_helper_ttl_sec: int = 3500  # inferenceCredentialHelperTtlSec (refresh before 1h STS expiry)
+    cowork_config_mode: str = "static"  # "static" (MDM profile) or "dynamic" (bootstrap server)
 
     # Cowork beta features (managed configuration keys)
     cowork_chat_tab_enabled: bool = True  # chatTabEnabled — enables the Chat tab

--- a/source/tests/cli/commands/test_bootstrap_server.py
+++ b/source/tests/cli/commands/test_bootstrap_server.py
@@ -206,10 +206,17 @@ class TestLambdaHandler:
     def test_no_otel_when_endpoint_empty(self, mock_validate, reload_handler, monkeypatch):
         """Should not include OTEL fields when endpoint is empty."""
         monkeypatch.setenv("OTLP_ENDPOINT", "")
-        # Reload to pick up new env var
+        # Reload to pick up new env var using explicit path (avoids module collision)
+        import importlib.util
+
         if "index" in sys.modules:
             del sys.modules["index"]
-        import index as handler
+        spec = importlib.util.spec_from_file_location(
+            "index", os.path.join(_LAMBDA_DIR, "index.py")
+        )
+        handler = importlib.util.module_from_spec(spec)
+        sys.modules["index"] = handler
+        spec.loader.exec_module(handler)
 
         mock_validate_new = MagicMock(return_value={
             "sub": "user123",

--- a/source/tests/cli/commands/test_bootstrap_server.py
+++ b/source/tests/cli/commands/test_bootstrap_server.py
@@ -43,11 +43,20 @@ def set_env_vars(monkeypatch):
 @pytest.fixture
 def reload_handler(set_env_vars):
     """Reload the handler module after env vars are set."""
-    # Remove cached module to pick up new env vars
+    import importlib.util
+
+    # Remove any cached 'index' module to avoid cross-test pollution
     if "index" in sys.modules:
         del sys.modules["index"]
-    import index
-    return index
+
+    # Load specifically from the bootstrap_server directory
+    spec = importlib.util.spec_from_file_location(
+        "index", os.path.join(_LAMBDA_DIR, "index.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["index"] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 class TestLambdaHandler:

--- a/source/tests/cli/commands/test_bootstrap_server.py
+++ b/source/tests/cli/commands/test_bootstrap_server.py
@@ -35,7 +35,10 @@ def set_env_vars(monkeypatch):
     monkeypatch.setenv("OIDC_CLIENT_ID", "test-client-id")
     monkeypatch.setenv("OIDC_JWKS_ENDPOINT", "https://example.okta.com/oauth2/default/v1/keys")
     monkeypatch.setenv("DEFAULT_INFERENCE_REGION", "us-west-2")
-    monkeypatch.setenv("DEFAULT_INFERENCE_MODELS", "us.anthropic.claude-sonnet-4-20250514-v1:0,us.anthropic.claude-opus-4-20250514-v1:0")
+    monkeypatch.setenv(
+        "DEFAULT_INFERENCE_MODELS",
+        "us.anthropic.claude-sonnet-4-20250514-v1:0,us.anthropic.claude-opus-4-20250514-v1:0",
+    )
     monkeypatch.setenv("OTLP_ENDPOINT", "https://otel.example.com/v1/traces")
     monkeypatch.setenv("INFERENCE_SESSION_LIFETIME_SEC", "14400")
 
@@ -50,9 +53,7 @@ def reload_handler(set_env_vars):
         del sys.modules["index"]
 
     # Load specifically from the bootstrap_server directory
-    spec = importlib.util.spec_from_file_location(
-        "index", os.path.join(_LAMBDA_DIR, "index.py")
-    )
+    spec = importlib.util.spec_from_file_location("index", os.path.join(_LAMBDA_DIR, "index.py"))
     module = importlib.util.module_from_spec(spec)
     sys.modules["index"] = module
     spec.loader.exec_module(module)
@@ -211,17 +212,17 @@ class TestLambdaHandler:
 
         if "index" in sys.modules:
             del sys.modules["index"]
-        spec = importlib.util.spec_from_file_location(
-            "index", os.path.join(_LAMBDA_DIR, "index.py")
-        )
+        spec = importlib.util.spec_from_file_location("index", os.path.join(_LAMBDA_DIR, "index.py"))
         handler = importlib.util.module_from_spec(spec)
         sys.modules["index"] = handler
         spec.loader.exec_module(handler)
 
-        mock_validate_new = MagicMock(return_value={
-            "sub": "user123",
-            "email": "user@example.com",
-        })
+        mock_validate_new = MagicMock(
+            return_value={
+                "sub": "user123",
+                "email": "user@example.com",
+            }
+        )
 
         with patch.object(handler, "_validate_token", mock_validate_new):
             event = {"headers": {"authorization": "Bearer valid.token.here"}}

--- a/source/tests/cli/commands/test_bootstrap_server.py
+++ b/source/tests/cli/commands/test_bootstrap_server.py
@@ -1,4 +1,4 @@
-# ABOUTME: Unit tests for the CoWork Bootstrap Server Lambda handler
+# ABOUTME: Unit tests for the Claude Desktop Bootstrap Server Lambda handler
 # ABOUTME: Tests token validation, response format, error handling, and config generation
 
 """Tests for the bootstrap_server Lambda handler."""

--- a/source/tests/cli/commands/test_bootstrap_server.py
+++ b/source/tests/cli/commands/test_bootstrap_server.py
@@ -1,0 +1,321 @@
+# ABOUTME: Unit tests for the CoWork Bootstrap Server Lambda handler
+# ABOUTME: Tests token validation, response format, error handling, and config generation
+
+"""Tests for the bootstrap_server Lambda handler."""
+
+import json
+import os
+import sys
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Add the lambda function directory to path for import
+_LAMBDA_DIR = os.path.abspath(
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "..",
+        "..",
+        "deployment",
+        "infrastructure",
+        "lambda-functions",
+        "bootstrap_server",
+    )
+)
+sys.path.insert(0, _LAMBDA_DIR)
+
+
+@pytest.fixture(autouse=True)
+def set_env_vars(monkeypatch):
+    """Set required environment variables for all tests."""
+    monkeypatch.setenv("OIDC_ISSUER_URL", "https://example.okta.com/oauth2/default")
+    monkeypatch.setenv("OIDC_CLIENT_ID", "test-client-id")
+    monkeypatch.setenv("OIDC_JWKS_ENDPOINT", "https://example.okta.com/oauth2/default/v1/keys")
+    monkeypatch.setenv("DEFAULT_INFERENCE_REGION", "us-west-2")
+    monkeypatch.setenv("DEFAULT_INFERENCE_MODELS", "us.anthropic.claude-sonnet-4-20250514-v1:0,us.anthropic.claude-opus-4-20250514-v1:0")
+    monkeypatch.setenv("OTLP_ENDPOINT", "https://otel.example.com/v1/traces")
+    monkeypatch.setenv("INFERENCE_SESSION_LIFETIME_SEC", "14400")
+
+
+@pytest.fixture
+def reload_handler(set_env_vars):
+    """Reload the handler module after env vars are set."""
+    # Remove cached module to pick up new env vars
+    if "index" in sys.modules:
+        del sys.modules["index"]
+    import index
+    return index
+
+
+class TestLambdaHandler:
+    """Tests for lambda_handler function."""
+
+    def test_missing_authorization_header(self, reload_handler):
+        """Should return 401 when Authorization header is missing."""
+        event = {"headers": {}}
+        response = reload_handler.lambda_handler(event, None)
+
+        assert response["statusCode"] == 401
+        body = json.loads(response["body"])
+        assert body["error"] == "unauthorized"
+        assert "Missing Authorization header" in body["message"]
+
+    def test_invalid_auth_scheme(self, reload_handler):
+        """Should return 401 when auth scheme is not Bearer."""
+        event = {"headers": {"authorization": "Basic dXNlcjpwYXNz"}}
+        response = reload_handler.lambda_handler(event, None)
+
+        assert response["statusCode"] == 401
+        body = json.loads(response["body"])
+        assert body["error"] == "unauthorized"
+        assert "Bearer" in body["message"]
+
+    def test_empty_bearer_token(self, reload_handler):
+        """Should return 401 when Bearer token is empty."""
+        event = {"headers": {"authorization": "Bearer "}}
+
+        with patch.object(reload_handler, "_validate_token", side_effect=ValueError("No token provided")):
+            response = reload_handler.lambda_handler(event, None)
+
+        assert response["statusCode"] == 401
+
+    @patch("index._validate_token")
+    def test_expired_token(self, mock_validate, reload_handler):
+        """Should return 401 with token_expired error for expired tokens."""
+        mock_validate.side_effect = ValueError("Token has expired")
+
+        event = {"headers": {"authorization": "Bearer expired.token.here"}}
+        response = reload_handler.lambda_handler(event, None)
+
+        assert response["statusCode"] == 401
+        body = json.loads(response["body"])
+        assert body["error"] == "token_expired"
+
+    @patch("index._validate_token")
+    def test_invalid_issuer(self, mock_validate, reload_handler):
+        """Should return 403 for invalid issuer."""
+        mock_validate.side_effect = ValueError("Invalid token issuer")
+
+        event = {"headers": {"authorization": "Bearer bad.issuer.token"}}
+        response = reload_handler.lambda_handler(event, None)
+
+        assert response["statusCode"] == 403
+        body = json.loads(response["body"])
+        assert body["error"] == "forbidden"
+
+    @patch("index._validate_token")
+    def test_invalid_audience(self, mock_validate, reload_handler):
+        """Should return 403 for invalid audience."""
+        mock_validate.side_effect = ValueError("Invalid token audience")
+
+        event = {"headers": {"authorization": "Bearer bad.audience.token"}}
+        response = reload_handler.lambda_handler(event, None)
+
+        assert response["statusCode"] == 403
+        body = json.loads(response["body"])
+        assert body["error"] == "forbidden"
+
+    @patch("index._validate_token")
+    def test_invalid_signature(self, mock_validate, reload_handler):
+        """Should return 401 for invalid signature."""
+        mock_validate.side_effect = ValueError("Invalid token signature")
+
+        event = {"headers": {"authorization": "Bearer bad.sig.token"}}
+        response = reload_handler.lambda_handler(event, None)
+
+        assert response["statusCode"] == 401
+        body = json.loads(response["body"])
+        assert body["error"] == "unauthorized"
+
+    @patch("index._validate_token")
+    def test_successful_config_response(self, mock_validate, reload_handler):
+        """Should return 200 with full config for valid token."""
+        mock_validate.return_value = {
+            "sub": "user123",
+            "email": "user@example.com",
+            "iss": "https://example.okta.com/oauth2/default",
+            "aud": "test-client-id",
+            "exp": int(time.time()) + 3600,
+        }
+
+        event = {"headers": {"authorization": "Bearer valid.token.here"}}
+        response = reload_handler.lambda_handler(event, None)
+
+        assert response["statusCode"] == 200
+        body = json.loads(response["body"])
+
+        # Check required fields
+        assert body["inferenceProvider"] == "bedrock"
+        assert body["inferenceRegion"] == "us-west-2"
+        assert body["inferenceModels"] == [
+            "us.anthropic.claude-sonnet-4-20250514-v1:0",
+            "us.anthropic.claude-opus-4-20250514-v1:0",
+        ]
+        assert body["inferenceSessionLifetimeSec"] == 14400
+        assert "expiresAt" in body
+        assert body["expiresAt"] > int(time.time())
+
+        # Check user info
+        assert body["user"]["sub"] == "user123"
+        assert body["user"]["email"] == "user@example.com"
+
+        # Check OTEL config
+        assert body["otlpEndpoint"] == "https://otel.example.com/v1/traces"
+        assert body["otlpHeaders"]["x-user-id"] == "user123"
+        assert body["otlpHeaders"]["x-user-email"] == "user@example.com"
+
+    @patch("index._validate_token")
+    def test_cache_control_header(self, mock_validate, reload_handler):
+        """Should include Cache-Control: no-store in all responses."""
+        mock_validate.return_value = {
+            "sub": "user123",
+            "email": "user@example.com",
+        }
+
+        event = {"headers": {"authorization": "Bearer valid.token.here"}}
+        response = reload_handler.lambda_handler(event, None)
+
+        assert response["headers"]["Cache-Control"] == "no-store"
+
+    @patch("index._validate_token")
+    def test_content_type_header(self, mock_validate, reload_handler):
+        """Should return application/json content type."""
+        mock_validate.return_value = {
+            "sub": "user123",
+            "email": "user@example.com",
+        }
+
+        event = {"headers": {"authorization": "Bearer valid.token.here"}}
+        response = reload_handler.lambda_handler(event, None)
+
+        assert response["headers"]["Content-Type"] == "application/json"
+
+    @patch("index._validate_token")
+    def test_no_otel_when_endpoint_empty(self, mock_validate, reload_handler, monkeypatch):
+        """Should not include OTEL fields when endpoint is empty."""
+        monkeypatch.setenv("OTLP_ENDPOINT", "")
+        # Reload to pick up new env var
+        if "index" in sys.modules:
+            del sys.modules["index"]
+        import index as handler
+
+        mock_validate_new = MagicMock(return_value={
+            "sub": "user123",
+            "email": "user@example.com",
+        })
+
+        with patch.object(handler, "_validate_token", mock_validate_new):
+            event = {"headers": {"authorization": "Bearer valid.token.here"}}
+            response = handler.lambda_handler(event, None)
+
+        body = json.loads(response["body"])
+        assert "otlpEndpoint" not in body
+        assert "otlpHeaders" not in body
+
+    @patch("index._validate_token")
+    def test_user_identity_from_sub_claim(self, mock_validate, reload_handler):
+        """Should extract user identity from sub claim."""
+        mock_validate.return_value = {
+            "sub": "auth0|abc123",
+            "preferred_username": "jsmith",
+        }
+
+        event = {"headers": {"authorization": "Bearer valid.token.here"}}
+        response = reload_handler.lambda_handler(event, None)
+
+        body = json.loads(response["body"])
+        assert body["user"]["sub"] == "auth0|abc123"
+        # Falls back to preferred_username when email is missing
+        assert body["user"]["email"] == "jsmith"
+
+    @patch("index._validate_token")
+    def test_expires_at_is_one_hour_from_now(self, mock_validate, reload_handler):
+        """Should set expiresAt to approximately 1 hour from now."""
+        mock_validate.return_value = {"sub": "user123", "email": "test@test.com"}
+
+        event = {"headers": {"authorization": "Bearer valid.token.here"}}
+        before = int(time.time()) + 3600
+        response = reload_handler.lambda_handler(event, None)
+        after = int(time.time()) + 3600
+
+        body = json.loads(response["body"])
+        assert before <= body["expiresAt"] <= after
+
+    def test_unhandled_exception_returns_500(self, reload_handler):
+        """Should return 500 for unhandled exceptions without leaking details."""
+        # Trigger an unexpected error by passing a non-dict event
+        with patch.object(reload_handler, "_validate_token", side_effect=RuntimeError("unexpected")):
+            event = {"headers": {"authorization": "Bearer valid.token.here"}}
+            response = reload_handler.lambda_handler(event, None)
+
+            # The RuntimeError is caught by the outer handler
+            assert response["statusCode"] == 500
+            body = json.loads(response["body"])
+            assert body["error"] == "internal_error"
+            assert "unexpected" not in body["message"]  # Don't leak internal error
+
+    def test_authorization_header_case_insensitive(self, reload_handler):
+        """Should handle Authorization header in different cases."""
+        # API Gateway v2 normalizes headers to lowercase
+        event = {"headers": {"Authorization": ""}}
+        response = reload_handler.lambda_handler(event, None)
+
+        assert response["statusCode"] == 401
+
+
+class TestValidateToken:
+    """Tests for _validate_token function."""
+
+    def test_empty_token_raises(self, reload_handler):
+        """Should raise ValueError for empty token."""
+        with pytest.raises(ValueError, match="No token provided"):
+            reload_handler._validate_token("")
+
+    def test_none_token_raises(self, reload_handler):
+        """Should raise ValueError for None token."""
+        with pytest.raises(ValueError, match="No token provided"):
+            reload_handler._validate_token(None)
+
+    @patch("index.HAS_PYJWT", False)
+    def test_no_pyjwt_raises(self, reload_handler):
+        """Should raise ValueError when PyJWT is not available."""
+        reload_handler.HAS_PYJWT = False
+        with pytest.raises(ValueError, match="PyJWT library not available"):
+            reload_handler._validate_token("some.token.here")
+        reload_handler.HAS_PYJWT = True  # restore
+
+
+class TestBuildConfigResponse:
+    """Tests for _build_config_response function."""
+
+    def test_basic_config_structure(self, reload_handler):
+        """Should return properly structured config."""
+        claims = {"sub": "user1", "email": "user1@example.com"}
+        config = reload_handler._build_config_response(claims)
+
+        assert config["inferenceProvider"] == "bedrock"
+        assert config["inferenceRegion"] == "us-west-2"
+        assert isinstance(config["inferenceModels"], list)
+        assert config["inferenceSessionLifetimeSec"] == 14400
+        assert "expiresAt" in config
+        assert config["user"]["sub"] == "user1"
+        assert config["user"]["email"] == "user1@example.com"
+
+    def test_models_parsed_from_comma_separated(self, reload_handler):
+        """Should parse comma-separated model list."""
+        claims = {"sub": "u", "email": "e"}
+        config = reload_handler._build_config_response(claims)
+
+        assert len(config["inferenceModels"]) == 2
+        assert "us.anthropic.claude-sonnet-4-20250514-v1:0" in config["inferenceModels"]
+        assert "us.anthropic.claude-opus-4-20250514-v1:0" in config["inferenceModels"]
+
+    def test_fallback_to_sub_when_no_email(self, reload_handler):
+        """Should use sub claim when email is missing."""
+        claims = {"sub": "user-sub-id"}
+        config = reload_handler._build_config_response(claims)
+
+        assert config["user"]["email"] == "user-sub-id"


### PR DESCRIPTION
## Why

PR #670 introduced the Bootstrap Server for dynamic per-user configuration delivery, but restricted it to OIDC deployments only. IDC users (the majority of enterprise deployments using IAM Identity Center) were excluded because there's no standard JWT flow for user validation.

However, we already solved this exact problem for the **quota API** (#598/#633) — using IAM auth (SigV4) on API Gateway. This PR extends the bootstrap server with the same proven pattern.

## Status

> **⚠️ This PR needs to be rebased onto #706** (device-code bootstrap), which supersedes #670.
> The IDC auth concept here is valid but must be ported to #706's architecture (different CFN template, different Lambda structure, device-code flow).
> See #706 for the go-forward bootstrap implementation.

## Depends On
- ~~PR #670 (base bootstrap server)~~ → **PR #706** (device-code bootstrap) — merge #706 first, then port IDC auth into that codebase

## What

| Auth Mode | How Client Authenticates | How Server Identifies User |
|-----------|--------------------------|---------------------------|
| **OIDC** | Authorization: Bearer jwt | JWT claims (sub, email) |
| **IDC** (new) | SigV4-signed request | ARN session name (user@company.com) |

### Architecture (IDC mode)

```
credential-process (Go binary)
  → aws sso login → gets STS session credentials
  → SigV4-signs GET /config
  → API Gateway (AuthorizationType: AWS_IAM, validates SigV4)
  → Lambda reads requestContext.authorizer.iam
  → Parses user email from ARN: arn:aws:sts::ACCT:assumed-role/Role/user@co.com
  → Returns per-user config JSON
```

**No Cognito. No JWT. No new dependencies.** Just IAM — which IDC already has.

## How IDC Users Are Identified

IDC ARN format: `arn:aws:sts::123456789:assumed-role/AWSReservedSSO_PermSetName_xxx/user@company.com`

The last segment after `/` is the session name — which IDC sets to the user's email.

## Risk: LOW
- Additive — OIDC mode is unchanged
- Proven pattern — identical to quota API IAM auth (#598)
- Backward compatible

## Testing
- Needs full rewrite after porting to #706 architecture