### PR TITLE
feat(e2e): profile-driven test harness — 61 tests across 16 profiles covering auth, OS, monitoring, delivery, and quota

### DIFF
--- a/.github/size-budget.json
+++ b/.github/size-budget.json
@@ -1,0 +1,15 @@
+{
+  "description": "Binary size budgets (bytes). Fail CI if exceeded.",
+  "budgets": {
+    "credential-process-linux-amd64": 26214400,
+    "credential-process-darwin-arm64": 26214400,
+    "credential-process-windows-amd64.exe": 27262976,
+    "otel-helper-linux-amd64": 15728640,
+    "otel-helper-darwin-arm64": 15728640,
+    "otel-helper-windows-amd64.exe": 16777216
+  },
+  "notes": {
+    "credential-process": "25MB base + 1MB headroom. Windows slightly larger due to PE overhead.",
+    "otel-helper": "15MB base + 1MB headroom. Smaller binary, fewer dependencies."
+  }
+}

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -83,11 +83,46 @@ jobs:
           retention-days: 1
 
   # ---------------------------------------------------------------------------
+  # Smoke test — fast-fail before deploying expensive infrastructure
+  # ---------------------------------------------------------------------------
+  smoke:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download Linux binary
+        uses: actions/download-artifact@v4
+        with:
+          name: binaries-linux-amd64
+          path: source/go/dist/
+
+      - name: Make binaries executable
+        run: chmod +x source/go/dist/*
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install test dependencies
+        run: pip install pytest pytest-timeout pytest-rerunfailures boto3 requests tenacity PyJWT
+
+      - name: Run smoke test (profile 09 — passthrough, no infra)
+        run: |
+          pytest tests/e2e/test_credential_output.py tests/e2e/test_explain_contract.py \
+            --profile 09-passthrough-linux-none \
+            -v --timeout=10 \
+            -x  # fail fast
+        env:
+          E2E_BINARY_PATH: source/go/dist/credential-process-linux-amd64
+
+  # ---------------------------------------------------------------------------
   # Deploy shared E2E infrastructure
   # ---------------------------------------------------------------------------
   infra:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, smoke]
     timeout-minutes: 15
     environment: e2e-testing
 
@@ -139,7 +174,7 @@ jobs:
   # Run E2E tests across profile matrix
   # ---------------------------------------------------------------------------
   test:
-    needs: [build, infra]
+    needs: [build, smoke, infra]
     timeout-minutes: 20
     environment: e2e-testing
 
@@ -234,7 +269,7 @@ jobs:
 
       - name: Install test dependencies
         run: |
-          pip install pytest pytest-timeout boto3 requests tenacity PyJWT
+          pip install pytest pytest-timeout pytest-rerunfailures boto3 requests tenacity PyJWT
 
       - name: Download binaries
         uses: actions/download-artifact@v4

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -30,6 +30,10 @@ env:
   AWS_REGION: us-east-1
   E2E_STACK_PREFIX: ccwb-e2e-${{ github.run_id }}
 
+concurrency:
+  group: e2e-matrix-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # ---------------------------------------------------------------------------
   # Build binaries for all 3 OS platforms

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -1,0 +1,292 @@
+name: E2E Matrix Tests
+
+on:
+  schedule:
+    # Weekday nightly at 3 AM UTC
+    - cron: '0 3 * * 1-5'
+
+  workflow_dispatch:
+    inputs:
+      profile:
+        description: 'Specific profile to run (e.g., 01-oidc-cognito-linux-central). Leave empty for full matrix.'
+        required: false
+        type: string
+      keep_infra:
+        description: 'Keep infrastructure after tests (for debugging)'
+        required: false
+        type: boolean
+        default: false
+
+  pull_request:
+    paths:
+      - 'deployment/**'
+      - 'source/go/**'
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: us-east-1
+  E2E_STACK_PREFIX: ccwb-e2e-${{ github.run_id }}
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Build binaries for all 3 OS platforms
+  # ---------------------------------------------------------------------------
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            goos: linux
+            goarch: amd64
+            binary_suffix: linux-amd64
+          - os: windows-latest
+            goos: windows
+            goarch: amd64
+            binary_suffix: windows-amd64
+          - os: macos-latest
+            goos: darwin
+            goarch: arm64
+            binary_suffix: darwin-arm64
+
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: source/go/go.mod
+
+      - name: Build credential-process
+        working-directory: source/go
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: '0'
+        run: |
+          go build -ldflags="-s -w" -o dist/credential-process-${{ matrix.binary_suffix }}${{ matrix.goos == 'windows' && '.exe' || '' }} ./cmd/credential-process/
+          go build -ldflags="-s -w" -o dist/otel-helper-${{ matrix.binary_suffix }}${{ matrix.goos == 'windows' && '.exe' || '' }} ./cmd/otel-helper/
+
+      - name: Upload binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: binaries-${{ matrix.binary_suffix }}
+          path: source/go/dist/
+          retention-days: 1
+
+  # ---------------------------------------------------------------------------
+  # Deploy shared E2E infrastructure
+  # ---------------------------------------------------------------------------
+  infra:
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 15
+    environment: e2e-testing
+
+    outputs:
+      stack_outputs: ${{ steps.deploy.outputs.stack_outputs }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.E2E_AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install CDK
+        run: npm install -g aws-cdk
+
+      - name: Deploy E2E stacks
+        id: deploy
+        working-directory: deployment
+        run: |
+          # Deploy shared infrastructure for E2E tests
+          cdk deploy \
+            --require-approval never \
+            --outputs-file /tmp/stack-outputs.json \
+            -c stackPrefix="${E2E_STACK_PREFIX}" \
+            -c e2eMode=true \
+            "${E2E_STACK_PREFIX}-auth" \
+            "${E2E_STACK_PREFIX}-monitoring" \
+            "${E2E_STACK_PREFIX}-quota" \
+            "${E2E_STACK_PREFIX}-config"
+
+          # Export outputs as JSON artifact
+          echo "stack_outputs=$(cat /tmp/stack-outputs.json | jq -c .)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload stack outputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: stack-outputs
+          path: /tmp/stack-outputs.json
+          retention-days: 1
+
+  # ---------------------------------------------------------------------------
+  # Run E2E tests across profile matrix
+  # ---------------------------------------------------------------------------
+  test:
+    needs: [build, infra]
+    timeout-minutes: 20
+    environment: e2e-testing
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Linux profiles
+          - profile: '01-oidc-cognito-linux-central'
+            os: ubuntu-latest
+            platform: linux-x64
+          - profile: '02-oidc-direct-linux-central-block'
+            os: ubuntu-latest
+            platform: linux-x64
+          - profile: '03-oidc-direct-linux-bootstrap-alert'
+            os: ubuntu-latest
+            platform: linux-x64
+          - profile: '07-idc-linux-central-block'
+            os: ubuntu-latest
+            platform: linux-x64
+          - profile: '09-passthrough-linux-none'
+            os: ubuntu-latest
+            platform: linux-x64
+          - profile: '10-oidc-direct-linux-bootstrap-finegrained'
+            os: ubuntu-latest
+            platform: linux-x64
+          - profile: '11-oidc-direct-linux-sidecar-block'
+            os: ubuntu-latest
+            platform: linux-x64
+          # Windows profiles
+          - profile: '04-oidc-cognito-windows-central'
+            os: windows-latest
+            platform: windows-x64
+          - profile: '05-oidc-direct-windows-none'
+            os: windows-latest
+            platform: windows-x64
+          - profile: '08-idc-windows-sidecar'
+            os: windows-latest
+            platform: windows-x64
+          # macOS profiles
+          - profile: '06-oidc-direct-macos-sidecar-finegrained'
+            os: macos-latest
+            platform: macos-arm64
+          - profile: '12-oidc-cognito-macos-central-alert'
+            os: macos-latest
+            platform: macos-arm64
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check if specific profile requested
+        if: inputs.profile != '' && inputs.profile != matrix.profile
+        run: |
+          echo "Skipping ${{ matrix.profile }} — only running ${{ inputs.profile }}"
+          exit 0
+
+      # On PRs, only run canary profile
+      - name: Skip non-canary on PR
+        if: github.event_name == 'pull_request' && matrix.profile != '01-oidc-cognito-linux-central'
+        run: |
+          echo "PR mode: only running canary profile 01"
+          exit 0
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.E2E_AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install test dependencies
+        run: |
+          pip install pytest pytest-timeout boto3 requests tenacity PyJWT
+
+      - name: Download binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: binaries-${{ matrix.platform == 'linux-x64' && 'linux-amd64' || matrix.platform == 'windows-x64' && 'windows-amd64' || 'darwin-arm64' }}
+          path: source/go/dist/
+
+      - name: Make binaries executable
+        if: runner.os != 'Windows'
+        run: chmod +x source/go/dist/*
+
+      - name: Download stack outputs
+        uses: actions/download-artifact@v4
+        with:
+          name: stack-outputs
+          path: tests/e2e/artifacts/
+
+      - name: Run E2E tests
+        env:
+          E2E_PROFILE: ${{ matrix.profile }}
+          E2E_STACK_OUTPUTS: tests/e2e/artifacts/stack-outputs.json
+          PYTEST_TIMEOUT: 300
+        run: |
+          pytest tests/e2e/ \
+            --profile "${{ matrix.profile }}" \
+            -v \
+            --timeout=300 \
+            --tb=short \
+            -x \
+            --junitxml=test-results-${{ matrix.profile }}.xml
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ matrix.profile }}
+          path: test-results-${{ matrix.profile }}.xml
+          retention-days: 7
+
+  # ---------------------------------------------------------------------------
+  # Teardown infrastructure (always runs)
+  # ---------------------------------------------------------------------------
+  teardown:
+    runs-on: ubuntu-latest
+    needs: [test]
+    if: always() && !inputs.keep_infra
+    timeout-minutes: 15
+    environment: e2e-testing
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.E2E_AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install CDK
+        run: npm install -g aws-cdk
+
+      - name: Destroy E2E stacks
+        working-directory: deployment
+        run: |
+          cdk destroy \
+            --force \
+            -c stackPrefix="${E2E_STACK_PREFIX}" \
+            "${E2E_STACK_PREFIX}-config" \
+            "${E2E_STACK_PREFIX}-quota" \
+            "${E2E_STACK_PREFIX}-monitoring" \
+            "${E2E_STACK_PREFIX}-auth" \
+          || echo "Teardown had errors (some resources may need manual cleanup)"

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -117,6 +117,29 @@ jobs:
         env:
           E2E_BINARY_PATH: source/go/dist/credential-process-linux-amd64
 
+      - name: Check binary size budget
+        run: |
+          echo "## Binary Size Check" >> $GITHUB_STEP_SUMMARY
+          budget_file=".github/size-budget.json"
+          failed=0
+          for binary in source/go/dist/*; do
+            name=$(basename "$binary")
+            size=$(stat -f%z "$binary" 2>/dev/null || stat -c%s "$binary")
+            budget=$(python3 -c "import json; d=json.load(open('$budget_file')); print(d['budgets'].get('$name', 0))")
+            if [ "$budget" -gt 0 ]; then
+              size_mb=$(echo "scale=1; $size / 1048576" | bc)
+              budget_mb=$(echo "scale=1; $budget / 1048576" | bc)
+              if [ "$size" -gt "$budget" ]; then
+                echo "❌ $name: ${size_mb}MB exceeds budget ${budget_mb}MB" >> $GITHUB_STEP_SUMMARY
+                echo "::error::$name (${size_mb}MB) exceeds size budget (${budget_mb}MB)"
+                failed=1
+              else
+                echo "✅ $name: ${size_mb}MB (budget: ${budget_mb}MB)" >> $GITHUB_STEP_SUMMARY
+              fi
+            fi
+          done
+          if [ "$failed" -eq 1 ]; then exit 1; fi
+
   # ---------------------------------------------------------------------------
   # Deploy shared E2E infrastructure
   # ---------------------------------------------------------------------------
@@ -299,15 +322,92 @@ jobs:
             --timeout=300 \
             --tb=short \
             -x \
-            --junitxml=test-results-${{ matrix.profile }}.xml
+            --junitxml=report-${{ matrix.profile }}.xml
 
-      - name: Upload test results
+      - name: Upload test report
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results-${{ matrix.profile }}
-          path: test-results-${{ matrix.profile }}.xml
-          retention-days: 7
+          name: test-report-${{ matrix.profile }}
+          path: report-*.xml
+          retention-days: 14
+
+  # ---------------------------------------------------------------------------
+  # Test summary + badge
+  # ---------------------------------------------------------------------------
+  summary:
+    needs: test
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all test reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: test-report-*
+          merge-multiple: true
+
+      - name: Generate test summary
+        run: |
+          echo "## E2E Test Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          for report in report-*.xml; do
+            if [ -f "$report" ]; then
+              profile=$(echo "$report" | sed 's/report-//;s/\.xml//')
+              tests=$(grep -o 'tests="[0-9]*"' "$report" | head -1 | grep -o '[0-9]*')
+              failures=$(grep -o 'failures="[0-9]*"' "$report" | head -1 | grep -o '[0-9]*')
+              errors=$(grep -o 'errors="[0-9]*"' "$report" | head -1 | grep -o '[0-9]*')
+              if [ "${failures:-0}" = "0" ] && [ "${errors:-0}" = "0" ]; then
+                echo "✅ **$profile**: $tests tests passed" >> $GITHUB_STEP_SUMMARY
+              else
+                echo "❌ **$profile**: $tests tests, $failures failures, $errors errors" >> $GITHUB_STEP_SUMMARY
+              fi
+            fi
+          done
+
+      - name: Generate badge
+        run: |
+          total=0
+          passed=0
+          failed=0
+          for report in report-*.xml; do
+            if [ -f "$report" ]; then
+              t=$(grep -o 'tests="[0-9]*"' "$report" | head -1 | grep -o '[0-9]*')
+              f=$(grep -o 'failures="[0-9]*"' "$report" | head -1 | grep -o '[0-9]*')
+              e=$(grep -o 'errors="[0-9]*"' "$report" | head -1 | grep -o '[0-9]*')
+              total=$((total + ${t:-0}))
+              failed=$((failed + ${f:-0} + ${e:-0}))
+            fi
+          done
+          passed=$((total - failed))
+
+          if [ "$failed" -eq 0 ]; then
+            color="brightgreen"
+            message="${passed}/${total} passing"
+          elif [ "$failed" -le 2 ]; then
+            color="yellow"
+            message="${passed}/${total} (${failed} flaky)"
+          else
+            color="red"
+            message="${passed}/${total} (${failed} failed)"
+          fi
+
+          cat > badge.json <<EOF
+          {
+            "schemaVersion": 1,
+            "label": "E2E Tests",
+            "message": "$message",
+            "color": "$color"
+          }
+          EOF
+
+          echo "Badge: $message ($color)"
+
+      - name: Upload badge
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-badge
+          path: badge.json
+          retention-days: 90
 
   # ---------------------------------------------------------------------------
   # Teardown infrastructure (always runs)
@@ -335,14 +435,48 @@ jobs:
       - name: Install CDK
         run: npm install -g aws-cdk
 
-      - name: Destroy E2E stacks
-        working-directory: deployment
+      - name: Destroy E2E infrastructure
+        if: ${{ !inputs.keep_infra }}
         run: |
-          cdk destroy \
-            --force \
-            -c stackPrefix="${E2E_STACK_PREFIX}" \
-            "${E2E_STACK_PREFIX}-config" \
-            "${E2E_STACK_PREFIX}-quota" \
-            "${E2E_STACK_PREFIX}-monitoring" \
-            "${E2E_STACK_PREFIX}-auth" \
-          || echo "Teardown had errors (some resources may need manual cleanup)"
+          destroy_stacks() {
+            aws cloudformation list-stacks \
+              --stack-status-filter CREATE_COMPLETE UPDATE_COMPLETE \
+              --query "StackSummaries[?starts_with(StackName, '${E2E_STACK_PREFIX}')].StackName" \
+              --output text | tr '\t' '\n' | while read -r stack; do
+              echo "Destroying: $stack"
+              aws cloudformation delete-stack --stack-name "$stack" || true
+            done
+          }
+
+          # First attempt
+          destroy_stacks
+
+          # Wait for deletions
+          sleep 30
+
+          # Check for stragglers (DELETE_FAILED due to race conditions)
+          stragglers=$(aws cloudformation list-stacks \
+            --stack-status-filter DELETE_FAILED \
+            --query "StackSummaries[?starts_with(StackName, '${E2E_STACK_PREFIX}')].StackName" \
+            --output text)
+
+          if [ -n "$stragglers" ]; then
+            echo "⚠️ Retry: Found stacks in DELETE_FAILED state"
+            echo "$stragglers" | tr '\t' '\n' | while read -r stack; do
+              echo "Retrying: $stack"
+              aws cloudformation delete-stack --stack-name "$stack" --retain-resources || true
+            done
+            sleep 60
+          fi
+
+          # Final check — warn but don't fail (manual cleanup may be needed)
+          remaining=$(aws cloudformation list-stacks \
+            --stack-status-filter CREATE_COMPLETE UPDATE_COMPLETE DELETE_FAILED \
+            --query "StackSummaries[?starts_with(StackName, '${E2E_STACK_PREFIX}')].StackName" \
+            --output text)
+
+          if [ -n "$remaining" ]; then
+            echo "::warning::Orphan stacks remaining (manual cleanup needed): $remaining"
+          else
+            echo "✅ All E2E stacks cleaned up"
+          fi

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -274,15 +274,19 @@ jobs:
       - name: Check if profile should run
         id: should_run
         shell: bash
+        env:
+          INPUT_PROFILE: ${{ inputs.profile }}
+          MATRIX_PROFILE: ${{ matrix.profile }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           skip="false"
           # Skip if a specific profile was requested and this isn't it
-          if [[ -n "${{ inputs.profile }}" && "${{ inputs.profile }}" != "${{ matrix.profile }}" ]]; then
-            echo "Skipping ${{ matrix.profile }} — only running ${{ inputs.profile }}"
+          if [[ -n "$INPUT_PROFILE" && "$INPUT_PROFILE" != "$MATRIX_PROFILE" ]]; then
+            echo "Skipping $MATRIX_PROFILE — only running $INPUT_PROFILE"
             skip="true"
           fi
           # On PRs, only run canary profiles (01 Linux + 04 Windows)
-          if [[ "${{ github.event_name }}" == "pull_request" && "${{ matrix.profile }}" != "01-oidc-cognito-linux-central" && "${{ matrix.profile }}" != "04-oidc-cognito-windows-central" ]]; then
+          if [[ "$EVENT_NAME" == "pull_request" && "$MATRIX_PROFILE" != "01-oidc-cognito-linux-central" && "$MATRIX_PROFILE" != "04-oidc-cognito-windows-central" ]]; then
             echo "PR mode: only running canary profiles 01 (Linux) and 04 (Windows)"
             skip="true"
           fi

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -139,6 +139,11 @@ jobs:
     timeout-minutes: 20
     environment: e2e-testing
 
+    # Platform focus: Windows and macOS get extra profiles due to historical
+    # issues with keyring chunking (#649), .cmd fallback (#567), install.bat
+    # syntax (#427), CRLF in generated scripts (#428), and macOS Keychain
+    # integration (#349, #664). PRs run both Linux and Windows canary to
+    # catch platform regressions early.
     strategy:
       fail-fast: false
       matrix:
@@ -175,11 +180,23 @@ jobs:
           - profile: '08-idc-windows-sidecar'
             os: windows-latest
             platform: windows-x64
+          - profile: '13-oidc-direct-windows-sidecar-alert'
+            os: windows-latest
+            platform: windows-x64
+          - profile: '14-oidc-cognito-windows-central-block'
+            os: windows-latest
+            platform: windows-x64
           # macOS profiles
           - profile: '06-oidc-direct-macos-sidecar-finegrained'
             os: macos-latest
             platform: macos-arm64
           - profile: '12-oidc-cognito-macos-central-alert'
+            os: macos-latest
+            platform: macos-arm64
+          - profile: '15-oidc-direct-macos-central-block'
+            os: macos-latest
+            platform: macos-arm64
+          - profile: '16-idc-macos-sidecar'
             os: macos-latest
             platform: macos-arm64
 
@@ -194,11 +211,11 @@ jobs:
           echo "Skipping ${{ matrix.profile }} — only running ${{ inputs.profile }}"
           exit 0
 
-      # On PRs, only run canary profile
+      # On PRs, run Linux + Windows canary profiles to catch cross-platform regressions
       - name: Skip non-canary on PR
-        if: github.event_name == 'pull_request' && matrix.profile != '01-oidc-cognito-linux-central'
+        if: github.event_name == 'pull_request' && matrix.profile != '01-oidc-cognito-linux-central' && matrix.profile != '04-oidc-cognito-windows-central'
         run: |
-          echo "PR mode: only running canary profile 01"
+          echo "PR mode: only running canary profiles 01 (Linux) and 04 (Windows)"
           exit 0
 
       - name: Configure AWS credentials (OIDC)

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -2,7 +2,7 @@ name: E2E Matrix Tests
 
 on:
   schedule:
-    # Weekday nightly at 3 AM UTC
+    # Weekday nightly at 3 AM UTC (beta branch only)
     - cron: '0 3 * * 1-5'
 
   workflow_dispatch:
@@ -18,6 +18,8 @@ on:
         default: false
 
   pull_request:
+    branches:
+      - beta
     paths:
       - 'deployment/**'
       - 'source/go/**'
@@ -39,6 +41,8 @@ jobs:
   # Build binaries for all 3 OS platforms
   # ---------------------------------------------------------------------------
   build:
+    # Schedule crons always fire on default branch — skip if not beta
+    if: github.event_name != 'schedule' || github.ref == 'refs/heads/beta'
     strategy:
       matrix:
         include:

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -128,7 +128,7 @@ jobs:
           failed=0
           for binary in source/go/dist/*; do
             name=$(basename "$binary")
-            size=$(stat -f%z "$binary" 2>/dev/null || stat -c%s "$binary")
+            size=$(stat -c%s "$binary" 2>/dev/null || stat -f%z "$binary")
             budget=$(python3 -c "import json; d=json.load(open('$budget_file')); print(d['budgets'].get('$name', 0))")
             if [ "$budget" -gt 0 ]; then
               size_mb=$(echo "scale=1; $size / 1048576" | bc)
@@ -271,50 +271,60 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Check if specific profile requested
-        if: inputs.profile != '' && inputs.profile != matrix.profile
+      - name: Check if profile should run
+        id: should_run
+        shell: bash
         run: |
-          echo "Skipping ${{ matrix.profile }} — only running ${{ inputs.profile }}"
-          exit 0
-
-      # On PRs, run Linux + Windows canary profiles to catch cross-platform regressions
-      - name: Skip non-canary on PR
-        if: github.event_name == 'pull_request' && matrix.profile != '01-oidc-cognito-linux-central' && matrix.profile != '04-oidc-cognito-windows-central'
-        run: |
-          echo "PR mode: only running canary profiles 01 (Linux) and 04 (Windows)"
-          exit 0
+          skip="false"
+          # Skip if a specific profile was requested and this isn't it
+          if [[ -n "${{ inputs.profile }}" && "${{ inputs.profile }}" != "${{ matrix.profile }}" ]]; then
+            echo "Skipping ${{ matrix.profile }} — only running ${{ inputs.profile }}"
+            skip="true"
+          fi
+          # On PRs, only run canary profiles (01 Linux + 04 Windows)
+          if [[ "${{ github.event_name }}" == "pull_request" && "${{ matrix.profile }}" != "01-oidc-cognito-linux-central" && "${{ matrix.profile }}" != "04-oidc-cognito-windows-central" ]]; then
+            echo "PR mode: only running canary profiles 01 (Linux) and 04 (Windows)"
+            skip="true"
+          fi
+          echo "skip=$skip" >> "$GITHUB_OUTPUT"
 
       - name: Configure AWS credentials (OIDC)
+        if: steps.should_run.outputs.skip != 'true'
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.E2E_AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - uses: actions/setup-python@v5
+        if: steps.should_run.outputs.skip != 'true'
         with:
           python-version: '3.11'
 
       - name: Install test dependencies
+        if: steps.should_run.outputs.skip != 'true'
         run: |
           pip install pytest pytest-timeout pytest-rerunfailures boto3 requests tenacity PyJWT
 
       - name: Download binaries
+        if: steps.should_run.outputs.skip != 'true'
         uses: actions/download-artifact@v4
         with:
           name: binaries-${{ matrix.platform == 'linux-x64' && 'linux-amd64' || matrix.platform == 'windows-x64' && 'windows-amd64' || 'darwin-arm64' }}
           path: source/go/dist/
 
       - name: Make binaries executable
-        if: runner.os != 'Windows'
+        if: steps.should_run.outputs.skip != 'true' && runner.os != 'Windows'
         run: chmod +x source/go/dist/*
 
       - name: Download stack outputs
+        if: steps.should_run.outputs.skip != 'true'
         uses: actions/download-artifact@v4
         with:
           name: stack-outputs
           path: tests/e2e/artifacts/
 
       - name: Run E2E tests
+        if: steps.should_run.outputs.skip != 'true'
         env:
           E2E_PROFILE: ${{ matrix.profile }}
           E2E_STACK_OUTPUTS: tests/e2e/artifacts/stack-outputs.json
@@ -329,7 +339,7 @@ jobs:
             --junitxml=report-${{ matrix.profile }}.xml
 
       - name: Upload test report
-        if: always()
+        if: always() && steps.should_run.outputs.skip != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: test-report-${{ matrix.profile }}

--- a/.gitignore
+++ b/.gitignore
@@ -63,9 +63,12 @@ source/.ccwb-config/
 
 guidance-submission/
 tests/
+!tests/e2e/
+!tests/e2e/**
 !source/tests/
 !source/tests/**
 source/tests/**/__pycache__/
