### PR TITLE
fix(package): resolve Cognito identity pool ID from stack outputs, not profile name

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -273,45 +273,13 @@ class PackageCommand(Command):
             )
             return 1
 
-        # Get federation identifier — try profile first, fall back to CloudFormation
-        federation_type = profile.federation_type
-        identity_pool_id = None
-        federated_role_arn = None
-
-        if not getattr(profile, "sso_enabled", True):
-            # SSO disabled — no auth stack to query, no federation needed
-            console.print("[dim]SSO disabled — skipping auth stack lookup[/dim]")
-        elif federation_type == "direct" and getattr(profile, "federated_role_arn", None):
-            federated_role_arn = profile.federated_role_arn
-            console.print(f"[dim]Using role ARN from profile: {federated_role_arn}[/dim]")
-        elif federation_type != "direct" and getattr(profile, "identity_pool_name", None):
-            identity_pool_id = profile.identity_pool_name
-            console.print(f"[dim]Using identity pool from profile: {identity_pool_id}[/dim]")
-        else:
-            # Fall back to CloudFormation stack outputs
-            console.print("[yellow]Fetching deployment information from CloudFormation...[/yellow]")
-            stack_outputs = get_stack_outputs(
-                profile.stack_names.get("auth", f"{profile.identity_pool_name}-stack"), profile.aws_region
-            )
-
-            if not stack_outputs:
-                console.print("[red]Could not fetch stack outputs. Is the stack deployed?[/red]")
-                return 1
-
-            federation_type = stack_outputs.get("FederationType", profile.federation_type)
-
-            if federation_type == "direct":
-                federated_role_arn = stack_outputs.get("DirectSTSRoleArn")
-                if not federated_role_arn or federated_role_arn == "N/A":
-                    federated_role_arn = stack_outputs.get("FederatedRoleArn")
-                if not federated_role_arn or federated_role_arn == "N/A":
-                    console.print("[red]Direct STS Role ARN not found in stack outputs.[/red]")
-                    return 1
-            else:
-                identity_pool_id = stack_outputs.get("IdentityPoolId")
-                if not identity_pool_id:
-                    console.print("[red]Identity Pool ID not found in stack outputs.[/red]")
-                    return 1
+        # Resolve federation identifier (role ARN for direct STS, Identity Pool ID
+        # for Cognito). See _resolve_federation: Cognito ALWAYS reads the pool ID
+        # from CloudFormation stack outputs because identity_pool_name is only a
+        # name, not the "<region>:<uuid>" pool ID.
+        federation_type, identity_pool_id, federated_role_arn = self._resolve_federation(profile, console)
+        if getattr(profile, "sso_enabled", True) and not (identity_pool_id or federated_role_arn):
+            return 1
 
         # Welcome
         console.print(
@@ -2001,30 +1969,11 @@ RUN pyinstaller \
         for plat, helper_path in built_otel_helpers:
             shutil.copy2(helper_path, output_dir / helper_path.name)
 
-        # Get federation info — try profile first, fall back to CloudFormation
-        federation_type = profile.federation_type
-        federation_identifier = None
-
-        if federation_type == "direct" and getattr(profile, "federated_role_arn", None):
-            federation_identifier = profile.federated_role_arn
-            console.print(f"[dim]Using role ARN from profile: {federation_identifier}[/dim]")
-        elif federation_type != "direct" and getattr(profile, "identity_pool_name", None):
-            federation_identifier = profile.identity_pool_name
-            console.print(f"[dim]Using identity pool from profile: {federation_identifier}[/dim]")
-        else:
-            console.print("[cyan]Fetching deployment information from CloudFormation...[/cyan]")
-            stack_outputs = get_stack_outputs(
-                profile.stack_names.get("auth", f"{profile.identity_pool_name}-stack"), profile.aws_region
-            )
-            if not stack_outputs:
-                console.print("[red]Could not fetch stack outputs. Is the stack deployed?[/red]")
-                return 1
-
-            federation_type = stack_outputs.get("FederationType", profile.federation_type)
-            if federation_type == "direct":
-                federation_identifier = stack_outputs.get("DirectSTSRoleArn") or stack_outputs.get("FederatedRoleArn")
-            else:
-                federation_identifier = stack_outputs.get("IdentityPoolId")
+        # Resolve federation identifier (role ARN for direct STS, Identity Pool ID
+        # for Cognito) — see _resolve_federation. Cognito ALWAYS reads the pool ID
+        # from stack outputs; identity_pool_name is a name, not the pool ID.
+        federation_type, identity_pool_id, federated_role_arn = self._resolve_federation(profile, console)
+        federation_identifier = federated_role_arn if federation_type == "direct" else identity_pool_id
 
         if not federation_identifier or federation_identifier == "N/A":
             console.print("[red]Federation identifier not found in profile or stack outputs.[/red]")
@@ -2081,6 +2030,63 @@ RUN pyinstaller \
         console.print(f"\nBinaries copied from: [dim]{source_dir}[/dim]")
         console.print("\n[bold]Next: Run '[cyan]poetry run ccwb distribute --per-os[/cyan]' to create distribution packages.[/bold]")
         return 0
+
+    def _resolve_federation(self, profile, console):
+        r"""Resolve federation details for packaging.
+
+        Returns a ``(federation_type, identity_pool_id, federated_role_arn)``
+        tuple. On success exactly one of ``identity_pool_id`` /
+        ``federated_role_arn`` is set; both are ``None`` when SSO is disabled or
+        when resolution fails (the caller is expected to handle the failure).
+
+        IMPORTANT — Cognito Identity Pool federation ALWAYS resolves the pool ID
+        from the deployed CloudFormation stack outputs. ``profile.identity_pool_name``
+        holds only a human-readable name (e.g. ``"claude-code-auth"``); the real
+        pool ID has the form ``"<region>:<uuid>"`` and is created by
+        ``ccwb deploy``. Using the name as the identity pool ID produces a
+        ``config.json`` that fails Cognito ``GetId`` validation
+        (``[\w-]+:[0-9a-f-]+``), breaking authentication for every distributed
+        user. Direct STS keeps a profile shortcut because the profile stores the
+        real role ARN.
+        """
+        federation_type = profile.federation_type
+
+        if not getattr(profile, "sso_enabled", True):
+            # SSO disabled — no auth stack to query, no federation needed.
+            console.print("[dim]SSO disabled — skipping auth stack lookup[/dim]")
+            return federation_type, None, None
+
+        # Direct STS: the profile stores the real role ARN, so it is a safe shortcut.
+        if federation_type == "direct" and getattr(profile, "federated_role_arn", None):
+            console.print(f"[dim]Using role ARN from profile: {profile.federated_role_arn}[/dim]")
+            return federation_type, None, profile.federated_role_arn
+
+        # Cognito (and direct without a cached ARN) must read from the stack: the
+        # profile never holds the real identity pool ID, only its name.
+        console.print("[yellow]Fetching deployment information from CloudFormation...[/yellow]")
+        stack_outputs = get_stack_outputs(
+            profile.stack_names.get("auth", f"{profile.identity_pool_name}-stack"), profile.aws_region
+        )
+        if not stack_outputs:
+            console.print("[red]Could not fetch stack outputs. Is the stack deployed?[/red]")
+            return federation_type, None, None
+
+        federation_type = stack_outputs.get("FederationType", profile.federation_type)
+
+        if federation_type == "direct":
+            federated_role_arn = stack_outputs.get("DirectSTSRoleArn")
+            if not federated_role_arn or federated_role_arn == "N/A":
+                federated_role_arn = stack_outputs.get("FederatedRoleArn")
+            if not federated_role_arn or federated_role_arn == "N/A":
+                console.print("[red]Direct STS Role ARN not found in stack outputs.[/red]")
+                return federation_type, None, None
+            return federation_type, None, federated_role_arn
+
+        identity_pool_id = stack_outputs.get("IdentityPoolId")
+        if not identity_pool_id:
+            console.print("[red]Identity Pool ID not found in stack outputs.[/red]")
+            return federation_type, None, None
+        return federation_type, identity_pool_id, None
 
     def _create_config(
         self,

--- a/source/tests/cli/commands/test_package.py
+++ b/source/tests/cli/commands/test_package.py
@@ -6,6 +6,7 @@
 import json
 import tempfile
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 from claude_code_with_bedrock.cli.commands.package import PackageCommand
 from claude_code_with_bedrock.config import Profile
@@ -115,3 +116,89 @@ class TestPackageCommandCrossRegion:
             assert "AWS_REGION" in installer_content or "aws_region" in installer_content
             # The fallback should now have the interpolated region value
             assert "us-west-2" in installer_content or "config.json" in installer_content
+
+
+
+class TestResolveFederation:
+    """Regression tests for federation identifier resolution.
+
+    Guards against the bug where `ccwb package` used `identity_pool_name` (a
+    human-readable name) as the Cognito identity pool ID, producing a config.json
+    that failed Cognito GetId validation ([\\w-]+:[0-9a-f-]+).
+    """
+
+    def _profile(self, **overrides):
+        defaults = {
+            "name": "test",
+            "provider_domain": "example.auth.us-east-1.amazoncognito.com",
+            "client_id": "test-client-id",
+            "credential_storage": "keyring",
+            "aws_region": "us-east-1",
+            "identity_pool_name": "claude-code-auth",  # a NAME, not the pool ID
+            "federation_type": "cognito",
+            "monitoring_enabled": False,
+        }
+        defaults.update(overrides)
+        return Profile(**defaults)
+
+    def test_cognito_resolves_pool_id_from_stack_not_name(self):
+        """Cognito must use the stack's IdentityPoolId (region:uuid), never the
+        identity_pool_name. Core regression guard for the GetId ValidationException."""
+        command = PackageCommand()
+        profile = self._profile()
+        console = MagicMock()
+        fake_outputs = {
+            "FederationType": "cognito",
+            "IdentityPoolId": "us-east-1:00000000-0000-0000-0000-000000000000",
+        }
+        with patch(
+            "claude_code_with_bedrock.cli.commands.package.get_stack_outputs",
+            return_value=fake_outputs,
+        ):
+            federation_type, identity_pool_id, federated_role_arn = command._resolve_federation(profile, console)
+
+        assert federation_type == "cognito"
+        assert identity_pool_id == "us-east-1:00000000-0000-0000-0000-000000000000"
+        # Must NOT fall back to the human-readable name (the original bug)
+        assert identity_pool_id != "claude-code-auth"
+        assert federated_role_arn is None
+
+    def test_direct_uses_profile_role_arn_without_stack(self):
+        """Direct STS keeps the profile shortcut — the profile stores the real ARN."""
+        command = PackageCommand()
+        arn = "arn:aws:iam::123456789012:role/BedrockRole"
+        profile = self._profile(federation_type="direct", federated_role_arn=arn)
+        console = MagicMock()
+        with patch("claude_code_with_bedrock.cli.commands.package.get_stack_outputs") as mock_stack:
+            federation_type, identity_pool_id, federated_role_arn = command._resolve_federation(profile, console)
+
+        assert federation_type == "direct"
+        assert federated_role_arn == arn
+        assert identity_pool_id is None
+        mock_stack.assert_not_called()  # no stack lookup needed for direct shortcut
+
+    def test_cognito_missing_pool_id_returns_none(self):
+        """If the stack has no IdentityPoolId, resolution fails gracefully (no name fallback)."""
+        command = PackageCommand()
+        profile = self._profile()
+        console = MagicMock()
+        with patch(
+            "claude_code_with_bedrock.cli.commands.package.get_stack_outputs",
+            return_value={"FederationType": "cognito"},
+        ):
+            federation_type, identity_pool_id, federated_role_arn = command._resolve_federation(profile, console)
+
+        assert identity_pool_id is None
+        assert federated_role_arn is None
+
+    def test_sso_disabled_returns_no_identifier(self):
+        """SSO disabled needs no federation identifier and performs no stack lookup."""
+        command = PackageCommand()
+        profile = self._profile(sso_enabled=False)
+        console = MagicMock()
+        with patch("claude_code_with_bedrock.cli.commands.package.get_stack_outputs") as mock_stack:
+            federation_type, identity_pool_id, federated_role_arn = command._resolve_federation(profile, console)
+
+        assert identity_pool_id is None
+        assert federated_role_arn is None
+        mock_stack.assert_not_called()


### PR DESCRIPTION
Closes #720

## Problem

For **Cognito Identity Pool** federation, `ccwb package` wrote the identity pool **name** (e.g. `claude-code-auth`) into `config.json` as `identity_pool_id`, instead of the real pool **ID** (`<region>:<uuid>`). At runtime `credential-process` then calls Cognito `GetId` with an invalid identifier and fails:

```
ValidationException ... Value 'claude-code-auth' at 'identityPoolId' failed to
satisfy constraint: Member must satisfy regular expression pattern: [\w-]+:[0-9a-f-]+
```

This blocks AWS credential exchange (Bedrock auth) and prevents the monitoring/OTEL id-token from being cached, so per-user telemetry silently degrades to anonymous. Every Cognito package built from the affected code is broken.

## Root cause

The federation-identifier resolution short-circuited for Cognito:

```python
elif federation_type != "direct" and getattr(profile, "identity_pool_name", None):
    identity_pool_id = profile.identity_pool_name   # BUG: name used as the ID
else:
    identity_pool_id = stack_outputs.get("IdentityPoolId")  # correct, but dead code for Cognito
```

`profile.identity_pool_name` is only a name; the real pool ID is created by `ccwb deploy` and exposed as the CloudFormation stack output `IdentityPoolId`. The `Profile` schema has no `identity_pool_id` field by design, so the package step must read it from the stack. The same buggy pattern existed in **two** places: the package path (`run()`) and the `--regenerate-installers` path.

## Fix

- Extract a shared `_resolve_federation(profile, console)` helper used by both code paths. For Cognito federation the identity pool ID is **always** read from the stack output `IdentityPoolId`.
- **Direct STS is unchanged** — the profile role-ARN shortcut is preserved (the profile stores the real ARN), and SSO-disabled handling is preserved.
- De-duplicates the previously copy-pasted resolution logic.

## Tests

Added `TestResolveFederation` (4 cases):
- Cognito resolves the pool ID from the stack output (and explicitly **not** the name) — regression guard
- Direct STS uses the profile role ARN with no stack lookup
- Missing `IdentityPoolId` in stack outputs fails gracefully (no name fallback)
- SSO-disabled returns no identifier and performs no stack lookup

Full suite: **920 passed** (+4 new), no new failures. (One pre-existing unrelated e2e failure about `ap-southeast-2` in `test_context_show_displays_profile_details` is present on `main` independent of this change.)

## Backward compatibility

- Direct STS federation: identical behavior.
- Cognito federation: now produces a valid `identity_pool_id` (`<region>:<uuid>`) — previously broken.
- No schema/config changes; no changes to `_create_config` output shape.