### PR TITLE
fix(quota): reset idle users' daily counter in monitor alerts and CLI display

### DIFF
--- a/deployment/infrastructure/lambda-functions/quota_monitor/index.py
+++ b/deployment/infrastructure/lambda-functions/quota_monitor/index.py
@@ -222,6 +222,25 @@ def update_quota_metrics(usage_data):
     print(f"Updated UserQuotaMetrics for {len(usage_data)} users")
 
 
+def _build_usage_entry(item, current_date):
+    """Build a usage_data entry for threshold checking, applying the stale-day guard.
+
+    Mirrors quota_check.get_user_usage: if the stored daily_date is not today
+    (UTC), the daily counter belongs to a prior day and must be treated as 0.
+    Otherwise an idle user whose daily_tokens froze above the limit gets a fresh
+    "daily exceeded" alert every new UTC day even though they had no activity.
+    Monthly (total_tokens) is unaffected — it accumulates across the whole month.
+    """
+    daily_tokens = float(item.get("daily_tokens", 0))
+    daily_date = item.get("daily_date")
+    if daily_date != current_date:
+        daily_tokens = 0
+    return {
+        "total_tokens": float(item.get("total_tokens", 0)),
+        "daily_tokens": daily_tokens,
+    }
+
+
 def lambda_handler(event, context):
     """Fetch usage from PromQL, update DynamoDB, check quotas, send alerts."""
     print(f"Starting quota monitoring at {datetime.now(timezone.utc).isoformat()}")
@@ -242,30 +261,29 @@ def lambda_handler(event, context):
         # Step 2: Read cumulative totals from DynamoDB for threshold checking
         current_month = now.strftime("%Y-%m")
         usage_data = {}
+        # NOTE: daily_date MUST be projected so we can apply the same stale-day
+        # guard that quota_check uses (quota_check/index.py). Without it, an idle
+        # user's frozen daily_tokens is read verbatim and re-alerted every new UTC
+        # day even though they had no activity.
+        projection = "email, total_tokens, daily_tokens, daily_date"
         response = quota_table.scan(
             FilterExpression=Attr("sk").eq(f"MONTH#{current_month}") & Attr("pk").begins_with("USER#"),
-            ProjectionExpression="email, total_tokens, daily_tokens",
+            ProjectionExpression=projection,
         )
         for item in response.get("Items", []):
             email = item.get("email")
             if email:
-                usage_data[email] = {
-                    "total_tokens": float(item.get("total_tokens", 0)),
-                    "daily_tokens": float(item.get("daily_tokens", 0)),
-                }
+                usage_data[email] = _build_usage_entry(item, current_date)
         while "LastEvaluatedKey" in response:
             response = quota_table.scan(
                 FilterExpression=Attr("sk").eq(f"MONTH#{current_month}") & Attr("pk").begins_with("USER#"),
-                ProjectionExpression="email, total_tokens, daily_tokens",
+                ProjectionExpression=projection,
                 ExclusiveStartKey=response["LastEvaluatedKey"],
             )
             for item in response.get("Items", []):
                 email = item.get("email")
                 if email:
-                    usage_data[email] = {
-                        "total_tokens": float(item.get("total_tokens", 0)),
-                        "daily_tokens": float(item.get("daily_tokens", 0)),
-                    }
+                    usage_data[email] = _build_usage_entry(item, current_date)
 
         if not usage_data:
             print("No usage data in DynamoDB")

