### PR TITLE
feat(init): add web search opt-in to ccwb init wizard

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1472,8 +1472,7 @@ class InitCommand(Command):
         ws_region = config.get("web_search", {}).get("region") or WEBSEARCH_SUPPORTED_REGIONS[0]
         console.print(
             "Give Claude a hosted web-search tool via Amazon Bedrock AgentCore Gateway.\n"
-            f"[dim]Deploys to {ws_region}. Requires an OIDC provider (not IDC). "
-            "See: assets/docs/WEB_SEARCH.md[/dim]"
+            f"[dim]Currently available in {ws_region} only.[/dim]"
         )
 
         # Only show the prompt for OIDC-compatible providers

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -29,7 +29,7 @@ from claude_code_with_bedrock.cli.utils.progress import WizardProgress
 from claude_code_with_bedrock.cli.utils.validators import (
     validate_oidc_provider_domain,
 )
-from claude_code_with_bedrock.config import Config, Profile
+from claude_code_with_bedrock.config import WEBSEARCH_SUPPORTED_REGIONS, Config, Profile
 
 
 def validate_identity_pool_name(value: str) -> bool | str:
@@ -1467,6 +1467,42 @@ class InitCommand(Command):
                     )
                 config["codebuild"]["region"] = None
 
+        # Web Search (AgentCore Gateway)
+        console.print("\n[bold]Web Search[/bold]")
+        ws_region = config.get("web_search", {}).get("region") or WEBSEARCH_SUPPORTED_REGIONS[0]
+        console.print(
+            "Give Claude a hosted web-search tool via Amazon Bedrock AgentCore Gateway.\n"
+            f"[dim]Deploys to {ws_region}. Requires an OIDC provider (not IDC). "
+            "See: assets/docs/WEB_SEARCH.md[/dim]"
+        )
+
+        # Only show the prompt for OIDC-compatible providers
+        provider_type = config.get("provider_type")
+        auth_type = config.get("auth_type", "oidc")
+        if auth_type == "idc":
+            console.print(
+                "[dim]Web search is not available for IAM Identity Center (IDC) deployments "
+                "(Claude Desktop does not yet support SigV4 for MCP servers).[/dim]"
+            )
+            config.setdefault("web_search", {})["enabled"] = False
+        else:
+            enable_websearch = questionary.confirm(
+                "Enable web search?",
+                default=config.get("web_search", {}).get("enabled", False),
+            ).ask()
+
+            if "web_search" not in config:
+                config["web_search"] = {}
+            config["web_search"]["enabled"] = enable_websearch
+
+            if enable_websearch:
+                console.print(
+                    f"[green]\u2713[/green] Web search gateway will be deployed to {ws_region}\n"
+                    "[dim]  Run 'ccwb deploy websearch' after init to provision the gateway.[/dim]"
+                )
+            else:
+                console.print("[dim]Web search disabled — can be enabled later via 'ccwb init'.[/dim]")
+
         # Claude Desktop MDM configuration
         console.print("\n[bold]Claude Desktop Support[/bold]")
         console.print("Generate MDM configuration for Claude Desktop with Amazon Bedrock")
@@ -2641,6 +2677,7 @@ class InitCommand(Command):
             "cowork_3p_extra_keys": config_data.get("cowork_3p", {}).get("extra_keys", {}),
             "cowork_service_token": config_data.get("cowork_3p", {}).get("service_token", ""),
             "cowork_config_delivery": config_data.get("cowork", {}).get("config_delivery", "static"),
+            "web_search_enabled": config_data.get("web_search", {}).get("enabled", False),
             "cowork_chat_tab_enabled": config_data.get("cowork_3p", {}).get("chat_tab_enabled", True),
             "cowork_chat_advanced_file_analysis": config_data.get("cowork_3p", {}).get(
                 "chat_advanced_file_analysis", True
@@ -3006,6 +3043,9 @@ class InitCommand(Command):
                     existing_config["codebuild"]["region"] = profile.codebuild_region
                 if getattr(profile, "codebuild_prior_regions", None):
                     existing_config["codebuild"]["prior_regions"] = profile.codebuild_prior_regions
+
+            # Add web search configuration
+            existing_config["web_search"] = {"enabled": getattr(profile, "web_search_enabled", False)}
 
             # Add Claude Desktop (cowork_3p) configuration
             cowork_3p_config = {"enabled": profile.cowork_3p_enabled}


### PR DESCRIPTION
## Why

The websearch feature series (#641, #647) tells users to "re-run ccwb init" to configure web search, but no PR actually adds the init wizard prompt. This closes that gap.

## What

Adds an **"Enable web search?"** confirm prompt to the `ccwb init` wizard:

```
Web Search
Give Claude a hosted web-search tool via Amazon Bedrock AgentCore Gateway.
Currently available in us-east-1 only.

? Enable web search? (y/N)
✓ Web search gateway will be deployed to us-east-1
  Run 'ccwb deploy websearch' after init to provision the gateway.
```

### Behaviour

| Auth Type | Prompt? | Default |
|-----------|---------|---------|
| OIDC (cognito, okta, azure, auth0, google, generic) | Yes | No |
| IDC | Skipped with explanation | Forced disabled |

### Config mapping

- Wizard: `config["web_search"]["enabled"]`
- Profile: `web_search_enabled` (bool, default False)
- Round-trips on re-init: profile → config → profile ✓

## Dependencies

> ⚠️ **Stacked on #709** (init wizard terminology). Merge #709 first, then this.
>
> Also depends on #641 landing (which adds `web_search_enabled` to the Profile dataclass). Without #641, the field silently gets `setattr`'d but isn't in the dataclass yet — harmless but technically incomplete until both merge.

## Credits

This prompt integrates the init wizard design from @antkawam's original PR #640 into the decomposed series.

Co-authored-by: antkawam <antkawam@users.noreply.github.com>
Co-authored-by: chiararelandini <chiararelandini@users.noreply.github.com>

## Review

@chiararelandini — would appreciate your review since this integrates with your deploy wiring (#641). The wizard sets `web_search_enabled=True` on the profile, which your `deploy-all` loop checks to include the websearch stack.
