### PR TITLE
feat: Claude Apps Gateway deployment infrastructure

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,7 +133,7 @@
         "filename": ".github/workflows/scanners.yml",
         "hashed_secret": "e13e3c9a62cdea546f7974a45df6e4bf191b8fe8",
         "is_verified": false,
-        "line_number": 20,
+        "line_number": 26,
         "is_secret": false
       }
     ],
@@ -177,13 +177,31 @@
         "is_secret": false
       }
     ],
+    "deployment/infrastructure/claude-apps-gateway-infra.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "deployment/infrastructure/claude-apps-gateway-infra.yaml",
+        "hashed_secret": "b93b6adf9879e2ed0d3732745c687f5d5cfb61e5",
+        "is_verified": false,
+        "line_number": 143,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "deployment/infrastructure/claude-apps-gateway-infra.yaml",
+        "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
+        "is_verified": false,
+        "line_number": 185,
+        "is_secret": false
+      }
+    ],
     "deployment/infrastructure/cognito-user-pool-setup.yaml": [
       {
         "type": "Secret Keyword",
         "filename": "deployment/infrastructure/cognito-user-pool-setup.yaml",
         "hashed_secret": "7cb6efb98ba5972a9b5090dc2e517fe14d12cb04",
         "is_verified": false,
-        "line_number": 132,
+        "line_number": 139,
         "is_secret": false
       },
       {
@@ -191,7 +209,7 @@
         "filename": "deployment/infrastructure/cognito-user-pool-setup.yaml",
         "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
         "is_verified": false,
-        "line_number": 216,
+        "line_number": 223,
         "is_secret": false
       },
       {
@@ -199,7 +217,7 @@
         "filename": "deployment/infrastructure/cognito-user-pool-setup.yaml",
         "hashed_secret": "a79d4b27b11304d1bb1ef7b4a0d4a59306364487",
         "is_verified": false,
-        "line_number": 405,
+        "line_number": 412,
         "is_secret": false
       },
       {
@@ -207,7 +225,7 @@
         "filename": "deployment/infrastructure/cognito-user-pool-setup.yaml",
         "hashed_secret": "8318df9ecda039deac9868adf1944a29a95c7114",
         "is_verified": false,
-        "line_number": 407,
+        "line_number": 414,
         "is_secret": false
       },
       {
@@ -215,7 +233,7 @@
         "filename": "deployment/infrastructure/cognito-user-pool-setup.yaml",
         "hashed_secret": "11c6b3aa1d9a48dc8fb3b50de8bd6f6ccbefc69a",
         "is_verified": false,
-        "line_number": 413,
+        "line_number": 420,
         "is_secret": false
       },
       {
@@ -223,7 +241,7 @@
         "filename": "deployment/infrastructure/cognito-user-pool-setup.yaml",
         "hashed_secret": "f05861f3e072021bda08543eb4cb53af4932e841",
         "is_verified": false,
-        "line_number": 414,
+        "line_number": 421,
         "is_secret": false
       },
       {
@@ -231,7 +249,7 @@
         "filename": "deployment/infrastructure/cognito-user-pool-setup.yaml",
         "hashed_secret": "7a6ad15bdcaec1832cda7f5d1bb19bc14e84484e",
         "is_verified": false,
-        "line_number": 422,
+        "line_number": 429,
         "is_secret": false
       },
       {
@@ -239,7 +257,7 @@
         "filename": "deployment/infrastructure/cognito-user-pool-setup.yaml",
         "hashed_secret": "aa28f3aadffe5c469a1d4438b0248ff152faaf2b",
         "is_verified": false,
-        "line_number": 457,
+        "line_number": 464,
         "is_secret": false
       },
       {
@@ -247,7 +265,7 @@
         "filename": "deployment/infrastructure/cognito-user-pool-setup.yaml",
         "hashed_secret": "b5efa98bf8cea69847a5d296c92d0f3b7983b9cb",
         "is_verified": false,
-        "line_number": 458,
+        "line_number": 465,
         "is_secret": false
       },
       {
@@ -255,7 +273,7 @@
         "filename": "deployment/infrastructure/cognito-user-pool-setup.yaml",
         "hashed_secret": "1ca44c212ca11001056046dee0d18206eac14bcb",
         "is_verified": false,
-        "line_number": 459,
+        "line_number": 466,
         "is_secret": false
       },
       {
@@ -263,7 +281,7 @@
         "filename": "deployment/infrastructure/cognito-user-pool-setup.yaml",
         "hashed_secret": "9f6c3892ec3856655074324afff87edf62a39f4c",
         "is_verified": false,
-        "line_number": 460,
+        "line_number": 467,
         "is_secret": false
       }
     ],
@@ -273,7 +291,7 @@
         "filename": "source/claude_code_with_bedrock/cli/utils/cowork_3p.py",
         "hashed_secret": "a0422442dba3fda71eda7b743f0e726ad8af17a5",
         "is_verified": false,
-        "line_number": 222,
+        "line_number": 345,
         "is_secret": false
       }
     ],
@@ -456,5 +474,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-20T09:09:16Z"
+  "generated_at": "2026-06-30T12:41:26Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -181,9 +181,17 @@
       {
         "type": "Secret Keyword",
         "filename": "deployment/infrastructure/claude-apps-gateway-infra.yaml",
+        "hashed_secret": "602e1573840beca17c69ac75024757bdbde1cac9",
+        "is_verified": false,
+        "line_number": 209,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "deployment/infrastructure/claude-apps-gateway-infra.yaml",
         "hashed_secret": "b93b6adf9879e2ed0d3732745c687f5d5cfb61e5",
         "is_verified": false,
-        "line_number": 143,
+        "line_number": 210,
         "is_secret": false
       },
       {
@@ -191,7 +199,7 @@
         "filename": "deployment/infrastructure/claude-apps-gateway-infra.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 185,
+        "line_number": 259,
         "is_secret": false
       }
     ],
@@ -474,5 +482,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-30T12:41:26Z"
+  "generated_at": "2026-07-02T13:53:39Z"
 }

