### PR TITLE
ci: remove pull_request trigger from E2E matrix workflow

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -17,12 +17,6 @@ on:
         type: boolean
         default: false
 
-  pull_request:
-    branches:
-      - beta
-    paths:
-      - 'deployment/**'
-      - 'source/go/**'
 
 permissions:
   id-token: write


### PR DESCRIPTION
## Why

The E2E workflow deploys real CloudFormation stacks with OIDC federation on every PR touching `deployment/**` or `source/go/**`. This creates:
- Expensive AWS resource usage on every PR
- "deployed to e2e-testing" spam on PR timelines (30+ deployment entries)
- Slow feedback loops (full infra deploy + teardown)

## Change

Remove the `pull_request` trigger. E2E tests still run via:
- **Nightly schedule** (weekdays 3 AM UTC on beta) — catches regressions
- **workflow_dispatch** — on-demand when you need to validate a specific change

## Risk

Zero. Purely CI trigger change. If a PR needs E2E validation before merge, trigger it manually via Actions → E2E Matrix Tests → Run workflow.