+tests/e2e/artifacts/
 assets/docs/planning
 
 .pytest_cache/

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,3 +1,5 @@
+![E2E Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock/feat/e2e-matrix-harness/tests/e2e/badge.json)
+
 # E2E Test Harness
 
 Profile-driven end-to-end testing across authentication flows, operating systems, monitoring modes, config delivery mechanisms, and quota enforcement strategies.

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -2,6 +2,21 @@
 
 Profile-driven end-to-end testing across authentication flows, operating systems, monitoring modes, config delivery mechanisms, and quota enforcement strategies.
 
+## Platform Focus
+
+Windows and macOS receive extra testing attention due to historical platform-specific issues:
+
+| Issue | Platform | Problem |
+|-------|----------|---------|
+| #427 | Windows | `install.bat` syntax errors (`& was unexpected`) |
+| #428 | Windows | CRLF line endings in generated `.sh` scripts |
+| #349 | macOS | Keychain integration failures |
+| #567 | Windows | `.cmd` fallback not invoking `.ps1` correctly |
+| #649 | Windows | DPAPI keyring retrieval taking 10-17s |
+| #664 | macOS | ARM64 binary detection / Rosetta fallback |
+
+Profiles 13-16 specifically target these platforms with stress scenarios (keyring chunking under load, sidecar monitoring, quota enforcement). The PR canary runs both Linux (profile 01) and Windows (profile 04) to catch regressions before merge.
+
 ## How It Works
 
 Each test scenario is defined by a **profile JSON** file in `tests/e2e/profiles/`. A profile declares:
@@ -139,6 +154,10 @@ Running the full nightly matrix costs approximately **$0.50/month**:
 | 10 | oidc-direct-linux-bootstrap-finegrained | OIDC/Direct | Linux | Central | Bootstrap | Block+FG |
 | 11 | oidc-direct-linux-sidecar-block | OIDC/Direct | Linux | Sidecar | Static | Block |
 | 12 | oidc-cognito-macos-central-alert | OIDC/Cognito | macOS | Central | Static | Alert |
+| 13 | oidc-direct-windows-sidecar-alert | OIDC/Direct | Windows | Sidecar | Static | Alert |
+| 14 | oidc-cognito-windows-central-block | OIDC/Cognito | Windows | Central | Static | Block |
+| 15 | oidc-direct-macos-central-block | OIDC/Direct | macOS | Central | Static | Block |
+| 16 | idc-macos-sidecar | IDC | macOS | Sidecar | Static | — |
 
 ### Dimensions Covered
 
@@ -194,17 +213,21 @@ pytest tests/e2e/ --profile 01-oidc-cognito-linux-central --co
 ```
 tests/e2e/
 ├── conftest.py              # Shared fixtures, CLI args, skip logic
+├── helpers.py               # Shared utility functions (extracted from conftest)
 ├── profiles/                # Profile JSON definitions
 │   ├── 01-oidc-cognito-linux-central.json
 │   ├── 02-oidc-direct-linux-central-block.json
 │   ├── ...
-│   └── 12-oidc-cognito-macos-central-alert.json
+│   ├── 13-oidc-direct-windows-sidecar-alert.json
+│   ├── 14-oidc-cognito-windows-central-block.json
+│   ├── 15-oidc-direct-macos-central-block.json
+│   └── 16-idc-macos-sidecar.json
 ├── test_auth_flow.py        # Authentication tests
 ├── test_credential_output.py # Output format tests
 ├── test_monitoring_pipeline.py # OTLP proxy tests
 ├── test_quota_enforcement.py # Quota tests
 ├── test_config_delivery.py  # Bootstrap config tests
-├── test_binary_platform.py  # Platform-specific tests
+├── test_binary_platform.py  # Platform-specific tests (Windows + macOS)
 ├── artifacts/               # (gitignored) Stack outputs at runtime
 └── README.md                # This file
 ```

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,210 @@
+# E2E Test Harness
+
+Profile-driven end-to-end testing across authentication flows, operating systems, monitoring modes, config delivery mechanisms, and quota enforcement strategies.
+
+## How It Works
+
+Each test scenario is defined by a **profile JSON** file in `tests/e2e/profiles/`. A profile declares:
+
+- **Auth type**: OIDC (Cognito/Direct STS), IDC (device auth), or Passthrough (ambient creds)
+- **Platform**: linux-x64, windows-x64, macos-arm64
+- **Monitoring mode**: central (port 4318), sidecar (port 4319), or none
+- **Config delivery**: static (env vars) or bootstrap (API endpoint)
+- **Quota**: enabled/disabled, enforcement mode (block/alert), fine-grained policies
+- **Tests**: which test modules apply to this profile
+
+The test harness automatically skips test modules not declared in the active profile.
+
+## Running Locally
+
+### Prerequisites
+
+1. AWS credentials with access to deploy E2E stacks
+2. Python 3.11+ with test dependencies
+3. Built binaries for your platform
+
+### Setup
+
+```bash
+# Install dependencies
+pip install pytest pytest-timeout boto3 requests tenacity PyJWT
+
+# Build binaries (from source/go/)
+cd source/go
+go build -o dist/credential-process-linux-amd64 ./cmd/credential-process/
+go build -o dist/otel-helper-linux-amd64 ./cmd/otel-helper/
+cd ../..
+
+# Deploy E2E infrastructure (optional — needed for integration tests)
+cd deployment
+cdk deploy -c e2eMode=true ccwb-e2e-local-auth ccwb-e2e-local-monitoring ccwb-e2e-local-quota ccwb-e2e-local-config
+cd ..
+```
+
+### Run Tests
+
+```bash
+# Run a specific profile
+pytest tests/e2e/ --profile 01-oidc-cognito-linux-central -v
+
+# Run with environment variable
+E2E_PROFILE=09-passthrough-linux-none pytest tests/e2e/ -v
+
+# Skip slow tests (CloudWatch assertions)
+pytest tests/e2e/ --profile 01-oidc-cognito-linux-central -v -m "not slow"
+
+# Run only auth tests
+pytest tests/e2e/test_auth_flow.py --profile 01-oidc-cognito-linux-central -v
+```
+
+### Without AWS Infrastructure
+
+Tests skip gracefully when AWS credentials or stack outputs are unavailable:
+
+```bash
+# This will skip integration tests but validate test structure
+pytest tests/e2e/ --profile 09-passthrough-linux-none --co
+```
+
+## Adding a New Scenario
+
+1. Create a profile JSON in `tests/e2e/profiles/`:
+
+```json
+{
+  "name": "13-my-new-scenario",
+  "description": "Description of what this tests",
+  "auth": {"type": "oidc", "federation": "direct", "provider": "okta"},
+  "platform": "linux-x64",
+  "monitoring": {"mode": "central"},
+  "config_delivery": "static",
+  "quota": {"enabled": false},
+  "tests": ["auth_flow", "credential_output", "monitoring_pipeline"]
+}
+```
+
+2. Add to the matrix in `.github/workflows/e2e-matrix.yml`:
+
+```yaml
+- profile: '13-my-new-scenario'
+  os: ubuntu-latest
+  platform: linux-x64
+```
+
+3. Commit and push — CI will pick it up automatically.
+
+## CI Setup
+
+### GitHub OIDC Trust
+
+The workflow uses GitHub's OIDC provider to authenticate with AWS (no long-lived secrets):
+
+1. Create an IAM OIDC identity provider for `token.actions.githubusercontent.com`
+2. Create an IAM role with trust policy for your repo
+3. Set `E2E_AWS_ROLE_ARN` as a repository variable
+4. Create a protected environment called `e2e-testing`
+
+### Protected Environment
+
+The `e2e-testing` environment provides:
+- Deployment protection rules (optional reviewers for manual triggers)
+- Environment-scoped secrets and variables
+- Audit trail of deployments
+
+## Cost Estimate
+
+Running the full nightly matrix costs approximately **$0.50/month**:
+
+| Resource | Cost |
+|----------|------|
+| CloudFormation stacks (deployed ~20 min/night) | ~$0.10/month |
+| DynamoDB on-demand (test writes) | ~$0.01/month |
+| CloudWatch metrics/logs | ~$0.15/month |
+| GitHub Actions minutes (12 jobs × 10 min) | ~$0.24/month |
+| **Total** | **~$0.50/month** |
+
+## Profile Coverage Matrix
+
+| # | Profile | Auth | Platform | Monitoring | Delivery | Quota |
+|---|---------|------|----------|------------|----------|-------|
+| 01 | oidc-cognito-linux-central | OIDC/Cognito | Linux | Central | Static | — |
+| 02 | oidc-direct-linux-central-block | OIDC/Direct | Linux | Central | Static | Block |
+| 03 | oidc-direct-linux-bootstrap-alert | OIDC/Direct | Linux | Central | Bootstrap | Alert |
+| 04 | oidc-cognito-windows-central | OIDC/Cognito | Windows | Central | Static | — |
+| 05 | oidc-direct-windows-none | OIDC/Direct | Windows | None | Static | — |
+| 06 | oidc-direct-macos-sidecar-finegrained | OIDC/Direct | macOS | Sidecar | Static | Block+FG |
+| 07 | idc-linux-central-block | IDC | Linux | Central | Static | Block/SigV4 |
+| 08 | idc-windows-sidecar | IDC | Windows | Sidecar | Static | — |
+| 09 | passthrough-linux-none | Passthrough | Linux | None | Static | — |
+| 10 | oidc-direct-linux-bootstrap-finegrained | OIDC/Direct | Linux | Central | Bootstrap | Block+FG |
+| 11 | oidc-direct-linux-sidecar-block | OIDC/Direct | Linux | Sidecar | Static | Block |
+| 12 | oidc-cognito-macos-central-alert | OIDC/Cognito | macOS | Central | Static | Alert |
+
+### Dimensions Covered
+
+- **Auth types**: OIDC (Cognito federation, Direct STS), IDC (device auth), Passthrough
+- **IdP providers**: Cognito, Okta, Azure AD
+- **Platforms**: Linux x64, Windows x64, macOS ARM64
+- **Monitoring**: Central (port 4318), Sidecar (port 4319), None
+- **Config delivery**: Static (env vars), Bootstrap (API)
+- **Quota enforcement**: Block, Alert, Fine-grained (DynamoDB policies), SigV4 auth
+- **Quota auth**: API key, SigV4
+
+## Debugging Failures
+
+### Keep Infrastructure
+
+Use `--keep-infra` in manual workflow dispatch to prevent teardown:
+
+```
+gh workflow run e2e-matrix.yml -f keep_infra=true -f profile=01-oidc-cognito-linux-central
+```
+
+### Local Debugging
+
+```bash
+# Run with verbose output
+pytest tests/e2e/ --profile 01-oidc-cognito-linux-central -v -s --tb=long
+
+# Run single test
+pytest tests/e2e/test_auth_flow.py::TestAuthFlow::test_initial_auth_produces_valid_creds \
+  --profile 01-oidc-cognito-linux-central -v -s
+
+# Check what would run (collect only)
+pytest tests/e2e/ --profile 01-oidc-cognito-linux-central --co
+```
+
+### Common Issues
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| All tests skip | No `--profile` or `E2E_PROFILE` set | Set profile |
+| Binary not found | Wrong platform or build missing | Check `source/go/dist/` |
+| Stack outputs missing | Infrastructure not deployed | Deploy stacks or set `E2E_STACK_OUTPUTS` |
+| CloudWatch test timeout | Metric propagation delay | Increase retry timeout or mark as slow |
+| Port not listening | Proxy failed to start | Check binary stderr, system ports |
+
+## Test Markers
+
+- `@pytest.mark.e2e` — All E2E tests (use `-m e2e` to run only E2E)
+- `@pytest.mark.slow` — Tests with long waits (CloudWatch propagation)
+
+## File Structure
+
+```
+tests/e2e/
+├── conftest.py              # Shared fixtures, CLI args, skip logic
+├── profiles/                # Profile JSON definitions
+│   ├── 01-oidc-cognito-linux-central.json
+│   ├── 02-oidc-direct-linux-central-block.json
+│   ├── ...
+│   └── 12-oidc-cognito-macos-central-alert.json
+├── test_auth_flow.py        # Authentication tests
+├── test_credential_output.py # Output format tests
+├── test_monitoring_pipeline.py # OTLP proxy tests
+├── test_quota_enforcement.py # Quota tests
+├── test_config_delivery.py  # Bootstrap config tests
+├── test_binary_platform.py  # Platform-specific tests
+├── artifacts/               # (gitignored) Stack outputs at runtime
+└── README.md                # This file
+```

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -112,15 +112,16 @@ pytest tests/e2e/ --profile 09-passthrough-linux-none --co
 
 ## Branch Support
 
-This harness runs on **both `beta` and `main`** branches:
+This harness runs on the **`beta` branch only** — beta is the validation gate before promoting to main.
 
-| Branch | Trigger | Behavior |
-|--------|---------|----------|
-| `beta` | Nightly (3 AM UTC, weekdays) + PRs touching `deployment/` or `source/go/` | Full 16-profile matrix |
-| `main` | Nightly (3 AM UTC, weekdays) | Full 16-profile matrix (validates release candidates) |
-| PRs | Automatic on relevant file changes | Smoke only (profile 09 + Windows canary) — fast feedback, no infra cost |
+| Trigger | Branch | Behavior |
+|---------|--------|----------|
+| Nightly (3 AM UTC, weekdays) | `beta` | Full 16-profile matrix |
+| PRs targeting `beta` | `beta` | Smoke only (profile 09 + Windows canary) — fast feedback, no infra cost |
+| Manual dispatch | Any branch | Full matrix or single profile (`-f profile=...`) |
+| `main` | — | No E2E runs. Releases are validated on beta first. |
 
-The workflow file lives on both branches. No branch-specific configuration needed.
+The workflow skips if triggered on `main` by the cron scheduler.
 
 ## CI Setup (One-Time, ~10 minutes)
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -110,23 +110,128 @@ pytest tests/e2e/ --profile 09-passthrough-linux-none --co
 
 3. Commit and push — CI will pick it up automatically.
 
-## CI Setup
+## Branch Support
 
-### GitHub OIDC Trust
+This harness runs on **both `beta` and `main`** branches:
 
-The workflow uses GitHub's OIDC provider to authenticate with AWS (no long-lived secrets):
+| Branch | Trigger | Behavior |
+|--------|---------|----------|
+| `beta` | Nightly (3 AM UTC, weekdays) + PRs touching `deployment/` or `source/go/` | Full 16-profile matrix |
+| `main` | Nightly (3 AM UTC, weekdays) | Full 16-profile matrix (validates release candidates) |
+| PRs | Automatic on relevant file changes | Smoke only (profile 09 + Windows canary) — fast feedback, no infra cost |
 
-1. Create an IAM OIDC identity provider for `token.actions.githubusercontent.com`
-2. Create an IAM role with trust policy for your repo
-3. Set `E2E_AWS_ROLE_ARN` as a repository variable
-4. Create a protected environment called `e2e-testing`
+The workflow file lives on both branches. No branch-specific configuration needed.
 
-### Protected Environment
+## CI Setup (One-Time, ~10 minutes)
 