--- a/assets/docs/CLAUDE_GATEWAY.md
+++ b/assets/docs/CLAUDE_GATEWAY.md
@@ -1,0 +1,100 @@
+# Claude Apps Gateway
+
+The Claude Apps Gateway is a self-hosted control plane that sits between your developers' Claude Code CLI and Amazon Bedrock. Developers sign in with corporate SSO instead of managing cloud credentials — the Gateway holds the upstream Bedrock credential and handles authentication, policy enforcement, spend caps, and telemetry.
+
+## When to use the Gateway
+
+| Scenario | Use Gateway? | Alternative |
+|----------|-------------|-------------|
+| Many Claude Code CLI developers, need SSO | ✅ Yes | credential-process per machine |
+| Per-user spend limits needed | ✅ Yes | CCWB quota stack (token-based) |
+| Centralized managed settings | ✅ Yes | MDM-deployed managed-settings.json |
+| Claude Desktop (Cowork) users | ❌ No | credential-helper + MDM/bootstrap |
+| Small team, simple setup | Maybe | credential-process is simpler |
+
+## What the Gateway provides
+
+- **SSO login** — developers authenticate via your IdP (Okta, Azure, Google). No API keys on laptops.
+- **Managed settings** — model allowlists, permissions, and policies delivered at sign-in.
+- **Spend caps** — daily, weekly, monthly limits per user, group, or org (USD-based).
+- **OTLP telemetry** — per-user metrics exported to your observability stack.
+- **Upstream routing** — routes to Bedrock with failover support. Clients don't know or care about the upstream.
+
+## Architecture
+
+```
+Developer laptop                    Your AWS account
+─────────────────                   ────────────────
+Claude Code CLI  ──── HTTPS ────►  ALB
+                                    │
+                                    ▼
+                                   ECS Fargate
+                                   (claude gateway)  ────►  Amazon Bedrock
+                                    │
+                                    ▼
+                                   RDS PostgreSQL
+                                   (sessions, policy)
+```
+
+The Gateway is the `claude` binary running in server mode (`claude gateway --port 8080`). Same executable your developers already have.
+
+## Deploying
+
+```bash
+# Requires networking stack (VPC + subnets) + OIDC client secret in SecretsManager
+ccwb deploy gateway
+```
+
+After deploy, you'll see:
+```
+✓ Claude Apps Gateway deployed!
+Gateway URL: http://<alb-dns-name>
+
+To connect Claude Code CLI, set in managed-settings.json:
+  {"forceLoginMethod": "gateway", "forceLoginGatewayUrl": "http://<alb-dns-name>"}
+```
+
+## Connecting developers
+
+Add the Gateway URL to `managed-settings.json` (deployed via MDM, `ccwb package`, or manually):
+
+```json
+{
+  "forceLoginMethod": "gateway",
+  "forceLoginGatewayUrl": "https://gateway.yourcompany.com"
+}
+```
+
+When a developer runs `claude`, the CLI:
+1. Detects `forceLoginGatewayUrl` in settings
+2. Redirects to your IdP for SSO login
+3. Receives a short-lived session token from the Gateway
+4. All inference routes through the Gateway to Bedrock
+
+No Bedrock credentials on developer machines. Offboard a developer by removing them from your IdP.
+
+## Relationship to other CCWB components
+
+| Component | With Gateway | Without Gateway |
+|-----------|-------------|-----------------|
+| **credential-process** | Not needed for CLI (Gateway handles auth) | Required per machine |
+| **Monitoring (central)** | Gateway exports OTLP directly | otel-helper + collector |
+| **Monitoring (sidecar)** | Gateway replaces sidecar for CLI | Local otelcol per machine |
+| **Quota** | Gateway has native spend caps (USD) | DynamoDB + Lambda (token-based) |
+| **Claude Desktop** | Still needs credential-helper (Gateway is CLI-only) | Same |
+| **Distribution/packaging** | Minimal package (just managed-settings.json) | Full package with binaries |
+
+## Tearing down
+
+```bash
+ccwb destroy gateway
+```
+
+Removes the ECS service, RDS instance, ALB, and all associated resources. Does not affect other CCWB stacks.
+
+## References
+
+- [Claude Apps Gateway docs](https://code.claude.com/docs/en/claude-apps-gateway)
+- [Gateway configuration reference](https://code.claude.com/docs/en/claude-apps-gateway-config)
+- [Gateway deployment guide](https://code.claude.com/docs/en/claude-apps-gateway-deploy)
+- [Announcement blog](https://claude.com/blog/introducing-the-claude-apps-gateway)

--- a/deployment/infrastructure/claude-apps-gateway-infra.yaml
+++ b/deployment/infrastructure/claude-apps-gateway-infra.yaml
@@ -38,12 +38,10 @@ Parameters:
     Default: us-east-1
     Description: AWS region for Bedrock model inference
 
-  GatewayImage:
+  ClaudeBinaryUrl:
     Type: String
-    Description: >-
-      Container image with the claude binary and gateway.yaml baked in.
-      Build your own image following the gateway deployment guide, or use
-      the official image when available. No default — must be provided.
+    Default: 'https://storage.googleapis.com/anthropic-public/claude-code/claude-linux-arm64'
+    Description: URL to download the claude Linux binary for the gateway image build
 
   DbInstanceClass:
     Type: String
@@ -222,7 +220,7 @@ Resources:
       TaskRoleArn: !GetAtt TaskRole.Arn
       ContainerDefinitions:
         - Name: gateway
-          Image: !Ref GatewayImage
+          Image: !Sub '${AWS::AccountId}.dkr.ecr.${AWS::Region}.${AWS::URLSuffix}/${GatewayEcrRepo}:latest'
           # NOTE: The gateway requires a config file (gateway.yaml). The exact
           # interface depends on your claude binary version. Options:
           # 1. Bake gateway.yaml into your container image
@@ -268,6 +266,128 @@ Resources:
             Interval: 30
             Timeout: 5
             Retries: 3
+
+
+  # ECR Repository for gateway images (built by CodeBuild)
+  GatewayEcrRepo:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: !Sub '${AWS::StackName}-gateway'
+      ImageScanningConfiguration:
+        ScanOnPush: true
+      LifecyclePolicy:
+        LifecyclePolicyText: '{"rules":[{"rulePriority":1,"selection":{"tagStatus":"untagged","countType":"imageCountMoreThan","countNumber":5},"action":{"type":"expire"}}]}'
+
+  # CodeBuild project — builds the gateway container image automatically
+  GatewayBuildRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: codebuild.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: GatewayBuildAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: ecr:GetAuthorizationToken
+                Resource: '*'
+              - Effect: Allow
+                Action:
+                  - ecr:BatchCheckLayerAvailability
+                  - ecr:CompleteLayerUpload
+                  - ecr:InitiateLayerUpload
+                  - ecr:PutImage
+                  - ecr:UploadLayerPart
+                Resource: !GetAtt GatewayEcrRepo.Arn
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*'
+
+  GatewayBuildProject:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Name: !Sub '${AWS::StackName}-build'
+      ServiceRole: !GetAtt GatewayBuildRole.Arn
+      Artifacts:
+        Type: NO_ARTIFACTS
+      Environment:
+        Type: ARM_CONTAINER
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/amazonlinux2-aarch64-standard:3.0
+        PrivilegedMode: true
+        EnvironmentVariables:
+          - Name: ECR_REPO_URI
+            Value: !Sub '${AWS::AccountId}.dkr.ecr.${AWS::Region}.${AWS::URLSuffix}/${GatewayEcrRepo}'
+          - Name: CLAUDE_BINARY_URL
+            Value: !Ref ClaudeBinaryUrl
+          - Name: OIDC_ISSUER_URL
+            Value: !Ref OidcIssuerUrl
+          - Name: OIDC_CLIENT_ID
+            Value: !Ref OidcClientId
+          - Name: OIDC_CLIENT_SECRET_ARN
+            Value: !Ref OidcClientSecretArn
+          - Name: BEDROCK_REGION
+            Value: !Ref BedrockRegion
+          - Name: GATEWAY_PORT
+            Value: !Ref GatewayPort
+          - Name: DB_HOST
+            Value: !GetAtt Database.Endpoint.Address
+          - Name: DB_SECRET_ARN
+            Value: !Ref DbPassword
+      Source:
+        Type: NO_SOURCE
+        BuildSpec: |
+          version: 0.2
+          phases:
+            pre_build:
+              commands:
+                - aws ecr get-login-password | docker login --username AWS --password-stdin $ECR_REPO_URI
+                - curl -fsSL $CLAUDE_BINARY_URL -o claude && chmod +x claude
+            build:
+              commands:
+                - |
+                  cat > gateway.yaml << EOF
+                  listen:
+                    port: $GATEWAY_PORT
+                  oidc:
+                    issuer: "$OIDC_ISSUER_URL"
+                    client_id: "$OIDC_CLIENT_ID"
+                    client_secret_arn: "$OIDC_CLIENT_SECRET_ARN"
+                  store:
+                    type: postgres
+                    host: "$DB_HOST"
+                    port: 5432
+                    database: gateway
+                    user: gateway
+                    password_secret_arn: "$DB_SECRET_ARN"
+                  upstreams:
+                    - provider: bedrock
+                      region: "$BEDROCK_REGION"
+                  EOF
+                - |
+                  cat > Dockerfile << EOF
+                  FROM public.ecr.aws/amazonlinux/amazonlinux:2023-minimal
+                  RUN dnf install -y curl && dnf clean all
+                  COPY claude /usr/local/bin/claude
+                  COPY gateway.yaml /etc/gateway/gateway.yaml
+                  RUN chmod +x /usr/local/bin/claude
+                  EXPOSE $GATEWAY_PORT
+                  ENTRYPOINT ["claude", "gateway", "--config", "/etc/gateway/gateway.yaml"]
+                  EOF
+                - docker build -t $ECR_REPO_URI:latest .
+            post_build:
+              commands:
+                - docker push $ECR_REPO_URI:latest
+      TimeoutInMinutes: 10
 
   GatewayService:
     Type: AWS::ECS::Service
@@ -353,3 +473,9 @@ Outputs:
   ClusterArn:
     Description: ECS cluster ARN
     Value: !GetAtt EcsCluster.Arn
+  GatewayBuildProjectName:
+    Description: CodeBuild project name — trigger to rebuild gateway image
+    Value: !Ref GatewayBuildProject
+  GatewayEcrRepositoryUri:
+    Description: ECR repository URI for the gateway image
+    Value: !Sub '${AWS::AccountId}.dkr.ecr.${AWS::Region}.${AWS::URLSuffix}/${GatewayEcrRepo}'

--- a/deployment/infrastructure/claude-apps-gateway-infra.yaml
+++ b/deployment/infrastructure/claude-apps-gateway-infra.yaml
@@ -56,8 +56,26 @@ Parameters:
     Default: 8080
     Description: Port the gateway listens on inside the container
 
+  ALBScheme:
+    Type: String
+    Default: internal
+    AllowedValues: [internet-facing, internal]
+    Description: >-
+      ALB scheme. 'internal' recommended per Claude apps gateway docs
+      (developers connect via VPN/private network). Use 'internet-facing'
+      only if developers access from the public internet.
+
+  CertificateArn:
+    Type: String
+    Default: ''
+    Description: >-
+      Optional ACM certificate ARN for HTTPS. When provided, enables an
+      HTTPS listener on port 443. Required for production (IdPs reject
+      HTTP callback URLs).
+
 Conditions:
   HasPrivateSubnets: !Not [!Equals [!Join ['', !Ref PrivateSubnetIds], '']]
+  HasCertificate: !Not [!Equals [!Ref CertificateArn, '']]
 
 Resources:
   # Security Groups
@@ -244,7 +262,9 @@ Resources:
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: gateway
           HealthCheck:
-            Command: ['CMD-SHELL', 'curl -sf http://localhost:8080/health || exit 1']
+            Command:
+              - CMD-SHELL
+              - !Sub 'curl -sf http://localhost:${GatewayPort}/health || exit 1'
             Interval: 30
             Timeout: 5
             Retries: 3
@@ -256,6 +276,7 @@ Resources:
       Cluster: !Ref EcsCluster
       TaskDefinition: !Ref TaskDefinition
       DesiredCount: 1
+      HealthCheckGracePeriodSeconds: 120
       LaunchType: FARGATE
       NetworkConfiguration:
         AwsvpcConfiguration:
@@ -272,7 +293,7 @@ Resources:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
       Type: application
-      Scheme: internet-facing
+      Scheme: !Ref ALBScheme
       SecurityGroups: [!Ref AlbSecurityGroup]
       Subnets: !Ref SubnetIds
 
@@ -293,13 +314,36 @@ Resources:
       Port: 80
       Protocol: HTTP
       DefaultActions:
+        - !If
+          - HasCertificate
+          - Type: redirect
+            RedirectConfig:
+              Protocol: HTTPS
+              Port: '443'
+              StatusCode: HTTP_301
+          - Type: forward
+            TargetGroupArn: !Ref TargetGroup
+
+  HttpsListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Condition: HasCertificate
+    Properties:
+      LoadBalancerArn: !Ref LoadBalancer
+      Port: 443
+      Protocol: HTTPS
+      Certificates:
+        - CertificateArn: !Ref CertificateArn
+      DefaultActions:
         - Type: forward
           TargetGroupArn: !Ref TargetGroup
 
 Outputs:
   GatewayUrl:
     Description: Gateway URL — use as forceLoginGatewayUrl in managed-settings.json
-    Value: !Sub 'http://${LoadBalancer.DNSName}'
+    Value: !If
+      - HasCertificate
+      - !Sub 'https://${LoadBalancer.DNSName}'
+      - !Sub 'http://${LoadBalancer.DNSName}'
   GatewayHealthEndpoint:
     Description: Health check endpoint
     Value: !Sub 'http://${LoadBalancer.DNSName}/health'

--- a/deployment/infrastructure/claude-apps-gateway-infra.yaml
+++ b/deployment/infrastructure/claude-apps-gateway-infra.yaml
@@ -1,0 +1,302 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >-
+  Claude Apps Gateway — self-hosted control plane for Claude Code CLI.
+  Deploys the gateway as a Fargate container with PostgreSQL (RDS) and ALB.
+  Provides corporate SSO, managed settings delivery, per-user spend caps,
+  and OTLP telemetry for Claude Code on Amazon Bedrock.
+
+Parameters:
+  VpcId:
+    Type: AWS::EC2::VPC::Id
+    Description: VPC ID (from networking stack)
+
+  SubnetIds:
+    Type: List<AWS::EC2::Subnet::Id>
+    Description: Public subnet IDs for ALB (at least 2 AZs)
+
+  PrivateSubnetIds:
+    Type: CommaDelimitedList
+    Default: ''
+    Description: Private subnet IDs for ECS tasks and RDS. Uses SubnetIds if empty.
+
+  OidcIssuerUrl:
+    Type: String
+    Description: OIDC issuer URL for developer authentication
+    AllowedPattern: '^https://.*'
+
+  OidcClientId:
+    Type: String
+    Description: OIDC client ID registered with your IdP
+    MinLength: 1
+
+  OidcClientSecretArn:
+    Type: String
+    Description: SecretsManager ARN containing the OIDC client secret
+
+  BedrockRegion:
+    Type: String
+    Default: us-east-1
+    Description: AWS region for Bedrock model inference
+
+  GatewayImage:
+    Type: String
+    Default: 'public.ecr.aws/anthropic/claude:latest'
+    Description: Container image (claude binary with gateway support)
+
+  DbInstanceClass:
+    Type: String
+    Default: db.t4g.micro
+    AllowedValues: [db.t4g.micro, db.t4g.small, db.t4g.medium, db.r6g.large]
+    Description: RDS instance size
+
+  GatewayPort:
+    Type: Number
+    Default: 8080
+    Description: Port the gateway listens on inside the container
+
+Conditions:
+  HasPrivateSubnets: !Not [!Equals [!Join ['', !Ref PrivateSubnetIds], '']]
+
+Resources:
+  # Security Groups
+  AlbSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Claude Apps Gateway ALB
+      VpcId: !Ref VpcId
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 80
+          ToPort: 80
+          CidrIp: 0.0.0.0/0
+
+  TaskSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Claude Apps Gateway tasks
+      VpcId: !Ref VpcId
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: !Ref GatewayPort
+          ToPort: !Ref GatewayPort
+          SourceSecurityGroupId: !Ref AlbSecurityGroup
+
+  DbSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Claude Apps Gateway RDS
+      VpcId: !Ref VpcId
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 5432
+          ToPort: 5432
+          SourceSecurityGroupId: !Ref TaskSecurityGroup
+
+  # RDS PostgreSQL
+  DbSubnetGroup:
+    Type: AWS::RDS::DBSubnetGroup
+    Properties:
+      DBSubnetGroupDescription: Subnets for Gateway DB
+      SubnetIds: !If [HasPrivateSubnets, !Ref PrivateSubnetIds, !Ref SubnetIds]
+
+  DbPassword:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: Claude Apps Gateway database password
+      GenerateSecretString:
+        SecretStringTemplate: '{"username": "gateway"}'
+        GenerateStringKey: password
+        PasswordLength: 32
+        ExcludeCharacters: '"@/\'
+
+  Database:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      Engine: postgres
+      EngineVersion: '16'
+      DBInstanceClass: !Ref DbInstanceClass
+      AllocatedStorage: 20
+      StorageEncrypted: true
+      MasterUsername: gateway
+      MasterUserPassword: !Sub '{{resolve:secretsmanager:${DbPassword}:SecretString:password}}'
+      DBSubnetGroupName: !Ref DbSubnetGroup
+      VPCSecurityGroups:
+        - !Ref DbSecurityGroup
+      BackupRetentionPeriod: 7
+      DeletionProtection: false
+      PubliclyAccessible: false
+      Tags:
+        - Key: Name
+          Value: !Sub '${AWS::StackName}-db'
+
+  # ECS
+  EcsCluster:
+    Type: AWS::ECS::Cluster
+    Properties:
+      ClusterName: !Sub '${AWS::StackName}-cluster'
+      CapacityProviders: [FARGATE]
+
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub '/ecs/${AWS::StackName}'
+      RetentionInDays: 14
+
+  TaskExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy'
+      Policies:
+        - PolicyName: SecretsAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: secretsmanager:GetSecretValue
+                Resource:
+                  - !Ref DbPassword
+                  - !Ref OidcClientSecretArn
+
+  TaskRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: BedrockAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - bedrock:InvokeModel
+                  - bedrock:InvokeModelWithResponseStream
+                Resource: '*'
+
+  TaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: !Sub '${AWS::StackName}-gateway'
+      Cpu: '1024'
+      Memory: '2048'
+      NetworkMode: awsvpc
+      RequiresCompatibilities: [FARGATE]
+      ExecutionRoleArn: !GetAtt TaskExecutionRole.Arn
+      TaskRoleArn: !GetAtt TaskRole.Arn
+      ContainerDefinitions:
+        - Name: gateway
+          Image: !Ref GatewayImage
+          Command: ['claude', 'gateway', '--port', '8080']
+          PortMappings:
+            - ContainerPort: !Ref GatewayPort
+              Protocol: tcp
+          Environment:
+            - Name: CLAUDE_GATEWAY_OIDC_ISSUER
+              Value: !Ref OidcIssuerUrl
+            - Name: CLAUDE_GATEWAY_OIDC_CLIENT_ID
+              Value: !Ref OidcClientId
+            - Name: CLAUDE_GATEWAY_UPSTREAM_PROVIDER
+              Value: bedrock
+            - Name: CLAUDE_GATEWAY_UPSTREAM_REGION
+              Value: !Ref BedrockRegion
+            - Name: CLAUDE_GATEWAY_DB_HOST
+              Value: !GetAtt Database.Endpoint.Address
+            - Name: CLAUDE_GATEWAY_DB_PORT
+              Value: '5432'
+            - Name: CLAUDE_GATEWAY_DB_NAME
+              Value: gateway
+            - Name: CLAUDE_GATEWAY_DB_USER
+              Value: gateway
+          Secrets:
+            - Name: CLAUDE_GATEWAY_OIDC_CLIENT_SECRET
+              ValueFrom: !Ref OidcClientSecretArn
+            - Name: CLAUDE_GATEWAY_DB_PASSWORD
+              ValueFrom: !Sub '${DbPassword}:password::'
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref LogGroup
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: gateway
+          HealthCheck:
+            Command: ['CMD-SHELL', 'curl -sf http://localhost:8080/health || exit 1']
+            Interval: 30
+            Timeout: 5
+            Retries: 3
+
+  GatewayService:
+    Type: AWS::ECS::Service
+    DependsOn: HttpListener
+    Properties:
+      Cluster: !Ref EcsCluster
+      TaskDefinition: !Ref TaskDefinition
+      DesiredCount: 1
+      LaunchType: FARGATE
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          Subnets: !If [HasPrivateSubnets, !Ref PrivateSubnetIds, !Ref SubnetIds]
+          SecurityGroups: [!Ref TaskSecurityGroup]
+      LoadBalancers:
+        - ContainerName: gateway
+          ContainerPort: !Ref GatewayPort
+          TargetGroupArn: !Ref TargetGroup
+
+  # ALB
+  LoadBalancer:
+    Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Properties:
+      Type: application
+      Scheme: internet-facing
+      SecurityGroups: [!Ref AlbSecurityGroup]
+      Subnets: !Ref SubnetIds
+
+  TargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Port: !Ref GatewayPort
+      Protocol: HTTP
+      VpcId: !Ref VpcId
+      TargetType: ip
+      HealthCheckPath: /health
+      HealthCheckIntervalSeconds: 30
+
+  HttpListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      LoadBalancerArn: !Ref LoadBalancer
+      Port: 80
+      Protocol: HTTP
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: !Ref TargetGroup
+
+Outputs:
+  GatewayUrl:
+    Description: Gateway URL — use as forceLoginGatewayUrl in managed-settings.json
+    Value: !Sub 'http://${LoadBalancer.DNSName}'
+  GatewayHealthEndpoint:
+    Description: Health check endpoint
+    Value: !Sub 'http://${LoadBalancer.DNSName}/health'
+  DatabaseEndpoint:
+    Description: RDS PostgreSQL endpoint
+    Value: !GetAtt Database.Endpoint.Address
+  ClusterArn:
+    Description: ECS cluster ARN
+    Value: !GetAtt EcsCluster.Arn

--- a/deployment/infrastructure/claude-apps-gateway-infra.yaml
+++ b/deployment/infrastructure/claude-apps-gateway-infra.yaml
@@ -135,7 +135,7 @@ Resources:
     Type: AWS::RDS::DBInstance
     Properties:
       Engine: postgres
-      EngineVersion: '17'
+      EngineVersion: '17.6'
       DBInstanceClass: !Ref DbInstanceClass
       AllocatedStorage: 20
       StorageEncrypted: true

--- a/deployment/infrastructure/claude-apps-gateway-infra.yaml
+++ b/deployment/infrastructure/claude-apps-gateway-infra.yaml
@@ -71,14 +71,37 @@ Parameters:
       HTTPS listener on port 443. Required for production (IdPs reject
       HTTP callback URLs).
 
+  LogsKmsKeyArn:
+    Type: String
+    Default: ''
+    Description: >-
+      Optional KMS key ARN for encrypting CloudWatch Logs. When omitted,
+      logs use the default service encryption.
+
+  ALBAccessLogsBucket:
+    Type: String
+    Default: ''
+    Description: >-
+      Optional S3 bucket name for ALB access logs. When provided, enables
+      access logging on the load balancer.
+
 Conditions:
   HasPrivateSubnets: !Not [!Equals [!Join ['', !Ref PrivateSubnetIds], '']]
   HasCertificate: !Not [!Equals [!Ref CertificateArn, '']]
+  HasKmsKey: !Not [!Equals [!Ref LogsKmsKeyArn, '']]
+  HasALBAccessLogs: !Not [!Equals [!Ref ALBAccessLogsBucket, '']]
 
 Resources:
   # Security Groups
   AlbSecurityGroup:
     Type: AWS::EC2::SecurityGroup
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W2
+            reason: ALB must accept inbound traffic from developers (internal VPN or internet-facing)
+          - id: W9
+            reason: ALB ingress intentionally open — access controlled by OIDC authentication at the gateway
     Properties:
       GroupDescription: Claude Apps Gateway ALB
       VpcId: !Ref VpcId
@@ -92,27 +115,71 @@ Resources:
           ToPort: 80
           CidrIp: 0.0.0.0/0
 
+  AlbToTaskEgress:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      GroupId: !Ref AlbSecurityGroup
+      IpProtocol: tcp
+      FromPort: !Ref GatewayPort
+      ToPort: !Ref GatewayPort
+      DestinationSecurityGroupId: !Ref TaskSecurityGroup
+      Description: ALB to Gateway tasks
+
   TaskSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: Claude Apps Gateway tasks
       VpcId: !Ref VpcId
-      SecurityGroupIngress:
-        - IpProtocol: tcp
-          FromPort: !Ref GatewayPort
-          ToPort: !Ref GatewayPort
-          SourceSecurityGroupId: !Ref AlbSecurityGroup
+
+  TaskFromAlbIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref TaskSecurityGroup
+      IpProtocol: tcp
+      FromPort: !Ref GatewayPort
+      ToPort: !Ref GatewayPort
+      SourceSecurityGroupId: !Ref AlbSecurityGroup
+      Description: Allow traffic from ALB
+
+  TaskToDbEgress:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      GroupId: !Ref TaskSecurityGroup
+      IpProtocol: tcp
+      FromPort: 5432
+      ToPort: 5432
+      DestinationSecurityGroupId: !Ref DbSecurityGroup
+      Description: Tasks to RDS PostgreSQL
+
+  TaskToHttpsEgress:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      GroupId: !Ref TaskSecurityGroup
+      IpProtocol: tcp
+      FromPort: 443
+      ToPort: 443
+      CidrIp: 0.0.0.0/0
+      Description: HTTPS to Bedrock API and OIDC issuer
 
   DbSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: Claude Apps Gateway RDS
       VpcId: !Ref VpcId
-      SecurityGroupIngress:
-        - IpProtocol: tcp
-          FromPort: 5432
-          ToPort: 5432
-          SourceSecurityGroupId: !Ref TaskSecurityGroup
+      SecurityGroupEgress:
+        - IpProtocol: -1
+          CidrIp: 127.0.0.1/32
+          Description: Deny all outbound (RDS managed, egress not needed)
+
+  DbFromTaskIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref DbSecurityGroup
+      IpProtocol: tcp
+      FromPort: 5432
+      ToPort: 5432
+      SourceSecurityGroupId: !Ref TaskSecurityGroup
+      Description: Allow PostgreSQL from Gateway tasks
 
   # RDS PostgreSQL
   DbSubnetGroup:
@@ -139,13 +206,13 @@ Resources:
       DBInstanceClass: !Ref DbInstanceClass
       AllocatedStorage: 20
       StorageEncrypted: true
-      MasterUsername: gateway
+      MasterUsername: !Sub '{{resolve:secretsmanager:${DbPassword}:SecretString:username}}'
       MasterUserPassword: !Sub '{{resolve:secretsmanager:${DbPassword}:SecretString:password}}'
       DBSubnetGroupName: !Ref DbSubnetGroup
       VPCSecurityGroups:
         - !Ref DbSecurityGroup
       BackupRetentionPeriod: 7
-      DeletionProtection: false
+      DeletionProtection: true
       PubliclyAccessible: false
       Tags:
         - Key: Name
@@ -157,12 +224,19 @@ Resources:
     Properties:
       ClusterName: !Sub '${AWS::StackName}-cluster'
       CapacityProviders: [FARGATE]
+      Tags:
+        - Key: Name
+          Value: !Sub '${AWS::StackName}-cluster'
 
   LogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub '/ecs/${AWS::StackName}'
       RetentionInDays: 14
+      KmsKeyId: !If
+        - HasKmsKey
+        - !Ref LogsKmsKeyArn
+        - !Ref AWS::NoValue
 
   TaskExecutionRole:
     Type: AWS::IAM::Role
@@ -189,6 +263,11 @@ Resources:
 
   TaskRole:
     Type: AWS::IAM::Role
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W11
+            reason: Bedrock InvokeModel scoped to foundation-model/* — specific model ARNs unknown at deploy time
     Properties:
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
@@ -206,7 +285,7 @@ Resources:
                 Action:
                   - bedrock:InvokeModel
                   - bedrock:InvokeModelWithResponseStream
-                Resource: '*'
+                Resource: !Sub 'arn:${AWS::Partition}:bedrock:${BedrockRegion}::foundation-model/*'
 
   TaskDefinition:
     Type: AWS::ECS::TaskDefinition
@@ -281,6 +360,11 @@ Resources:
   # CodeBuild project — builds the gateway container image automatically
   GatewayBuildRole:
     Type: AWS::IAM::Role
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W11
+            reason: ecr:GetAuthorizationToken requires Resource '*' — does not support resource-level permissions
     Properties:
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
@@ -296,7 +380,7 @@ Resources:
             Statement:
               - Effect: Allow
                 Action: ecr:GetAuthorizationToken
-                Resource: '*'
+                Resource: '*'  # cfn_nag:W12 — ecr:GetAuthorizationToken does not support resource-level permissions
               - Effect: Allow
                 Action:
                   - ecr:BatchCheckLayerAvailability
@@ -310,10 +394,17 @@ Resources:
                   - logs:CreateLogGroup
                   - logs:CreateLogStream
                   - logs:PutLogEvents
-                Resource: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*'
+                Resource: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/codebuild/${AWS::StackName}-build:*'
 
   GatewayBuildProject:
     Type: AWS::CodeBuild::Project
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W32
+            reason: Build artifacts are Docker images pushed to ECR; no S3 artifacts to encrypt
+          - id: W28
+            reason: Name uses !Sub with stack name — unique per deployment, replacement safe
     Properties:
       Name: !Sub '${AWS::StackName}-build'
       ServiceRole: !GetAtt GatewayBuildRole.Arn
@@ -411,11 +502,27 @@ Resources:
   # ALB
   LoadBalancer:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W52
+            reason: Access logging is opt-in via ALBAccessLogsBucket parameter
     Properties:
       Type: application
       Scheme: !Ref ALBScheme
       SecurityGroups: [!Ref AlbSecurityGroup]
       Subnets: !Ref SubnetIds
+      LoadBalancerAttributes:
+        - !If
+          - HasALBAccessLogs
+          - Key: access_logs.s3.enabled
+            Value: 'true'
+          - !Ref AWS::NoValue
+        - !If
+          - HasALBAccessLogs
+          - Key: access_logs.s3.bucket
+            Value: !Ref ALBAccessLogsBucket
+          - !Ref AWS::NoValue
 
   TargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
@@ -429,6 +536,11 @@ Resources:
 
   HttpListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W56
+            reason: HTTP listener redirects to HTTPS when certificate provided; without cert this is dev/internal only
     Properties:
       LoadBalancerArn: !Ref LoadBalancer
       Port: 80
@@ -451,6 +563,7 @@ Resources:
       LoadBalancerArn: !Ref LoadBalancer
       Port: 443
       Protocol: HTTPS
+      SslPolicy: ELBSecurityPolicy-TLS13-1-2-2021-06
       Certificates:
         - CertificateArn: !Ref CertificateArn
       DefaultActions:

--- a/deployment/infrastructure/claude-apps-gateway-infra.yaml
+++ b/deployment/infrastructure/claude-apps-gateway-infra.yaml
@@ -40,8 +40,10 @@ Parameters:
 
   GatewayImage:
     Type: String
-    Default: 'public.ecr.aws/anthropic/claude:latest'
-    Description: Container image (claude binary with gateway support)
+    Description: >-
+      Container image with the claude binary and gateway.yaml baked in.
+      Build your own image following the gateway deployment guide, or use
+      the official image when available. No default — must be provided.
 
   DbInstanceClass:
     Type: String
@@ -203,7 +205,13 @@ Resources:
       ContainerDefinitions:
         - Name: gateway
           Image: !Ref GatewayImage
-          Command: ['claude', 'gateway', '--port', '8080']
+          # NOTE: The gateway requires a config file (gateway.yaml). The exact
+          # interface depends on your claude binary version. Options:
+          # 1. Bake gateway.yaml into your container image
+          # 2. Mount from EFS or SSM Parameter Store via init container
+          # 3. Use environment variables if your version supports them
+          # See: https://code.claude.com/docs/en/claude-apps-gateway-config
+          Command: ['claude', 'gateway', '--config', '/etc/gateway/gateway.yaml']
           PortMappings:
             - ContainerPort: !Ref GatewayPort
               Protocol: tcp
@@ -251,6 +259,7 @@ Resources:
       LaunchType: FARGATE
       NetworkConfiguration:
         AwsvpcConfiguration:
+          AssignPublicIp: !If [HasPrivateSubnets, DISABLED, ENABLED]
           Subnets: !If [HasPrivateSubnets, !Ref PrivateSubnetIds, !Ref SubnetIds]
           SecurityGroups: [!Ref TaskSecurityGroup]
       LoadBalancers:

--- a/deployment/infrastructure/claude-apps-gateway-infra.yaml
+++ b/deployment/infrastructure/claude-apps-gateway-infra.yaml
@@ -135,7 +135,7 @@ Resources:
     Type: AWS::RDS::DBInstance
     Properties:
       Engine: postgres
-      EngineVersion: '16'
+      EngineVersion: '17'
       DBInstanceClass: !Ref DbInstanceClass
       AllocatedStorage: 20
       StorageEncrypted: true

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -1054,9 +1054,7 @@ class DeployCommand(Command):
                 stack_name = profile.stack_names.get("gateway", f"{profile.identity_pool_name}-gateway")
 
                 # Require networking stack
-                networking_stack = profile.stack_names.get(
-                    "networking", f"{profile.identity_pool_name}-networking"
-                )
+                networking_stack = profile.stack_names.get("networking", f"{profile.identity_pool_name}-networking")
                 networking_outputs = get_stack_outputs(networking_stack, profile.aws_region)
 
                 if not networking_outputs or not networking_outputs.get("VpcId"):
@@ -1069,9 +1067,8 @@ class DeployCommand(Command):
 
                 # OIDC params
                 oidc_issuer_url, oidc_client_id = self._resolve_oidc_config(profile)
-                client_secret_arn = (
-                    getattr(profile, 'distribution_idp_client_secret_arn', '')
-                    or getattr(profile, 'client_secret_arn', '')
+                client_secret_arn = getattr(profile, "distribution_idp_client_secret_arn", "") or getattr(
+                    profile, "client_secret_arn", ""
                 )
 
                 if not oidc_issuer_url or not oidc_client_id:
@@ -1104,13 +1101,13 @@ class DeployCommand(Command):
                 )
 
                 if result == 0:
-
                     # Trigger CodeBuild to build the gateway image
                     build_project = outputs.get("GatewayBuildProjectName", "") if outputs else ""
                     if build_project:
                         console.print("[cyan]Building gateway image (CodeBuild)...[/cyan]")
                         try:
                             import boto3 as _boto3
+
                             cb = _boto3.client("codebuild", region_name=profile.aws_region)
                             build_resp = cb.start_build(projectName=build_project)
                             build_id = build_resp["build"]["id"]
@@ -1124,9 +1121,7 @@ class DeployCommand(Command):
                     console.print("\n[bold green]✓ Claude Apps Gateway deployed![/bold green]")
                     console.print(f"\n[bold]Gateway URL:[/bold] {gateway_url}")
                     console.print("\n[dim]To connect Claude Code CLI, set in managed-settings.json:[/dim]")
-                    console.print(
-                        f'  {{"forceLoginMethod": "gateway", "forceLoginGatewayUrl": "{gateway_url}"}}'
-                    )
+                    console.print(f'  {{"forceLoginMethod": "gateway", "forceLoginGatewayUrl": "{gateway_url}"}}')
 
                 return result
 

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -189,10 +189,12 @@ class DeployCommand(Command):
                 else:
                     console.print("[yellow]CodeBuild is not enabled in your configuration.[/yellow]")
                     return 1
+            elif stack_arg == "gateway":
+                stacks_to_deploy.append(("gateway", "Claude Apps Gateway (ECS + RDS + ALB)"))
             else:
                 console.print(f"[red]Unknown stack: {stack_arg}[/red]")
                 console.print(
-                    "Valid stacks: auth, distribution, networking, monitoring, dashboard, cowork-dashboard, analytics, quota, codebuild\n"
+                    "Valid stacks: auth, distribution, networking, monitoring, dashboard, cowork-dashboard, analytics, quota, codebuild, gateway\n"
                 )
                 console.print("[dim]Tip: Use 'ccwb deploy' without arguments to deploy all enabled stacks.[/dim]")
                 console.print("[dim]Use 'ccwb deploy quota' for quota-specific updates or late enablement.[/dim]")
@@ -1047,6 +1049,72 @@ class DeployCommand(Command):
                     cf=cf,
                 )
 
+            elif stack_type == "gateway":
+                template = project_root / "deployment" / "infrastructure" / "claude-apps-gateway-infra.yaml"
+                stack_name = profile.stack_names.get("gateway", f"{profile.identity_pool_name}-gateway")
+
+                # Require networking stack
+                networking_stack = profile.stack_names.get(
+                    "networking", f"{profile.identity_pool_name}-networking"
+                )
+                networking_outputs = get_stack_outputs(networking_stack, profile.aws_region)
+
+                if not networking_outputs or not networking_outputs.get("VpcId"):
+                    console.print("[red]Error: Networking stack required for Gateway deployment.[/red]")
+                    console.print("[dim]Run 'ccwb deploy networking' first.[/dim]")
+                    return 1
+
+                vpc_id = networking_outputs.get("VpcId", "")
+                subnet_ids = networking_outputs.get("SubnetIds", "")
+
+                # OIDC params
+                oidc_issuer_url, oidc_client_id = self._resolve_oidc_config(profile)
+                client_secret_arn = (
+                    getattr(profile, 'distribution_idp_client_secret_arn', '')
+                    or getattr(profile, 'client_secret_arn', '')
+                )
+
+                if not oidc_issuer_url or not oidc_client_id:
+                    console.print("[red]Error: OIDC configuration required for Gateway deployment.[/red]")
+                    console.print("[dim]Configure OIDC authentication via 'ccwb init' first.[/dim]")
+                    return 1
+
+                if not client_secret_arn:
+                    console.print("[red]Error: OIDC client secret ARN required.[/red]")
+                    console.print(
+                        "[dim]Deploy the distribution stack first, or set "
+                        "distribution_idp_client_secret_arn in your profile.[/dim]"
+                    )
+                    return 1
+
+                params = [
+                    f"VpcId={vpc_id}",
+                    f"SubnetIds={subnet_ids}",
+                    f"OidcIssuerUrl={oidc_issuer_url}",
+                    f"OidcClientId={oidc_client_id}",
+                    f"OidcClientSecretArn={client_secret_arn}",
+                    f"BedrockRegion={profile.aws_region}",
+                ]
+
+                result = deploy_with_cf(
+                    template,
+                    stack_name,
+                    params,
+                    task_description="Deploying Claude Apps Gateway (ECS + RDS + ALB)...",
+                )
+
+                if result == 0:
+                    outputs = get_stack_outputs(stack_name, profile.aws_region)
+                    gateway_url = outputs.get("GatewayUrl", "N/A") if outputs else "N/A"
+                    console.print("\n[bold green]✓ Claude Apps Gateway deployed![/bold green]")
+                    console.print(f"\n[bold]Gateway URL:[/bold] {gateway_url}")
+                    console.print("\n[dim]To connect Claude Code CLI, set in managed-settings.json:[/dim]")
+                    console.print(
+                        f'  {{"forceLoginMethod": "gateway", "forceLoginGatewayUrl": "{gateway_url}"}}'
+                    )
+
+                return result
+
             else:
                 console.print(f"[red]Unknown stack type: {stack_type}[/red]")
                 return 1
@@ -1259,6 +1327,20 @@ class DeployCommand(Command):
             else:
                 template = project_root / "deployment" / "infrastructure" / "presigned-s3-distribution.yaml"
                 params = [f"IdentityPoolName={profile.identity_pool_name}"]
+            print_deploy_cmd(template, stack_name, params, ["CAPABILITY_NAMED_IAM"])
+
+        elif stack_type == "gateway":
+            template = project_root / "deployment" / "infrastructure" / "claude-apps-gateway-infra.yaml"
+            stack_name = profile.stack_names.get("gateway", f"{profile.identity_pool_name}-gateway")
+            networking_stack = profile.stack_names.get("networking", f"{profile.identity_pool_name}-networking")
+            params = [
+                f"VpcId=<VpcId from {networking_stack}>",
+                f"SubnetIds=<SubnetIds from {networking_stack}>",
+                f"OidcIssuerUrl={profile.provider_domain or '<issuer-url>'}",
+                f"OidcClientId={profile.client_id or '<client-id>'}",
+                f"OidcClientSecretArn=<secrets-manager-arn>",
+                f"BedrockRegion={profile.aws_region}",
+            ]
             print_deploy_cmd(template, stack_name, params, ["CAPABILITY_NAMED_IAM"])
 
         else:

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -1353,7 +1353,7 @@ class DeployCommand(Command):
                 f"SubnetIds=<SubnetIds from {networking_stack}>",
                 f"OidcIssuerUrl={profile.provider_domain or '<issuer-url>'}",
                 f"OidcClientId={profile.client_id or '<client-id>'}",
-                f"OidcClientSecretArn=<secrets-manager-arn>",
+                "OidcClientSecretArn=<secrets-manager-arn>",
                 f"BedrockRegion={profile.aws_region}",
             ]
             print_deploy_cmd(template, stack_name, params, ["CAPABILITY_NAMED_IAM"])

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -1104,6 +1104,21 @@ class DeployCommand(Command):
                 )
 
                 if result == 0:
+
+                    # Trigger CodeBuild to build the gateway image
+                    build_project = outputs.get("GatewayBuildProjectName", "") if outputs else ""
+                    if build_project:
+                        console.print("[cyan]Building gateway image (CodeBuild)...[/cyan]")
+                        try:
+                            import boto3 as _boto3
+                            cb = _boto3.client("codebuild", region_name=profile.aws_region)
+                            build_resp = cb.start_build(projectName=build_project)
+                            build_id = build_resp["build"]["id"]
+                            console.print(f"[dim]Build started: {build_id}[/dim]")
+                            console.print("[dim]ECS will pull the image once build completes (~2-3 min).[/dim]")
+                        except Exception as e:
+                            console.print(f"[yellow]Warning: Could not trigger image build: {e}[/yellow]")
+
                     outputs = get_stack_outputs(stack_name, profile.aws_region)
                     gateway_url = outputs.get("GatewayUrl", "N/A") if outputs else "N/A"
                     console.print("\n[bold green]✓ Claude Apps Gateway deployed![/bold green]")

--- a/source/claude_code_with_bedrock/cli/commands/destroy.py
+++ b/source/claude_code_with_bedrock/cli/commands/destroy.py
@@ -17,6 +17,7 @@ from claude_code_with_bedrock.config import Config
 # All destroyable stacks in reverse dependency order (destroy-all uses this sequence).
 # Keep in sync with deploy.py's stack types when adding new stacks.
 DESTROYABLE_STACKS = [
+    "gateway",
     "codebuild",
     "analytics",
     "quota",


### PR DESCRIPTION
## Summary

Adds `ccwb deploy gateway` and `ccwb destroy gateway` to deploy the [Claude Apps Gateway](https://claude.com/blog/introducing-the-claude-apps-gateway) as self-hosted infrastructure on AWS. **One command — no Docker knowledge required.**

The Gateway is a control plane for Claude Code CLI that provides corporate SSO login, centrally enforced policy, per-user spend caps, managed settings delivery, and OTLP telemetry — without provisioning individual cloud credentials per developer.

> **Claude Desktop is out of scope** — continues using credential-helper + MDM/bootstrap.

Ref #719

## What happens when you run `ccwb deploy gateway`

1. CloudFormation creates: ECR repo + CodeBuild project + ECS cluster + RDS PostgreSQL + ALB
2. deploy.py automatically triggers CodeBuild
3. CodeBuild: downloads `claude` binary → generates `gateway.yaml` from your OIDC config → builds Docker image → pushes to ECR
4. ECS pulls the image and starts serving
5. Gateway URL + connection instructions printed

**Admin never writes a Dockerfile or touches Docker.**

## How developers connect

After deploying, set in `managed-settings.json`:

```json
{
  "forceLoginMethod": "gateway",
  "forceLoginGatewayUrl": "https://<gateway-alb-dns>"
}
```

Developer runs `claude` → redirected to corporate SSO → authenticated → Gateway routes inference to Bedrock. No API keys or cloud credentials on developer machines.

## Infrastructure

```
Developer (Claude Code CLI)
        │
        │ forceLoginGatewayUrl
        ▼
┌─────────────────────┐
│  ALB (HTTP/HTTPS)   │  ← internal by default (per docs)
└────────┬────────────┘
         │
┌────────▼────────────┐
│  ECS Fargate        │
│  (claude gateway)   │──── Amazon Bedrock
└────────┬────────────┘
         │
┌────────▼────────────┐
│  RDS PostgreSQL 17  │
│  (session state)    │
└─────────────────────┘

Built by:
┌─────────────────────┐
│  CodeBuild          │──── ECR (gateway image)
│  (auto-triggered)   │
└─────────────────────┘
```

## Key design decisions

| Decision | Choice | Rationale |
|----------|--------|-----------|
| Image build | CodeBuild (auto-triggered) | Zero Docker knowledge for admins |
| ALB scheme | `internal` (default) | Per official docs — Gateway should be on private network |
| HTTPS | Optional (CertificateArn param) | Redirects HTTP→HTTPS when cert provided |
| PostgreSQL | RDS 17 (encrypted, private) | Managed, no ops burden |
| AssignPublicIp | Conditional | ENABLED for public subnets, DISABLED for private |
| Config delivery | CodeBuild generates gateway.yaml from CFN params | Config always in sync with profile |

## Prerequisites

1. Networking stack deployed (`ccwb deploy networking`)
2. OIDC client secret in SecretsManager
3. IdP app registration (same one used for credential-process)

## Backwards compatible

- New stack — doesn't touch existing auth, monitoring, quota, or distribution
- Not in "deploy all" sequence — only deployed via explicit `ccwb deploy gateway`
- Existing deployments completely unchanged
- `ccwb destroy gateway` removes all resources cleanly

## Documentation

See `assets/docs/CLAUDE_GATEWAY.md` for the full guide.

cc @jiem-ying
