### PR TITLE
docs(idc): demote claude-bedrock launcher to optional

### DIFF
--- a/assets/docs/LOCAL_TESTING.md
+++ b/assets/docs/LOCAL_TESTING.md
@@ -202,16 +202,28 @@ your browser; on a headless box or over SSH it detects the lack of a local
 browser (via `SSH_CONNECTION`/`SSH_TTY` or no `DISPLAY`) and instead shows a URL
 you open on any other device.
 
-**Use the `claude-bedrock` launcher instead of `claude` directly.** The installer
-generates a launcher next to the binaries
-(`~/claude-code-with-bedrock/claude-bedrock`, or `claude-bedrock.cmd` on Windows).
-It signs you in (showing the verification URL live in your terminal — a no-op if
-you already have a valid session), then runs Claude Code:
+**Just run `claude`.** When no valid session exists, Claude Code invokes the
+`awsAuthRefresh` hook, which signs you in — opening your browser on a desktop, or
+printing a verification URL + code on a headless/SSH host — then continues once
+you approve. It also refreshes your session automatically after that.
+
+```bash
+claude
+# First run (or after the SSO session expires): a sign-in prompt appears.
+# Desktop: your browser opens. Headless/SSH: a verification URL + code print;
+# open the URL on any device with a browser and approve. Claude Code continues.
+```
+
+**Optional: the `claude-bedrock` launcher.** The installer also generates a
+launcher next to the binaries (`~/claude-code-with-bedrock/claude-bedrock`, or
+`claude-bedrock.cmd` on Windows). It signs you in *first*, then starts Claude
+Code. The only functional difference is the sign-in step has no time limit —
+in-session sign-in via `claude` is capped at ~165s (see the callout below) — so
+the launcher can make a slow first sign-in (e.g. MFA on another device) smoother.
 
 ```bash
 ~/claude-code-with-bedrock/claude-bedrock
-# First run: a verification URL + code print to your terminal.
-# Open the URL on any device with a browser, approve — then Claude Code starts.
+# Signs you in (a no-op if a valid session is already cached), then runs claude.
 
 # Optional: add the folder to PATH so you can just type `claude-bedrock`:
 export PATH="$HOME/claude-code-with-bedrock:$PATH"
@@ -235,14 +247,15 @@ device-authorization login is built into the credential process binary, and the
 SSO token is cached in `~/.aws/sso/cache/` (refreshed automatically until the
 session fully expires).
 
-> **Why a launcher instead of plain `claude`?** The IDC sign-in is interactive
-> (browser approval), but Claude Code runs the credential helper
-> non-interactively and cannot display its prompt reliably — so it can't be
-> driven from inside a running session. If you start `claude` without an active
-> sign-in, the credential process fails fast and Claude Code flashes a brief
-> "Cloud authentication" error before retrying — easy to miss, leaving `claude`
-> apparently stuck. The `claude-bedrock` launcher avoids this by running the
-> sign-in first, in your terminal, where the URL is shown and persists.
+> **Do I still need the launcher?** No — plain `claude` handles first sign-in,
+> re-authentication, and refresh on its own, because Claude Code runs the
+> `awsAuthRefresh` (`--login`) hook and surfaces its sign-in prompt live in the
+> "Cloud authentication" panel. The launcher remains as an optional convenience
+> for one edge: Claude Code caps the `awsAuthRefresh` hook at 180 seconds (the
+> credential process stops at 165s to print a message first), so a sign-in that
+> takes longer than that — e.g. MFA on a separate device — will time out in-session
+> but has no time limit when run via the launcher. If the in-session prompt times
+> out, just send Claude Code another message to show a fresh sign-in link.
 >
 > If you need to see a credential error that already scrolled away, run Claude
 > Code with debug logging: `CLAUDE_CODE_DEBUG_LOGS_DIR=~/.claude/debug claude
@@ -263,9 +276,10 @@ which work together:
   the credential-process JSON schema is accepted in **v2.1.181+**.)
 - **`awsAuthRefresh`** (`--login`) — fires on the first credential failure and
   its output **is displayed to the user**. This is the only channel that can
-  surface the sign-in message, because `awsCredentialExport` discards stderr.
-  When there's no valid SSO session, this is what tells the user to relaunch
-  with `claude-bedrock` instead of leaving `claude` silently retrying.
+  surface the sign-in prompt, because `awsCredentialExport` discards stderr.
+  When there's no valid SSO session, this runs the interactive device-auth flow
+  in-session (browser on desktop, URL + code on headless), so `claude` recovers
+  without relaunching. It is capped at Claude Code's 180s hook timeout.
 
 Without `awsCredentialExport`, credentials are resolved only once at startup, so
 after the session duration elapses Claude Code retries expired credentials
@@ -275,5 +289,7 @@ role. To prevent that silent wrong-identity fallback, IDC settings also set
 credentials error instead.
 
 The separate ~8-hour SSO **session** expiry still requires an interactive
