### PR TITLE
fix(websearch): validate Cognito tokens via client_id claim

### DIFF
--- a/deployment/infrastructure/bedrock-agentcore-gateway.yaml
+++ b/deployment/infrastructure/bedrock-agentcore-gateway.yaml
@@ -43,8 +43,23 @@ Parameters:
     Type: String
     Default: ''
     Description: >-
-      OIDC client_id (required when AuthType=oidc, ignored for idc). The
-      gateway validates the id_token's 'aud' claim against this value.
+      OIDC client_id (required when AuthType=oidc, ignored for idc). Validated
+      against the token's 'aud' or 'client_id' claim depending on
+      JwtValidationMode.
+
+  JwtValidationMode:
+    Type: String
+    Default: audience
+    AllowedValues:
+      - audience
+      - client_id
+    Description: >-
+      How the CUSTOM_JWT authorizer validates the inbound token (OIDC only).
+      'audience' validates the token 'aud' claim via AllowedAudience — use for
+      Entra ID, Okta, Auth0, Google and generic OIDC, which place the client id
+      in 'aud'. 'client_id' validates the 'client_id' claim via AllowedClients —
+      use for Amazon Cognito, whose access tokens carry 'client_id' and have no
+      'aud' claim. The deploy CLI sets this automatically from the provider type.
 
   DomainExcludeList:
     Type: CommaDelimitedList
@@ -55,6 +70,7 @@ Parameters:
 
 Conditions:
   IsOIDC: !Equals [!Ref AuthType, 'oidc']
+  UseClientId: !Equals [!Ref JwtValidationMode, 'client_id']
   HasDenylist: !Not [!Equals [!Join ['', !Ref DomainExcludeList], '']]
 
 Resources:
@@ -113,18 +129,23 @@ Resources:
         Mcp:
           SupportedVersions:
             - '2025-03-26'
-      # OIDC deployments use CUSTOM_JWT (validates id_token aud claim).
+      # OIDC deployments use CUSTOM_JWT. The validated claim depends on the IdP:
+      # Cognito access tokens carry 'client_id' (no 'aud'), so they validate via
+      # AllowedClients; Entra ID, Okta, Auth0, Google and generic OIDC place the
+      # client id in 'aud', so they validate via AllowedAudience. JwtValidationMode
+      # selects between the two (set automatically by the deploy CLI).
       # IDC deployments use AWS_IAM (validates caller's SigV4 credentials).
       AuthorizerType: !If [IsOIDC, CUSTOM_JWT, AWS_IAM]
       AuthorizerConfiguration: !If
         - IsOIDC
-        - CustomJWTAuthorizer:
-            DiscoveryUrl: !Ref DiscoveryUrl
-            # AllowedAudience validates the id_token's 'aud' claim, which every
-            # OIDC provider sets to client_id. Works uniformly across Cognito,
-            # Okta, Auth0, Entra ID, and Google.
-            AllowedAudience:
-              - !Ref ClientId
+        - CustomJWTAuthorizer: !If
+            - UseClientId
+            - DiscoveryUrl: !Ref DiscoveryUrl
+              AllowedClients:
+                - !Ref ClientId
+            - DiscoveryUrl: !Ref DiscoveryUrl
+              AllowedAudience:
+                - !Ref ClientId
         - !Ref 'AWS::NoValue'
 
   WebSearchTarget:


### PR DESCRIPTION
## What

The merged AgentCore Gateway template (#607) hard-codes the CUSTOM_JWT authorizer to validate the inbound token's `aud` claim:

```yaml
CustomJWTAuthorizer:
  DiscoveryUrl: !Ref DiscoveryUrl
  AllowedAudience:
    - !Ref ClientId
```

on the assumption that every OIDC provider places the client id in `aud`. **This is not true for Amazon Cognito.** Cognito **access tokens** carry the app client id in the **`client_id`** claim and have **no `aud`** claim, so the gateway rejects them and web search fails to authorize.

This restores the per-IdP claim selection that existed in the original PR before it was simplified at merge:

- new parameter `JwtValidationMode` (`audience` | `client_id`)
- new condition `UseClientId`
- the authorizer now validates via **`AllowedClients`** in `client_id` mode (Cognito) and **`AllowedAudience`** in `audience` mode (Entra ID, Okta, Auth0, Google, generic OIDC).

`Default: audience` preserves the current behavior, so **existing OIDC deployments are unaffected**.

## Why this is correct

The official AWS examples configure the Cognito gateway authorizer with `allowedClients` (not `allowedAudience`):

```python
auth_config = { "customJWTAuthorizer": { "allowedClients": [cognito_client_id], "discoveryUrl": cognito_discovery_url } }
```

Per the AgentCore docs, `allowedClients` validates the `client_id` claim and `allowedAudience` validates the `aud` claim — so the right field depends on the IdP.

## Scope

- Template-only change. Backward compatible (default mode = `audience`).
- The deploy CLI sets `JwtValidationMode` automatically from `provider_type` (`cognito` → `client_id`, otherwise `audience`). That wiring lives in the deploy PR #641 (`build_websearch_params`) and is **not** part of this PR, since it depends on code not yet on `beta`. This template PR should merge first.

## Testing

- `cfn-lint` clean (only the pre-existing W3037 false positive on the newer `bedrock-agentcore:InvokeWebSearch` action, unrelated to this change).
- Verified the conditional renders `AllowedClients: [ClientId]` for `JwtValidationMode=client_id` and `AllowedAudience: [ClientId]` for `audience`.
