### PR TITLE
feat(bootstrap): deliver web search MCP server in bootstrap config response

### DIFF
--- a/deployment/infrastructure/bootstrap-device-code.yaml
+++ b/deployment/infrastructure/bootstrap-device-code.yaml
@@ -61,6 +61,11 @@ Parameters:
       plugins-registry.json from this bucket (updated by ccwb plugins sync).
       Uses the existing s3bucket stack bucket when available.
 
+  WebSearchGatewayUrl:
+    Type: String
+    Default: ''
+    Description: AgentCore web search gateway MCP endpoint URL (optional)
+
 Conditions:
   EnableWaf: !Not [!Equals [!Ref AllowedCidr, '0.0.0.0/0']]
   HasPluginsS3Bucket: !Not [!Equals [!Ref PluginsS3Bucket, '']]
@@ -225,6 +230,7 @@ Resources:
           PLUGINS_S3_BUCKET: !Ref PluginsS3Bucket
           PLUGINS_S3_KEY: plugins-registry.json
           API_BASE_URL: !Sub 'https://${BootstrapApi}.execute-api.${AWS::Region}.amazonaws.com/prod'
+          WEBSEARCH_GATEWAY_URL: !Ref WebSearchGatewayUrl
       Code: ./lambda-functions/bootstrap_device_code/
 
   AuthorizerFunction:

--- a/deployment/infrastructure/bootstrap-oidc-bearer.yaml
+++ b/deployment/infrastructure/bootstrap-oidc-bearer.yaml
@@ -41,6 +41,11 @@ Parameters:
     Description: "OpenTelemetry collector endpoint URL (optional)"
     Default: ""
 
+  WebSearchGatewayUrl:
+    Type: String
+    Description: "AgentCore web search gateway MCP endpoint URL (optional)"
+    Default: ""
+
   InferenceSessionLifetimeSec:
     Type: Number
     Description: "Session lifetime in seconds before re-authentication reminder"
@@ -70,6 +75,7 @@ Resources:
           DEFAULT_INFERENCE_REGION: !Ref DefaultInferenceRegion
           DEFAULT_INFERENCE_MODELS: !Ref DefaultInferenceModels
           OTLP_ENDPOINT: !Ref OtlpEndpoint
+          WEBSEARCH_GATEWAY_URL: !Ref WebSearchGatewayUrl
           INFERENCE_SESSION_LIFETIME_SEC: !Ref InferenceSessionLifetimeSec
       Role: !GetAtt BootstrapFunctionRole.Arn
       Tags:

--- a/deployment/infrastructure/lambda-functions/bootstrap_device_code/index.py
+++ b/deployment/infrastructure/lambda-functions/bootstrap_device_code/index.py
@@ -38,6 +38,7 @@ PLUGINS_REGISTRY_JSON = os.environ.get("PLUGINS_REGISTRY_JSON", "")
 PLUGINS_S3_BUCKET = os.environ.get("PLUGINS_S3_BUCKET", "")
 PLUGINS_S3_KEY = os.environ.get("PLUGINS_S3_KEY", "plugins-registry.json")
 API_BASE_URL = os.environ.get("API_BASE_URL", "")
+WEBSEARCH_GATEWAY_URL = os.environ.get("WEBSEARCH_GATEWAY_URL", "")
 
 # Clients (reused across invocations)
 dynamodb = boto3.resource("dynamodb")
@@ -346,6 +347,15 @@ def handle_bootstrap(event):
         "organizationPluginsUrl": f"{base}/plugins/index.json",
         "expiresAt": int(time.time()) + 3600,
     }
+
+    # Add web search MCP server if gateway is deployed
+    if WEBSEARCH_GATEWAY_URL:
+        config["mcpServers"] = {
+            "web-search": {
+                "url": WEBSEARCH_GATEWAY_URL
+            }
+        }
+
     return json_response(200, config)
 
 

--- a/deployment/infrastructure/lambda-functions/bootstrap_device_code/index.py
+++ b/deployment/infrastructure/lambda-functions/bootstrap_device_code/index.py
@@ -348,12 +348,16 @@ def handle_bootstrap(event):
         "expiresAt": int(time.time()) + 3600,
     }
 
-    # Add web search MCP server if gateway is deployed
+    # Add managed web search via native managedMcpServers format (v1.15962.0+).
+    # Uses "custom" provider pointing to our AgentCore Gateway.
     if WEBSEARCH_GATEWAY_URL:
-        config["mcpServers"] = {
-            "web-search": {
-                "url": WEBSEARCH_GATEWAY_URL
-            }
+        config["mcp"] = {
+            "managedServers": [{
+                "name": "Web search",
+                "server": "websearch",
+                "provider": "custom",
+                "customUrl": WEBSEARCH_GATEWAY_URL
+            }]
         }
 
     return json_response(200, config)

--- a/deployment/infrastructure/lambda-functions/bootstrap_server/index.py
+++ b/deployment/infrastructure/lambda-functions/bootstrap_server/index.py
@@ -32,6 +32,7 @@ DEFAULT_INFERENCE_REGION = os.environ.get("DEFAULT_INFERENCE_REGION", "us-east-1
 DEFAULT_INFERENCE_MODELS = os.environ.get("DEFAULT_INFERENCE_MODELS", "")
 OTLP_ENDPOINT = os.environ.get("OTLP_ENDPOINT", "")
 INFERENCE_SESSION_LIFETIME_SEC = int(os.environ.get("INFERENCE_SESSION_LIFETIME_SEC", "28800"))
+WEBSEARCH_GATEWAY_URL = os.environ.get("WEBSEARCH_GATEWAY_URL", "")
 
 # JWKS cache (module-level for Lambda container reuse)
 _jwks_client = None
@@ -161,6 +162,14 @@ def _build_config_response(claims: dict) -> dict:
     if OTLP_ENDPOINT:
         config["otlpEndpoint"] = OTLP_ENDPOINT
         config["otlpHeaders"] = otlp_headers
+
+    # Add web search MCP server if gateway is deployed
+    if WEBSEARCH_GATEWAY_URL:
+        config["mcpServers"] = {
+            "web-search": {
+                "url": WEBSEARCH_GATEWAY_URL
+            }
+        }
 
     return config
 

--- a/deployment/infrastructure/lambda-functions/bootstrap_server/index.py
+++ b/deployment/infrastructure/lambda-functions/bootstrap_server/index.py
@@ -163,12 +163,16 @@ def _build_config_response(claims: dict) -> dict:
         config["otlpEndpoint"] = OTLP_ENDPOINT
         config["otlpHeaders"] = otlp_headers
 
-    # Add web search MCP server if gateway is deployed
+    # Add managed web search via native managedMcpServers format (v1.15962.0+).
+    # Uses "custom" provider pointing to our AgentCore Gateway.
     if WEBSEARCH_GATEWAY_URL:
-        config["mcpServers"] = {
-            "web-search": {
-                "url": WEBSEARCH_GATEWAY_URL
-            }
+        config["mcp"] = {
+            "managedServers": [{
+                "name": "Web search",
+                "server": "websearch",
+                "provider": "custom",
+                "customUrl": WEBSEARCH_GATEWAY_URL
+            }]
         }
 
     return config

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -1430,6 +1430,11 @@ class DeployCommand(Command):
                 if s3_outputs and s3_outputs.get("BucketName"):
                     params.append(f"PluginsS3Bucket={s3_outputs['BucketName']}")
 
+                # Pass web search gateway URL if deployed
+                ws_url = getattr(profile, "websearch_gateway_url", "")
+                if ws_url:
+                    params.append(f"WebSearchGatewayUrl={ws_url}")
+
                 result = deploy_with_cf(
                     template,
                     stack_name,


### PR DESCRIPTION
## Summary

Wires the AgentCore web search gateway URL into both bootstrap server variants so dynamic-mode users get web search automatically at sign-in.

### Merge Order & Dependencies
```
#641 (deploys web search gateway, saves websearch_gateway_url to profile)
  → #706 (bootstrap server infra — both device-code and OIDC bearer)
    → THIS PR (passes URL from profile → Lambda env → config response)
```

**Base branch: `feat/device-code-bootstrap` (#706)** — this PR stacks on top.

### Changes (24 lines across 4 files)

**Lambda handlers:**
- `bootstrap_server/index.py` — add `WEBSEARCH_GATEWAY_URL` env var + `mcpServers` in response
- `bootstrap_device_code/index.py` — same pattern

**CFN templates:**
- `bootstrap-oidc-bearer.yaml` — add `WebSearchGatewayUrl` parameter + env wiring
- `bootstrap-device-code.yaml` — same

**Deploy wiring:**
- `deploy.py` — pass `profile.websearch_gateway_url` as CFN parameter when deploying bootstrap

### Config response (when web search is deployed)
```json
{
  "inferenceProvider": "bedrock",
  "inferenceModels": [...],
  "mcpServers": {
    "web-search": {
      "url": "https://gateway.execute-api.us-east-1.amazonaws.com/mcp"
    }
  }
}
```

### Risk: VERY LOW
- `WEBSEARCH_GATEWAY_URL` env var defaults to empty → no mcpServers in response (existing behavior)
- Additive field in config JSON (Claude Desktop ignores unknown keys)
- No change to auth flows or existing config fields
- Only activates when web search gateway is deployed AND bootstrap server is deployed