-re-login — relaunch with `claude-bedrock`, which runs `--login` (URL shown live)
-before starting Claude Code.
+re-login. This happens in-session: `claude` runs `awsAuthRefresh` (`--login`) and
+shows the sign-in prompt live (browser on desktop, URL + code on headless). The
+`claude-bedrock` launcher does the same sign-in up front, without the in-session
+180s hook cap — useful if the re-login step is slow.

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -3300,17 +3300,33 @@ else
 fi
 """
 
-        # IDC auth needs a launcher wrapper that signs in before launching Claude.
+        # IDC auth keeps a launcher wrapper that signs in before launching Claude.
         # OIDC auth handles sign-in transparently, so no launcher is needed.
+        #
+        # As of the awsAuthRefresh --login gate fix (credential-process now polls
+        # device-auth and surfaces the verification URL/code live when invoked via
+        # awsAuthRefresh), in-session recovery DOES work: an expired SSO session
+        # can be renewed from inside a running `claude` via the credential hook.
+        # The launcher is nonetheless kept for now because:
+        #   1. Claude Code does not auto-invoke awsAuthRefresh on a 401 yet
+        #      (anthropics/claude-code#67529, open) \u2014 recovery is manual via
+        #      /login -> "Claude Platform on AWS - refresh credentials" (v2.1.186+).
+        #      The launcher's pre-flight signs in BEFORE the first prompt, so the
+        #      user never hits the manual-recovery step.
+        #   2. Session-start behavior when the SSO session is fully dead (silent
+        #      awsCredentialExport fails, then whether Claude Code falls through to
+        #      awsAuthRefresh) is not yet verified across OSes.
+        # Revisit removing the launcher once #67529 lands and start-up fallback is
+        # confirmed; track via LOCAL_TESTING.md's "why a launcher" note.
         _is_idc = getattr(profile, "effective_auth_type", getattr(profile, "auth_type", None)) == "idc"
         if _is_idc:
             installer_content += """
 # Generate a 'claude-bedrock' launcher wrapper.
 # It signs in (a no-op when the session is still valid) so the verification URL
-# is shown live in the user's terminal, THEN launches Claude Code. This avoids
-# the "run claude \u2192 silent hang" trap for IDC: the interactive sign-in can't be
-# surfaced through Claude Code's own credential refresh, so we front-run it here
-# where stdout/stderr go straight to the terminal.
+# is shown live in the user's terminal, THEN launches Claude Code. In-session
+# recovery via the awsAuthRefresh hook now works too, but Claude Code does not
+# auto-trigger it on a 401 yet (anthropics/claude-code#67529) \u2014 front-running the
+# sign-in here means the user is authenticated before the first prompt.
 CRED_PROC="$ACTUAL_HOME/claude-code-with-bedrock/credential-process"
 LAUNCHER="$ACTUAL_HOME/claude-code-with-bedrock/claude-bedrock"
 FIRST_PROFILE=$(echo $PROFILES | awk '{print $1}')
@@ -3337,13 +3353,17 @@ for PROFILE_NAME in $PROFILES; do
     echo "  - $PROFILE_NAME"
 done
 echo
-echo ">>> Start Claude Code with the launcher, NOT 'claude' directly:"
-echo "      $LAUNCHER"
+echo ">>> Start Claude Code the usual way:"
+echo "      claude"
 echo
-echo "    The launcher signs you in (shows the sign-in URL in your terminal when"
-echo "    needed) and then starts Claude Code. If you run 'claude' directly without"
-echo "    an active sign-in, it can briefly flash a sign-in error and then keep"
-echo "    retrying \u2014 easy to miss. The launcher avoids that."
+echo "    It signs you in automatically when needed \u2014 opening your browser, or"
+echo "    showing a sign-in link on headless/SSH hosts \u2014 and refreshes your session"
+echo "    on its own after that."
+echo
+echo "    Optional: a 'claude-bedrock' launcher is also installed. It signs you in"
+echo "    first, then starts Claude Code, which can make the very first sign-in"
+echo "    smoother (no time limit on the sign-in step). Use it if you prefer:"
+echo "      $LAUNCHER"
 echo
 echo "Tip: add it to your PATH so you can just run 'claude-bedrock':"
 echo "  export PATH=\\"$ACTUAL_HOME/claude-code-with-bedrock:\\$PATH\\""
