### PR TITLE
docs: add nested CLAUDE.md for per-component AI agent context

### DIFF
--- a/.claude/rules/breaking-change-checklist.md
+++ b/.claude/rules/breaking-change-checklist.md
@@ -1,0 +1,59 @@
+# Breaking Change Checklist
+
+Run this checklist before submitting any PR that touches **Tier 1** files
+(config.py, deploy.py, credential-process, otel-helper, bedrock-auth-*.yaml).
+
+## Backward Compatibility
+
+- [ ] Old `profile.json` files (without the new field) still load without error
+- [ ] New config fields have default values that preserve existing behavior
+- [ ] Existing CLI commands still work with no arguments (no new required params)
+- [ ] Deployed stacks can be updated in-place (no resource replacement that breaks state)
+
+## Cross-Component Parity
+
+- [ ] Python `config.py` field mirrored in Go `config.go` (or justified skip)
+- [ ] `--explain` JSON output updated if config shape changed
+- [ ] `package.py` and `distribute.py` agree on binary names (contract test passes)
+- [ ] Changes in deploy affect `VALID_STACKS`/`DESTROYABLE_STACKS` if new stack added
+
+## Auth Mode Coverage
+
+- [ ] Tested with **OIDC** (JWT Bearer token flow)
+- [ ] Tested with **IDC** (IAM SigV4, no JWT)
+- [ ] Tested with **none** (anonymous, hashed principal)
+- [ ] Graceful error if feature requires a specific auth mode (not silent failure)
+
+## Platform Coverage
+
+- [ ] Windows CI passes (filepath, .exe resolution, PowerShell compat)
+- [ ] macOS works (Keychain access, launchd paths)
+- [ ] Linux works (no macOS-specific APIs assumed)
+
+## Testing
+
+- [ ] Regression test: fails without fix, passes with fix
+- [ ] Edge cases: empty strings, None values, missing env vars
+- [ ] Non-interactive mode works (no uncaught `questionary` or `input()` calls)
+
+## CFN-Specific (if touching templates)
+
+- [ ] `!Sub "arn:${AWS::Partition}:..."` (never hardcode `arn:aws:`)
+- [ ] Conditions use positive names (`HasX`, not `NoX`)
+- [ ] New parameters have `Default` values
+- [ ] One route resource per route-key (no duplicate route conflicts)
+- [ ] IAM actions are exact (no wildcards), scoped to specific resources
+- [ ] `cfn-lint` passes on modified templates
+
+## Pre-Push Verification
+
+```bash
+# Python
+cd source && ruff check . && ruff format --check . && poetry run pytest tests/ -q
+
+# Go
+cd source/go && go test ./... -race -count=1 && go vet ./...
+
+# CFN
+cfn-lint deployment/infrastructure/*.yaml
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,12 @@
 # CLAUDE.md
 
 Project rules for AI coding agents. Detailed rules in `.claude/rules/`.
+Subdirectory `CLAUDE.md` files provide focused context per component:
+- `source/CLAUDE.md` — Python CLI, tests, config patterns
+- `source/go/CLAUDE.md` — Go binaries, --explain contract, Windows guards
+- `deployment/CLAUDE.md` — CloudFormation templates, IAM, conditions
+- `deployment/infrastructure/lambda-functions/CLAUDE.md` — Lambda auth, response patterns
+- `docs/CLAUDE.md` — Documentation naming, security, structure
 
 ## Key Principles
 

--- a/deployment/CLAUDE.md
+++ b/deployment/CLAUDE.md
@@ -1,0 +1,51 @@
+# CLAUDE.md — CloudFormation Templates
+
+## Quick Commands
+
+```bash
+cfn-lint deployment/infrastructure/*.yaml    # Validate all templates
+cfn-lint deployment/infrastructure/my-stack.yaml  # Validate single template
+```
+
+## Key Rules
+
+### Partition & Region
+- **Always** use `!Sub "arn:${AWS::Partition}:..."` — never hardcode `arn:aws:`.
+- This ensures GovCloud (`aws-us-gov`) and China (`aws-cn`) compatibility.
+- Use `${AWS::Region}`, `${AWS::AccountId}` — never hardcode account/region.
+
+### Conditions Pattern
+- Name conditions positively: `HasOidcAuth`, `HasQuotaEnabled` (not `NoOidc`).
+- Empty string = disabled: `!Equals [!Ref ParamName, ""]` for optional params.
+- Use `!If [ConditionName, TrueValue, FalseValue]` — never duplicate resources.
+
+### Route-Key Conflicts
+- **One resource per route-key.** Don't create two `AWS::ApiGatewayV2::Route` for the same path.
+- Use `!If` inside a single route resource to switch `AuthorizationType` or `Target`.
+- See issue #682 for the pattern that caused a production regression.
+
+### IAM Permissions
+- Exact actions only — no `s3:*` or `Action: "*"`.
+- Scope `Resource` to the specific ARN (use `!Sub` with resource refs).
+- Match IAM actions to actual API calls in the Lambda code.
+- See `.claude/rules/iam-actions.md`.
+
+### Stack Ordering
+- Destroy order matters — dependent stacks must be destroyed first.
+- See `.claude/rules/stack-ordering.md` for the canonical order.
+- New stacks: add to both `VALID_STACKS` and `DESTROYABLE_STACKS` in `deploy.py`.
+
+### Parameters
+- New parameters must have `Default` values (backwards compat with existing deployments).
+- Use `AllowedValues` where the set is finite (auth modes, regions).
+- Mark sensitive params with `NoEcho: true`.
+
+### Outputs & Exports
+- Conditional outputs need `Condition:` — don't export values that might not exist.
+- Export names: `${AWS::StackName}-ResourceName` format.
+
+## Common Pitfalls
+- Don't use `DependsOn` for implicit dependencies (Ref/GetAtt already creates them).
+- Don't put `!Sub` inside `!If` values that contain no variables (cfn-lint error).
+- Don't create `DeletionPolicy: Retain` without documenting manual cleanup steps.
+- Don't reference `AWS::StackName` in resource names if you plan nested stacks.

--- a/deployment/infrastructure/lambda-functions/CLAUDE.md
+++ b/deployment/infrastructure/lambda-functions/CLAUDE.md
@@ -1,0 +1,48 @@
+# CLAUDE.md — Lambda Functions
+
+## Structure
+
+Each Lambda lives in its own directory under `deployment/infrastructure/lambda-functions/`:
+```
+bootstrap_server/       — OIDC Bearer bootstrap (stateless)
+bootstrap_device_code/  — RFC 8628 device-code + plugin delivery
+quota_api/              — Usage check + cost-based enforcement
+```
+
+## Key Rules
+
+### Security — Fail Closed
+- **Never** accept auth without full cryptographic validation.
+- If PyJWT is unavailable, return 500 — don't fall back to claims-only.
+- Log `ERROR:` prefix for security failures (CloudWatch alerting).
+
+### Response Format
+- Always use a `_response(status_code, body)` helper for consistent JSON responses.
+- Error responses: `{"error": "<code>", "message": "<human-readable>"}`.
+- Success responses: domain-specific JSON (config, quota status, etc.).
+
+### Identity Extraction
+- **OIDC:** JWT claims (`sub`, `email`) from validated token.
+- **IDC (IAM):** `requestContext.authorizer.iam.userArn` — parse session name for email.
+- ARN format: `arn:aws:sts::ACCOUNT:assumed-role/Role/user@company.com`
+
+### Dependencies
+- Bundle all dependencies in the deployment package (don't rely on runtime having them).
+- `requirements.txt` in each Lambda directory — deployed via Layer or inline.
+- PyJWT, cryptography, requests — must be bundled for auth Lambdas.
+
+### Logging
+- Format: `print(f"ERROR|WARNING|INFO: <message>")` — no logging framework.
+- Never log tokens, secrets, or full request bodies.
+- Log: request path, auth mode used, user identifier (email/sub), error details.
+
+### DynamoDB Patterns (device-code)
+- TTL field: `expires_at` (epoch seconds) — DynamoDB auto-deletes expired items.
+- Consistent reads for grant validation (eventual consistency = race condition).
+- Condition expressions for atomic state transitions (`pending` → `authorized`).
+
+## Common Pitfalls
+- Don't import modules that aren't in the Lambda runtime or your bundled deps.
+- Don't use `boto3` session caching across invocations for IAM-scoped clients.
+- Don't return stack traces in error responses (log them, return generic message).
+- Don't hardcode region — use `os.environ["AWS_REGION"]` (Lambda sets this).

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,0 +1,36 @@
+# CLAUDE.md — Documentation
+
+## Naming Conventions
+- **Claude Desktop** (not "CoWork", "Cowork", "Co-Work", or "Claude for Desktop")
+- **Claude Code** (not "the CLI", "ccwb CLI", or "Claude Code CLI")
+- **Historical Usage Analytics** (not just "Analytics")
+- **IAM Identity Center** or **IDC** (not "SSO" in new docs)
+- **Cognito** — mark as "legacy" when referencing old auth flows
+
+## Key Rules
+
+### Don't Duplicate
+- README.md is the entry point — keep it concise (users skim).
+- Detailed docs live in `assets/docs/` — link from README, don't inline.
+- If content exists in another doc, link to it — don't copy.
+
+### Security in Docs
+- **Never** include real AWS account IDs, internal URLs, or API keys in examples.
+- Use placeholder format: `123456789012`, `https://your-api.execute-api.region.amazonaws.com`
+- Redact in code samples: `export OIDC_ISSUER_URL=https://your-idp.example.com`
+
+### Code Samples
+- Test that code samples actually work (or clearly mark as pseudocode).
+- Include the auth mode each sample applies to (OIDC/IDC/both).
+- Show both success and error cases where relevant.
+
+### Changelog
+- Update `CHANGELOG.md` for user-facing changes only (not internal refactors).
+- Format: `## [version] - YYYY-MM-DD` with Added/Changed/Fixed/Removed sections.
+- Link to PR numbers for traceability.
+
+## Common Pitfalls
+- Don't create new top-level docs files — use `assets/docs/` subdirectory.
+- Don't document internal implementation details in user-facing docs.
+- Don't use em-dashes (—) in file paths or command examples.
+- Don't reference branch names (`beta`) in user docs — users see `main` releases only.

--- a/source/CLAUDE.md
+++ b/source/CLAUDE.md
@@ -1,0 +1,46 @@
+# CLAUDE.md — Python CLI (`ccwb`) + Tests
+
+## Quick Commands
+
+```bash
+cd source
+ruff check .                    # Lint (must pass before push)
+ruff format .                   # Format (must pass before push)
+poetry run pytest tests/ -q     # Run all tests
+poetry run pytest tests/cli/ -q # Run only CLI tests
+```
+
+## Key Rules
+
+### Config Changes
+- Add new fields to `claude_code_with_bedrock/config.py` dataclass with a **default value** (backwards compat).
+- Mirror the field in `go/internal/config/config.go` — see `.claude/rules/config-sync.md`.
+- Add to `--explain` output if user-visible — update `tests/test_explain_contract.py`.
+
+### CLI Commands
+- All commands live in `claude_code_with_bedrock/cli/commands/`.
+- Register new commands in `__init__.py`.
+- Interactive prompts: **always** guard with `sys.stdin.isatty()` check — CI and `--non-interactive` must work.
+- New commands need tests in `tests/cli/commands/test_<name>.py`.
+
+### Auth Coverage
+- Any code touching identity/credentials must handle all three auth modes:
+  - **OIDC** (JWT Bearer), **IDC** (IAM/SigV4), **none** (anonymous/hashed principal)
+- Test the matrix. See `.claude/rules/auth-type-compat.md`.
+
+### Testing Patterns
+- Tests mirror source structure: `tests/cli/commands/`, `tests/`, etc.
+- Regression tests required for bug fixes (fail without fix, pass with it).
+- Use `dataclasses.replace()` to derive test profiles from `PROFILE_MODES`.
+- Windows tests are **blocking** — test `pathlib.Path` and `os.sep` handling.
+
+### Package ↔ Distribute Contract
+- Binary names in `package.py` must exist in `distribute.py`'s allowlist.
+- Platform normalization: generic tokens (`linux`) → qualified (`linux-x64`) early.
+- See `.claude/rules/distribution-manifest-parity.md`.
+
+## Common Pitfalls
+- Don't use `rm -rf` in tests — use `tmp_path` fixtures.
+- Don't hardcode `/` as path separator — use `pathlib.Path`.
+- Don't call `questionary.select()` without `_is_interactive()` guard.
+- Don't add optional imports without try/except and feature-gate.

--- a/source/go/CLAUDE.md
+++ b/source/go/CLAUDE.md
@@ -1,0 +1,50 @@
+# CLAUDE.md — Go Binaries (credential-process + otel-helper)
+
+## Quick Commands
+
+```bash
+cd source/go
+go build ./cmd/credential-process    # Build credential-process
+go build ./cmd/otel-helper           # Build otel-helper
+go test ./... -race -count=1         # Run all tests (race detector on)
+go vet ./...                         # Static analysis
+```
+
+## Key Rules
+
+### Build & Version Injection
+- Production builds use `_go_ldflags()` from `package.py` — injects git version + commit.
+- Without ldflags, binary reports version "dev" — this is expected for local builds.
+- Cross-compile targets: `linux-x64`, `linux-arm64`, `darwin-x64`, `darwin-arm64`, `windows-x64`.
+
+### --explain Contract
+- `credential-process --explain` outputs JSON describing resolved config (no auth, no network).
+- Schema is validated by Python tests: `tests/test_explain_contract.py`.
+- New fields: add to `ExplainOutput` struct with `json:"field_name,omitempty"`.
+- **Never** make `--explain` perform auth or network calls — it's a diagnostic tool.
+
+### --status Contract (otel-helper)
+- `otel-helper --status` outputs proxy health + cached headers as JSON.
+- Same rules as `--explain`: no side effects, no network, fast exit.
+
+### Config Parity
+- `internal/config/config.go` must mirror `claude_code_with_bedrock/config.py`.
+- See `.claude/rules/credential-helper-parity.md` and `.claude/rules/config-sync.md`.
+- When Python adds a field, Go must add it too (and vice versa).
+
+### Windows
+- **Always** use `filepath.Join` (OS-aware) — never `path.Join` (POSIX only).
+- Binary resolution: check `.exe`, then `.cmd`, then `.ps1` (fallback chain).
+- Test with `GOOS=windows GOARCH=amd64 go build` to catch compile errors.
+- See `.claude/rules/windows-platform-guards.md`.
+
+### Token Handling
+- Single `provider.TokenEndpointURL()` builder — see `.claude/rules/token-endpoint-single-builder.md`.
+- Never construct token URLs inline; always go through the centralized builder.
+- Credential recursion: never invoke self — see `.claude/rules/credential-recursion.md`.
+
+## Common Pitfalls
+- Don't log secrets or tokens (even at debug level).
+- Don't use `os.Exit()` in library code — return errors, let `main()` exit.
+- Don't assume `HOME` exists — use `os.UserHomeDir()` with fallback.
+- Don't hardcode `arn:aws:` — always read partition from config/environment.

--- a/source/go/cmd/CLAUDE.md
+++ b/source/go/cmd/CLAUDE.md
@@ -1,0 +1,43 @@
+# CLAUDE.md — Go Command Entrypoints
+
+## Structure
+
+```
+cmd/
+├── credential-process/main.go   — AWS credential helper (called by AWS SDK)
+├── otel-helper/main.go          — OTEL proxy + header injection
+└── azure-assertion-smoke/       — Azure OIDC assertion test utility
+```
+
+## Adding a New Flag
+
+1. Define with `flag.String()`/`flag.Bool()` in `main()` — group with related flags.
+2. Add handling **after** `flag.Parse()` in the appropriate early-exit section.
+3. Short flags: only `-p` (profile) and `-v` (version) have short forms. Be conservative.
+4. Update `--explain` output if the flag affects resolved configuration.
+5. Add to Python `tests/test_explain_contract.py` if it changes JSON output.
+
+## Adding a New Subcommand
+
+This binary uses **flags, not subcommands** (it's a credential-process, not a CLI toolkit).
+New functionality should be a new `--flag`, not a positional subcommand.
+Exception: if it's a wholly separate binary, create a new directory under `cmd/`.
+
+## Entrypoint Patterns
+
+### credential-process/main.go
+- Early exits: `--version`, `--explain`, `--check-expiration`, `--clear-cache` — no auth, no network.
+- Main path: read config → resolve tokens → STS federation → quota check → emit credentials.
+- **Exit codes matter:** non-zero = AWS SDK retries or fails. Only exit non-zero for real failures.
+- Stderr for debug output (`debugPrint`), stdout for credential JSON only.
+
+### otel-helper/main.go
+- `--status`: JSON health check (no side effects).
+- Main path: start local proxy, inject OTEL headers, forward to collector.
+- Must handle graceful shutdown (SIGINT/SIGTERM).
+
+## Key Constraints
+- No interactive prompts except `--login` (which is explicitly user-initiated).
+- Credential output format: AWS credential-process spec (Version 1 JSON on stdout).
+- Never log tokens or credentials to stderr (even in debug mode).
+- Profile resolution: `--profile` flag → `CCWB_PROFILE` env → default "ClaudeCode".


### PR DESCRIPTION
## Why

AI coding agents (Claude Code, Codex, etc.) load `CLAUDE.md` for project context. Currently all guidance lives in the root file (69 lines) + 26 `.claude/rules/` files. When an agent works in `source/go/` to fix a credential-process bug, it has no targeted guidance — it must parse all 26 rules looking for what's relevant.

Nested `CLAUDE.md` files give **directory-scoped context** that loads automatically when an agent opens that directory.

## What

| File | Focus | Key Content |
|------|-------|-------------|
| `source/CLAUDE.md` | Python CLI + tests | Ruff, interactive guards, config patterns, test structure |
| `source/go/CLAUDE.md` | Go binaries | Build/test commands, --explain contract, Windows, config parity |
| `deployment/CLAUDE.md` | CloudFormation | Partition refs, conditions, route-key conflicts, IAM scoping |
| `deployment/.../lambda-functions/CLAUDE.md` | Lambda code | Fail-closed auth, response format, identity extraction, DynamoDB |
| `docs/CLAUDE.md` | Documentation | Naming (Claude Desktop, not CoWork), security, no-duplication |

Each file is **≤40 lines of actionable rules** — not documentation prose. They cross-reference `.claude/rules/` for detailed explanations.

## Impact

- **Velocity:** Agents get relevant context in <1s instead of parsing 26 rules
- **Reliability:** Common pitfalls documented per component (route-key conflicts, partition hardcoding)
- **Backwards compat:** Config change rules explicit (`add default` → `mirror in Go`)
- **Regression prevention:** Testing patterns scoped to each component

## Risk: Very Low
- Docs-only change (Tier 3)
- No code changes
- Additive — doesn't modify existing `.claude/rules/` files
- Root `CLAUDE.md` updated with directory listing (one line per component)