### PR TITLE
fix(deploy): pass profile tags to CloudFormation stacks

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -434,6 +434,7 @@ class DeployCommand(Command):
                         template_path=template_path,
                         parameters=boto3_params,
                         capabilities=capabilities or ["CAPABILITY_NAMED_IAM"],
+                        tags=profile.tags if profile.tags else None,
                         on_event=lambda e: progress.update(
                             task,
                             description=f"{e.get('LogicalResourceId', 'Stack')} - {e.get('ResourceStatus', '')}"

--- a/source/tests/cli/commands/test_deploy_tags.py
+++ b/source/tests/cli/commands/test_deploy_tags.py
@@ -1,0 +1,81 @@
+# ABOUTME: Regression test — profile.tags must be passed to CloudFormation deploy_stack
+# ABOUTME: Catches the bug where tags were collected by init but silently dropped during deploy
+
+"""Verify that deploy passes profile.tags through to CloudFormationManager.deploy_stack()."""
+
+from unittest.mock import MagicMock, patch
+
+from claude_code_with_bedrock.cli.commands.deploy import DeployCommand
+from claude_code_with_bedrock.config import Profile
+
+
+def _make_profile(**overrides):
+    import dataclasses
+
+    field_names = {f.name for f in dataclasses.fields(Profile)}
+    defaults = {
+        "name": "TestProfile",
+        "provider_domain": "company.okta.com",
+        "client_id": "test-client-id",
+        "credential_storage": "session",
+        "aws_region": "us-east-1",
+        "identity_pool_name": "claude-code-test",
+        "sso_enabled": True,
+        "provider_type": "okta",
+        "monitoring_enabled": False,
+        "quota_monitoring_enabled": False,
+        "federation_type": "direct",
+        "federated_role_arn": "arn:aws:iam::123456789012:role/BedrockRole",
+    }
+    defaults.update(overrides)
+    return Profile(**{k: v for k, v in defaults.items() if k in field_names})
+
+
+class TestDeployPassesTags:
+    """Tags configured in the profile must reach CloudFormationManager.deploy_stack()."""
+
+    @patch("claude_code_with_bedrock.cli.commands.deploy.CloudFormationManager")
+    def test_tags_passed_to_deploy_stack(self, MockCFManager):
+        """deploy_stack receives profile.tags when tags are configured."""
+        tags = {"Environment": "production", "CostCenter": "12345"}
+        profile = _make_profile(tags=tags)
+
+        mock_manager = MagicMock()
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.outputs = {}
+        mock_manager.deploy_stack.return_value = mock_result
+        MockCFManager.return_value = mock_manager
+
+        command = DeployCommand()
+        console = MagicMock()
+        console.print = MagicMock()
+
+        command._deploy_stack("auth", profile, console, mock_manager)
+
+        call_kwargs = mock_manager.deploy_stack.call_args
+        assert call_kwargs is not None, "deploy_stack was never called"
+        assert call_kwargs.kwargs.get("tags") == tags or call_kwargs[1].get("tags") == tags
+
+    @patch("claude_code_with_bedrock.cli.commands.deploy.CloudFormationManager")
+    def test_no_tags_when_profile_has_none(self, MockCFManager):
+        """deploy_stack receives tags=None when profile has no tags."""
+        profile = _make_profile(tags={})
+
+        mock_manager = MagicMock()
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.outputs = {}
+        mock_manager.deploy_stack.return_value = mock_result
+        MockCFManager.return_value = mock_manager
+
+        command = DeployCommand()
+        console = MagicMock()
+        console.print = MagicMock()
+
+        command._deploy_stack("auth", profile, console, mock_manager)
+
+        call_kwargs = mock_manager.deploy_stack.call_args
+        assert call_kwargs is not None, "deploy_stack was never called"
+        passed_tags = call_kwargs.kwargs.get("tags") if call_kwargs.kwargs else call_kwargs[1].get("tags", "MISSING")
+        assert passed_tags is None, f"Expected None for empty tags, got {passed_tags}"


### PR DESCRIPTION
## Why

`ccwb init` collects resource tags and stores them in `profile.tags`. `CloudFormationManager.deploy_stack()` accepts a `tags` parameter and correctly formats them for the CloudFormation API. But `_deploy_stack()` in `deploy.py` never passes them through — so all deployed stacks are missing user-configured tags.

## What

Add `tags=profile.tags if profile.tags else None` to the `manager.deploy_stack()` call.

## Test plan

- [x] Regression test: `test_deploy_tags.py` verifies tags reach `deploy_stack()`
- [x] Regression test: empty tags pass `None` (no empty dict sent to CF API)
- [x] Pre-commit hooks pass

🤖 Generated with Claude Code