@@ -3636,9 +3656,11 @@ for /f %%p in ('powershell -NoProfile -Command "$c=Get-Content config.json|Conve
             installer_content += """
 REM Generate a 'claude-bedrock.cmd' launcher.
 REM It signs in first (no-op if the session is still valid) so the verification
-REM URL is shown live in the user's console, THEN launches Claude Code. This
-REM avoids the "run claude -> silent hang" trap for IDC, whose interactive
-REM sign-in cannot be surfaced through Claude Code's own credential refresh.
+REM URL is shown live in the user's console, THEN launches Claude Code.
+REM In-session recovery via the awsAuthRefresh hook now works too, but Claude Code
+REM does not auto-trigger it on a 401 yet (anthropics/claude-code#67529) --
+REM front-running the sign-in here means the user is authenticated before the
+REM first prompt.
 REM
 REM Written with plain batch 'echo' redirection (NOT PowerShell) so the embedded
 REM quotes survive. In this script %%X%% becomes literal %X% in the .cmd, and
@@ -3666,13 +3688,17 @@ for /f %%p in ('powershell -NoProfile -Command "(Get-Content config.json | Conve
     echo   - %%p
 )
 echo.
-echo ^>^>^> Start Claude Code with the launcher, NOT 'claude' directly:
-echo       %USERPROFILE%\\claude-code-with-bedrock\\claude-bedrock.cmd
+echo ^>^>^> Start Claude Code the usual way:
+echo       claude
 echo.
-echo     The launcher signs you in (shows the sign-in URL in your terminal when
-echo     needed) and then starts Claude Code. If you run 'claude' directly without
-echo     an active sign-in, it can briefly flash a sign-in error and then keep
-echo     retrying - easy to miss. The launcher avoids that.
+echo     It signs you in automatically when needed - opening your browser, or
+echo     showing a sign-in link on headless/SSH hosts - and refreshes your session
+echo     on its own after that.
+echo.
+echo     Optional: a 'claude-bedrock' launcher is also installed. It signs you in
+echo     first, then starts Claude Code, which can make the very first sign-in
+echo     smoother ^(no time limit on the sign-in step^). Use it if you prefer:
+echo       %USERPROFILE%\\claude-code-with-bedrock\\claude-bedrock.cmd
 echo.
 echo Tip: add that folder to your PATH so you can just run 'claude-bedrock'.
 echo.
@@ -3950,12 +3976,16 @@ Available metrics include:
             # IDC needs BOTH:
             #   - awsCredentialExport for the silent ~hourly role-credential refresh
             #     (SSO session still valid -> re-mint via STS, no browser); and
-            #   - awsAuthRefresh so that when there is NO valid SSO session, the binary's
-            #     fail-fast message ("relaunch with claude-bedrock") is shown to the user
-            #     instead of a silent retry loop. The fail-fast guard makes the binary
-            #     exit immediately here, so awsAuthRefresh does NOT hang (the original
-            #     reason it was dropped for IDC). The ~8h SSO-session re-login itself
-            #     still happens out-of-band via the claude-bedrock launcher.
+            #   - awsAuthRefresh (--login) so that when there is NO valid SSO session,
+            #     the device-auth flow runs IN-SESSION: the credential-process --login
+            #     gate now polls device authorization and surfaces the verification
+            #     URL/code live (Claude Code streams the hook's stderr), so the ~8h
+            #     SSO re-login can complete from inside a running `claude`. On headless
+            #     hosts with discarded stderr (the silent awsCredentialExport path) the
+            #     binary still fails fast rather than hanging. NOTE: Claude Code does
+            #     not auto-invoke awsAuthRefresh on a 401 yet (anthropics/claude-code
+            #     #67529) — until it does, the claude-bedrock launcher front-runs the
+            #     sign-in so the user is authenticated before the first prompt.
             #
             # Non-IDC (OIDC) session profiles keep just awsAuthRefresh — their refresh
             # can be interactive (browser), which is exactly what that hook is for.


### PR DESCRIPTION
## Why

With in-session IDC re-auth now working (#731), plain `claude` handles first sign-in, re-authentication, and refresh on its own — it runs the `awsAuthRefresh --login` hook and surfaces the sign-in prompt live. Verified on desktop and headless SSH for cold start, silent refresh, dead refresh token, and timeout.

But the installer output and `LOCAL_TESTING.md` still told users to run the launcher **"NOT `claude` directly"** and justified it with a now-false rationale ("Claude Code cannot drive interactive sign-in from a running session"). That misleads users into thinking the launcher is mandatory.

## What

- **Installer completion messages** (Unix + Windows): present `claude` as the normal way to start, with `claude-bedrock` as an *optional* convenience for a smoother first sign-in (its direct `--login` has no 165s in-session cap).
- **`LOCAL_TESTING.md`:** rewrite the "why a launcher" callout to "do I still need the launcher? no", document the one edge it still helps (the 180s `awsAuthRefresh` hook cap), and update the session-expiry notes to describe in-session recovery instead of relaunching.
- **`package.py` comment blocks:** correct the launcher rationale.

The launcher is **retained** (still built, installed, documented) — only its framing changes from required to optional.

## Notes

- Depends on #731 for accuracy; merge that first.
- Docs/installer-message only; no behavior change. `package.py` parses; generated scripts unchanged in structure.