-The `e2e-testing` environment provides:
-- Deployment protection rules (optional reviewers for manual triggers)
-- Environment-scoped secrets and variables
-- Audit trail of deployments
+### Prerequisites
+
+- AWS account with CloudFormation access
+- Repository admin access (for secrets/environments)
+- `aws` CLI configured locally (for the OIDC trust setup)
+
+### Step 1: Create GitHub OIDC Identity Provider
+
+This allows GitHub Actions to authenticate to AWS without long-lived secrets.
+
+```bash
+# Check if OIDC provider already exists
+aws iam list-open-id-connect-providers | grep token.actions.githubusercontent.com
+
+# If not, create it:
+aws iam create-open-id-connect-provider \
+  --url https://token.actions.githubusercontent.com \
+  --thumbprint-list 6938fd4d98bab03faadb97b34396831e3780aea1 \
+  --client-id-list sts.amazonaws.com
+```
+
+> **Note:** Most AWS accounts already have this provider (used by many GitHub Actions workflows). If it exists, skip this step.
+
+### Step 2: Create the E2E IAM Role
+
+```bash
+# Get your AWS account ID
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+
+# Create trust policy (replace OWNER/REPO with your fork)
+cat > /tmp/e2e-trust-policy.json << 'EOF'
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::ACCOUNT_ID:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+        },
+        "StringLike": {
+          "token.actions.githubusercontent.com:sub": "repo:OWNER/REPO:*"
+        }
+      }
+    }
+  ]
+}
+EOF
+
+# Replace placeholders
+sed -i "s/ACCOUNT_ID/$ACCOUNT_ID/g" /tmp/e2e-trust-policy.json
+sed -i "s|OWNER/REPO|wirjo/guidance-for-claude-code-with-amazon-bedrock|g" /tmp/e2e-trust-policy.json
+
+# Create the role
+aws iam create-role \
+  --role-name ccwb-e2e-github-actions \
+  --assume-role-policy-document file:///tmp/e2e-trust-policy.json
+
+# Attach permissions (CloudFormation + resources the stacks create)
+aws iam attach-role-policy \
+  --role-name ccwb-e2e-github-actions \
+  --policy-arn arn:aws:iam::aws:policy/PowerUserAccess
+
+# Get the role ARN (you'll need this in Step 3)
+aws iam get-role --role-name ccwb-e2e-github-actions --query Role.Arn --output text
+```
+
+> **Security note:** `PowerUserAccess` is broad. For production, scope down to CloudFormation, DynamoDB, CloudWatch, Lambda, IAM (create/delete roles with path prefix), and S3. The E2E stacks are ephemeral (~20 min lifetime) so blast radius is limited.
+
+### Step 3: Configure GitHub Repository
+
+```bash
+# Set the role ARN as a repository variable
+gh variable set E2E_AWS_ROLE_ARN --body "arn:aws:iam::123456789012:role/ccwb-e2e-github-actions"
+
+# Create the protected environment (provides audit trail + optional reviewers)
+gh api repos/{owner}/{repo}/environments/e2e-testing -X PUT
+```
+
+Or via GitHub UI:
+1. **Settings → Variables → Actions** → New variable: `E2E_AWS_ROLE_ARN` = your role ARN
+2. **Settings → Environments** → New: `e2e-testing` (optionally add reviewers for manual dispatch)
+
+### Step 4: Verify
+
+```bash
+# Trigger a manual run with a single profile (cheapest test)
+gh workflow run e2e-matrix.yml -f profile=09-passthrough-linux-none
+
+# Watch the run
+gh run watch
+```
+
+If the smoke job passes, you're good. The passthrough profile doesn't need any infra, so it validates the workflow mechanics without AWS cost.
+
+### Troubleshooting Setup
+
+| Problem | Fix |
+|---------|-----|
+| `Not authorized to perform sts:AssumeRoleWithWebIdentity` | Check trust policy — repo name must match exactly (case-sensitive) |
+| `No OpenIDConnect provider found` | Run Step 1 to create the OIDC provider |
+| Workflow not triggering on PRs | Check that PR modifies files under `deployment/` or `source/go/` |
+| `E2E_AWS_ROLE_ARN` not found | Set as **repository variable** (not secret) — secrets aren't visible in fork PRs |
+| Stack creation failed | Check CloudFormation events. Most common: IAM permission boundary blocking role creation |
 
 ## Cost Estimate
 

--- a/tests/e2e/__init__.py
+++ b/tests/e2e/__init__.py
@@ -1,0 +1,1 @@
+"""E2E test package for CCWB credential-process and monitoring."""

--- a/tests/e2e/badge-template.json
+++ b/tests/e2e/badge-template.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "E2E Tests",
+  "message": "unknown",
+  "color": "lightgrey"
+}

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -5,6 +5,7 @@ Profile-driven testing across auth flows, OS, monitoring modes,
 config delivery, and quota enforcement.
 """
 
+import datetime
 import json
 import os
 import subprocess
@@ -41,6 +42,13 @@ def pytest_configure(config):
     )
     config.addinivalue_line(
         "markers", "flaky_coldstart: May fail due to cold-start latency (auto-reruns)"
+    )
+    config.addinivalue_line(
+        "markers", "timeout: Set test timeout in seconds (requires pytest-timeout)"
+    )
+    config.addinivalue_line(
+        "markers",
+        "flaky: Mark test for automatic reruns on failure (requires pytest-rerunfailures)",
     )
 
 
@@ -136,7 +144,9 @@ def credential_process_binary(e2e_profile) -> Path:
     # Also check E2E_BINARY_PATH env var
     env_path = os.environ.get("E2E_BINARY_PATH")
     if env_path:
-        return Path(env_path)
+        env_binary = Path(env_path)
+        if env_binary.exists():
+            return env_binary
 
     pytest.skip(f"Binary not found for platform {platform}: {binary_name}")
 
@@ -164,7 +174,9 @@ def otel_helper_binary(e2e_profile) -> Path:
 
     env_path = os.environ.get("E2E_OTEL_BINARY_PATH")
     if env_path:
-        return Path(env_path)
+        env_binary = Path(env_path)
+        if env_binary.exists():
+            return env_binary
 
     pytest.skip(f"otel-helper binary not found for platform {platform}")
 
@@ -315,8 +327,6 @@ def query_cloudwatch_metric(cloudwatch_client):
         dimensions: list,
         period: int = 60,
     ) -> float:
-        import datetime
-
         end_time = datetime.datetime.utcnow()
         start_time = end_time - datetime.timedelta(minutes=5)
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,386 @@
+"""
+E2E Test Harness — Shared Fixtures and Configuration
+
+Profile-driven testing across auth flows, OS, monitoring modes,
+config delivery, and quota enforcement.
+"""
+
+import json
+import os
+import socket
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import boto3
+import pytest
+from tenacity import retry, stop_after_delay, wait_exponential
+
+# ---------------------------------------------------------------------------
+# pytest CLI options
+# ---------------------------------------------------------------------------
+
+PROFILES_DIR = Path(__file__).parent / "profiles"
+
+
+def pytest_addoption(parser):
+    """Add --profile CLI arg for selecting E2E profile."""
+    parser.addoption(
+        "--profile",
+        action="store",
+        default=None,
+        help="E2E profile name (without .json extension) or full path",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Core fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def e2e_profile(request) -> Dict[str, Any]:
+    """Load E2E profile JSON based on --profile arg or E2E_PROFILE env var."""
+    profile_name = request.config.getoption("--profile") or os.environ.get("E2E_PROFILE")
+
+    if not profile_name:
+        pytest.skip("E2E not configured: set --profile or E2E_PROFILE env var")
+
+    # Support both name and full path
+    profile_path = Path(profile_name)
+    if not profile_path.exists():
+        profile_path = PROFILES_DIR / f"{profile_name}.json"
+
+    if not profile_path.exists():
+        pytest.skip(f"E2E profile not found: {profile_path}")
+
+    with open(profile_path) as f:
+        profile = json.load(f)
+
+    return profile
+
+
+@pytest.fixture(scope="session")
+def credential_process_binary(e2e_profile) -> Path:
+    """Resolve credential-process binary path for the profile's platform."""
+    platform = e2e_profile["platform"]
+    base_dir = Path(__file__).parent.parent.parent / "source" / "go"
+
+    platform_map = {
+        "linux-x64": "credential-process-linux-amd64",
+        "windows-x64": "credential-process-windows-amd64.exe",
+        "macos-arm64": "credential-process-darwin-arm64",
+    }
+
+    binary_name = platform_map.get(platform)
+    if not binary_name:
+        pytest.skip(f"Unsupported platform: {platform}")
+
+    # Check dist/ and build/ locations
+    for search_dir in ["dist", "build", "."]:
+        binary_path = base_dir / search_dir / binary_name
+        if binary_path.exists():
+            return binary_path
+
+    # Also check E2E_BINARY_PATH env var
+    env_path = os.environ.get("E2E_BINARY_PATH")
+    if env_path:
+        return Path(env_path)
+
+    pytest.skip(f"Binary not found for platform {platform}: {binary_name}")
+
+
+@pytest.fixture(scope="session")
+def otel_helper_binary(e2e_profile) -> Path:
+    """Resolve otel-helper binary path for the profile's platform."""
+    platform = e2e_profile["platform"]
+    base_dir = Path(__file__).parent.parent.parent / "source" / "go"
+
+    platform_map = {
+        "linux-x64": "otel-helper-linux-amd64",
+        "windows-x64": "otel-helper-windows-amd64.exe",
+        "macos-arm64": "otel-helper-darwin-arm64",
+    }
+
+    binary_name = platform_map.get(platform)
+    if not binary_name:
+        pytest.skip(f"Unsupported platform for otel-helper: {platform}")
+
+    for search_dir in ["dist", "build", "."]:
+        binary_path = base_dir / search_dir / binary_name
+        if binary_path.exists():
+            return binary_path
+
+    env_path = os.environ.get("E2E_OTEL_BINARY_PATH")
+    if env_path:
+        return Path(env_path)
+
+    pytest.skip(f"otel-helper binary not found for platform {platform}")
+
+
+@pytest.fixture(scope="session")
+def stack_outputs() -> Dict[str, str]:
+    """Read deployed stack outputs from artifact JSON."""
+    outputs_path = os.environ.get(
+        "E2E_STACK_OUTPUTS",
+        str(Path(__file__).parent / "artifacts" / "stack-outputs.json"),
+    )
+
+    if not Path(outputs_path).exists():
+        pytest.skip(f"Stack outputs not found: {outputs_path}")
+
+    with open(outputs_path) as f:
+        return json.load(f)
+
+
+# ---------------------------------------------------------------------------
+# Helper fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def aws_region() -> str:
+    """Get AWS region from env or default."""
+    return os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", "us-east-1"))
+
+
+@pytest.fixture(scope="session")
+def dynamodb_client(aws_region):
+    """Create DynamoDB client for quota operations."""
+    try:
+        return boto3.client("dynamodb", region_name=aws_region)
+    except Exception:
+        pytest.skip("AWS credentials not available for DynamoDB")
+
+
+@pytest.fixture(scope="session")
+def cloudwatch_client(aws_region):
+    """Create CloudWatch client for metric queries."""
+    try:
+        return boto3.client("cloudwatch", region_name=aws_region)
+    except Exception:
+        pytest.skip("AWS credentials not available for CloudWatch")
+
+
+# ---------------------------------------------------------------------------
+# Utility functions exposed as fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def run_credential_process(credential_process_binary, e2e_profile):
+    """Factory fixture: invoke credential-process binary with profile env vars."""
+
+    def _run(
+        extra_args: Optional[list] = None,
+        extra_env: Optional[Dict[str, str]] = None,
+        timeout: int = 30,
+        context: str = "initial",
+    ) -> subprocess.CompletedProcess:
+        env = os.environ.copy()
+
+        # Set profile-derived env vars
+        auth = e2e_profile["auth"]
+        env["CCWB_AUTH_TYPE"] = auth["type"]
+        if auth.get("federation"):
+            env["CCWB_AUTH_FEDERATION"] = auth["federation"]
+        if auth.get("provider"):
+            env["CCWB_AUTH_PROVIDER"] = auth["provider"]
+
+        # Monitoring config
+        monitoring = e2e_profile.get("monitoring", {})
+        if monitoring.get("mode"):
+            env["CCWB_MONITORING_MODE"] = monitoring["mode"]
+
+        # Config delivery
+        env["CCWB_CONFIG_DELIVERY"] = e2e_profile.get("config_delivery", "static")
+
+        # Quota config
+        quota = e2e_profile.get("quota", {})
+        if quota.get("enabled"):
+            env["CCWB_QUOTA_ENABLED"] = "true"
+            if quota.get("enforcement"):
+                env["CCWB_QUOTA_ENFORCEMENT"] = quota["enforcement"]
+            if quota.get("fine_grained"):
+                env["CCWB_QUOTA_FINE_GRAINED"] = "true"
+
+        # Context (initial vs mid-session-refresh)
+        env["CCWB_AUTH_CONTEXT"] = context
+
+        # Override with caller-provided env
+        if extra_env:
+            env.update(extra_env)
+
+        cmd = [str(credential_process_binary)]
+        if extra_args:
+            cmd.extend(extra_args)
+
+        return subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=env,
+        )
+
+    return _run
+
+
+@pytest.fixture(scope="session")
+def wait_for_port():
+    """Factory fixture: TCP connect poll with retry."""
+
+    def _wait(port: int, host: str = "127.0.0.1", timeout: float = 10.0) -> bool:
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            try:
+                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                sock.settimeout(1.0)
+                sock.connect((host, port))
+                sock.close()
+                return True
+            except (ConnectionRefusedError, OSError, socket.timeout):
+                time.sleep(0.5)
+        return False
+
+    return _wait
+
+
+@pytest.fixture(scope="session")
+def query_cloudwatch_metric(cloudwatch_client):
+    """Factory fixture: polls CloudWatch metric with exponential backoff."""
+
+    @retry(
+        stop=stop_after_delay(90),
+        wait=wait_exponential(multiplier=2, min=5, max=30),
+    )
+    def _query(
+        namespace: str,
+        metric_name: str,
+        dimensions: list,
+        period: int = 60,
+    ) -> float:
+        import datetime
+
+        end_time = datetime.datetime.utcnow()
+        start_time = end_time - datetime.timedelta(minutes=5)
+
+        response = cloudwatch_client.get_metric_statistics(
+            Namespace=namespace,
+            MetricName=metric_name,
+            Dimensions=dimensions,
+            StartTime=start_time,
+            EndTime=end_time,
+            Period=period,
+            Statistics=["Sum"],
+        )
+
+        datapoints = response.get("Datapoints", [])
+        if not datapoints:
+            raise ValueError(f"No datapoints for {namespace}/{metric_name}")
+
+        return datapoints[-1]["Sum"]
+
+    return _query
+
+
+@pytest.fixture(scope="session")
+def seed_quota_usage(dynamodb_client):
+    """Factory fixture: write token usage to DynamoDB quota table."""
+
+    def _seed(table_name: str, user: str, tokens: int):
+        dynamodb_client.put_item(
+            TableName=table_name,
+            Item={
+                "pk": {"S": f"USER#{user}"},
+                "sk": {"S": "USAGE#current"},
+                "tokens_used": {"N": str(tokens)},
+                "updated_at": {"S": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())},
+            },
+        )
+
+    return _seed
+
+
+@pytest.fixture(scope="session")
+def set_user_quota_policy(dynamodb_client):
+    """Factory fixture: write per-user quota policy to DynamoDB."""
+
+    def _set(table_name: str, user: str, limit: int):
+        dynamodb_client.put_item(
+            TableName=table_name,
+            Item={
+                "pk": {"S": f"USER#{user}"},
+                "sk": {"S": "POLICY#quota"},
+                "token_limit": {"N": str(limit)},
+                "enforcement": {"S": "block"},
+                "updated_at": {"S": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())},
+            },
+        )
+
+    return _set
+
+
+@pytest.fixture(scope="session")
+def set_group_quota_policy(dynamodb_client):
+    """Factory fixture: write group-level quota policy to DynamoDB."""
+
+    def _set(table_name: str, group: str, limit: int):
+        dynamodb_client.put_item(
+            TableName=table_name,
+            Item={
+                "pk": {"S": f"GROUP#{group}"},
+                "sk": {"S": "POLICY#quota"},
+                "token_limit": {"N": str(limit)},
+                "enforcement": {"S": "block"},
+                "updated_at": {"S": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())},
+            },
+        )
+
+    return _set
+
+
+# ---------------------------------------------------------------------------
+# Auto-skip logic based on profile test declarations
+# ---------------------------------------------------------------------------
+
+
+def pytest_collection_modifyitems(config, items):
+    """Skip tests whose module is not declared in the active profile."""
+    profile_name = config.getoption("--profile") or os.environ.get("E2E_PROFILE")
+    if not profile_name:
+        return
+
+    # Load profile
+    profile_path = Path(profile_name)
+    if not profile_path.exists():
+        profile_path = PROFILES_DIR / f"{profile_name}.json"
+    if not profile_path.exists():
+        return
+
+    with open(profile_path) as f:
+        profile = json.load(f)
+
+    declared_tests = set(profile.get("tests", []))
+
+    # Map test module names to profile test declarations
+    module_to_profile_test = {
+        "test_auth_flow": "auth_flow",
+        "test_credential_output": "credential_output",
+        "test_monitoring_pipeline": "monitoring_pipeline",
+        "test_quota_enforcement": "quota_enforcement",
+        "test_config_delivery": "config_delivery",
+        "test_binary_platform": "binary_platform",
+    }
+
+    for item in items:
+        module_name = item.module.__name__.split(".")[-1]
+        profile_test_name = module_to_profile_test.get(module_name)
+
+        if profile_test_name and profile_test_name not in declared_tests:
+            item.add_marker(
+                pytest.mark.skip(
+                    reason=f"Profile '{profile.get('name')}' does not include '{profile_test_name}'"
+                )
+            )

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -26,6 +26,24 @@ from . import helpers
 PROFILES_DIR = Path(__file__).parent / "profiles"
 
 
+def pytest_configure(config):
+    """Register custom markers."""
+    config.addinivalue_line("markers", "e2e: End-to-end test requiring infrastructure")
+    config.addinivalue_line(
+        "markers", "slow: Test with long wait (CloudWatch propagation)"
+    )
+    config.addinivalue_line(
+        "markers",
+        "flaky_cloudwatch: May fail due to CloudWatch propagation delay (auto-reruns)",
+    )
+    config.addinivalue_line(
+        "markers", "flaky_eventual: May fail due to eventual consistency (auto-reruns)"
+    )
+    config.addinivalue_line(
+        "markers", "flaky_coldstart: May fail due to cold-start latency (auto-reruns)"
+    )
+
+
 def pytest_addoption(parser):
     """Add --profile CLI arg for selecting E2E profile."""
     parser.addoption(

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -7,15 +7,17 @@ config delivery, and quota enforcement.
 
 import json
 import os
-import socket
 import subprocess
 import time
+import uuid
 from pathlib import Path
 from typing import Any, Dict, Optional
 
 import boto3
 import pytest
 from tenacity import retry, stop_after_delay, wait_exponential
+
+from . import helpers
 
 # ---------------------------------------------------------------------------
 # pytest CLI options
@@ -40,9 +42,21 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture(scope="session")
+def run_id() -> str:
+    """Unique ID per test session for parallel safety.
+
+    Used in test user emails, DynamoDB partition keys, and any shared state
+    that could collide between concurrent runs.
+    """
+    return uuid.uuid4().hex[:12]
+
+
+@pytest.fixture(scope="session")
 def e2e_profile(request) -> Dict[str, Any]:
     """Load E2E profile JSON based on --profile arg or E2E_PROFILE env var."""
-    profile_name = request.config.getoption("--profile") or os.environ.get("E2E_PROFILE")
+    profile_name = request.config.getoption("--profile") or os.environ.get(
+        "E2E_PROFILE"
+    )
 
     if not profile_name:
         pytest.skip("E2E not configured: set --profile or E2E_PROFILE env var")
@@ -142,7 +156,9 @@ def stack_outputs() -> Dict[str, str]:
 @pytest.fixture(scope="session")
 def aws_region() -> str:
     """Get AWS region from env or default."""
-    return os.environ.get("AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", "us-east-1"))
+    return os.environ.get(
+        "AWS_REGION", os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+    )
 
 
 @pytest.fixture(scope="session")
@@ -232,17 +248,7 @@ def wait_for_port():
     """Factory fixture: TCP connect poll with retry."""
 
     def _wait(port: int, host: str = "127.0.0.1", timeout: float = 10.0) -> bool:
-        deadline = time.time() + timeout
-        while time.time() < deadline:
-            try:
-                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                sock.settimeout(1.0)
-                sock.connect((host, port))
-                sock.close()
-                return True
-            except (ConnectionRefusedError, OSError, socket.timeout):
-                time.sleep(0.5)
-        return False
+        return helpers.wait_for_port(host=host, port=port, timeout=timeout)
 
     return _wait
 
@@ -339,6 +345,43 @@ def set_group_quota_policy(dynamodb_client):
         )
 
     return _set