--- a/source/claude_code_with_bedrock/cli/commands/quota.py
+++ b/source/claude_code_with_bedrock/cli/commands/quota.py
@@ -1213,7 +1213,7 @@ class QuotaUsageCommand(Command):
         Returns:
             Dictionary with usage data (total_tokens, daily_tokens, etc.).
         """
-        from datetime import datetime
+        from datetime import datetime, timezone
 
         import boto3
 
@@ -1232,17 +1232,31 @@ class QuotaUsageCommand(Command):
             dynamodb = boto3.resource("dynamodb", region_name=profile.aws_region)
             table = dynamodb.Table(table_name)
 
-            # Get current month
-            current_month = datetime.utcnow().strftime("%Y-%m")
+            # Use tz-aware UTC so the month and day boundaries match the Lambdas
+            # (quota_check/quota_monitor use datetime.now(timezone.utc)). A naive
+            # utcnow() here risks an off-by-one at the day boundary.
+            now = datetime.now(timezone.utc)
+            current_month = now.strftime("%Y-%m")
+            current_date = now.strftime("%Y-%m-%d")
 
             # Query for user's monthly usage
             response = table.get_item(Key={"pk": f"USER#{email}", "sk": f"MONTH#{current_month}"})
 
             item = response.get("Item", {})
+
+            # Apply the same stale-day guard as quota_check.get_user_usage: if the
+            # stored daily_date is not today, the daily counter belongs to a prior
+            # day and must display as 0. Without this, an idle user's frozen
+            # daily_tokens shows a stale over-limit percentage that never resets.
+            daily_tokens = int(item.get("daily_tokens", 0))
+            daily_date = item.get("daily_date")
+            if daily_date != current_date:
+                daily_tokens = 0
+
             return {
                 "total_tokens": int(item.get("total_tokens", 0)),
-                "daily_tokens": int(item.get("daily_tokens", 0)),
-                "daily_date": item.get("daily_date"),
+                "daily_tokens": daily_tokens,
+                "daily_date": daily_date,
                 "input_tokens": int(item.get("input_tokens", 0)),
                 "output_tokens": int(item.get("output_tokens", 0)),
                 "cache_tokens": int(item.get("cache_tokens", 0)),

--- a/source/tests/cli/commands/test_quota_usage_stale_day.py
+++ b/source/tests/cli/commands/test_quota_usage_stale_day.py
@@ -1,0 +1,86 @@
+# ABOUTME: Tests that 'ccwb quota usage' applies the stale-day guard to daily_tokens
+# ABOUTME: An idle user's frozen daily counter must display as 0 on a new UTC day
+
+"""Regression tests for QuotaUsageCommand._get_user_usage stale-day reset.
+
+Without the guard, the CLI read daily_tokens verbatim, so an idle user whose
+daily_date is from a prior day kept showing a stale over-limit percentage that
+never reset — matching what admins saw alongside the repeating alert emails.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from claude_code_with_bedrock.cli.commands.quota import QuotaUsageCommand
+
+
+def _today() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def _yesterday() -> str:
+    return (datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y-%m-%d")
+
+
+def _make_profile():
+    profile = MagicMock()
+    profile.user_quota_metrics_table = "TestUserQuotaMetrics"
+    profile.aws_region = "us-east-1"
+    profile.stack_names = {}
+    return profile
+
+
+def _patch_table(item: dict):
+    """Return a patch context yielding a boto3.resource whose table returns `item`."""
+    table = MagicMock()
+    table.get_item.return_value = {"Item": item}
+    resource = MagicMock()
+    resource.Table.return_value = table
+    return patch("boto3.resource", return_value=resource)
+
+
+@pytest.fixture
+def command():
+    return QuotaUsageCommand()
+
+
+def test_stale_day_resets_daily_tokens(command):
+    profile = _make_profile()
+    item = {
+        "total_tokens": 3_355_533,
+        "daily_tokens": 3_355_533,  # frozen above limit
+        "daily_date": _yesterday(),
+    }
+    with _patch_table(item):
+        usage = command._get_user_usage(profile, "idle.user@example.com")
+
+    assert usage["daily_tokens"] == 0, "stale daily counter must display as 0"
+    assert usage["total_tokens"] == 3_355_533, "monthly total must be untouched"
+    assert usage["daily_date"] == _yesterday()
+
+
+def test_same_day_keeps_daily_tokens(command):
+    profile = _make_profile()
+    item = {
+        "total_tokens": 3_355_533,
+        "daily_tokens": 3_355_533,
+        "daily_date": _today(),
+    }
+    with _patch_table(item):
+        usage = command._get_user_usage(profile, "active.user@example.com")
+
+    assert usage["daily_tokens"] == 3_355_533, "same-day daily usage must be preserved"
+
+
+def test_missing_daily_date_resets(command):
+    """A row without daily_date (legacy) is treated as stale -> 0."""
+    profile = _make_profile()
+    item = {"total_tokens": 1000, "daily_tokens": 500}
+    with _patch_table(item):
+        usage = command._get_user_usage(profile, "legacy.user@example.com")
+
+    assert usage["daily_tokens"] == 0

--- a/source/tests/test_quota_monitor_lambda.py
+++ b/source/tests/test_quota_monitor_lambda.py
@@ -1,0 +1,168 @@
+# ABOUTME: Tests for the quota_monitor Lambda's stale-day guard on the daily counter
+# ABOUTME: Idle users whose daily_date is not today must not re-alert as "daily exceeded"
+
+"""Tests for quota_monitor daily stale-day reset in the threshold/alert step.
+
+Regression: an idle user's daily_tokens froze above the daily limit and a fresh
+"Daily Token Quota EXCEEDED" alert went out every new UTC day, because the
+threshold step read daily_tokens verbatim (without the stale-day guard that
+quota_check already applies).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+LAMBDA_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "deployment"
+    / "infrastructure"
+    / "lambda-functions"
+    / "quota_monitor"
+    / "index.py"
+)
+
+
+def _load_quota_monitor(env: dict) -> object:
+    """Load the quota_monitor Lambda module fresh with the given environment."""
+    for key, value in env.items():
+        os.environ[key] = value
+
+    module_name = f"quota_monitor_index_{id(env)}"
+    spec = importlib.util.spec_from_file_location(module_name, LAMBDA_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def base_env():
+    return {
+        "QUOTA_TABLE": "TestQuotaTable",
+        "POLICIES_TABLE": "TestPoliciesTable",
+        "SNS_TOPIC_ARN": "arn:aws:sns:us-east-1:123456789012:test-alerts",
+        "ENABLE_FINEGRAINED_QUOTAS": "false",
+        "MONTHLY_TOKEN_LIMIT": "40000000",
+    }
+
+
+def _today() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def _yesterday() -> str:
+    return (datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y-%m-%d")
+
+
+def _scan_response(items: list[dict]) -> dict:
+    """A single-page DynamoDB scan response (no LastEvaluatedKey)."""
+    return {"Items": items}
+
+
+def _patch_monitor(mod, scan_item: dict, daily_token_limit: int = 2_000_000):
+    """Wire the monitor so it skips PromQL/update and scans a single user row.
+
+    Returns the MagicMock SNS client for assertions on published alerts.
+    """
+    # No new activity -> update step is a no-op and daily reset never happens
+    # via update_quota_metrics (this is the idle-user condition).
+    mod.fetch_usage_from_promql = MagicMock(return_value={})
+
+    mod.quota_table = MagicMock()
+    mod.quota_table.scan.return_value = _scan_response([scan_item])
+    # get_sent_alerts issues a query; return no prior alerts.
+    mod.quota_table.query.return_value = {"Items": []}
+
+    # Force the env-var policy to carry a daily limit so daily checks run.
+    base_policy = {
+        "policy_type": "default",
+        "identifier": "environment",
+        "monthly_token_limit": 40_000_000,
+        "daily_token_limit": daily_token_limit,
+        "warning_threshold_80": 32_000_000,
+        "warning_threshold_90": 36_000_000,
+        "enforcement_mode": "alert",
+        "enabled": True,
+    }
+    mod.resolve_user_quota = MagicMock(return_value=base_policy)
+
+    mod.sns_client = MagicMock()
+    return mod.sns_client
+
+
+def _daily_alert_published(sns_client) -> bool:
+    """True if any SNS publish call carried a Daily Token Quota alert."""
+    for call in sns_client.publish.call_args_list:
+        subject = call.kwargs.get("Subject", "")
+        if "Daily Token Quota" in subject:
+            return True
+    return False
+
+
+class TestStaleDailyReset:
+    def test_idle_user_stale_day_no_daily_alert(self, base_env):
+        """daily_date=yesterday + daily_tokens over limit + no activity -> no alert."""
+        mod = _load_quota_monitor(base_env)
+        sns = _patch_monitor(
+            mod,
+            scan_item={
+                "email": "idle.user@example.com",
+                "total_tokens": 3_355_533,
+                "daily_tokens": 3_355_533,  # frozen, above 2,000,000 limit
+                "daily_date": _yesterday(),
+            },
+        )
+
+        result = mod.lambda_handler({}, None)
+        assert result["statusCode"] == 200
+        assert not _daily_alert_published(sns), "stale daily counter must not re-alert"
+
+    def test_active_user_same_day_over_limit_still_alerts(self, base_env):
+        """daily_date=today + over limit -> daily alert IS generated (no over-correction)."""
+        mod = _load_quota_monitor(base_env)
+        sns = _patch_monitor(
+            mod,
+            scan_item={
+                "email": "active.user@example.com",
+                "total_tokens": 3_355_533,
+                "daily_tokens": 3_355_533,  # above 2,000,000 limit, today
+                "daily_date": _today(),
+            },
+        )
+
+        result = mod.lambda_handler({}, None)
+        assert result["statusCode"] == 200
+        assert _daily_alert_published(sns), "genuine same-day over-limit must still alert"
+
+    def test_build_usage_entry_zeros_stale_daily(self, base_env):
+        """_build_usage_entry applies the stale-day guard; monthly is untouched."""
+        mod = _load_quota_monitor(base_env)
+        item = {
+            "email": "idle.user@example.com",
+            "total_tokens": 3_355_533,
+            "daily_tokens": 3_355_533,
+            "daily_date": _yesterday(),
+        }
+        entry = mod._build_usage_entry(item, _today())
+        assert entry["daily_tokens"] == 0
+        assert entry["total_tokens"] == 3_355_533
+
+    def test_build_usage_entry_keeps_same_day_daily(self, base_env):
+        mod = _load_quota_monitor(base_env)
+        item = {
+            "email": "active.user@example.com",
+            "total_tokens": 3_355_533,
+            "daily_tokens": 3_355_533,
+            "daily_date": _today(),
+        }
+        entry = mod._build_usage_entry(item, _today())
+        assert entry["daily_tokens"] == 3_355_533


### PR DESCRIPTION
## Why

An idle user whose daily token counter froze above the daily limit kept receiving a fresh **"Daily Token Quota EXCEEDED"** alert email **every new UTC day**, and `ccwb quota usage` kept showing the same stale over-limit percentage. Neither reset, even though the user had no recent activity.

The daily counter is only rolled over to a new day as a *side effect of new activity* — `update_quota_metrics()` is gated on a PromQL delta (`if delta <= 0: continue`), and idle users aren't returned by the query at all. So an idle user's `daily_tokens`/`daily_date` stay frozen until they use Claude Code again (or the month rolls over).

The **real-time enforcement** path (`quota_check`) already guards against this — it treats `daily_tokens` as `0` when the stored `daily_date` is not today — so users were **never wrongly blocked**. But two other readers lacked the same guard:

1. **quota_monitor threshold/alert step** read `daily_tokens` verbatim (and didn't even project `daily_date`), so a frozen value re-fired a daily `exceeded` alert against each new day's date-stamped dedup key.
2. **`ccwb quota usage` (`_get_user_usage`)** returned `daily_tokens` raw — it read `daily_date` but never compared it to today.

## What

Apply the same read-time stale-day guard `quota_check` already uses in both places:

- **quota_monitor** (`lambda_handler` Step 2): project `daily_date` in the scan and zero the daily counter via a new `_build_usage_entry()` helper when `daily_date != current_date`.
- **CLI** (`_get_user_usage`): zero `daily_tokens` on a stale day, and switch to tz-aware UTC (`datetime.now(timezone.utc)`) so the day boundary matches the Lambdas exactly (avoids an off-by-one at midnight).

After this change, all three surfaces — monitor (alerting), check (enforcement), CLI (display) — agree that *a daily counter whose `daily_date` is not today is `0`*.

Monthly counters are unaffected: they accumulate across the whole month and a new month uses a fresh sort key (`MONTH#YYYY-MM`). Genuine same-day over-limit alerts still fire (no over-correction).

## Tests

Per project rules (every bug fix includes a test that fails without the fix):

- `source/tests/test_quota_monitor_lambda.py` (new):
  - idle user with stale `daily_date` over the limit + no activity → **no** daily alert
  - active user, same-day over-limit → daily alert **is** generated (guards against over-correction)
  - `_build_usage_entry` zeros a stale daily counter while leaving the monthly total intact
- `source/tests/cli/commands/test_quota_usage_stale_day.py` (new):
  - stale `daily_date` → displayed `daily_tokens == 0`, monthly untouched
  - same-day → daily usage preserved
  - missing `daily_date` (legacy row) → treated as stale → `0`

Verified the regression tests fail on `beta` without the fix and pass with it. Full quota suite (91 tests) green.

## Affected files / tiers (per `.claude/rules/review-tiers.md`)

| File | Defect | Tier |
|------|--------|------|
| `deployment/infrastructure/lambda-functions/quota_monitor/index.py` | idle reset missing in scan/threshold step | Tier 2 |
| `source/claude_code_with_bedrock/cli/commands/quota.py` | `_get_user_usage` no stale-day guard | Tier 2 |
| `deployment/infrastructure/lambda-functions/quota_check/index.py` | reference (already correct) | — |
