### PR TITLE
feat(websearch): inject web search as native managedMcpServers in Claude Desktop MDM config

### DIFF
--- a/assets/docs/COWORK_3P.md
+++ b/assets/docs/COWORK_3P.md
@@ -293,7 +293,7 @@ Administrators often need to set additional MDM keys beyond the defaults generat
 |-----|---------|
 | `coworkEgressAllowedHosts` | Allow Claude Desktop to access external hosts (required for Web Fetch) |
 | `coworkWebSearchEnabled` | Enable web search capability |
-| `managedMcpServers` | Deploy managed MCP servers (e.g., Brave Search for web search on Bedrock) |
+| `managedMcpServers` | Deploy managed MCP servers (e.g., web search via AgentCore Gateway) |
 | `disabledBuiltinTools` | Lock down specific tools |
 | `allowedWorkspaceFolders` | Restrict workspace access to approved directories |
 

--- a/source/claude_code_with_bedrock/cli/commands/cowork.py
+++ b/source/claude_code_with_bedrock/cli/commands/cowork.py
@@ -12,6 +12,7 @@ from rich.panel import Panel
 
 from claude_code_with_bedrock.cli.utils.cowork_3p import (
     add_monitoring_config,
+    add_websearch_mcp_config,
     build_mdm_config,
     derive_model_aliases,
     generate_json,
@@ -124,6 +125,9 @@ class CoworkGenerateCommand(Command):
 
         # Add monitoring OTLP endpoint if available
         add_monitoring_config(mdm_config, profile, console)
+
+        # Add the AgentCore web search gateway as a managed MCP server (if enabled)
+        add_websearch_mcp_config(mdm_config, profile, console)
 
         # Generate requested formats
         generated = []

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -51,7 +51,7 @@ def _extract_azure_tenant_id(domain: str) -> str:
 # Provider types supported by the AgentCore Web Search gateway. The CUSTOM_JWT
 # authorizer is provider-agnostic (validates any OIDC id_token), so all OIDC
 # providers work. Non-OIDC (idc, none) have no id_token to validate.
-WEBSEARCH_SUPPORTED_PROVIDERS = ("cognito", "azure", "okta", "auth0", "google", "generic")
+WEBSEARCH_SUPPORTED_PROVIDERS = ("cognito", "azure", "okta", "auth0", "google", "generic", "idc")
 
 
 def get_websearch_region(profile) -> str:

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -29,7 +29,7 @@ from claude_code_with_bedrock.cli.utils.helpers import (
     find_nearest_codebuild_region,
     get_codebuild_region,
 )
-from claude_code_with_bedrock.config import Config
+from claude_code_with_bedrock.config import WEBSEARCH_SUPPORTED_REGIONS, Config
 
 # Azure tenant ID GUID pattern — matches UUIDs in various URL formats:
 #   login.microsoftonline.com/{tenant-id}/v2.0
@@ -46,6 +46,169 @@ def _extract_azure_tenant_id(domain: str) -> str:
     """
     match = _AZURE_GUID_PATTERN.search(domain)
     return match.group(0) if match else domain
+
+
+# Provider types supported by the AgentCore Web Search gateway. The CUSTOM_JWT
+# authorizer is provider-agnostic (validates any OIDC id_token), so all OIDC
+# providers work. Non-OIDC (idc, none) have no id_token to validate.
+WEBSEARCH_SUPPORTED_PROVIDERS = ("cognito", "azure", "okta", "auth0", "google", "generic")
+
+
+def get_websearch_region(profile) -> str:
+    """Region the web search gateway stack deploys into (defaults to us-east-1)."""
+    return getattr(profile, "websearch_region", None) or WEBSEARCH_SUPPORTED_REGIONS[0]
+
+
+def websearch_preflight(profile) -> tuple[bool, str | None]:
+    """Validate that web search can be deployed for this profile.
+
+    Returns (ok, error_message). When ok is False, the caller must NOT deploy
+    the gateway stack and should surface error_message. Mirrors the per-provider
+    guards used elsewhere in deploy (e.g. quota requires OIDC/IDC).
+    """
+    provider = getattr(profile, "provider_type", None)
+    if provider not in WEBSEARCH_SUPPORTED_PROVIDERS:
+        return False, (
+            f"Web search requires an OIDC provider (one of: "
+            f"{', '.join(WEBSEARCH_SUPPORTED_PROVIDERS)}). "
+            f"Current provider_type: '{provider}'."
+        )
+
+    region = get_websearch_region(profile)
+    if region not in WEBSEARCH_SUPPORTED_REGIONS:
+        return False, (
+            f"Web search region '{region}' is not supported. "
+            f"Supported regions: {', '.join(WEBSEARCH_SUPPORTED_REGIONS)}."
+        )
+
+    if provider == "cognito" and not (
+        getattr(profile, "cognito_user_pool_id", None) and getattr(profile, "client_id", None)
+    ):
+        return False, "Cognito web search requires cognito_user_pool_id and client_id in the profile."
+
+    if provider == "azure":
+        has_issuer = getattr(profile, "oidc_issuer_url", None) or getattr(profile, "provider_domain", None)
+        if not (has_issuer and getattr(profile, "client_id", None)):
+            return False, (
+                "Azure (Entra ID) web search requires the Entra issuer and client_id in the profile. "
+                "Re-run 'ccwb init' to configure SSO."
+            )
+        # websearch_jwt_audience is optional: the gateway validates the id_token
+        # 'aud' claim, which defaults to client_id. Only set it when the Entra
+        # app is configured with a custom API audience (e.g. api://<app-id>).
+
+    if provider == "generic":
+        if not getattr(profile, "oidc_issuer_url", None):
+            return False, (
+                "Generic OIDC provider requires oidc_issuer_url to derive the "
+                "web-search gateway discovery URL. Re-run 'ccwb init'."
+            )
+
+    return True, None
+
+
+def _websearch_discovery_url(profile) -> str:
+    """Build the OIDC discovery URL for the gateway CUSTOM_JWT authorizer.
+
+    The gateway's expected issuer must match the id_token's actual `iss` claim,
+    so this derives the issuer per-provider and appends the well-known suffix.
+    """
+    provider = profile.provider_type
+    provider_domain = (getattr(profile, "provider_domain", "") or "").rstrip("/")
+
+    if provider == "cognito":
+        pool_id = profile.cognito_user_pool_id
+        pool_region = pool_id.split("_")[0] if pool_id and "_" in pool_id else profile.aws_region
+        return f"https://cognito-idp.{pool_region}.amazonaws.com/{pool_id}/.well-known/openid-configuration"
+    elif provider == "azure":
+        tenant_id = _extract_azure_tenant_id(getattr(profile, "oidc_issuer_url", None) or provider_domain or "")
+        return f"https://login.microsoftonline.com/{tenant_id}/v2.0/.well-known/openid-configuration"
+    elif provider == "okta":
+        return f"https://{provider_domain}/oauth2/default/.well-known/openid-configuration"
+    elif provider == "auth0":
+        return f"https://{provider_domain}/.well-known/openid-configuration"
+    elif provider == "google":
+        return "https://accounts.google.com/.well-known/openid-configuration"
+    elif provider == "generic":
+        issuer = (getattr(profile, "oidc_issuer_url", "") or "").rstrip("/")
+        if not issuer.startswith(("http://", "https://")):
+            issuer = f"https://{issuer}"
+        return f"{issuer}/.well-known/openid-configuration"
+    else:
+        raise ValueError(f"Unsupported provider_type '{provider}' for web search.")
+
+
+def build_websearch_params(profile) -> list[str]:
+    """Build CloudFormation parameter overrides for the web search gateway stack.
+
+    Matches the merged gateway template parameters (DiscoveryUrl, ClientId,
+    DomainExcludeList). The CUSTOM_JWT authorizer validates the inbound
+    id_token's 'aud' claim against ClientId; for an OIDC id_token aud == client_id.
+    The stack is deployed into a Web Search supported region via
+    ``get_websearch_region`` (region is no longer a template parameter).
+    """
+    discovery_url = _websearch_discovery_url(profile)
+    # The merged gateway template (PR #607) validates the inbound id_token's
+    # 'aud' claim against a single ClientId parameter (AllowedAudience: [ClientId]).
+    # For an OIDC id_token aud == client_id, so client_id works for every
+    # provider (Cognito, Okta, Auth0, Google, generic). Entra ID may override
+    # with a custom API audience (api://<app-id>) when the app is configured
+    # with one; otherwise the default aud (client_id) is used.
+    expected_audience = profile.client_id
+    if profile.provider_type == "azure" and getattr(profile, "websearch_jwt_audience", None):
+        expected_audience = profile.websearch_jwt_audience
+    params = [
+        f"DiscoveryUrl={discovery_url}",
+        f"ClientId={expected_audience}",
+    ]
+    denylist = getattr(profile, "websearch_domain_denylist", None) or []
+    if denylist:
+        params.append(f"DomainExcludeList={','.join(denylist)}")
+    return params
+
+
+def _poll_websearch_target_ready(
+    gateway_id: str, region: str, console, timeout: int = 600, interval: int = 15, session=None
+) -> bool:
+    """Poll the gateway's connector target until READY.
+
+    CFN CREATE_COMPLETE precedes the target reaching READY — the connector
+    provisions asynchronously. Returns True on READY, False on FAILED or timeout.
+    Uses the provided boto3 session to respect proxy/CA/endpoint config.
+    """
+    import time
+
+    try:
+        import boto3
+
+        if session is None:
+            session = boto3.Session(region_name=region)
+        client = session.client("bedrock-agentcore-control", region_name=region)
+    except Exception as e:
+        console.print(f"[yellow]\u26a0 Could not create AgentCore client to poll target: {e}[/yellow]")
+        return False
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            resp = client.list_gateway_targets(gatewayIdentifier=gateway_id, maxResults=1)
+            targets = resp.get("gatewayTargets", [])
+            if targets:
+                status = targets[0].get("status", "")
+                if status == "READY":
+                    console.print("[green]\u2713 Web search connector target is READY[/green]")
+                    return True
+                elif status == "FAILED":
+                    reason = targets[0].get("statusReason", "unknown")
+                    console.print(f"[red]\u2717 Connector target FAILED: {reason}[/red]")
+                    return False
+                console.print(f"[dim]  Connector status: {status}, waiting...[/dim]")
+        except Exception as e:
+            console.print(f"[yellow]  Poll error (retrying): {e}[/yellow]")
+        time.sleep(interval)
+
+    console.print(f"[yellow]\u26a0 Connector target did not reach READY within {timeout}s[/yellow]")
+    return False
 
 
 class DeployCommand(Command):
@@ -189,10 +352,20 @@ class DeployCommand(Command):
                 else:
                     console.print("[yellow]CodeBuild is not enabled in your configuration.[/yellow]")
                     return 1
+            elif stack_arg == "websearch":
+                if not getattr(profile, "web_search_enabled", False):
+                    console.print("[yellow]Web search is not enabled in your configuration.[/yellow]")
+                    console.print("Run 'poetry run ccwb init' and enable web search.")
+                    return 1
+                ok, msg = websearch_preflight(profile)
+                if not ok:
+                    console.print(f"[yellow]{msg}[/yellow]")
+                    return 1
+                stacks_to_deploy.append(("websearch", "AgentCore Gateway + Web Search connector"))
             else:
                 console.print(f"[red]Unknown stack: {stack_arg}[/red]")
                 console.print(
-                    "Valid stacks: auth, distribution, networking, monitoring, dashboard, cowork-dashboard, analytics, quota, codebuild\n"
+                    "Valid stacks: auth, distribution, networking, monitoring, dashboard, cowork-dashboard, analytics, quota, codebuild, websearch\n"
                 )
                 console.print("[dim]Tip: Use 'ccwb deploy' without arguments to deploy all enabled stacks.[/dim]")
                 console.print("[dim]Use 'ccwb deploy quota' for quota-specific updates or late enablement.[/dim]")
@@ -256,6 +429,15 @@ class DeployCommand(Command):
             if getattr(profile, "enable_codebuild", False):
                 stacks_to_deploy.append(("codebuild", "CodeBuild for Windows binary builds"))
 
+            # Web search gateway — independent stack, only needs the IdP from auth.
+            # Deployed cross-region (us-east-1) where the connector is available.
+            if getattr(profile, "web_search_enabled", False):
+                ok, msg = websearch_preflight(profile)
+                if ok:
+                    stacks_to_deploy.append(("websearch", "AgentCore Gateway + Web Search connector"))
+                else:
+                    console.print(f"[yellow]⚠ Skipping web search gateway: {msg}[/yellow]")
+
         # Initialize CloudFormation manager
         cf_manager = CloudFormationManager(region=profile.aws_region)
 
@@ -274,6 +456,10 @@ class DeployCommand(Command):
                 cb_region = get_codebuild_region(profile)
                 if cb_region != profile.aws_region:
                     status_manager = CloudFormationManager(region=cb_region)
+            elif stack_type == "websearch":
+                ws_region = get_websearch_region(profile)
+                if ws_region != profile.aws_region:
+                    status_manager = CloudFormationManager(region=ws_region)
             status = status_manager.get_stack_status(stack_name)
             if status and status in ["CREATE_COMPLETE", "UPDATE_COMPLETE", "UPDATE_ROLLBACK_COMPLETE"]:
                 status_display = "[green]Update[/green]"
@@ -310,6 +496,10 @@ class DeployCommand(Command):
                             cb_region = get_codebuild_region(profile)
                             if cb_region != profile.aws_region:
                                 del_mgr = CloudFormationManager(region=cb_region)
+                        elif stack_type == "websearch":
+                            ws_region = get_websearch_region(profile)
+                            if ws_region != profile.aws_region:
+                                del_mgr = CloudFormationManager(region=ws_region)
                         del_mgr.delete_stack(stack_name)
                         console.print(f"[green]✓ {stack_type} stack deletion initiated[/green]")
                     except Exception as e:
@@ -334,6 +524,19 @@ class DeployCommand(Command):
 
             result = self._deploy_stack(stack_type, profile, console, cf_manager)
             if result != 0:
+                if stack_type == "websearch":
+                    # Web search is an optional add-on. A failure here must not mark
+                    # the whole platform deploy as failed or abort stacks that follow;
+                    # surface it clearly with remediation and continue. (Running
+                    # 'ccwb deploy websearch' explicitly still returns non-zero.)
+                    console.print(
+                        "[yellow]⚠ Web search gateway deploy failed — this is optional and does not "
+                        "block the rest of the deployment.[/yellow]\n"
+                        "[dim]  Re-run 'ccwb deploy websearch' to retry, or "
+                        "'ccwb destroy websearch' to clean up.[/dim]"
+                    )
+                    console.print("")
+                    continue
                 failed = True
                 console.print(f"[red]Failed to deploy {stack_type} stack[/red]")
                 break
@@ -1047,6 +1250,48 @@ class DeployCommand(Command):
                     cf=cf,
                 )
 
+            elif stack_type == "websearch":
+                # Web search deploys into a region where the managed connector is
+                # available (us-east-1 today), which may differ from the main
+                # region. Build a dedicated manager for it (codebuild precedent).
+                ok, msg = websearch_preflight(profile)
+                if not ok:
+                    console.print(f"[red]{msg}[/red]")
+                    return 1
+                ws_region = get_websearch_region(profile)
+                cf = cf_manager if ws_region == profile.aws_region else CloudFormationManager(region=ws_region)
+                template = project_root / "deployment" / "infrastructure" / "bedrock-agentcore-gateway.yaml"
+                stack_name = profile.stack_names.get("websearch", f"{profile.identity_pool_name}-websearch")
+                params = build_websearch_params(profile)
+                result = deploy_with_cf(
+                    template,
+                    stack_name,
+                    params,
+                    task_description=f"Deploying AgentCore web search gateway in {ws_region}...",
+                    cf=cf,
+                )
+                if result == 0:
+                    # Persist gateway URL for package.py / credential-process
+                    outputs = cf.get_stack_outputs(stack_name)
+                    gateway_url = outputs.get("GatewayMcpEndpoint")
+                    if gateway_url:
+                        profile.websearch_gateway_url = gateway_url
+                        config = Config.load()
+                        config.save_profile(profile)
+                        console.print(f"[green]✓ Gateway URL saved: {gateway_url}[/green]")
+                    # Poll connector target until READY (async provisioning)
+                    outputs = cf.get_stack_outputs(stack_name)
+                    gateway_id = outputs.get("GatewayId")
+                    if gateway_id:
+                        ready = _poll_websearch_target_ready(gateway_id, ws_region, console, session=cf.session)
+                        if not ready:
+                            console.print(
+                                "[yellow]⚠ Connector target not yet READY. "
+                                "Re-run 'ccwb deploy websearch' to re-check, or "
+                                "'ccwb destroy websearch' to tear down.[/yellow]"
+                            )
+                return result
+
             else:
                 console.print(f"[red]Unknown stack type: {stack_type}[/red]")
                 return 1
@@ -1413,6 +1658,7 @@ class DeployCommand(Command):
             "analytics": "Analytics Pipeline",
             "quota": "Quota Monitoring",
             "codebuild": "CodeBuild",
+            "websearch": "AgentCore Gateway + Web Search connector",
         }
 
         # Stack types that are being deployed
@@ -1423,14 +1669,18 @@ class DeployCommand(Command):
         for stack_type in all_stack_types:
             if stack_type not in deploying_types:
                 # This stack type is not being deployed - check if it exists.
-                # CodeBuild may live in a different region (cross-region builds), so
-                # check it there or a cross-region orphan is never detected.
+                # CodeBuild and websearch may live in a different region, so
+                # check them there or a cross-region orphan is never detected.
                 stack_name = profile.stack_names.get(stack_type, f"{profile.identity_pool_name}-{stack_type}")
                 mgr = cf_manager
                 if stack_type == "codebuild":
                     cb_region = get_codebuild_region(profile)
                     if cb_region != profile.aws_region:
                         mgr = CloudFormationManager(region=cb_region)
+                elif stack_type == "websearch":
+                    ws_region = get_websearch_region(profile)
+                    if ws_region != profile.aws_region:
+                        mgr = CloudFormationManager(region=ws_region)
                 status = mgr.get_stack_status(stack_name)
 
                 if status and status not in ["DELETE_COMPLETE", "DELETE_IN_PROGRESS"]:

--- a/source/claude_code_with_bedrock/cli/commands/destroy.py
+++ b/source/claude_code_with_bedrock/cli/commands/destroy.py
@@ -12,11 +12,12 @@ from rich.prompt import Confirm
 
 from claude_code_with_bedrock.cli.utils.cloudformation import CloudFormationManager
 from claude_code_with_bedrock.cli.utils.helpers import clear_cached_credentials, get_codebuild_region
-from claude_code_with_bedrock.config import Config
+from claude_code_with_bedrock.config import WEBSEARCH_SUPPORTED_REGIONS, Config
 
 # All destroyable stacks in reverse dependency order (destroy-all uses this sequence).
 # Keep in sync with deploy.py's stack types when adding new stacks.
 DESTROYABLE_STACKS = [
+    "websearch",
     "codebuild",
     "analytics",
     "quota",
@@ -143,12 +144,20 @@ class DestroyCommand(Command):
                 continue
             if stack == "codebuild" and not getattr(profile, "enable_codebuild", False):
                 continue
+            if stack == "websearch" and not getattr(profile, "web_search_enabled", False):
+                continue
 
             stack_name = profile.stack_names.get(stack, f"{profile.identity_pool_name}-{stack}")
             # CodeBuild may have been deployed cross-region (Windows container fleet
             # isn't in every region); delete it where it actually lives, or it's
             # silently orphaned in the build region while the destroy reports success.
-            stack_region = get_codebuild_region(profile) if stack == "codebuild" else profile.aws_region
+            # Web search likewise deploys into us-east-1 (managed connector region).
+            if stack == "codebuild":
+                stack_region = get_codebuild_region(profile)
+            elif stack == "websearch":
+                stack_region = getattr(profile, "websearch_region", None) or WEBSEARCH_SUPPORTED_REGIONS[0]
+            else:
+                stack_region = profile.aws_region
             console.print(f"Destroying {stack} stack: [cyan]{stack_name}[/cyan]")
 
             result = self._delete_stack(stack_name, stack_region, console)

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -3950,6 +3950,7 @@ Available metrics include:
         """
         from claude_code_with_bedrock.cli.utils.cowork_3p import (
             add_monitoring_config,
+            add_websearch_mcp_config,
             build_mdm_config,
             derive_model_aliases,
             generate_all,
@@ -3979,6 +3980,7 @@ Available metrics include:
                 mdm_config["inferenceSessionLifetimeSec"] = profile.cowork_inference_session_lifetime_sec
 
             add_monitoring_config(mdm_config, profile, console)
+            add_websearch_mcp_config(mdm_config, profile, console)
             generate_all(output_dir, mdm_config, console)
 
         except Exception as e:

--- a/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
+++ b/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
@@ -305,6 +305,17 @@ def add_websearch_mcp_config(mdm_config: dict, profile, console: Console) -> Non
     if not getattr(profile, "web_search_enabled", False):
         return
 
+    # IDC uses IAM auth (SigV4) for the gateway — Claude Desktop doesn't support
+    # SigV4 signing for managed MCP servers yet. Skip CoWork injection for IDC;
+    # Claude Code CLI handles IDC web search via the MCP auth header helper.
+    auth_type = getattr(profile, "effective_auth_type", getattr(profile, "auth_type", "oidc"))
+    if auth_type == "idc":
+        console.print(
+            "[dim]Web search: skipping CoWork config (IDC uses IAM auth; "
+            "Claude Desktop does not yet support SigV4 for MCP servers)[/dim]"
+        )
+        return
+
     url = _resolve_websearch_gateway_url(profile)
     if not url:
         console.print(

--- a/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
+++ b/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
@@ -252,6 +252,98 @@ def add_monitoring_config(mdm_config: dict, profile, console: Console) -> None:
         )
 
 
+WEBSEARCH_MCP_SERVER_NAME = "agentcore-websearch"
+
+
+def _oidc_issuer_for_profile(profile) -> str:
+    """OIDC issuer base URL for CoWork's oauth.authorizationServer (no well-known suffix).
+
+    Reuses deploy.py's per-provider discovery-URL derivation (single source of
+    truth) and strips the well-known suffix, so the issuer matches exactly what
+    the gateway's CUSTOM_JWT authorizer validates against. Imported lazily to
+    avoid a module-load cycle (deploy.py imports heavy CLI machinery).
+    """
+    from claude_code_with_bedrock.cli.commands.deploy import _websearch_discovery_url
+
+    suffix = "/.well-known/openid-configuration"
+    discovery = _websearch_discovery_url(profile)
+    return discovery[: -len(suffix)] if discovery.endswith(suffix) else discovery
+
+
+def _resolve_websearch_gateway_url(profile) -> str | None:
+    """Resolve the gateway MCP endpoint, profile-first with a CloudFormation fallback.
+
+    Prefers ``websearch_gateway_url`` saved on the profile by ``ccwb deploy``
+    (mirrors the OTLP-endpoint discovery precedent), falling back to the
+    ``websearch`` stack's ``GatewayMcpEndpoint`` output (the gateway is pinned to
+    us-east-1). Ensures exactly one ``/mcp`` suffix. Returns None when unresolved.
+    """
+    url = (getattr(profile, "websearch_gateway_url", "") or "").strip()
+    if not url:
+        stack = (getattr(profile, "stack_names", None) or {}).get("websearch")
+        region = getattr(profile, "websearch_region", None) or "us-east-1"
+        if stack:
+            try:
+                url = (get_stack_outputs(stack, region).get("GatewayMcpEndpoint") or "").strip()
+            except Exception:
+                url = ""
+    if not url:
+        return None
+    return url if url.rstrip("/").endswith("/mcp") else url.rstrip("/") + "/mcp"
+
+
+def add_websearch_mcp_config(mdm_config: dict, profile, console: Console) -> None:
+    """Inject the AgentCore web search gateway as a CoWork managed MCP server.
+
+    No-op unless ``web_search_enabled``. Resolves the gateway endpoint at
+    generation time (never a stale stored value beyond the profile cache).
+    CoWork authenticates with an OAuth authorization-code flow against the same
+    IdP, reusing the solution's ``client_id`` and the localhost callback already
+    registered for Claude Code — so no secret is stored in the MDM config.
+    Preserves any administrator-defined ``managedMcpServers`` and de-dupes by name.
+    """
+    if not getattr(profile, "web_search_enabled", False):
+        return
+
+    url = _resolve_websearch_gateway_url(profile)
+    if not url:
+        console.print(
+            "[yellow]⚠ Web search is enabled but the gateway endpoint could not be resolved; "
+            "generating CoWork config without the web search MCP server.[/yellow]\n"
+            "[dim]  Run 'ccwb deploy websearch' first.[/dim]"
+        )
+        return
+
+    # Use native managedMcpServers "websearch" server type (v1.15962.0+)
+    # with "custom" provider pointing to our AgentCore Gateway.
+    entry = {
+        "name": WEBSEARCH_MCP_SERVER_NAME,
+        "server": "websearch",
+        "provider": "custom",
+        "customUrl": url,
+    }
+
+    # managedMcpServers is a JSON-encoded string in the MDM config. Merge with any
+    # admin-defined entries (e.g. from cowork_3p_extra_keys), keeping all and
+    # de-duping by name so a re-run never creates a duplicate web search entry.
+    existing_raw = mdm_config.get("managedMcpServers")
+    servers: list = []
+    if isinstance(existing_raw, str) and existing_raw.strip():
+        try:
+            parsed = json.loads(existing_raw)
+            if isinstance(parsed, list):
+                servers = parsed
+        except (ValueError, TypeError):
+            servers = []
+    elif isinstance(existing_raw, list):
+        servers = list(existing_raw)
+
+    servers = [s for s in servers if not (isinstance(s, dict) and s.get("name") == WEBSEARCH_MCP_SERVER_NAME)]
+    servers.append(entry)
+    mdm_config["managedMcpServers"] = json.dumps(servers)
+    console.print(f"[dim]Added {WEBSEARCH_MCP_SERVER_NAME} MCP server to CoWork config ({url})[/dim]")
+
+
 def _mdm_keys(config: dict) -> dict:
     """Return config without internal underscore-prefixed keys."""
     return {k: v for k, v in config.items() if not k.startswith("_")}

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -9,6 +9,10 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+# AWS regions where the Amazon Bedrock AgentCore managed Web Search connector
+# is available. Extend this list as regional availability expands.
+WEBSEARCH_SUPPORTED_REGIONS = ["us-east-1"]
+
 
 @dataclass
 class Profile:
@@ -163,6 +167,16 @@ class Profile:
         True  # chatAdvancedFileAnalysisEnabled — code execution for file analysis
     )
     cowork_inference_session_lifetime_sec: int | None = None  # inferenceSessionLifetimeSec — re-auth reminder timer
+
+    # Web search (AgentCore Gateway + managed Web Search connector)
+    # Opt-in, default off. Deploys an optional AgentCore Gateway stack whose
+    # inbound CUSTOM_JWT authorizer reuses the existing OIDC IdP. The gateway
+    # serves both Claude Code (via headersHelper) and Claude Cowork (via MDM).
+    web_search_enabled: bool = False  # Enable the web search gateway
+    websearch_gateway_url: str = ""  # Gateway MCP endpoint URL (populated after deploy)
+    websearch_region: str | None = None  # Region for the gateway stack (allow-list; None = default us-east-1)
+    websearch_jwt_audience: str | None = None  # Entra ID (audience mode) only: aud the authorizer accepts
+    websearch_domain_denylist: list[str] = field(default_factory=list)  # Optional domains to exclude from results
 
     # Legacy field support
     @property

--- a/source/tests/cli/commands/test_deploy_orphan_region.py
+++ b/source/tests/cli/commands/test_deploy_orphan_region.py
@@ -16,6 +16,10 @@ def _profile(**overrides):
     p.stack_names = {}
     p.aws_region = "ap-southeast-1"
     p.codebuild_region = None
+    # Keep web search in the main region by default so these codebuild-focused
+    # tests don't build an extra (web search) cross-region manager. Tests that
+    # exercise web search set websearch_region explicitly.
+    p.websearch_region = "ap-southeast-1"
     for k, v in overrides.items():
         setattr(p, k, v)
     return p
@@ -64,3 +68,28 @@ def test_orphan_check_no_extra_manager_when_codebuild_same_region():
 
     # codebuild_region resolves to aws_region, so no separate manager is constructed.
     assert built == []
+
+
+def test_orphan_check_uses_websearch_region_for_websearch_stack():
+    """When web search is cross-region, the orphan status check must hit that region."""
+    profile = _profile(websearch_region="us-east-1")  # main region is ap-southeast-1
+    main_mgr = MagicMock()
+    main_mgr.get_stack_status.return_value = None  # nothing in main region
+
+    ws_mgr = MagicMock()
+    ws_mgr.get_stack_status.return_value = "CREATE_COMPLETE"
+
+    captured_regions = []
+
+    def _mgr_factory(region):
+        captured_regions.append(region)
+        return ws_mgr
+
+    cmd = DeployCommand()
+    with patch("claude_code_with_bedrock.cli.commands.deploy.CloudFormationManager", side_effect=_mgr_factory):
+        orphaned = cmd._check_orphaned_stacks([], profile, main_mgr, MagicMock())
+
+    # A region-specific manager was built for us-east-1 (the web search region).
+    assert "us-east-1" in captured_regions
+    # websearch is reported orphaned because it was found in us-east-1, not main.
+    assert any(stack_type == "websearch" for stack_type, _, _ in orphaned)

--- a/source/tests/test_cowork_websearch_mdm.py
+++ b/source/tests/test_cowork_websearch_mdm.py
@@ -1,0 +1,106 @@
+# ABOUTME: Tests for injecting the AgentCore web search gateway into the CoWork MDM config
+# ABOUTME: Covers add_websearch_mcp_config: opt-in gating, entry shape, merge/dedup, URL resolution
+
+"""Unit tests for add_websearch_mcp_config (CoWork managedMcpServers injection)."""
+
+import json
+
+from rich.console import Console
+
+from claude_code_with_bedrock.cli.utils.cowork_3p import (
+    WEBSEARCH_MCP_SERVER_NAME,
+    add_websearch_mcp_config,
+)
+from claude_code_with_bedrock.config import Profile
+
+_CONSOLE = Console()
+
+
+def _profile(**overrides) -> Profile:
+    data = {
+        "name": "test",
+        "provider_domain": "us-east-1abc.auth.eu-central-1.amazoncognito.com",
+        "client_id": "client123",
+        "credential_storage": "keyring",
+        "aws_region": "eu-central-1",
+        "identity_pool_name": "ccwb",
+        "provider_type": "cognito",
+        "cognito_user_pool_id": "eu-central-1_AbCdEf",
+        "web_search_enabled": True,
+        "websearch_gateway_url": "https://gw-abc.gateway.bedrock-agentcore.us-east-1.amazonaws.com/mcp",
+        "redirect_port": 8400,
+    }
+    data.update(overrides)
+    return Profile.from_dict(data)
+
+
+def _servers(mdm_config: dict) -> list:
+    raw = mdm_config.get("managedMcpServers")
+    return json.loads(raw) if raw else []
+
+
+def test_disabled_is_noop():
+    mdm = {}
+    add_websearch_mcp_config(mdm, _profile(web_search_enabled=False), _CONSOLE)
+    assert "managedMcpServers" not in mdm
+
+
+def test_enabled_adds_entry_with_expected_shape():
+    """v1.15962.0+ native managedMcpServers format with server=websearch, provider=custom."""
+    mdm = {}
+    add_websearch_mcp_config(mdm, _profile(), _CONSOLE)
+    servers = _servers(mdm)
+    assert len(servers) == 1
+    entry = servers[0]
+    assert entry["name"] == WEBSEARCH_MCP_SERVER_NAME
+    assert entry["server"] == "websearch"
+    assert entry["provider"] == "custom"
+    assert entry["customUrl"] == "https://gw-abc.gateway.bedrock-agentcore.us-east-1.amazonaws.com/mcp"
+
+
+def test_managed_mcp_servers_is_json_encoded_string():
+    mdm = {}
+    add_websearch_mcp_config(mdm, _profile(), _CONSOLE)
+    assert isinstance(mdm["managedMcpServers"], str)
+
+
+def test_appends_mcp_suffix_when_missing():
+    mdm = {}
+    add_websearch_mcp_config(
+        mdm,
+        _profile(websearch_gateway_url="https://gw-abc.gateway.bedrock-agentcore.us-east-1.amazonaws.com"),
+        _CONSOLE,
+    )
+    assert _servers(mdm)[0]["customUrl"].endswith("/mcp")
+    assert not _servers(mdm)[0]["customUrl"].endswith("/mcp/mcp")
+
+
+def test_does_not_double_mcp_suffix():
+    mdm = {}
+    add_websearch_mcp_config(mdm, _profile(), _CONSOLE)
+    assert _servers(mdm)[0]["customUrl"].count("/mcp") == 1
+
+
+def test_preserves_admin_defined_servers_and_dedupes():
+    admin_entry = {"name": "github", "server": "websearch", "provider": "brave"}
+    mdm = {"managedMcpServers": json.dumps([admin_entry])}
+    add_websearch_mcp_config(mdm, _profile(), _CONSOLE)
+    servers = _servers(mdm)
+    names = [s["name"] for s in servers]
+    assert "github" in names
+    assert names.count(WEBSEARCH_MCP_SERVER_NAME) == 1
+    assert len(servers) == 2
+
+
+def test_rerun_does_not_duplicate_websearch_entry():
+    mdm = {}
+    add_websearch_mcp_config(mdm, _profile(), _CONSOLE)
+    add_websearch_mcp_config(mdm, _profile(), _CONSOLE)
+    servers = _servers(mdm)
+    assert [s["name"] for s in servers].count(WEBSEARCH_MCP_SERVER_NAME) == 1
+
+
+def test_unresolved_endpoint_warns_and_skips():
+    mdm = {}
+    add_websearch_mcp_config(mdm, _profile(websearch_gateway_url="", stack_names={}), _CONSOLE)
+    assert "managedMcpServers" not in mdm

--- a/source/tests/test_websearch_gateway.py
+++ b/source/tests/test_websearch_gateway.py
@@ -1,0 +1,249 @@
+# ABOUTME: Tests for the web search gateway wiring (config + deploy)
+# ABOUTME: Covers Profile backward-compat, provider/region guards, and CFN param derivation
+
+"""Unit tests for the AgentCore web search gateway deploy wiring (PR 2)."""
+
+from claude_code_with_bedrock.cli.commands.deploy import (
+    _websearch_discovery_url,
+    build_websearch_params,
+    get_websearch_region,
+    websearch_preflight,
+)
+from claude_code_with_bedrock.config import WEBSEARCH_SUPPORTED_REGIONS, Profile
+
+
+def _cognito_profile(**overrides) -> Profile:
+    data = {
+        "name": "test",
+        "provider_domain": "us-east-1abc.auth.us-east-1.amazoncognito.com",
+        "client_id": "client123",
+        "credential_storage": "keyring",
+        "aws_region": "eu-central-1",
+        "identity_pool_name": "ccwb",
+        "provider_type": "cognito",
+        "cognito_user_pool_id": "eu-central-1_AbCdEf",
+        "web_search_enabled": True,
+    }
+    data.update(overrides)
+    return Profile.from_dict(data)
+
+
+def _azure_profile(**overrides) -> Profile:
+    data = {
+        "name": "test",
+        "provider_domain": "login.microsoftonline.com/11111111-2222-3333-4444-555555555555/v2.0",
+        "client_id": "appclient123",
+        "credential_storage": "keyring",
+        "aws_region": "eu-central-1",
+        "identity_pool_name": "ccwb",
+        "provider_type": "azure",
+        "oidc_issuer_url": "https://login.microsoftonline.com/11111111-2222-3333-4444-555555555555/v2.0",
+        "web_search_enabled": True,
+        "websearch_jwt_audience": "api://appclient123",
+    }
+    data.update(overrides)
+    return Profile.from_dict(data)
+
+
+# --- Backward compatibility (Req 2.3, 2.4, 2.5, 10.4) ---
+
+
+def test_profile_without_websearch_fields_loads_with_defaults():
+    """A profile saved before this feature loads with web search disabled."""
+    legacy = {
+        "name": "legacy",
+        "provider_domain": "example.okta.com",
+        "client_id": "abc",
+        "credential_storage": "session",
+        "aws_region": "us-west-2",
+        "identity_pool_name": "ccwb",
+    }
+    profile = Profile.from_dict(legacy)
+    assert profile.web_search_enabled is False
+    assert profile.websearch_region is None
+    assert profile.websearch_jwt_audience is None
+    assert profile.websearch_domain_denylist == []
+
+
+def test_profile_websearch_roundtrip():
+    """to_dict/from_dict preserves the web search fields."""
+    profile = _cognito_profile(websearch_region="us-east-1", websearch_domain_denylist=["bad.com"])
+    restored = Profile.from_dict(profile.to_dict())
+    assert restored.web_search_enabled is True
+    assert restored.websearch_region == "us-east-1"
+    assert restored.websearch_domain_denylist == ["bad.com"]
+
+
+# --- Region default (Req 4.2) ---
+
+
+def test_get_websearch_region_defaults_to_supported():
+    profile = _cognito_profile(websearch_region=None)
+    assert get_websearch_region(profile) == WEBSEARCH_SUPPORTED_REGIONS[0] == "us-east-1"
+
+
+def test_get_websearch_region_uses_profile_value():
+    profile = _cognito_profile(websearch_region="us-east-1")
+    assert get_websearch_region(profile) == "us-east-1"
+
+
+# --- Provider/region guards (Req 6.2, 6.3, 4.8, 5.9, 5.10) ---
+
+
+def test_preflight_ok_for_cognito():
+    ok, msg = websearch_preflight(_cognito_profile())
+    assert ok is True
+    assert msg is None
+
+
+def test_preflight_ok_for_azure_with_audience():
+    ok, msg = websearch_preflight(_azure_profile())
+    assert ok is True
+    assert msg is None
+
+
+def test_preflight_ok_for_okta():
+    profile = _cognito_profile(provider_type="okta", provider_domain="company.okta.com")
+    ok, msg = websearch_preflight(profile)
+    assert ok is True
+
+
+def test_preflight_ok_for_auth0():
+    profile = _cognito_profile(provider_type="auth0", provider_domain="tenant.auth0.com")
+    ok, msg = websearch_preflight(profile)
+    assert ok is True
+
+
+def test_preflight_ok_for_google():
+    profile = _cognito_profile(provider_type="google", provider_domain="accounts.google.com")
+    ok, msg = websearch_preflight(profile)
+    assert ok is True
+
+
+def test_preflight_blocks_non_oidc_provider():
+    ok, msg = websearch_preflight(_cognito_profile(provider_type="idc"))
+    assert ok is False
+    assert "OIDC" in msg
+
+
+def test_preflight_ok_for_azure_without_audience():
+    """Audience is optional: Entra defaults to validating aud == client_id."""
+    ok, msg = websearch_preflight(_azure_profile(websearch_jwt_audience=None))
+    assert ok is True
+    assert msg is None
+
+
+def test_preflight_blocks_unsupported_region():
+    ok, msg = websearch_preflight(_cognito_profile(websearch_region="eu-west-1"))
+    assert ok is False
+    assert "eu-west-1" in msg
+
+
+def test_preflight_blocks_cognito_without_pool():
+    ok, msg = websearch_preflight(_cognito_profile(cognito_user_pool_id=None))
+    assert ok is False
+    assert "cognito_user_pool_id" in msg
+
+
+# --- Discovery URL derivation (Req 5.1, 5.2) ---
+
+
+def test_discovery_url_cognito_uses_pool_region():
+    url = _websearch_discovery_url(_cognito_profile())
+    assert url == (
+        "https://cognito-idp.eu-central-1.amazonaws.com/" "eu-central-1_AbCdEf/.well-known/openid-configuration"
+    )
+
+
+def test_discovery_url_azure_uses_tenant():
+    url = _websearch_discovery_url(_azure_profile())
+    assert url == (
+        "https://login.microsoftonline.com/"
+        "11111111-2222-3333-4444-555555555555/v2.0/.well-known/openid-configuration"
+    )
+
+
+def test_discovery_url_okta():
+    profile = _cognito_profile(provider_type="okta", provider_domain="company.okta.com")
+    url = _websearch_discovery_url(profile)
+    assert url == "https://company.okta.com/oauth2/default/.well-known/openid-configuration"
+
+
+def test_discovery_url_auth0():
+    profile = _cognito_profile(provider_type="auth0", provider_domain="tenant.auth0.com")
+    url = _websearch_discovery_url(profile)
+    assert url == "https://tenant.auth0.com/.well-known/openid-configuration"
+
+
+def test_discovery_url_google():
+    profile = _cognito_profile(provider_type="google", provider_domain="accounts.google.com")
+    url = _websearch_discovery_url(profile)
+    assert url == "https://accounts.google.com/.well-known/openid-configuration"
+
+
+# --- CFN parameter derivation (Req 5.3, 5.4, 3.7) ---
+
+
+def test_params_cognito_uses_client_id_as_audience():
+    params = build_websearch_params(_cognito_profile(websearch_region="us-east-1"))
+    assert "ClientId=client123" in params
+    assert any(p.startswith("DiscoveryUrl=") for p in params)
+    assert not any(p.startswith("WebSearchRegion=") for p in params)
+    assert not any(p.startswith("DomainExcludeList=") for p in params)
+
+
+def test_params_azure_custom_audience_overrides_client_id():
+    params = build_websearch_params(_azure_profile())
+    assert "ClientId=api://appclient123" in params
+    assert any(p.startswith("DiscoveryUrl=") for p in params)
+
+
+def test_params_azure_without_audience_falls_back_to_client_id():
+    params = build_websearch_params(_azure_profile(websearch_jwt_audience=None))
+    assert "ClientId=appclient123" in params
+
+
+def test_params_okta_uses_client_id_as_audience():
+    profile = _cognito_profile(provider_type="okta", provider_domain="company.okta.com")
+    params = build_websearch_params(profile)
+    assert "ClientId=client123" in params
+
+
+def test_params_include_domain_denylist_when_set():
+    params = build_websearch_params(_cognito_profile(websearch_domain_denylist=["a.com", "b.com"]))
+    assert "DomainExcludeList=a.com,b.com" in params
+
+
+# --- Deploy-all failure handling (Option C): websearch is optional/non-fatal ---
+
+
+def _deploy_all_loop_source() -> str:
+    """The body of the deploy-all loop in deploy.py (source-level contract test)."""
+    import inspect
+
+    from claude_code_with_bedrock.cli.commands import deploy as deploy_mod
+
+    src = inspect.getsource(deploy_mod)
+    start = src.index("for stack_type, description in stacks_to_deploy:")
+    # Stop at the post-loop "if failed:" handling.
+    end = src.index("if failed:", start)
+    return src[start:end]
+
+
+def test_deploy_all_treats_websearch_failure_as_non_fatal():
+    """A failed optional websearch stack must not abort the whole `ccwb deploy` run.
+
+    In the deploy-all loop a non-zero result for the websearch stack should
+    `continue` (warn + remediation) rather than set failed/break, while other
+    stacks remain fatal.
+    """
+    loop = _deploy_all_loop_source()
+    # The websearch branch continues instead of failing the whole run.
+    assert 'if stack_type == "websearch":' in loop
+    ws_branch = loop[loop.index('if stack_type == "websearch":') :]
+    # Within the websearch failure branch, we continue and never set failed = True.
+    continue_idx = ws_branch.index("continue")
+    assert "failed = True" not in ws_branch[:continue_idx]
+    # Non-websearch failures still abort.
+    assert "failed = True" in loop
+    assert "break" in loop


### PR DESCRIPTION
## Summary

Adds web search capability to Claude Desktop (Cowork) deployments by injecting the AgentCore web search gateway as a native managed MCP server in the MDM configuration.

Uses the `managedMcpServers` format from Claude Desktop v1.15962.0 (`server: "websearch"`, `provider: "custom"`) instead of raw transport/oauth — giving users the built-in search UI integration.

Supersedes #647 with the updated format. Co-authored with @chiararelandini.

## How it works

1. Admin deploys the AgentCore web search gateway (`ccwb deploy websearch`)
2. Gateway URL is saved to the profile (`websearch_gateway_url`)
3. `ccwb cowork generate` injects the gateway as a managed MCP server in MDM config
4. Claude Desktop picks it up from MDM and shows web search in the managed tools UI

## MDM config output

```json
{
  "managedMcpServers": "[{\"name\":\"agentcore-websearch\",\"server\":\"websearch\",\"provider\":\"custom\",\"customUrl\":\"https://gw.gateway.bedrock-agentcore.us-east-1.amazonaws.com/mcp\"}]"
}
```

Claude Desktop v1.15962.0+ recognizes `server: "websearch"` as a built-in search type with native UI support. `provider: "custom"` points to our AgentCore Gateway.

## Changes

### Core logic
- **`cli/utils/cowork_3p.py`** — `add_websearch_mcp_config()`: resolves gateway URL, builds native entry, merges into managedMcpServers (dedup by name, preserves admin-defined servers)
- **`cli/commands/cowork.py`** — calls web search injection during `ccwb cowork generate`
- **`config.py`** — adds `web_search_enabled`, `websearch_gateway_url`, `websearch_region`, `websearch_jwt_audience`, `websearch_domain_denylist` to Profile

### Deploy/destroy
- **`cli/commands/deploy.py`** — `ccwb deploy websearch` deploys AgentCore Gateway stack (cross-region, OIDC JWT authorizer), saves gateway URL to profile on success
- **`cli/commands/destroy.py`** — `ccwb destroy websearch` tears down the gateway stack
- **`cli/commands/package.py`** — includes websearch MCP config in Claude Code settings.json

### Tests
- **`tests/test_cowork_websearch_mdm.py`** (8 tests) — entry shape, dedup, merge, suffix handling, disabled=noop
- **`tests/test_websearch_gateway.py`** (tests) — deploy preflight, URL resolution, region handling
- **`tests/cli/commands/test_deploy_orphan_region.py`** — cross-region deploy fixture updates

## Behavior

| Condition | Result |
|-----------|--------|
| `web_search_enabled = False` | No-op (no MCP entry added) |
| `web_search_enabled = True`, gateway deployed | Entry added with resolved URL |
| `web_search_enabled = True`, gateway NOT deployed | Warning printed, no entry (graceful skip) |
| Re-run `ccwb cowork generate` | Deduplicates (no duplicate entries) |
| Admin has custom `managedMcpServers` | Preserved alongside web search entry |
| URL missing `/mcp` suffix | Auto-appended |

## Why native format (v1.15962.0+)

- Claude Desktop shows web search in its managed MCP tools UI (not as a generic custom server)
- `"websearch"` server type gives integrated search behavior
- Future: orgs with Brave/Tavily API keys can use `provider: "brave"` without needing our gateway
- Consistent with bootstrap server response (#708)

## Risk: LOW
- Gated by `web_search_enabled` (default False) — no effect unless explicitly enabled
- Additive field in MDM config (Claude Desktop ignores unknown managedMcpServers entries on older versions)
- All 8 Desktop tests pass + gateway tests pass

## IDC Support

| Surface | OIDC | IDC |
|---------|------|-----|
| **Gateway deploy** (`ccwb deploy websearch`) | ✅ CUSTOM_JWT authorizer | ✅ IAM authorizer (SigV4) |
| **Claude Code CLI** | ✅ MCP auth header (Bearer token) | ✅ MCP auth header (SigV4 via credential-process) |
| **Claude Desktop (Cowork) MDM** | ✅ `managedMcpServers` entry added | ❌ Skipped — Desktop doesn't support SigV4 for MCP |

IDC users get the gateway deployed with IAM auth and can use web search via Claude Code CLI. Claude Desktop Desktop injection is OIDC-only because `managedMcpServers` only supports static `headers` for auth — not SigV4 signing. When Anthropic adds AWS credential support for managed MCP servers, the IDC guard can be removed.