+
+
+# ---------------------------------------------------------------------------
+# Quota cleanup fixture (use with request.addfinalizer)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def quota_cleanup(dynamodb_client, aws_region):
+    """Fixture that registers cleanup of quota data after each test.
+
+    Usage in tests:
+        def test_something(quota_cleanup):
+            quota_cleanup("my-table", "test-user-123")
+            # ... test logic ...
+            # cleanup happens automatically after test
+    """
+    cleanup_items = []
+
+    def _register(table_name: str, user: str):
+        cleanup_items.append((table_name, user))
+
+    yield _register
+
+    # Finalizer: clean up all registered quota data
+    for table_name, user in cleanup_items:
+        helpers.cleanup_quota_data(table=table_name, user=user, region=aws_region)
+
+
+@pytest.fixture
+def test_user_email(run_id):
+    """Generate a unique test user email scoped to this run."""
+
+    def _email(prefix: str = "e2e") -> str:
+        return f"{prefix}-{run_id}@test.ccwb.internal"
+
+    return _email
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -52,6 +52,24 @@ def run_id() -> str:
 
 
 @pytest.fixture(scope="session")
+def isolated_config_dir(tmp_path_factory, e2e_profile, run_id) -> Path:
+    """Create an isolated config directory per profile to prevent cross-profile pollution.
+
+    Each profile gets its own temp dir for config, caches, and keyring data.
+    This allows parallel execution without ~/claude-code-with-bedrock/ collisions.
+    """
+    profile_name = e2e_profile["name"]
+    config_dir = tmp_path_factory.mktemp(f"ccwb-{profile_name}-{run_id}")
+
+    # Create expected subdirectories
+    (config_dir / "cache").mkdir()
+    (config_dir / "tokens").mkdir()
+    (config_dir / "keyring").mkdir()
+
+    return config_dir
+
+
+@pytest.fixture(scope="session")
 def e2e_profile(request) -> Dict[str, Any]:
     """Load E2E profile JSON based on --profile arg or E2E_PROFILE env var."""
     profile_name = request.config.getoption("--profile") or os.environ.get(
@@ -185,7 +203,9 @@ def cloudwatch_client(aws_region):
 
 
 @pytest.fixture(scope="session")
-def run_credential_process(credential_process_binary, e2e_profile):
+def run_credential_process(
+    credential_process_binary, e2e_profile, isolated_config_dir, run_id
+):
     """Factory fixture: invoke credential-process binary with profile env vars."""
 
     def _run(
@@ -195,6 +215,13 @@ def run_credential_process(credential_process_binary, e2e_profile):
         context: str = "initial",
     ) -> subprocess.CompletedProcess:
         env = os.environ.copy()
+
+        # Cross-profile isolation: each profile gets its own config/cache/token dirs
+        env["CCWB_CONFIG_DIR"] = str(isolated_config_dir)
+        env["CCWB_CACHE_DIR"] = str(isolated_config_dir / "cache")
+        env["CCWB_TOKEN_DIR"] = str(isolated_config_dir / "tokens")
+        env["E2E_RUN_ID"] = run_id
+        env["E2E_PROFILE"] = e2e_profile["name"]
 
         # Set profile-derived env vars
         auth = e2e_profile["auth"]
@@ -223,6 +250,9 @@ def run_credential_process(credential_process_binary, e2e_profile):
 
         # Context (initial vs mid-session-refresh)
         env["CCWB_AUTH_CONTEXT"] = context
+
+        if context == "mid-session-refresh":
+            env["CCWB_FORCE_REFRESH"] = "1"
 
         # Override with caller-provided env
         if extra_env:

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -1,0 +1,400 @@
+"""
+E2E Test Harness — Shared Helpers
+
+Utility functions extracted from conftest.py for reuse across test modules.
+These are pure functions (no pytest fixtures) — conftest wraps them in fixtures.
+"""
+
+import base64
+import json
+import os
+import platform
+import signal
+import socket
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import boto3
+
+
+# ---------------------------------------------------------------------------
+# Token / credential helpers
+# ---------------------------------------------------------------------------
+
+
+def patch_token_expiry(
+    cache_dir: Path,
+    profile_name: str,
+    expired: bool = True,
+) -> Path:
+    """Modify cached JWT's exp claim to simulate token expiry or validity.
+
+    Args:
+        cache_dir: Directory containing cached token files.
+        profile_name: Profile name to locate the cached token.
+        expired: If True, set exp to past. If False, set exp to +1 hour.
+
+    Returns:
+        Path to the patched token file.
+    """
+    token_path = cache_dir / f"{profile_name}.json"
+
+    if not token_path.exists():
+        raise FileNotFoundError(f"Token cache not found: {token_path}")
+
+    with open(token_path) as f:
+        token_data = json.load(f)
+
+    # Decode the JWT payload (without verification)
+    access_token = token_data.get("AccessToken", token_data.get("access_token", ""))
+    parts = access_token.split(".")
+    if len(parts) != 3:
+        raise ValueError(
+            f"Token is not a valid JWT (expected 3 parts, got {len(parts)})"
+        )
+
+    # Decode payload
+    payload_b64 = parts[1] + "=" * (4 - len(parts[1]) % 4)
+    payload = json.loads(base64.urlsafe_b64decode(payload_b64))
+
+    # Patch exp claim
+    if expired:
+        payload["exp"] = int(time.time()) - 3600  # 1 hour ago
+    else:
+        payload["exp"] = int(time.time()) + 3600  # 1 hour from now
+
+    # Re-encode payload (signature will be invalid, but that's fine for testing)
+    patched_payload = (
+        base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b"=").decode()
+    )
+    parts[1] = patched_payload
+
+    # Write back
+    token_key = "AccessToken" if "AccessToken" in token_data else "access_token"
+    token_data[token_key] = ".".join(parts)
+
+    with open(token_path, "w") as f:
+        json.dump(token_data, f)
+
+    return token_path
+
+
+# ---------------------------------------------------------------------------
+# Process / port helpers
+# ---------------------------------------------------------------------------
+
+
+def kill_process_on_port(port: int) -> bool:
+    """Find and kill process listening on a port (cross-platform).
+
+    Args:
+        port: TCP port number.
+
+    Returns:
+        True if a process was killed, False if none found.
+    """
+    system = platform.system()
+
+    try:
+        if system == "Windows":
+            # Use netstat to find PID, then taskkill
+            result = subprocess.run(
+                ["netstat", "-ano"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            for line in result.stdout.splitlines():
+                if f":{port}" in line and "LISTENING" in line:
+                    parts = line.strip().split()
+                    pid = parts[-1]
+                    subprocess.run(
+                        ["taskkill", "/F", "/PID", pid],
+                        capture_output=True,
+                        timeout=10,
+                    )
+                    return True
+        else:
+            # Unix: use lsof or fuser
+            result = subprocess.run(
+                ["lsof", "-ti", f":{port}"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                for pid_str in result.stdout.strip().splitlines():
+                    pid = int(pid_str.strip())
+                    os.kill(pid, signal.SIGKILL)
+                return True
+    except (subprocess.TimeoutExpired, OSError, ValueError):
+        pass
+
+    return False
+
+
+def wait_for_port(
+    host: str = "127.0.0.1",
+    port: int = 4318,
+    timeout: float = 10.0,
+) -> bool:
+    """TCP connect poll with retry until port is accepting connections.
+
+    Args:
+        host: Hostname to connect to.
+        port: Port number.
+        timeout: Max seconds to wait.
+
+    Returns:
+        True if port became available, False on timeout.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(1.0)
+            sock.connect((host, port))
+            sock.close()
+            return True
+        except (ConnectionRefusedError, OSError, socket.timeout):
+            time.sleep(0.5)
+        finally:
+            try:
+                sock.close()
+            except Exception:
+                pass
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Cognito helpers
+# ---------------------------------------------------------------------------
+
+
+def create_cognito_test_user(
+    pool_id: str,
+    email: str,
+    password: str,
+    region: str = "us-east-1",
+) -> Dict[str, Any]:
+    """Create a test user in Cognito User Pool via Admin API.
+
+    Args:
+        pool_id: Cognito User Pool ID.
+        email: User email address.
+        password: User password.
+        region: AWS region.
+
+    Returns:
+        Dict with user creation response.
+    """
+    client = boto3.client("cognito-idp", region_name=region)
+
+    # Create user
+    response = client.admin_create_user(
+        UserPoolId=pool_id,
+        Username=email,
+        UserAttributes=[
+            {"Name": "email", "Value": email},
+            {"Name": "email_verified", "Value": "true"},
+        ],
+        TemporaryPassword=password,
+        MessageAction="SUPPRESS",
+    )
+
+    # Set permanent password
+    client.admin_set_user_password(
+        UserPoolId=pool_id,
+        Username=email,
+        Password=password,
+        Permanent=True,
+    )
+
+    return response
+
+
+def cognito_auth_headless(
+    pool_id: str,
+    client_id: str,
+    email: str,
+    password: str,
+    region: str = "us-east-1",
+) -> Dict[str, str]:
+    """Authenticate via AdminInitiateAuth (headless, no browser).
+
+    Args:
+        pool_id: Cognito User Pool ID.
+        client_id: App client ID.
+        email: User email.
+        password: User password.
+        region: AWS region.
+
+    Returns:
+        Dict with AccessToken, IdToken, RefreshToken.
+    """
+    client = boto3.client("cognito-idp", region_name=region)
+
+    response = client.admin_initiate_auth(
+        UserPoolId=pool_id,
+        ClientId=client_id,
+        AuthFlow="ADMIN_USER_PASSWORD_AUTH",
+        AuthParameters={
+            "USERNAME": email,
+            "PASSWORD": password,
+        },
+    )
+
+    auth_result = response.get("AuthenticationResult", {})
+    return {
+        "AccessToken": auth_result.get("AccessToken", ""),
+        "IdToken": auth_result.get("IdToken", ""),
+        "RefreshToken": auth_result.get("RefreshToken", ""),
+    }
+
+
+# ---------------------------------------------------------------------------
+# DynamoDB / Quota helpers
+# ---------------------------------------------------------------------------
+
+
+def seed_quota_usage(
+    table: str,
+    user: str,
+    tokens: int,
+    region: str = "us-east-1",
+) -> None:
+    """Write token usage to DynamoDB quota table.
+
+    Args:
+        table: DynamoDB table name.
+        user: User identifier (partition key component).
+        tokens: Number of tokens used.
+        region: AWS region.
+    """
+    client = boto3.client("dynamodb", region_name=region)
+    client.put_item(
+        TableName=table,
+        Item={
+            "pk": {"S": f"USER#{user}"},
+            "sk": {"S": "USAGE#current"},
+            "tokens_used": {"N": str(tokens)},
+            "updated_at": {"S": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())},
+        },
+    )
+
+
+def set_user_quota_policy(
+    table: str,
+    user: str,
+    limit: int,
+    region: str = "us-east-1",
+) -> None:
+    """Write per-user quota policy to DynamoDB.
+
+    Args:
+        table: DynamoDB table name.
+        user: User identifier.
+        limit: Token limit.
+        region: AWS region.
+    """
+    client = boto3.client("dynamodb", region_name=region)
+    client.put_item(
+        TableName=table,
+        Item={
+            "pk": {"S": f"USER#{user}"},
+            "sk": {"S": "POLICY#quota"},
+            "token_limit": {"N": str(limit)},
+            "enforcement": {"S": "block"},
+            "updated_at": {"S": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())},
+        },
+    )
+
+
+def cleanup_quota_data(
+    table: str,
+    user: str,
+    region: str = "us-east-1",
+) -> None:
+    """Delete test quota items from DynamoDB after test.
+
+    Args:
+        table: DynamoDB table name.
+        user: User identifier.
+        region: AWS region.
+    """
+    client = boto3.client("dynamodb", region_name=region)
+
+    # Delete usage and policy items
+    for sk in ["USAGE#current", "POLICY#quota"]:
+        try:
+            client.delete_item(
+                TableName=table,
+                Key={
+                    "pk": {"S": f"USER#{user}"},
+                    "sk": {"S": sk},
+                },
+            )
+        except client.exceptions.ResourceNotFoundException:
+            pass
+        except Exception:
+            # Best-effort cleanup — don't fail the test
+            pass
+
+
+# ---------------------------------------------------------------------------
+# CloudWatch helpers
+# ---------------------------------------------------------------------------
+
+
+def wait_for_cloudwatch_metric(
+    namespace: str,
+    metric: str,
+    dimensions: List[Dict[str, str]],
+    region: str = "us-east-1",
+    timeout: float = 90.0,
+) -> Optional[float]:
+    """Poll CloudWatch for a metric with exponential backoff.
+
+    Args:
+        namespace: CloudWatch namespace.
+        metric: Metric name.
+        dimensions: List of dimension dicts with Name/Value keys.
+        region: AWS region.
+        timeout: Max seconds to poll.
+
+    Returns:
+        Metric sum value, or None on timeout.
+    """
+    import datetime
+
+    client = boto3.client("cloudwatch", region_name=region)
+
+    wait_time = 5.0
+    deadline = time.time() + timeout
+
+    while time.time() < deadline:
+        end_time = datetime.datetime.utcnow()
+        start_time = end_time - datetime.timedelta(minutes=5)
+
+        response = client.get_metric_statistics(
+            Namespace=namespace,
+            MetricName=metric,
+            Dimensions=dimensions,
+            StartTime=start_time,
+            EndTime=end_time,
+            Period=60,
+            Statistics=["Sum"],
+        )
+
+        datapoints = response.get("Datapoints", [])
+        if datapoints:
+            # Return most recent datapoint
+            sorted_points = sorted(datapoints, key=lambda d: d["Timestamp"])
+            return sorted_points[-1]["Sum"]
+
+        time.sleep(wait_time)
+        wait_time = min(wait_time * 2, 30.0)
+
+    return None

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -6,6 +6,7 @@ These are pure functions (no pytest fixtures) — conftest wraps them in fixture
 """
 
 import base64
+import datetime
 import json
 import os
 import platform
@@ -367,8 +368,6 @@ def wait_for_cloudwatch_metric(
     Returns:
         Metric sum value, or None on timeout.
     """
-    import datetime
-
     client = boto3.client("cloudwatch", region_name=region)
 
     wait_time = 5.0

--- a/tests/e2e/markers.py
+++ b/tests/e2e/markers.py
@@ -1,0 +1,19 @@
+"""
+Custom pytest markers for the E2E test harness.
+
+Usage:
+    @pytest.mark.flaky_cloudwatch
+    def test_metric_arrives(...):
+        ...
+"""
+
+import pytest
+
+# Marker for tests that depend on CloudWatch metric propagation (60-120s delay)
+flaky_cloudwatch = pytest.mark.flaky(reruns=2, reruns_delay=30)
+
+# Marker for tests that depend on eventual consistency (DynamoDB, S3)
+flaky_eventual = pytest.mark.flaky(reruns=1, reruns_delay=5)
+
+# Marker for tests that may hit cold-start latency (Lambda, OIDC provider)
+flaky_coldstart = pytest.mark.flaky(reruns=1, reruns_delay=10)

--- a/tests/e2e/profiles/01-oidc-cognito-linux-central.json
+++ b/tests/e2e/profiles/01-oidc-cognito-linux-central.json
@@ -1,0 +1,10 @@
+{
+  "name": "01-oidc-cognito-linux-central",
+  "description": "Baseline: OIDC + Cognito federation + Linux + Central monitoring + No quota",
+  "auth": {"type": "oidc", "federation": "cognito", "provider": "cognito"},
+  "platform": "linux-x64",
+  "monitoring": {"mode": "central"},
+  "config_delivery": "static",
+  "quota": {"enabled": false},
+  "tests": ["auth_flow", "credential_output", "monitoring_pipeline"]
+}

--- a/tests/e2e/profiles/02-oidc-direct-linux-central-block.json
+++ b/tests/e2e/profiles/02-oidc-direct-linux-central-block.json
@@ -1,0 +1,10 @@
+{
+  "name": "02-oidc-direct-linux-central-block",
+  "description": "Enterprise: OIDC + Direct STS + Linux + Central + Quota block",
+  "auth": {"type": "oidc", "federation": "direct", "provider": "okta"},
+  "platform": "linux-x64",
+  "monitoring": {"mode": "central"},
+  "config_delivery": "static",
+  "quota": {"enabled": true, "enforcement": "block", "fine_grained": false},
+  "tests": ["auth_flow", "credential_output", "monitoring_pipeline", "quota_enforcement"]
+}

--- a/tests/e2e/profiles/03-oidc-direct-linux-bootstrap-alert.json
+++ b/tests/e2e/profiles/03-oidc-direct-linux-bootstrap-alert.json
@@ -1,0 +1,10 @@
+{
+  "name": "03-oidc-direct-linux-bootstrap-alert",
+  "description": "Bootstrap delivery + alert-only quota",
+  "auth": {"type": "oidc", "federation": "direct", "provider": "okta"},
+  "platform": "linux-x64",
+  "monitoring": {"mode": "central"},
+  "config_delivery": "bootstrap",
+  "quota": {"enabled": true, "enforcement": "alert", "fine_grained": false},
+  "tests": ["auth_flow", "credential_output", "config_delivery", "quota_enforcement"]
+}

--- a/tests/e2e/profiles/04-oidc-cognito-windows-central.json
+++ b/tests/e2e/profiles/04-oidc-cognito-windows-central.json
@@ -1,0 +1,10 @@
+{
+  "name": "04-oidc-cognito-windows-central",
+  "description": "Windows: OIDC + Cognito + Central monitoring",
+  "auth": {"type": "oidc", "federation": "cognito", "provider": "cognito"},
+  "platform": "windows-x64",
+  "monitoring": {"mode": "central"},
+  "config_delivery": "static",
+  "quota": {"enabled": false},
+  "tests": ["auth_flow", "credential_output", "binary_platform"]
+}

--- a/tests/e2e/profiles/05-oidc-direct-windows-none.json
+++ b/tests/e2e/profiles/05-oidc-direct-windows-none.json
@@ -1,0 +1,10 @@
+{
+  "name": "05-oidc-direct-windows-none",
+  "description": "Minimal Windows: OIDC + Direct STS + No monitoring",
+  "auth": {"type": "oidc", "federation": "direct", "provider": "azure"},
+  "platform": "windows-x64",
+  "monitoring": {"mode": "none"},
+  "config_delivery": "static",
+  "quota": {"enabled": false},
+  "tests": ["auth_flow", "credential_output", "binary_platform"]
+}

--- a/tests/e2e/profiles/06-oidc-direct-macos-sidecar-finegrained.json
+++ b/tests/e2e/profiles/06-oidc-direct-macos-sidecar-finegrained.json
@@ -1,0 +1,10 @@
+{
+  "name": "06-oidc-direct-macos-sidecar-finegrained",
+  "description": "macOS + Sidecar + Fine-grained quota (DynamoDB policies)",
+  "auth": {"type": "oidc", "federation": "direct", "provider": "okta"},
+  "platform": "macos-arm64",
+  "monitoring": {"mode": "sidecar"},
+  "config_delivery": "static",
+  "quota": {"enabled": true, "enforcement": "block", "fine_grained": true},
+  "tests": ["auth_flow", "credential_output", "monitoring_pipeline", "quota_enforcement"]
+}

--- a/tests/e2e/profiles/07-idc-linux-central-block.json
+++ b/tests/e2e/profiles/07-idc-linux-central-block.json
@@ -1,0 +1,10 @@
+{
+  "name": "07-idc-linux-central-block",
+  "description": "IDC: device auth + Central monitoring + SigV4 quota",
+  "auth": {"type": "idc", "federation": "none"},
+  "platform": "linux-x64",
+  "monitoring": {"mode": "central"},
+  "config_delivery": "static",
+  "quota": {"enabled": true, "enforcement": "block", "fine_grained": false, "auth_method": "sigv4"},
+  "tests": ["auth_flow", "credential_output", "monitoring_pipeline", "quota_enforcement"]
+}

--- a/tests/e2e/profiles/08-idc-windows-sidecar.json
+++ b/tests/e2e/profiles/08-idc-windows-sidecar.json
@@ -1,0 +1,10 @@
+{
+  "name": "08-idc-windows-sidecar",
+  "description": "IDC + Windows + Sidecar monitoring",
+  "auth": {"type": "idc", "federation": "none"},
+  "platform": "windows-x64",
+  "monitoring": {"mode": "sidecar"},
+  "config_delivery": "static",
+  "quota": {"enabled": false},
+  "tests": ["auth_flow", "credential_output", "binary_platform"]
+}

--- a/tests/e2e/profiles/09-passthrough-linux-none.json
+++ b/tests/e2e/profiles/09-passthrough-linux-none.json
@@ -1,0 +1,10 @@
+{
+  "name": "09-passthrough-linux-none",
+  "description": "Minimal: ambient credentials, no monitoring, no quota",
+  "auth": {"type": "passthrough", "federation": "none"},
+  "platform": "linux-x64",
+  "monitoring": {"mode": "none"},
+  "config_delivery": "static",
+  "quota": {"enabled": false},
+  "tests": ["auth_flow", "credential_output"]
+}

--- a/tests/e2e/profiles/10-oidc-direct-linux-bootstrap-finegrained.json
+++ b/tests/e2e/profiles/10-oidc-direct-linux-bootstrap-finegrained.json
@@ -1,0 +1,10 @@
+{
+  "name": "10-oidc-direct-linux-bootstrap-finegrained",
+  "description": "Max complexity: OIDC + Bootstrap + Fine-grained + Central",
+  "auth": {"type": "oidc", "federation": "direct", "provider": "okta"},
+  "platform": "linux-x64",
+  "monitoring": {"mode": "central"},
+  "config_delivery": "bootstrap",
+  "quota": {"enabled": true, "enforcement": "block", "fine_grained": true},
+  "tests": ["auth_flow", "credential_output", "monitoring_pipeline", "config_delivery", "quota_enforcement"]
+}

--- a/tests/e2e/profiles/11-oidc-direct-linux-sidecar-block.json
+++ b/tests/e2e/profiles/11-oidc-direct-linux-sidecar-block.json
@@ -1,0 +1,10 @@
+{
+  "name": "11-oidc-direct-linux-sidecar-block",
+  "description": "Sidecar + hard block quota",
+  "auth": {"type": "oidc", "federation": "direct", "provider": "okta"},
+  "platform": "linux-x64",
+  "monitoring": {"mode": "sidecar"},
+  "config_delivery": "static",
+  "quota": {"enabled": true, "enforcement": "block", "fine_grained": false},
+  "tests": ["auth_flow", "credential_output", "monitoring_pipeline", "quota_enforcement"]
+}

--- a/tests/e2e/profiles/12-oidc-cognito-macos-central-alert.json
+++ b/tests/e2e/profiles/12-oidc-cognito-macos-central-alert.json
@@ -1,0 +1,10 @@
+{
+  "name": "12-oidc-cognito-macos-central-alert",
+  "description": "macOS + Cognito + Central + Alert-only quota",
+  "auth": {"type": "oidc", "federation": "cognito", "provider": "cognito"},
+  "platform": "macos-arm64",
+  "monitoring": {"mode": "central"},
+  "config_delivery": "static",
+  "quota": {"enabled": true, "enforcement": "alert", "fine_grained": false},
+  "tests": ["auth_flow", "credential_output", "monitoring_pipeline", "quota_enforcement"]
+}

--- a/tests/e2e/profiles/13-oidc-direct-windows-sidecar-alert.json
+++ b/tests/e2e/profiles/13-oidc-direct-windows-sidecar-alert.json
@@ -1,0 +1,10 @@
+{
+  "name": "13-oidc-direct-windows-sidecar-alert",
+  "description": "Windows + Sidecar + Alert quota (tests .cmd/.ps1 otel-helper fallback)",
+  "auth": {"type": "oidc", "federation": "direct", "provider": "okta"},
+  "platform": "windows-x64",
+  "monitoring": {"mode": "sidecar"},
+  "config_delivery": "static",
+  "quota": {"enabled": true, "enforcement": "alert", "fine_grained": false},
+  "tests": ["auth_flow", "credential_output", "monitoring_pipeline", "quota_enforcement", "binary_platform"]
+}

--- a/tests/e2e/profiles/14-oidc-cognito-windows-central-block.json
+++ b/tests/e2e/profiles/14-oidc-cognito-windows-central-block.json
@@ -1,0 +1,10 @@
+{
+  "name": "14-oidc-cognito-windows-central-block",
+  "description": "Windows + Cognito + Central + Block quota (keyring chunking under load)",
+  "auth": {"type": "oidc", "federation": "cognito", "provider": "cognito"},
+  "platform": "windows-x64",
+  "monitoring": {"mode": "central"},
+  "config_delivery": "static",
+  "quota": {"enabled": true, "enforcement": "block", "fine_grained": false},
+  "tests": ["auth_flow", "credential_output", "monitoring_pipeline", "quota_enforcement", "binary_platform"]
+}

--- a/tests/e2e/profiles/15-oidc-direct-macos-central-block.json
+++ b/tests/e2e/profiles/15-oidc-direct-macos-central-block.json
@@ -1,0 +1,10 @@
+{
+  "name": "15-oidc-direct-macos-central-block",
+  "description": "macOS ARM + Direct STS + Central + Block (tests macOS keychain integration)",
+  "auth": {"type": "oidc", "federation": "direct", "provider": "okta"},
+  "platform": "macos-arm64",
+  "monitoring": {"mode": "central"},
+  "config_delivery": "static",
+  "quota": {"enabled": true, "enforcement": "block", "fine_grained": false},
+  "tests": ["auth_flow", "credential_output", "monitoring_pipeline", "quota_enforcement", "binary_platform"]
+}

--- a/tests/e2e/profiles/16-idc-macos-sidecar.json
+++ b/tests/e2e/profiles/16-idc-macos-sidecar.json
@@ -1,0 +1,10 @@
+{
+  "name": "16-idc-macos-sidecar",
+  "description": "macOS + IDC + Sidecar (tests device auth + sidecar on macOS)",
+  "auth": {"type": "idc", "federation": null, "provider": null},
+  "platform": "macos-arm64",
+  "monitoring": {"mode": "sidecar"},
+  "config_delivery": "static",
+  "quota": {"enabled": false},
+  "tests": ["auth_flow", "credential_output", "monitoring_pipeline", "binary_platform"]
+}

--- a/tests/e2e/pytest.ini
+++ b/tests/e2e/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    e2e: End-to-end integration tests requiring deployed infrastructure
+    slow: Tests with long waits (e.g., CloudWatch metric propagation)

--- a/tests/e2e/pytest.ini
+++ b/tests/e2e/pytest.ini
@@ -2,3 +2,5 @@
 markers =
     e2e: End-to-end integration tests requiring deployed infrastructure
     slow: Tests with long waits (e.g., CloudWatch metric propagation)
+    timeout: Set test timeout in seconds (requires pytest-timeout)
+    flaky: Mark test for automatic reruns on failure (requires pytest-rerunfailures)

--- a/tests/e2e/test_auth_flow.py
+++ b/tests/e2e/test_auth_flow.py
@@ -21,8 +21,7 @@ class TestAuthFlow:
         result = run_credential_process(context="initial")
 
         assert result.returncode == 0, (
-            f"credential-process exited {result.returncode}\n"
-            f"stderr: {result.stderr}"
+            f"credential-process exited {result.returncode}\nstderr: {result.stderr}"
         )
 
         creds = json.loads(result.stdout)
@@ -47,9 +46,7 @@ class TestAuthFlow:
         assert second.returncode == 0
         second_creds = json.loads(second.stdout)
 
-        assert elapsed_ms < 200, (
-            f"Cache hit took {elapsed_ms:.0f}ms (expected <200ms)"
-        )
+        assert elapsed_ms < 200, f"Cache hit took {elapsed_ms:.0f}ms (expected <200ms)"
         assert first_creds["AccessKeyId"] == second_creds["AccessKeyId"], (
             "Cache miss: different AccessKeyId on second call"
         )

--- a/tests/e2e/test_auth_flow.py
+++ b/tests/e2e/test_auth_flow.py
@@ -1,0 +1,111 @@
+"""
+E2E Tests — Authentication Flow
+
+Verifies that the credential-process binary authenticates correctly
+across all auth types (OIDC, IDC, passthrough) and federation modes.
+"""
+
+import json
+import time
+
+import pytest
+
+pytestmark = [pytest.mark.e2e]
+
+
+class TestAuthFlow:
+    """Authentication flow tests — run for all profiles with 'auth_flow' in tests list."""
+
+    def test_initial_auth_produces_valid_creds(self, run_credential_process):
+        """Binary exits 0, produces JSON on stdout, AccessKeyId starts with ASIA."""
+        result = run_credential_process(context="initial")
+
+        assert result.returncode == 0, (
+            f"credential-process exited {result.returncode}\n"
+            f"stderr: {result.stderr}"
+        )
+
+        creds = json.loads(result.stdout)
+        assert "AccessKeyId" in creds, "Missing AccessKeyId in output"
+        assert creds["AccessKeyId"].startswith("ASIA"), (
+            f"AccessKeyId should start with ASIA (temporary creds), got: {creds['AccessKeyId'][:8]}"
+        )
+
+    def test_credential_cache_hit_fast(self, run_credential_process):
+        """Second invocation completes in <200ms with same credentials (cache hit)."""
+        # First call to warm cache
+        first = run_credential_process(context="initial")
+        assert first.returncode == 0
+
+        first_creds = json.loads(first.stdout)
+
+        # Second call should be fast (cached)
+        start = time.time()
+        second = run_credential_process(context="initial")
+        elapsed_ms = (time.time() - start) * 1000
+
+        assert second.returncode == 0
+        second_creds = json.loads(second.stdout)
+
+        assert elapsed_ms < 200, (
+            f"Cache hit took {elapsed_ms:.0f}ms (expected <200ms)"
+        )
+        assert first_creds["AccessKeyId"] == second_creds["AccessKeyId"], (
+            "Cache miss: different AccessKeyId on second call"
+        )
+
+    def test_expired_token_silent_refresh(self, run_credential_process, e2e_profile):
+        """When token is expired, mid-session refresh gets new creds without browser."""
+        if e2e_profile["auth"]["type"] == "passthrough":
+            pytest.skip("Passthrough auth does not use token refresh")
+
+        # Simulate expired token via env override
+        result = run_credential_process(
+            context="mid-session-refresh",
+            extra_env={"CCWB_TOKEN_EXPIRY_OVERRIDE": "2020-01-01T00:00:00Z"},
+        )
+
+        assert result.returncode == 0, (
+            f"Silent refresh failed (exit {result.returncode})\nstderr: {result.stderr}"
+        )
+
+        creds = json.loads(result.stdout)
+        assert creds["AccessKeyId"].startswith("ASIA")
+
+        # Should NOT contain browser-launch indicators
+        assert "opening browser" not in result.stderr.lower(), (
+            "Silent refresh should not open browser"
+        )
+
+    def test_revoked_refresh_exits_nonzero(self, run_credential_process, e2e_profile):
+        """When refresh token is revoked, mid-session refresh fails gracefully."""
+        if e2e_profile["auth"]["type"] == "passthrough":
+            pytest.skip("Passthrough auth does not use refresh tokens")
+
+        result = run_credential_process(
+            context="mid-session-refresh",
+            extra_env={
+                "CCWB_TOKEN_EXPIRY_OVERRIDE": "2020-01-01T00:00:00Z",
+                "CCWB_REFRESH_TOKEN_OVERRIDE": "revoked-invalid-token",
+            },
+        )
+
+        assert result.returncode != 0, (
+            "Expected non-zero exit when refresh token is revoked"
+        )
+
+    def test_explain_matches_profile(self, run_credential_process, e2e_profile):
+        """--explain output auth.mode matches profile.auth.type."""
+        result = run_credential_process(extra_args=["--explain"])
+
+        assert result.returncode == 0, (
+            f"--explain failed (exit {result.returncode})\nstderr: {result.stderr}"
+        )
+
+        explain = json.loads(result.stdout)
+        expected_mode = e2e_profile["auth"]["type"]
+
+        assert explain.get("auth", {}).get("mode") == expected_mode, (
+            f"Explain auth.mode={explain.get('auth', {}).get('mode')} "
+            f"doesn't match profile auth.type={expected_mode}"
+        )

--- a/tests/e2e/test_auth_flow.py
+++ b/tests/e2e/test_auth_flow.py
@@ -10,7 +10,7 @@ import time
 
 import pytest
 
-pytestmark = [pytest.mark.e2e]
+pytestmark = [pytest.mark.e2e, pytest.mark.timeout(30)]
 
 
 class TestAuthFlow:

--- a/tests/e2e/test_binary_platform.py
+++ b/tests/e2e/test_binary_platform.py
@@ -70,7 +70,7 @@ class TestBinaryPlatform:
                 capture_output=True,
                 text=True,
                 timeout=30,
-                shell=True,
+                shell=True,  # nosec B602 — intentional: testing .cmd shell fallback on Windows
             )
 
             assert result.returncode == 0, f".cmd fallback failed: {result.stderr}"
@@ -170,7 +170,7 @@ class TestBinaryPlatform:
             shutil.copy2(str(credential_process_binary), space_binary)
 
             if not _is_windows():
-                os.chmod(space_binary, 0o755)
+                os.chmod(space_binary, 0o755)  # nosec B103 — test binary needs execute permission
 
             # Execute from spaced path
             result = subprocess.run(

--- a/tests/e2e/test_binary_platform.py
+++ b/tests/e2e/test_binary_platform.py
@@ -15,7 +15,7 @@ import time
 
 import pytest
 
-pytestmark = [pytest.mark.e2e]
+pytestmark = [pytest.mark.e2e, pytest.mark.timeout(30)]
 
 
 def _is_windows() -> bool:

--- a/tests/e2e/test_binary_platform.py
+++ b/tests/e2e/test_binary_platform.py
@@ -2,7 +2,8 @@
 E2E Tests — Binary Platform Compatibility
 
 Verifies platform-specific binary behavior for Windows and macOS,
-including AV compatibility, keyring integration, and path handling.
+including AV compatibility, keyring integration, path handling,
+.cmd/.ps1 fallbacks, install scripts, and macOS Keychain.
 """
 
 import os
@@ -10,6 +11,7 @@ import platform
 import shutil
 import subprocess
 import tempfile
+import time
 
 import pytest
 
@@ -71,9 +73,7 @@ class TestBinaryPlatform:
                 shell=True,
             )
 
-            assert result.returncode == 0, (
-                f".cmd fallback failed: {result.stderr}"
-            )
+            assert result.returncode == 0, f".cmd fallback failed: {result.stderr}"
         finally:
             # Restore the .exe
             if os.path.exists(backup_path):
@@ -114,7 +114,7 @@ class TestBinaryPlatform:
             f"Keyring retrieve failed: {retrieve_result.stderr}"
         )
         assert test_token in retrieve_result.stdout, (
-            f"Retrieved token doesn't match stored token"
+            "Retrieved token doesn't match stored token"
         )
 
     def test_keyring_chunking_large_token(self, credential_process_binary, e2e_profile):
@@ -185,3 +185,477 @@ class TestBinaryPlatform:
             )
         finally:
             shutil.rmtree(space_dir, ignore_errors=True)
+
+
+# ===========================================================================
+# Windows-specific tests
+# ===========================================================================
+
+
+@pytest.mark.skipif(not _is_windows(), reason="Windows-only tests")
+class TestWindowsPlatform:
+    """Windows-specific binary and integration tests."""
+
+    def test_credential_process_exe_runs(self, credential_process_binary):
+        """credential-process.exe starts and returns version."""
+        exe_path = str(credential_process_binary)
+        assert exe_path.endswith(".exe"), f"Expected .exe binary, got: {exe_path}"
+
+        result = subprocess.run(
+            [exe_path, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        assert result.returncode == 0, (
+            f"credential-process.exe failed to run\n"
+            f"exit: {result.returncode}\n"
+            f"stderr: {result.stderr}"
+        )
+        output = result.stdout + result.stderr
+        assert output.strip(), "No version output from .exe"
+
+    def test_otel_helper_cmd_fallback(self, otel_helper_binary):
+        """When .exe is renamed/blocked, .cmd wrapper invokes .ps1 fallback."""
+        exe_path = str(otel_helper_binary)
+        if not exe_path.endswith(".exe"):
+            pytest.skip("Not a Windows .exe binary")
+
+        binary_dir = os.path.dirname(exe_path)
+        cmd_path = os.path.join(binary_dir, "otel-helper.cmd")
+        ps1_path = os.path.join(binary_dir, "otel-helper.ps1")
+
+        if not os.path.exists(cmd_path):
+            pytest.skip("otel-helper.cmd wrapper not found")
+        if not os.path.exists(ps1_path):
+            pytest.skip("otel-helper.ps1 fallback not found")
+
+        # Temporarily rename .exe to simulate it being blocked/missing
+        backup_path = exe_path + ".bak"
+        try:
+            os.rename(exe_path, backup_path)
+
+            result = subprocess.run(
+                ["cmd", "/c", cmd_path, "--version"],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+
+            assert result.returncode == 0, (
+                f".cmd fallback to .ps1 failed\n"
+                f"exit: {result.returncode}\n"
+                f"stderr: {result.stderr}"
+            )
+        finally:
+            if os.path.exists(backup_path):
+                os.rename(backup_path, exe_path)
+
+    def test_powershell_otel_helper_parity(self, otel_helper_binary):
+        """otel-helper.ps1 produces same output format as .exe."""
+        exe_path = str(otel_helper_binary)
+        binary_dir = os.path.dirname(exe_path)
+        ps1_path = os.path.join(binary_dir, "otel-helper.ps1")
+
+        if not os.path.exists(ps1_path):
+            pytest.skip("otel-helper.ps1 not found")
+
+        # Get .exe output
+        exe_result = subprocess.run(
+            [exe_path, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        # Get .ps1 output
+        ps1_result = subprocess.run(
+            [
+                "powershell",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                ps1_path,
+                "--version",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        if ps1_result.returncode != 0:
+            pytest.skip(f"PowerShell execution failed: {ps1_result.stderr}")
+
+        # Both should produce version output in the same format
+        exe_output = exe_result.stdout.strip()
+        ps1_output = ps1_result.stdout.strip()
+
+        # At minimum, both should output something non-empty
+        assert exe_output, "exe produced no version output"
+        assert ps1_output, "ps1 produced no version output"
+
+    def test_windows_keyring_chunking(self, credential_process_binary, tmp_path):
+        """Tokens >1280 chars are chunked correctly in Windows Credential Manager."""
+        # Windows Credential Manager has a 1280-byte limit per entry
+        # The binary should automatically chunk larger tokens
+        chunk_boundary_token = "X" * 1300  # Just over the limit
+
+        store_result = subprocess.run(
+            [
+                str(credential_process_binary),
+                "--keyring-store",
+                "--token",
+                chunk_boundary_token,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            cwd=str(tmp_path),
+        )
+
+        if store_result.returncode != 0 and "keyring" in store_result.stderr.lower():
+            pytest.skip(f"Windows keyring not available: {store_result.stderr}")
+
+        assert store_result.returncode == 0, (
+            f"Keyring chunked store failed: {store_result.stderr}"
+        )
+
+        # Retrieve and verify integrity
+        retrieve_result = subprocess.run(
+            [str(credential_process_binary), "--keyring-retrieve"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            cwd=str(tmp_path),
+        )
+
+        assert retrieve_result.returncode == 0, (
+            f"Keyring chunked retrieve failed: {retrieve_result.stderr}"
+        )
+        assert chunk_boundary_token in retrieve_result.stdout, (
+            f"Chunked token not preserved. Expected 1300 chars, "
+            f"got {len(retrieve_result.stdout.strip())} chars"
+        )
+
+    def test_windows_keyring_retrieval_latency(
+        self, credential_process_binary, tmp_path
+    ):
+        """Keyring operations complete in <2s (not 10-17s DPAPI hang)."""
+        test_token = f"latency-test-{os.getpid()}"
+
+        # Store
+        subprocess.run(
+            [str(credential_process_binary), "--keyring-store", "--token", test_token],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=str(tmp_path),
+        )
+
+        # Time the retrieval
+        start = time.perf_counter()
+        result = subprocess.run(
+            [str(credential_process_binary), "--keyring-retrieve"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=str(tmp_path),
+        )
+        elapsed = time.perf_counter() - start
+
+        if result.returncode != 0 and "keyring" in result.stderr.lower():
+            pytest.skip("Keyring not available for latency test")
+
+        assert elapsed < 2.0, (
+            f"Keyring retrieval took {elapsed:.1f}s (>2s threshold). "
+            f"Possible DPAPI hang — see issue #649"
+        )
+
+    def test_install_bat_execution(self, credential_process_binary, tmp_path):
+        """install.bat runs without '& was unexpected' errors."""
+        source_dir = (
+            credential_process_binary.parent.parent.parent
+            if hasattr(credential_process_binary, "parent")
+            else os.path.dirname(
+                os.path.dirname(os.path.dirname(str(credential_process_binary)))
+            )
+        )
+
+        # Look for install.bat in source tree
+        install_bat = None
+        for candidate in [
+            os.path.join(str(source_dir), "scripts", "install.bat"),
+            os.path.join(str(source_dir), "..", "scripts", "install.bat"),
+            os.path.join(str(source_dir), "..", "..", "scripts", "install.bat"),
+        ]:
+            if os.path.exists(candidate):
+                install_bat = candidate
+                break
+
+        if not install_bat:
+            pytest.skip("install.bat not found in source tree")
+
+        # Run install.bat in dry-run/help mode
+        result = subprocess.run(
+            ["cmd", "/c", install_bat, "--help"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            cwd=str(tmp_path),
+        )
+
+        # Check for the specific "& was unexpected" error
+        assert "was unexpected" not in result.stderr, (
+            f"install.bat has syntax error: {result.stderr}"
+        )
+
+    def test_reg_file_userprofile_paths(self, credential_process_binary, tmp_path):
+        """Generated .reg file uses %USERPROFILE% not ~/."""
+        # Run the binary with config export to generate .reg content
+        result = subprocess.run(
+            [str(credential_process_binary), "--export-reg"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            cwd=str(tmp_path),
+        )
+
+        if result.returncode != 0:
+            # Try alternative flag
+            result = subprocess.run(
+                [
+                    str(credential_process_binary),
+                    "--generate-config",
+                    "--format",
+                    "reg",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=15,
+                cwd=str(tmp_path),
+            )
+
+        if result.returncode != 0:
+            pytest.skip(f"Cannot generate .reg output: {result.stderr}")
+
+        output = result.stdout
+        if "~/" in output:
+            pytest.fail(
+                f".reg file contains Unix-style path '~/'. "
+                f"Should use %USERPROFILE% for Windows. Output:\n{output[:500]}"
+            )
+
+    def test_no_crlf_in_generated_scripts(self, credential_process_binary):
+        """Generated .sh scripts use LF line endings even on Windows."""
+        binary_dir = os.path.dirname(str(credential_process_binary))
+
+        # Find any .sh files in the dist/scripts directory
+        sh_files = []
+        for root, _dirs, files in os.walk(binary_dir):
+            for f in files:
+                if f.endswith(".sh"):
+                    sh_files.append(os.path.join(root, f))
+
+        # Also check parent directories
+        parent_dir = os.path.dirname(binary_dir)
+        for root, _dirs, files in os.walk(parent_dir):
+            for f in files:
+                if f.endswith(".sh"):
+                    sh_files.append(os.path.join(root, f))
+
+        if not sh_files:
+            pytest.skip("No .sh scripts found to check")
+
+        for sh_file in sh_files:
+            with open(sh_file, "rb") as fh:
+                content = fh.read()
+
+            if b"\r\n" in content:
+                pytest.fail(
+                    f"File {sh_file} has CRLF line endings. "
+                    f".sh scripts must use LF only (see issue #567)"
+                )
+
+    def test_long_path_support(self, credential_process_binary, tmp_path):
+        """Binary works when installed to path >200 chars."""
+        # Create a deeply nested path >200 chars total
+        deep_path = tmp_path
+        while len(str(deep_path)) < 210:
+            deep_path = deep_path / "a_long_directory_name_for_testing"
+        deep_path.mkdir(parents=True, exist_ok=True)
+
+        binary_name = os.path.basename(str(credential_process_binary))
+        long_binary = deep_path / binary_name
+
+        shutil.copy2(str(credential_process_binary), str(long_binary))
+
+        result = subprocess.run(
+            [str(long_binary), "--version"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        assert result.returncode == 0, (
+            f"Binary failed in long path ({len(str(long_binary))} chars)\n"
+            f"path: {long_binary}\n"
+            f"exit: {result.returncode}\n"
+            f"stderr: {result.stderr}"
+        )
+
+
+# ===========================================================================
+# macOS-specific tests
+# ===========================================================================
+
+
+@pytest.mark.skipif(not _is_macos(), reason="macOS-only tests")
+class TestMacOSPlatform:
+    """macOS-specific binary and integration tests."""
+
+    def test_credential_process_runs(self, credential_process_binary):
+        """credential-process binary executes on macOS ARM."""
+        result = subprocess.run(
+            [str(credential_process_binary), "--version"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        assert result.returncode == 0, (
+            f"credential-process failed on macOS\n"
+            f"exit: {result.returncode}\n"
+            f"stderr: {result.stderr}"
+        )
+        output = result.stdout + result.stderr
+        assert output.strip(), "No version output produced on macOS"
+
+    def test_macos_keychain_store_retrieve(self, credential_process_binary, tmp_path):
+        """Token roundtrips through macOS Keychain."""
+        test_token = f"e2e-macos-keychain-{os.getpid()}"
+
+        # Store token via binary's keychain integration
+        store_result = subprocess.run(
+            [str(credential_process_binary), "--keyring-store", "--token", test_token],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            cwd=str(tmp_path),
+        )
+
+        if store_result.returncode != 0 and "keychain" in store_result.stderr.lower():
+            pytest.skip(f"macOS Keychain not available: {store_result.stderr}")
+
+        assert store_result.returncode == 0, (
+            f"Keychain store failed: {store_result.stderr}"
+        )
+
+        # Retrieve token
+        retrieve_result = subprocess.run(
+            [str(credential_process_binary), "--keyring-retrieve"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            cwd=str(tmp_path),
+        )
+
+        assert retrieve_result.returncode == 0, (
+            f"Keychain retrieve failed: {retrieve_result.stderr}"
+        )
+        assert test_token in retrieve_result.stdout, (
+            "Retrieved token doesn't match stored token in Keychain"
+        )
+
+    def test_macos_keychain_large_token(self, credential_process_binary, tmp_path):
+        """Large tokens (>2KB) store/retrieve correctly from Keychain."""
+        # macOS Keychain doesn't have the same chunking limit as Windows,
+        # but we still test large payloads for correctness
+        large_token = "e2e-macos-large-" + "B" * 2500
+
+        store_result = subprocess.run(
+            [str(credential_process_binary), "--keyring-store", "--token", large_token],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            cwd=str(tmp_path),
+        )
+
+        if store_result.returncode != 0 and "keychain" in store_result.stderr.lower():
+            pytest.skip(f"macOS Keychain not available: {store_result.stderr}")
+
+        assert store_result.returncode == 0, (
+            f"Keychain large token store failed: {store_result.stderr}"
+        )
+
+        # Retrieve and verify integrity
+        retrieve_result = subprocess.run(
+            [str(credential_process_binary), "--keyring-retrieve"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            cwd=str(tmp_path),
+        )
+
+        assert retrieve_result.returncode == 0, (
+            f"Keychain large token retrieve failed: {retrieve_result.stderr}"
+        )
+        assert large_token in retrieve_result.stdout, (
+            f"Large token not preserved in macOS Keychain. "
+            f"Expected {len(large_token)} chars, got {len(retrieve_result.stdout.strip())} chars"
+        )
+
+    def test_browser_launch_default(self, credential_process_binary):
+        """OAuth flow launches default browser via 'open' command."""
+        # Verify 'open' command is available (macOS built-in)
+        which_result = subprocess.run(
+            ["which", "open"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        assert which_result.returncode == 0, "'open' command not found on macOS"
+
+        # Test that the binary references 'open' for browser launch
+        # by checking help/config output
+        result = subprocess.run(
+            [str(credential_process_binary), "--help"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+
+        # The binary should support browser-based auth on macOS
+        output = result.stdout + result.stderr
+        # Just verify the binary doesn't crash when asked about browser support
+        assert (
+            result.returncode == 0
+            or "help" in output.lower()
+            or "usage" in output.lower()
+        ), f"Binary crashed when checking browser support: {result.stderr}"
+
+    def test_universal_binary_detection(self, credential_process_binary):
+        """Binary is ARM64 native (not Rosetta x86_64)."""
+        # Use 'file' command to check binary architecture
+        result = subprocess.run(
+            ["file", str(credential_process_binary)],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+        assert result.returncode == 0, f"'file' command failed: {result.stderr}"
+
+        output = result.stdout
+        # Should be arm64 native, not x86_64 running under Rosetta
+        if "x86_64" in output and "arm64" not in output:
+            pytest.fail(
+                f"Binary is x86_64 only (would run under Rosetta). "
+                f"Expected ARM64 native build.\n"
+                f"file output: {output}"
+            )
+
+        # Accept: arm64, universal (arm64 + x86_64), or Mach-O 64-bit arm64
+        assert "arm64" in output or "universal" in output.lower(), (
+            f"Binary architecture unclear. Expected arm64.\nfile output: {output}"
+        )

--- a/tests/e2e/test_binary_platform.py
+++ b/tests/e2e/test_binary_platform.py
@@ -1,0 +1,187 @@
+"""
+E2E Tests — Binary Platform Compatibility
+
+Verifies platform-specific binary behavior for Windows and macOS,
+including AV compatibility, keyring integration, and path handling.
+"""
+
+import os
+import platform
+import shutil
+import subprocess
+import tempfile
+
+import pytest
+
+pytestmark = [pytest.mark.e2e]
+
+
+def _is_windows() -> bool:
+    return platform.system() == "Windows"
+
+
+def _is_macos() -> bool:
+    return platform.system() == "Darwin"
+
+
+class TestBinaryPlatform:
+    """Platform-specific binary tests — only for Windows/macOS profiles."""
+
+    def test_binary_executes_without_av_block(self, credential_process_binary):
+        """Binary starts and returns version without being blocked by AV."""
+        result = subprocess.run(
+            [str(credential_process_binary), "--version"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        assert result.returncode == 0, (
+            f"Binary failed to execute (possible AV block)\n"
+            f"exit: {result.returncode}\n"
+            f"stderr: {result.stderr}\n"
+            f"stdout: {result.stdout}"
+        )
+
+        # Should output some version string
+        output = result.stdout + result.stderr
+        assert output.strip(), "No version output produced"
+
+    @pytest.mark.skipif(not _is_windows(), reason="Windows-only test")
+    def test_cmd_fallback_when_exe_missing(self, credential_process_binary):
+        """On Windows, .cmd wrapper works when .exe is temporarily renamed."""
+        exe_path = str(credential_process_binary)
+        if not exe_path.endswith(".exe"):
+            pytest.skip("Not an .exe binary")
+
+        cmd_path = exe_path.replace(".exe", ".cmd")
+        if not os.path.exists(cmd_path):
+            pytest.skip(".cmd wrapper not found")
+
+        # Temporarily rename the .exe
+        backup_path = exe_path + ".bak"
+        try:
+            os.rename(exe_path, backup_path)
+
+            result = subprocess.run(
+                [cmd_path, "--version"],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                shell=True,
+            )
+
+            assert result.returncode == 0, (
+                f".cmd fallback failed: {result.stderr}"
+            )
+        finally:
+            # Restore the .exe
+            if os.path.exists(backup_path):
+                os.rename(backup_path, exe_path)
+
+    def test_keyring_store_and_retrieve(self, credential_process_binary, e2e_profile):
+        """Token can be stored in and retrieved from the keyring."""
+        platform_name = e2e_profile["platform"]
+        if "linux" in platform_name:
+            pytest.skip("Keyring tests for Windows/macOS only")
+
+        test_token = f"e2e-test-token-{os.getpid()}"
+
+        # Store token
+        store_result = subprocess.run(
+            [str(credential_process_binary), "--keyring-store", "--token", test_token],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+
+        if store_result.returncode != 0 and "keyring" in store_result.stderr.lower():
+            pytest.skip(f"Keyring not available: {store_result.stderr}")
+
+        assert store_result.returncode == 0, (
+            f"Keyring store failed: {store_result.stderr}"
+        )
+
+        # Retrieve token
+        retrieve_result = subprocess.run(
+            [str(credential_process_binary), "--keyring-retrieve"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+
+        assert retrieve_result.returncode == 0, (
+            f"Keyring retrieve failed: {retrieve_result.stderr}"
+        )
+        assert test_token in retrieve_result.stdout, (
+            f"Retrieved token doesn't match stored token"
+        )
+
+    def test_keyring_chunking_large_token(self, credential_process_binary, e2e_profile):
+        """Large token (2400+ chars) roundtrips correctly via keyring chunking."""
+        platform_name = e2e_profile["platform"]
+        if "linux" in platform_name:
+            pytest.skip("Keyring tests for Windows/macOS only")
+
+        # Generate a large token (2500 chars)
+        large_token = "e2e-large-" + "A" * 2490
+
+        # Store large token
+        store_result = subprocess.run(
+            [str(credential_process_binary), "--keyring-store", "--token", large_token],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+
+        if store_result.returncode != 0 and "keyring" in store_result.stderr.lower():
+            pytest.skip(f"Keyring not available: {store_result.stderr}")
+
+        assert store_result.returncode == 0, (
+            f"Keyring store (large) failed: {store_result.stderr}"
+        )
+
+        # Retrieve and verify
+        retrieve_result = subprocess.run(
+            [str(credential_process_binary), "--keyring-retrieve"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+
+        assert retrieve_result.returncode == 0, (
+            f"Keyring retrieve (large) failed: {retrieve_result.stderr}"
+        )
+        assert large_token in retrieve_result.stdout, (
+            f"Large token not preserved after chunked keyring roundtrip. "
+            f"Expected 2500 chars, got {len(retrieve_result.stdout.strip())} chars"
+        )
+
+    def test_paths_handle_spaces(self, credential_process_binary, e2e_profile):
+        """Binary works when installed in a path with spaces."""
+        # Create temp dir with spaces in name
+        space_dir = tempfile.mkdtemp(prefix="E2E Program Files ")
+
+        try:
+            binary_name = os.path.basename(str(credential_process_binary))
+            space_binary = os.path.join(space_dir, binary_name)
+
+            # Copy binary to spaced path
+            shutil.copy2(str(credential_process_binary), space_binary)
+
+            if not _is_windows():
+                os.chmod(space_binary, 0o755)
+
+            # Execute from spaced path
+            result = subprocess.run(
+                [space_binary, "--version"],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+
+            assert result.returncode == 0, (
+                f"Binary in spaced path failed (exit {result.returncode}): {result.stderr}"
+            )
+        finally:
+            shutil.rmtree(space_dir, ignore_errors=True)

--- a/tests/e2e/test_config_delivery.py
+++ b/tests/e2e/test_config_delivery.py
@@ -1,0 +1,149 @@
+"""
+E2E Tests — Config Delivery (Bootstrap Endpoint)
+
+Verifies the bootstrap config endpoint returns valid configuration,
+handles token validation, and includes OTLP headers.
+"""
+
+import json
+import time
+
+import jwt
+import pytest
+import requests
+
+pytestmark = [pytest.mark.e2e]
+
+
+@pytest.fixture
+def bootstrap_url(stack_outputs):
+    """Get bootstrap config endpoint URL from stack outputs."""
+    url = stack_outputs.get("BootstrapConfigUrl") or stack_outputs.get("ConfigEndpoint")
+    if not url:
+        pytest.skip("Bootstrap config URL not in stack outputs")
+    return url
+
+
+@pytest.fixture
+def valid_token(run_credential_process):
+    """Get a valid bearer token from the credential process."""
+    result = run_credential_process(
+        context="initial",
+        extra_args=["--token-only"],
+    )
+    if result.returncode != 0:
+        # Fallback: extract from explain
+        result = run_credential_process(extra_args=["--explain"])
+        if result.returncode == 0:
+            explain = json.loads(result.stdout)
+            token = explain.get("auth", {}).get("id_token")
+            if token:
+                return token
+        pytest.skip("Cannot obtain valid token for bootstrap tests")
+    return result.stdout.strip()
+
+
+class TestConfigDelivery:
+    """Config delivery tests — only for profiles with config_delivery=bootstrap."""
+
+    def test_bootstrap_endpoint_reachable(self, bootstrap_url, valid_token):
+        """GET /config with valid Bearer token returns 200."""
+        response = requests.get(
+            bootstrap_url,
+            headers={"Authorization": f"Bearer {valid_token}"},
+            timeout=15,
+        )
+
+        assert response.status_code == 200, (
+            f"Bootstrap endpoint returned {response.status_code}: {response.text[:200]}"
+        )
+
+    def test_bootstrap_returns_valid_config(self, bootstrap_url, valid_token):
+        """Response contains required config keys."""
+        response = requests.get(
+            bootstrap_url,
+            headers={"Authorization": f"Bearer {valid_token}"},
+            timeout=15,
+        )
+        assert response.status_code == 200
+
+        config = response.json()
+
+        required_keys = ["inferenceProvider", "inferenceRegion", "inferenceModels"]
+        for key in required_keys:
+            assert key in config, f"Missing required config key: {key}"
+
+        # Validate types
+        assert isinstance(config["inferenceProvider"], str)
+        assert isinstance(config["inferenceRegion"], str)
+        assert isinstance(config["inferenceModels"], list)
+        assert len(config["inferenceModels"]) > 0, "inferenceModels is empty"
+
+    def test_bootstrap_includes_otlp_headers(self, bootstrap_url, valid_token):
+        """Response includes otlpHeaders with x-user-email."""
+        response = requests.get(
+            bootstrap_url,
+            headers={"Authorization": f"Bearer {valid_token}"},
+            timeout=15,
+        )
+        assert response.status_code == 200
+
+        config = response.json()
+
+        otlp_headers = config.get("otlpHeaders", {})
+        assert otlp_headers, "otlpHeaders missing from config response"
+
+        # Check for user email header (case-insensitive)
+        header_keys_lower = {k.lower(): v for k, v in otlp_headers.items()}
+        assert "x-user-email" in header_keys_lower, (
+            f"otlpHeaders missing x-user-email. Keys: {list(otlp_headers.keys())}"
+        )
+
+    def test_bootstrap_rejects_expired_token(self, bootstrap_url):
+        """Expired JWT returns 401."""
+        # Create an expired JWT (not cryptographically valid but expired)
+        expired_token = jwt.encode(
+            {
+                "sub": "e2e-test-user",
+                "exp": int(time.time()) - 3600,  # 1 hour ago
+                "iat": int(time.time()) - 7200,
+                "iss": "e2e-test",
+            },
+            "fake-secret-for-e2e",
+            algorithm="HS256",
+        )
+
+        response = requests.get(
+            bootstrap_url,
+            headers={"Authorization": f"Bearer {expired_token}"},
+            timeout=15,
+        )
+
+        assert response.status_code == 401, (
+            f"Expired token should return 401, got {response.status_code}"
+        )
+
+    def test_bootstrap_rejects_wrong_audience(self, bootstrap_url):
+        """JWT with wrong audience returns 403."""
+        # Create a JWT with wrong audience
+        wrong_aud_token = jwt.encode(
+            {
+                "sub": "e2e-test-user",
+                "exp": int(time.time()) + 3600,
+                "iat": int(time.time()),
+                "iss": "e2e-test",
+                "aud": "wrong-audience-value",
+            },
+            "fake-secret-for-e2e",
+            algorithm="HS256",
+        )
+
+        response = requests.get(
+            bootstrap_url,
+            headers={"Authorization": f"Bearer {wrong_aud_token}"},
+            timeout=15,
+        )
+
+        assert response.status_code in (401, 403), (
+            f"Wrong audience should return 401 or 403, got {response.status_code}"
+        )

--- a/tests/e2e/test_config_delivery.py
+++ b/tests/e2e/test_config_delivery.py
@@ -12,7 +12,7 @@ import jwt
 import pytest
 import requests
 
-pytestmark = [pytest.mark.e2e]
+pytestmark = [pytest.mark.e2e, pytest.mark.timeout(30)]
 
 
 @pytest.fixture

--- a/tests/e2e/test_credential_output.py
+++ b/tests/e2e/test_credential_output.py
@@ -1,0 +1,82 @@
+"""
+E2E Tests — Credential Output Format
+
+Verifies the credential-process binary output conforms to the
+AWS credential_process specification (Version=1).
+"""
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+pytestmark = [pytest.mark.e2e]
+
+
+class TestCredentialOutput:
+    """Credential output format tests — run for all profiles."""
+
+    def test_output_matches_aws_credential_process_spec(self, run_credential_process):
+        """Output has Version=1 and all required keys per AWS spec."""
+        result = run_credential_process(context="initial")
+        assert result.returncode == 0, f"Exit {result.returncode}: {result.stderr}"
+
+        creds = json.loads(result.stdout)
+
+        # AWS credential_process spec requires these keys
+        assert creds.get("Version") == 1, (
+            f"Expected Version=1, got {creds.get('Version')}"
+        )
+
+        required_keys = ["AccessKeyId", "SecretAccessKey", "SessionToken", "Expiration"]
+        for key in required_keys:
+            assert key in creds, f"Missing required key: {key}"
+
+    def test_expiration_is_future(self, run_credential_process):
+        """Expiration timestamp is in the future."""
+        result = run_credential_process(context="initial")
+        assert result.returncode == 0
+
+        creds = json.loads(result.stdout)
+        expiration_str = creds["Expiration"]
+
+        # Parse ISO 8601 timestamp
+        # Handle both Z suffix and +00:00 format
+        expiration_str = expiration_str.replace("Z", "+00:00")
+        expiration = datetime.fromisoformat(expiration_str)
+
+        now = datetime.now(timezone.utc)
+        assert expiration > now, (
+            f"Expiration {expiration} is not in the future (now={now})"
+        )
+
+    def test_session_token_present(self, run_credential_process):
+        """SessionToken is present and non-empty."""
+        result = run_credential_process(context="initial")
+        assert result.returncode == 0
+
+        creds = json.loads(result.stdout)
+        session_token = creds.get("SessionToken", "")
+
+        assert session_token, "SessionToken is empty"
+        assert len(session_token) > 50, (
+            f"SessionToken suspiciously short ({len(session_token)} chars)"
+        )
+
+    def test_no_sensitive_data_on_stderr(self, run_credential_process):
+        """stderr does not leak AccessKeyId or SecretAccessKey."""
+        result = run_credential_process(context="initial")
+        assert result.returncode == 0
+
+        creds = json.loads(result.stdout)
+        access_key = creds["AccessKeyId"]
+        secret_key = creds["SecretAccessKey"]
+
+        stderr_lower = result.stderr.lower()
+
+        assert access_key.lower() not in stderr_lower, (
+            "AccessKeyId leaked to stderr"
+        )
+        assert secret_key.lower() not in stderr_lower, (
+            "SecretAccessKey leaked to stderr"
+        )

--- a/tests/e2e/test_credential_output.py
+++ b/tests/e2e/test_credential_output.py
@@ -10,7 +10,7 @@ from datetime import datetime, timezone
 
 import pytest
 
-pytestmark = [pytest.mark.e2e]
+pytestmark = [pytest.mark.e2e, pytest.mark.timeout(30)]
 
 
 class TestCredentialOutput:

--- a/tests/e2e/test_credential_output.py
+++ b/tests/e2e/test_credential_output.py
@@ -74,9 +74,7 @@ class TestCredentialOutput:
 
         stderr_lower = result.stderr.lower()
 
-        assert access_key.lower() not in stderr_lower, (
-            "AccessKeyId leaked to stderr"
-        )
+        assert access_key.lower() not in stderr_lower, "AccessKeyId leaked to stderr"
         assert secret_key.lower() not in stderr_lower, (
             "SecretAccessKey leaked to stderr"
         )

--- a/tests/e2e/test_error_messages.py
+++ b/tests/e2e/test_error_messages.py
@@ -1,0 +1,191 @@
+"""
+E2E Tests — Error Message Regression
+
+Validates that stderr messages for common failure scenarios remain
+stable and helpful. Prevents confusing UX drift for end users.
+
+These are snapshot-style tests: if the error message changes intentionally,
+update the expected substring. Unintentional changes fail the test.
+"""
+
+import subprocess
+
+import pytest
+
+pytestmark = [pytest.mark.e2e, pytest.mark.timeout(15)]
+
+
+class TestErrorMessages:
+    """Validate error messages for common failure scenarios."""
+
+    def test_missing_config_file_message(
+        self, credential_process_binary, isolated_config_dir
+    ):
+        """Missing config file produces a clear, actionable error."""
+        env = {
+            "CCWB_CONFIG_DIR": str(isolated_config_dir / "nonexistent"),
+            "PATH": "",
+        }
+        result = subprocess.run(
+            [str(credential_process_binary)],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env=env,
+        )
+        assert result.returncode != 0
+        stderr_lower = result.stderr.lower()
+        # Should mention config file and how to fix
+        assert any(
+            phrase in stderr_lower
+            for phrase in [
+                "config",
+                "not found",
+                "no such file",
+                "initialize",
+                "ccwb init",
+            ]
+        ), f"Unhelpful error for missing config: {result.stderr[:200]}"
+
+    def test_invalid_config_format_message(
+        self, credential_process_binary, isolated_config_dir
+    ):
+        """Malformed config produces a parse error, not a crash."""
+        config_dir = isolated_config_dir / "bad_config"
+        config_dir.mkdir(exist_ok=True)
+        (config_dir / "config.yaml").write_text("not: [valid: yaml: {{{}}")
+
+        env = {"CCWB_CONFIG_DIR": str(config_dir)}
+        result = subprocess.run(
+            [str(credential_process_binary)],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env=env,
+        )
+        assert result.returncode != 0
+        stderr_lower = result.stderr.lower()
+        assert any(
+            phrase in stderr_lower
+            for phrase in ["parse", "invalid", "yaml", "syntax", "config"]
+        ), f"Unhelpful error for bad config: {result.stderr[:200]}"
+
+    def test_unreachable_oidc_endpoint_message(
+        self, credential_process_binary, isolated_config_dir
+    ):
+        """Unreachable OIDC provider produces a timeout/connection error, not a crash."""
+        config_dir = isolated_config_dir / "unreachable_oidc"
+        config_dir.mkdir(exist_ok=True)
+        # Write a config pointing to an unreachable endpoint
+
+        config = {
+            "auth_type": "oidc",
+            "oidc_issuer": "https://192.0.2.1:9999/unreachable",  # RFC 5737 TEST-NET
+            "client_id": "test-client",
+            "federation": "direct",
+            "region": "us-east-1",
+        }
+        (config_dir / "config.yaml").write_text(
+            "\n".join(f"{k}: {v}" for k, v in config.items())
+        )
+
+        env = {"CCWB_CONFIG_DIR": str(config_dir)}
+        result = subprocess.run(
+            [str(credential_process_binary)],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            env=env,
+        )
+        assert result.returncode != 0
+        stderr_lower = result.stderr.lower()
+        assert any(
+            phrase in stderr_lower
+            for phrase in ["timeout", "connection", "unreachable", "dial", "connect"]
+        ), f"Unhelpful error for unreachable OIDC: {result.stderr[:200]}"
+
+    def test_expired_token_no_refresh_message(
+        self, credential_process_binary, isolated_config_dir
+    ):
+        """Expired token with no refresh token available produces auth-required message."""
+        config_dir = isolated_config_dir / "expired_no_refresh"
+        config_dir.mkdir(exist_ok=True)
+        # Create a token cache with an expired token and no refresh token
+        cache_dir = config_dir / "cache"
+        cache_dir.mkdir(exist_ok=True)
+
+        import json
+        import time
+
+        expired_cache = {
+            "access_token": "expired.token.value",
+            "expires_at": int(time.time()) - 3600,  # Expired 1 hour ago
+            "token_type": "Bearer",
+        }
+        (cache_dir / "token_cache.json").write_text(json.dumps(expired_cache))
+
+        env = {
+            "CCWB_CONFIG_DIR": str(config_dir),
+            "CCWB_CACHE_DIR": str(cache_dir),
+        }
+        result = subprocess.run(
+            [str(credential_process_binary)],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env=env,
+        )
+        assert result.returncode != 0
+        stderr_lower = result.stderr.lower()
+        assert any(
+            phrase in stderr_lower
+            for phrase in ["expired", "re-authenticate", "login", "refresh", "browser"]
+        ), f"Unhelpful error for expired token: {result.stderr[:200]}"
+
+    def test_version_flag_output(self, credential_process_binary):
+        """--version produces clean version string, not an error."""
+        result = subprocess.run(
+            [str(credential_process_binary), "--version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        assert result.returncode == 0, f"--version failed: {result.stderr}"
+        # Should contain a version-like string
+        version = result.stdout.strip()
+        assert version, "--version produced empty output"
+        assert "error" not in version.lower(), (
+            f"--version looks like an error: {version}"
+        )
+
+    def test_help_flag_output(self, credential_process_binary):
+        """--help produces usage info, not an error."""
+        result = subprocess.run(
+            [str(credential_process_binary), "--help"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        # Some CLIs exit 0 for help, some exit 2 — both are fine
+        assert result.returncode in (0, 2), (
+            f"--help exited {result.returncode}: {result.stderr}"
+        )
+        output = result.stdout + result.stderr
+        assert any(
+            phrase in output.lower()
+            for phrase in ["usage", "help", "credential", "options", "flags"]
+        ), f"--help doesn't look helpful: {output[:200]}"
+
+    def test_unknown_flag_message(self, credential_process_binary):
+        """Unknown flag produces a clear error mentioning the bad flag."""
+        result = subprocess.run(
+            [str(credential_process_binary), "--nonexistent-flag-xyz"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        assert result.returncode != 0
+        output = result.stdout + result.stderr
+        assert (
+            "nonexistent-flag-xyz" in output.lower() or "unknown" in output.lower()
+        ), f"Unknown flag error doesn't mention the flag: {output[:200]}"

--- a/tests/e2e/test_error_messages.py
+++ b/tests/e2e/test_error_messages.py
@@ -8,7 +8,10 @@ These are snapshot-style tests: if the error message changes intentionally,
 update the expected substring. Unintentional changes fail the test.
 """
 
+import json
+import os
 import subprocess
+import time
 
 import pytest
 
@@ -22,10 +25,8 @@ class TestErrorMessages:
         self, credential_process_binary, isolated_config_dir
     ):
         """Missing config file produces a clear, actionable error."""
-        env = {
-            "CCWB_CONFIG_DIR": str(isolated_config_dir / "nonexistent"),
-            "PATH": "",
-        }
+        env = os.environ.copy()
+        env["CCWB_CONFIG_DIR"] = str(isolated_config_dir / "nonexistent")
         result = subprocess.run(
             [str(credential_process_binary)],
             capture_output=True,
@@ -55,7 +56,8 @@ class TestErrorMessages:
         config_dir.mkdir(exist_ok=True)
         (config_dir / "config.yaml").write_text("not: [valid: yaml: {{{}}")
 
-        env = {"CCWB_CONFIG_DIR": str(config_dir)}
+        env = os.environ.copy()
+        env["CCWB_CONFIG_DIR"] = str(config_dir)
         result = subprocess.run(
             [str(credential_process_binary)],
             capture_output=True,
@@ -89,7 +91,8 @@ class TestErrorMessages:
             "\n".join(f"{k}: {v}" for k, v in config.items())
         )
 
-        env = {"CCWB_CONFIG_DIR": str(config_dir)}
+        env = os.environ.copy()
+        env["CCWB_CONFIG_DIR"] = str(config_dir)
         result = subprocess.run(
             [str(credential_process_binary)],
             capture_output=True,
@@ -114,9 +117,6 @@ class TestErrorMessages:
         cache_dir = config_dir / "cache"
         cache_dir.mkdir(exist_ok=True)
 
-        import json
-        import time
-
         expired_cache = {
             "access_token": "expired.token.value",
             "expires_at": int(time.time()) - 3600,  # Expired 1 hour ago
@@ -124,10 +124,9 @@ class TestErrorMessages:
         }
         (cache_dir / "token_cache.json").write_text(json.dumps(expired_cache))
 
-        env = {
-            "CCWB_CONFIG_DIR": str(config_dir),
-            "CCWB_CACHE_DIR": str(cache_dir),
-        }
+        env = os.environ.copy()
+        env["CCWB_CONFIG_DIR"] = str(config_dir)
+        env["CCWB_CACHE_DIR"] = str(cache_dir)
         result = subprocess.run(
             [str(credential_process_binary)],
             capture_output=True,

--- a/tests/e2e/test_explain_contract.py
+++ b/tests/e2e/test_explain_contract.py
@@ -1,0 +1,181 @@
+"""
+E2E Tests — --explain Contract Validation
+
+Verifies that credential-process --explain output matches the expected
+schema for each profile. Catches unintended config drift or field renames.
+"""
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = [pytest.mark.e2e, pytest.mark.timeout(10)]
+
+# Required top-level keys in --explain output
+REQUIRED_KEYS = {
+    "version",
+    "commit",
+    "profile",
+    "platform",
+    "auth",
+    "monitoring",
+    "quota",
+    "storage",
+    "paths",
+}
+
+# Required nested keys per section
+REQUIRED_AUTH_KEYS = {"mode", "reason"}
+REQUIRED_MONITORING_KEYS = {"enabled", "mode", "config_delivery"}
+REQUIRED_QUOTA_KEYS = {"enabled", "fail_mode", "auth_method"}
+REQUIRED_STORAGE_KEYS = {"mode"}
+REQUIRED_PLATFORM_KEYS = {"os", "arch"}
+REQUIRED_PATHS_KEYS = {"config_dir", "config_file"}
+
+
+class TestExplainContract:
+    """Validate --explain JSON schema matches expectations per profile."""
+
+    def test_explain_returns_valid_json(self, credential_process_binary):
+        """--explain exits 0 with parseable JSON."""
+        result = subprocess.run(
+            [str(credential_process_binary), "--explain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0, (
+            f"--explain exited {result.returncode}: {result.stderr}"
+        )
+        data = json.loads(result.stdout)
+        assert isinstance(data, dict)
+
+    def test_explain_has_required_top_level_keys(self, credential_process_binary):
+        """All required top-level sections present."""
+        result = subprocess.run(
+            [str(credential_process_binary), "--explain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        data = json.loads(result.stdout)
+        missing = REQUIRED_KEYS - set(data.keys())
+        assert not missing, f"Missing top-level keys in --explain: {missing}"
+
+    def test_explain_auth_section(self, credential_process_binary, e2e_profile):
+        """auth section has required keys and mode matches profile."""
+        result = subprocess.run(
+            [str(credential_process_binary), "--explain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        data = json.loads(result.stdout)
+        auth = data["auth"]
+
+        missing = REQUIRED_AUTH_KEYS - set(auth.keys())
+        assert not missing, f"Missing auth keys: {missing}"
+
+        # Mode should match profile declaration
+        expected_mode = e2e_profile["auth"]["type"]
+        assert auth["mode"] == expected_mode, (
+            f"--explain auth.mode={auth['mode']} but profile declares auth.type={expected_mode}"
+        )
+
+    def test_explain_monitoring_section(self, credential_process_binary, e2e_profile):
+        """monitoring section has required keys and mode matches profile."""
+        result = subprocess.run(
+            [str(credential_process_binary), "--explain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        data = json.loads(result.stdout)
+        monitoring = data["monitoring"]
+
+        missing = REQUIRED_MONITORING_KEYS - set(monitoring.keys())
+        assert not missing, f"Missing monitoring keys: {missing}"
+
+        expected_mode = e2e_profile["monitoring"]["mode"]
+        assert monitoring["mode"] == expected_mode, (
+            f"--explain monitoring.mode={monitoring['mode']} but profile declares {expected_mode}"
+        )
+
+    def test_explain_quota_section(self, credential_process_binary, e2e_profile):
+        """quota section has required keys and enabled matches profile."""
+        result = subprocess.run(
+            [str(credential_process_binary), "--explain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        data = json.loads(result.stdout)
+        quota = data["quota"]
+
+        missing = REQUIRED_QUOTA_KEYS - set(quota.keys())
+        assert not missing, f"Missing quota keys: {missing}"
+
+        expected_enabled = e2e_profile["quota"]["enabled"]
+        assert quota["enabled"] == expected_enabled, (
+            f"--explain quota.enabled={quota['enabled']} but profile declares {expected_enabled}"
+        )
+
+    def test_explain_platform_section(self, credential_process_binary):
+        """platform section has os and arch."""
+        result = subprocess.run(
+            [str(credential_process_binary), "--explain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        data = json.loads(result.stdout)
+        platform = data["platform"]
+
+        missing = REQUIRED_PLATFORM_KEYS - set(platform.keys())
+        assert not missing, f"Missing platform keys: {missing}"
+
+        # OS should match the actual runtime
+        expected_os = (
+            "windows"
+            if sys.platform == "win32"
+            else ("darwin" if sys.platform == "darwin" else "linux")
+        )
+        assert platform["os"] == expected_os, (
+            f"Platform OS mismatch: {platform['os']} vs {expected_os}"
+        )
+
+    def test_explain_version_and_commit(self, credential_process_binary):
+        """version and commit fields are non-empty strings."""
+        result = subprocess.run(
+            [str(credential_process_binary), "--explain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        data = json.loads(result.stdout)
+
+        assert data["version"], "version field is empty"
+        assert data["commit"], "commit field is empty"
+        assert data["version"] != "dev" or data["commit"] != "unknown", (
+            "Binary appears to be a development build (version=dev, commit=unknown)"
+        )
+
+    def test_explain_config_delivery_matches_profile(
+        self, credential_process_binary, e2e_profile
+    ):
+        """config_delivery field matches profile declaration."""
+        result = subprocess.run(
+            [str(credential_process_binary), "--explain"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        data = json.loads(result.stdout)
+
+        expected = e2e_profile.get("config_delivery", "static")
+        actual = data["monitoring"].get("config_delivery", "static")
+        assert actual == expected, (
+            f"--explain config_delivery={actual} but profile declares {expected}"
+        )

--- a/tests/e2e/test_monitoring_pipeline.py
+++ b/tests/e2e/test_monitoring_pipeline.py
@@ -13,7 +13,7 @@ import time
 import pytest
 import requests
 
-pytestmark = [pytest.mark.e2e]
+pytestmark = [pytest.mark.e2e, pytest.mark.timeout(30)]
 
 
 def _get_monitoring_port(profile: dict) -> int:
@@ -170,6 +170,7 @@ class TestMonitoringPipeline:
                 pytest.skip("OTEL headers cache not found (may not be applicable)")
 
     @pytest.mark.slow
+    @pytest.mark.timeout(120)
     def test_metric_arrives_in_cloudwatch(
         self,
         run_credential_process,

--- a/tests/e2e/test_monitoring_pipeline.py
+++ b/tests/e2e/test_monitoring_pipeline.py
@@ -7,7 +7,6 @@ self-heals, and delivers metrics to CloudWatch.
 
 import json
 import os
-import signal
 import subprocess
 import time
 
@@ -46,7 +45,9 @@ class TestMonitoringPipeline:
             f"OTLP proxy port {port} not listening after auth"
         )
 
-    def test_otlp_post_accepted(self, run_credential_process, wait_for_port, e2e_profile):
+    def test_otlp_post_accepted(
+        self, run_credential_process, wait_for_port, e2e_profile
+    ):
         """POST sample metric to OTLP proxy returns 200."""
         port = _get_monitoring_port(e2e_profile)
 
@@ -59,7 +60,14 @@ class TestMonitoringPipeline:
         sample_metric = {
             "resourceMetrics": [
                 {
-                    "resource": {"attributes": [{"key": "service.name", "value": {"stringValue": "e2e-test"}}]},
+                    "resource": {
+                        "attributes": [
+                            {
+                                "key": "service.name",
+                                "value": {"stringValue": "e2e-test"},
+                            }
+                        ]
+                    },
                     "scopeMetrics": [
                         {
                             "metrics": [
@@ -69,7 +77,9 @@ class TestMonitoringPipeline:
                                         "dataPoints": [
                                             {
                                                 "asInt": "1",
-                                                "timeUnixNano": str(int(time.time() * 1e9)),
+                                                "timeUnixNano": str(
+                                                    int(time.time() * 1e9)
+                                                ),
                                             }
                                         ]
                                     },
@@ -105,7 +115,7 @@ class TestMonitoringPipeline:
 
         # Find and kill the proxy process
         try:
-            kill_result = subprocess.run(
+            subprocess.run(
                 ["pkill", "-f", "otel-helper"],
                 capture_output=True,
                 timeout=5,
@@ -125,9 +135,7 @@ class TestMonitoringPipeline:
             f"Proxy did not self-heal: port {port} not listening after restart"
         )
 
-    def test_otel_headers_cache_populated(
-        self, run_credential_process, e2e_profile
-    ):
+    def test_otel_headers_cache_populated(self, run_credential_process, e2e_profile):
         """OTEL headers cache file exists and contains x-user-email."""
         result = run_credential_process(context="initial")
         assert result.returncode == 0
@@ -183,7 +191,11 @@ class TestMonitoringPipeline:
         sample_metric = {
             "resourceMetrics": [
                 {
-                    "resource": {"attributes": [{"key": "service.name", "value": {"stringValue": test_id}}]},
+                    "resource": {
+                        "attributes": [
+                            {"key": "service.name", "value": {"stringValue": test_id}}
+                        ]
+                    },
                     "scopeMetrics": [
                         {
                             "metrics": [
@@ -193,7 +205,9 @@ class TestMonitoringPipeline:
                                         "dataPoints": [
                                             {
                                                 "asInt": "42",
-                                                "timeUnixNano": str(int(time.time() * 1e9)),
+                                                "timeUnixNano": str(
+                                                    int(time.time() * 1e9)
+                                                ),
                                             }
                                         ]
                                     },

--- a/tests/e2e/test_monitoring_pipeline.py
+++ b/tests/e2e/test_monitoring_pipeline.py
@@ -1,0 +1,225 @@
+"""
+E2E Tests — Monitoring Pipeline (OTLP Proxy)
+
+Verifies the otel-helper proxy starts, accepts OTLP data,
+self-heals, and delivers metrics to CloudWatch.
+"""
+
+import json
+import os
+import signal
+import subprocess
+import time
+
+import pytest
+import requests
+
+pytestmark = [pytest.mark.e2e]
+
+
+def _get_monitoring_port(profile: dict) -> int:
+    """Get expected OTLP port based on monitoring mode."""
+    mode = profile.get("monitoring", {}).get("mode", "none")
+    if mode == "central":
+        return 4318
+    elif mode == "sidecar":
+        return 4319
+    else:
+        pytest.skip("Monitoring mode is 'none' — skipping monitoring tests")
+
+
+class TestMonitoringPipeline:
+    """Monitoring pipeline tests — only for profiles with monitoring.mode != 'none'."""
+
+    def test_proxy_starts_after_auth(
+        self, run_credential_process, wait_for_port, e2e_profile
+    ):
+        """OTLP proxy port is listening after credential-process auth."""
+        port = _get_monitoring_port(e2e_profile)
+
+        # Run credential process to trigger proxy start
+        result = run_credential_process(context="initial")
+        assert result.returncode == 0, f"Auth failed: {result.stderr}"
+
+        # Wait for proxy port
+        assert wait_for_port(port, timeout=15), (
+            f"OTLP proxy port {port} not listening after auth"
+        )
+
+    def test_otlp_post_accepted(self, run_credential_process, wait_for_port, e2e_profile):
+        """POST sample metric to OTLP proxy returns 200."""
+        port = _get_monitoring_port(e2e_profile)
+
+        # Ensure proxy is running
+        result = run_credential_process(context="initial")
+        assert result.returncode == 0
+        assert wait_for_port(port, timeout=15)
+
+        # POST a sample OTLP metric
+        sample_metric = {
+            "resourceMetrics": [
+                {
+                    "resource": {"attributes": [{"key": "service.name", "value": {"stringValue": "e2e-test"}}]},
+                    "scopeMetrics": [
+                        {
+                            "metrics": [
+                                {
+                                    "name": "e2e.test.counter",
+                                    "sum": {
+                                        "dataPoints": [
+                                            {
+                                                "asInt": "1",
+                                                "timeUnixNano": str(int(time.time() * 1e9)),
+                                            }
+                                        ]
+                                    },
+                                }
+                            ]
+                        }
+                    ],
+                }
+            ]
+        }
+
+        response = requests.post(
+            f"http://127.0.0.1:{port}/v1/metrics",
+            json=sample_metric,
+            headers={"Content-Type": "application/json"},
+            timeout=10,
+        )
+
+        assert response.status_code == 200, (
+            f"OTLP POST returned {response.status_code}: {response.text}"
+        )
+
+    def test_proxy_self_healing(
+        self, run_credential_process, wait_for_port, e2e_profile
+    ):
+        """After killing the proxy, re-running credential-process restarts it."""
+        port = _get_monitoring_port(e2e_profile)
+
+        # Start proxy via auth
+        result = run_credential_process(context="initial")
+        assert result.returncode == 0
+        assert wait_for_port(port, timeout=15)
+
+        # Find and kill the proxy process
+        try:
+            kill_result = subprocess.run(
+                ["pkill", "-f", "otel-helper"],
+                capture_output=True,
+                timeout=5,
+            )
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            pytest.skip("Cannot kill proxy process on this platform")
+
+        # Give it a moment to die
+        time.sleep(1)
+
+        # Re-run credential process — should restart proxy
+        result = run_credential_process(context="initial")
+        assert result.returncode == 0
+
+        # Proxy should be back
+        assert wait_for_port(port, timeout=15), (
+            f"Proxy did not self-heal: port {port} not listening after restart"
+        )
+
+    def test_otel_headers_cache_populated(
+        self, run_credential_process, e2e_profile
+    ):
+        """OTEL headers cache file exists and contains x-user-email."""
+        result = run_credential_process(context="initial")
+        assert result.returncode == 0
+
+        # Check common cache locations
+        home = os.path.expanduser("~")
+        cache_paths = [
+            os.path.join(home, ".ccwb", "otel-headers.json"),
+            os.path.join(home, ".config", "ccwb", "otel-headers.json"),
+            "/tmp/ccwb-otel-headers.json",
+        ]
+
+        cache_found = False
+        for cache_path in cache_paths:
+            if os.path.exists(cache_path):
+                with open(cache_path) as f:
+                    headers = json.load(f)
+                assert "x-user-email" in headers or "X-User-Email" in headers, (
+                    f"Cache at {cache_path} missing x-user-email header"
+                )
+                cache_found = True
+                break
+
+        if not cache_found:
+            # Check stderr for cache path hint
+            if "otel-headers" in result.stderr:
+                pytest.fail(
+                    f"Could not find OTEL headers cache. Tried: {cache_paths}\n"
+                    f"stderr hint: {result.stderr}"
+                )
+            else:
+                pytest.skip("OTEL headers cache not found (may not be applicable)")
+
+    @pytest.mark.slow
+    def test_metric_arrives_in_cloudwatch(
+        self,
+        run_credential_process,
+        wait_for_port,
+        query_cloudwatch_metric,
+        e2e_profile,
+        stack_outputs,
+    ):
+        """Query CloudWatch after posting metric — verifies end-to-end pipeline."""
+        port = _get_monitoring_port(e2e_profile)
+
+        # Auth and wait for proxy
+        result = run_credential_process(context="initial")
+        assert result.returncode == 0
+        assert wait_for_port(port, timeout=15)
+
+        # Post a uniquely-named metric
+        test_id = f"e2e-{int(time.time())}"
+        sample_metric = {
+            "resourceMetrics": [
+                {
+                    "resource": {"attributes": [{"key": "service.name", "value": {"stringValue": test_id}}]},
+                    "scopeMetrics": [
+                        {
+                            "metrics": [
+                                {
+                                    "name": "e2e.pipeline.verification",
+                                    "sum": {
+                                        "dataPoints": [
+                                            {
+                                                "asInt": "42",
+                                                "timeUnixNano": str(int(time.time() * 1e9)),
+                                            }
+                                        ]
+                                    },
+                                }
+                            ]
+                        }
+                    ],
+                }
+            ]
+        }
+
+        response = requests.post(
+            f"http://127.0.0.1:{port}/v1/metrics",
+            json=sample_metric,
+            headers={"Content-Type": "application/json"},
+            timeout=10,
+        )
+        assert response.status_code == 200
+
+        # Wait for metric to arrive in CloudWatch (with retry)
+        namespace = stack_outputs.get("MonitoringNamespace", "CCWB/E2E")
+
+        value = query_cloudwatch_metric(
+            namespace=namespace,
+            metric_name="e2e.pipeline.verification",
+            dimensions=[{"Name": "service.name", "Value": test_id}],
+        )
+
+        assert value >= 42, f"Expected metric sum >= 42, got {value}"

--- a/tests/e2e/test_monitoring_pipeline.py
+++ b/tests/e2e/test_monitoring_pipeline.py
@@ -171,6 +171,7 @@ class TestMonitoringPipeline:
 
     @pytest.mark.slow
     @pytest.mark.timeout(120)
+    @pytest.mark.flaky(reruns=2, reruns_delay=30)
     def test_metric_arrives_in_cloudwatch(
         self,
         run_credential_process,

--- a/tests/e2e/test_monitoring_pipeline.py
+++ b/tests/e2e/test_monitoring_pipeline.py
@@ -7,6 +7,7 @@ self-heals, and delivers metrics to CloudWatch.
 
 import json
 import os
+import tempfile
 import subprocess
 import time
 
@@ -145,7 +146,7 @@ class TestMonitoringPipeline:
         cache_paths = [
             os.path.join(home, ".ccwb", "otel-headers.json"),
             os.path.join(home, ".config", "ccwb", "otel-headers.json"),
-            "/tmp/ccwb-otel-headers.json",
+            os.path.join(tempfile.gettempdir(), "ccwb-otel-headers.json"),  # nosec B108
         ]
 
         cache_found = False

--- a/tests/e2e/test_quota_enforcement.py
+++ b/tests/e2e/test_quota_enforcement.py
@@ -9,7 +9,7 @@ import uuid
 
 import pytest
 
-pytestmark = [pytest.mark.e2e]
+pytestmark = [pytest.mark.e2e, pytest.mark.timeout(30)]
 
 
 @pytest.fixture

--- a/tests/e2e/test_quota_enforcement.py
+++ b/tests/e2e/test_quota_enforcement.py
@@ -46,6 +46,7 @@ class TestQuotaEnforcement:
             f"Under-quota user blocked (exit {result.returncode}): {result.stderr}"
         )
 
+    @pytest.mark.flaky(reruns=1, reruns_delay=5)
     def test_over_quota_blocks(
         self,
         run_credential_process,
@@ -124,6 +125,7 @@ class TestQuotaEnforcement:
             f"Quota recheck with refresh failed: {result.stderr}"
         )
 
+    @pytest.mark.flaky(reruns=1, reruns_delay=5)
     def test_fine_grained_user_policy_overrides_default(
         self,
         run_credential_process,
@@ -152,6 +154,7 @@ class TestQuotaEnforcement:
             f"User with generous per-user policy should pass: {result.stderr}"
         )
 
+    @pytest.mark.flaky(reruns=1, reruns_delay=5)
     def test_fine_grained_group_policy(
         self,
         run_credential_process,

--- a/tests/e2e/test_quota_enforcement.py
+++ b/tests/e2e/test_quota_enforcement.py
@@ -1,0 +1,204 @@
+"""
+E2E Tests — Quota Enforcement
+
+Verifies quota checking, blocking, alerting, and fine-grained
+policy enforcement via DynamoDB.
+"""
+
+import json
+import os
+import uuid
+
+import pytest
+
+pytestmark = [pytest.mark.e2e]
+
+
+@pytest.fixture
+def test_user():
+    """Generate a unique test user for quota isolation."""
+    return f"e2e-test-{uuid.uuid4().hex[:8]}@example.com"
+
+
+@pytest.fixture
+def quota_table(stack_outputs):
+    """Get DynamoDB quota table name from stack outputs."""
+    table = stack_outputs.get("QuotaTableName")
+    if not table:
+        pytest.skip("QuotaTableName not in stack outputs")
+    return table
+
+
+class TestQuotaEnforcement:
+    """Quota enforcement tests — only for profiles with quota.enabled."""
+
+    def test_under_quota_allows(
+        self, run_credential_process, seed_quota_usage, quota_table, test_user
+    ):
+        """Fresh user with low usage is allowed (exit 0)."""
+        # Seed minimal usage
+        seed_quota_usage(quota_table, test_user, tokens=10)
+
+        result = run_credential_process(
+            context="initial",
+            extra_env={"CCWB_USER_EMAIL": test_user},
+        )
+
+        assert result.returncode == 0, (
+            f"Under-quota user blocked (exit {result.returncode}): {result.stderr}"
+        )
+
+    def test_over_quota_blocks(
+        self,
+        run_credential_process,
+        seed_quota_usage,
+        quota_table,
+        test_user,
+        e2e_profile,
+    ):
+        """Over-limit user is blocked with non-zero exit (enforcement=block only)."""
+        if e2e_profile["quota"].get("enforcement") != "block":
+            pytest.skip("Only applicable for enforcement=block")
+
+        # Seed way over limit
+        seed_quota_usage(quota_table, test_user, tokens=999_999_999)
+
+        result = run_credential_process(
+            context="initial",
+            extra_env={"CCWB_USER_EMAIL": test_user},
+        )
+
+        assert result.returncode != 0, (
+            "Over-quota user should be blocked (non-zero exit)"
+        )
+        assert "quota" in result.stderr.lower() or "limit" in result.stderr.lower(), (
+            f"Expected quota-related error message, got: {result.stderr}"
+        )
+
+    def test_over_quota_alerts(
+        self,
+        run_credential_process,
+        seed_quota_usage,
+        quota_table,
+        test_user,
+        e2e_profile,
+    ):
+        """Over-limit user gets warning on stderr but still exits 0 (enforcement=alert)."""
+        if e2e_profile["quota"].get("enforcement") != "alert":
+            pytest.skip("Only applicable for enforcement=alert")
+
+        # Seed over limit
+        seed_quota_usage(quota_table, test_user, tokens=999_999_999)
+
+        result = run_credential_process(
+            context="initial",
+            extra_env={"CCWB_USER_EMAIL": test_user},
+        )
+
+        assert result.returncode == 0, (
+            f"Alert-only quota should not block (exit {result.returncode})"
+        )
+
+        # Should have warning on stderr
+        stderr_lower = result.stderr.lower()
+        assert "quota" in stderr_lower or "warning" in stderr_lower or "limit" in stderr_lower, (
+            f"Expected quota warning on stderr, got: {result.stderr}"
+        )
+
+    def test_quota_recheck_refreshes_token(
+        self, run_credential_process, seed_quota_usage, quota_table, test_user
+    ):
+        """Quota recheck with expired token triggers token refresh."""
+        seed_quota_usage(quota_table, test_user, tokens=10)
+
+        result = run_credential_process(
+            context="mid-session-refresh",
+            extra_env={
+                "CCWB_USER_EMAIL": test_user,
+                "CCWB_TOKEN_EXPIRY_OVERRIDE": "2020-01-01T00:00:00Z",
+            },
+        )
+
+        # Should still succeed (refresh + quota check)
+        assert result.returncode == 0, (
+            f"Quota recheck with refresh failed: {result.stderr}"
+        )
+
+    def test_fine_grained_user_policy_overrides_default(
+        self,
+        run_credential_process,
+        seed_quota_usage,
+        set_user_quota_policy,
+        quota_table,
+        test_user,
+        e2e_profile,
+    ):
+        """Per-user DynamoDB policy overrides default limit (fine_grained only)."""
+        if not e2e_profile["quota"].get("fine_grained"):
+            pytest.skip("Only applicable for fine_grained=true profiles")
+
+        # Seed usage that exceeds default but is under per-user limit
+        seed_quota_usage(quota_table, test_user, tokens=50_000)
+
+        # Set generous per-user policy
+        set_user_quota_policy(quota_table, test_user, limit=100_000)
+
+        result = run_credential_process(
+            context="initial",
+            extra_env={"CCWB_USER_EMAIL": test_user},
+        )
+
+        assert result.returncode == 0, (
+            f"User with generous per-user policy should pass: {result.stderr}"
+        )
+
+    def test_fine_grained_group_policy(
+        self,
+        run_credential_process,
+        seed_quota_usage,
+        set_group_quota_policy,
+        quota_table,
+        test_user,
+        e2e_profile,
+    ):
+        """Group-level DynamoDB policy applies to group members (fine_grained only)."""
+        if not e2e_profile["quota"].get("fine_grained"):
+            pytest.skip("Only applicable for fine_grained=true profiles")
+
+        test_group = f"e2e-group-{uuid.uuid4().hex[:8]}"
+
+        # Seed usage under group limit
+        seed_quota_usage(quota_table, test_user, tokens=5_000)
+
+        # Set group policy
+        set_group_quota_policy(quota_table, test_group, limit=10_000)
+
+        result = run_credential_process(
+            context="initial",
+            extra_env={
+                "CCWB_USER_EMAIL": test_user,
+                "CCWB_USER_GROUP": test_group,
+            },
+        )
+
+        assert result.returncode == 0, (
+            f"User under group quota should pass: {result.stderr}"
+        )
+
+    def test_quota_fail_open_on_api_error(
+        self, run_credential_process, test_user
+    ):
+        """When quota API is unreachable, credential-process still allows (fail-open)."""
+        result = run_credential_process(
+            context="initial",
+            extra_env={
+                "CCWB_USER_EMAIL": test_user,
+                # Point to unreachable endpoint to simulate API failure
+                "CCWB_QUOTA_ENDPOINT_OVERRIDE": "http://192.0.2.1:1/quota",
+                "CCWB_QUOTA_TIMEOUT_MS": "2000",
+            },
+        )
+
+        assert result.returncode == 0, (
+            f"Quota should fail-open when API unreachable (exit {result.returncode}): {result.stderr}"
+        )

--- a/tests/e2e/test_quota_enforcement.py
+++ b/tests/e2e/test_quota_enforcement.py
@@ -5,8 +5,6 @@ Verifies quota checking, blocking, alerting, and fine-grained
 policy enforcement via DynamoDB.
 """
 
-import json
-import os
 import uuid
 
 import pytest
@@ -101,9 +99,11 @@ class TestQuotaEnforcement:
 
         # Should have warning on stderr
         stderr_lower = result.stderr.lower()
-        assert "quota" in stderr_lower or "warning" in stderr_lower or "limit" in stderr_lower, (
-            f"Expected quota warning on stderr, got: {result.stderr}"
-        )
+        assert (
+            "quota" in stderr_lower
+            or "warning" in stderr_lower
+            or "limit" in stderr_lower
+        ), f"Expected quota warning on stderr, got: {result.stderr}"
 
     def test_quota_recheck_refreshes_token(
         self, run_credential_process, seed_quota_usage, quota_table, test_user
@@ -185,9 +185,7 @@ class TestQuotaEnforcement:
             f"User under group quota should pass: {result.stderr}"
         )
 
-    def test_quota_fail_open_on_api_error(
-        self, run_credential_process, test_user
-    ):
+    def test_quota_fail_open_on_api_error(self, run_credential_process, test_user):
         """When quota API is unreachable, credential-process still allows (fail-open)."""
         result = run_credential_process(
             context="initial",


### PR DESCRIPTION
## Why

Windows and macOS have historically been the source of most user-reported issues (#427, #428, #349, #567, #649, #664) — but we had no automated regression coverage for platform-specific behavior. This harness catches those bugs before they reach users, runs nightly on `beta`, and provides fast PR feedback via a smoke gate.

## What

A comprehensive E2E test harness that exercises `credential-process` and `otel-helper` binaries across **16 profiles** covering 5 dimensions:

| Dimension | Values |
|-----------|--------|
| Auth | OIDC (Cognito, Direct STS), IDC (device auth), Passthrough |
| Platform | Linux x64, Windows x64, macOS ARM64 |
| Monitoring | Central (4318), Sidecar (4319), None |
| Config delivery | Static (env vars), Bootstrap (API) |
| Quota | None, Block, Alert, Fine-grained |

**61 tests across 8 modules:**
- `test_auth_flow.py` — initial auth, cache hit, silent refresh, revoked refresh
- `test_credential_output.py` — AWS credential_process spec compliance
- `test_monitoring_pipeline.py` — proxy lifecycle, OTLP, self-healing, CloudWatch
- `test_quota_enforcement.py` — under/over, alert mode, fail-open, fine-grained policies
- `test_config_delivery.py` — bootstrap endpoint, token validation, schema
- `test_binary_platform.py` — Windows (9 tests), macOS (5 tests)
- `test_explain_contract.py` — `--explain` JSON schema validation per profile
- `test_error_messages.py` — stderr regression for common failures

**CI pipeline:**
```
build (3 OS) → smoke (fast-fail + size budget) → infra → test (16 parallel) → teardown (retry) → summary (badge)
```

**Branch support:**
| Trigger | Branch | Behavior |
|---------|--------|----------|
| Nightly (3 AM UTC, weekdays) | `beta` | Full 16-profile matrix |
| PRs targeting `beta` | `beta` | Smoke only (fast, no infra cost) |
| Manual dispatch | Any branch | Full matrix or single profile |
| `main` | — | No E2E runs. Validated on beta first. |

## Key design decisions

1. **Profile-driven** — each scenario is a JSON file. Adding a new scenario = one JSON + one matrix entry.
2. **No client testing needed** — exercises the binary contract only. Historical bugs were always below the client boundary.
3. **Cross-profile isolation** — each profile gets isolated temp dirs. Parallel-safe.
4. **Flaky quarantine** — CloudWatch tests auto-rerun (2×30s). DynamoDB tests auto-rerun (1×5s). Real failures still fail fast.
5. **Smoke gate** — passthrough profile + binary size check runs in 2 min before deploying infra.
6. **Teardown resilience** — retries DELETE_FAILED stacks, warns on orphans.

## Setup (one-time, ~10 min)

1. Create GitHub OIDC identity provider (most accounts already have one)
2. Create IAM role `ccwb-e2e-github-actions` with repo-scoped trust
3. Set `E2E_AWS_ROLE_ARN` repo variable + create `e2e-testing` environment
4. Verify: `gh workflow run e2e-matrix.yml -f profile=09-passthrough-linux-none`

Full copy-paste setup commands in `tests/e2e/README.md`.

## Cost

~$0.50/month (CFN stacks live ~20 min/night + GH Actions minutes).

## Files (34 changed, +3618 lines)

```
tests/e2e/
├── conftest.py, helpers.py, markers.py
├── profiles/ (16 JSON files)
├── test_auth_flow.py, test_credential_output.py
├── test_monitoring_pipeline.py, test_quota_enforcement.py
├── test_config_delivery.py, test_binary_platform.py
├── test_explain_contract.py, test_error_messages.py
├── badge-template.json, README.md
.github/
├── workflows/e2e-matrix.yml
└── size-budget.json
```
