### PR TITLE
feat(dashboard): add per-user cost/token panels to CoWork dashboard (#739)

### DIFF
--- a/deployment/infrastructure/cowork-dashboard.yaml
+++ b/deployment/infrastructure/cowork-dashboard.yaml
@@ -324,12 +324,71 @@ Resources:
               }
             },
             {
+              "type": "text",
+              "x": 0, "y": 18, "width": 24, "height": 1,
+              "properties": { "markdown": "## Per-User Breakdown\n*Desktop mode only — LAM events do not emit user_email*" }
+            },
+            {
+              "type": "metric",
+              "x": 0, "y": 19, "width": 12, "height": 6,
+              "properties": {
+                "title": "Top Users by Token Usage",
+                "view": "timeSeries",
+                "stacked": true,
+                "region": "${MetricsRegion}",
+                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(10, sum by (\"user_email\")({\"ClaudeCoWork\", MetricName=\"token.usage.input\"}))", "step": 60 }] }
+              }
+            },
+            {
+              "type": "metric",
+              "x": 12, "y": 19, "width": 12, "height": 6,
+              "properties": {
+                "title": "Estimated Cost by User (USD)",
+                "view": "timeSeries",
+                "stacked": true,
+                "region": "${MetricsRegion}",
+                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(10, sum by (\"user_email\")({\"ClaudeCoWork\", MetricName=\"cost.usage\"}))", "step": 60 }] }
+              }
+            },
+            {
+              "type": "metric",
+              "x": 0, "y": 25, "width": 12, "height": 6,
+              "properties": {
+                "title": "Session Turns by User",
+                "view": "timeSeries",
+                "stacked": true,
+                "region": "${MetricsRegion}",
+                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(10, sum by (\"user_email\")({\"ClaudeCoWork\", MetricName=\"session.turns\"}))", "step": 60 }] }
+              }
+            },
+            {
+              "type": "metric",
+              "x": 12, "y": 25, "width": 12, "height": 6,
+              "properties": {
+                "title": "Cost by Model",
+                "view": "timeSeries",
+                "stacked": true,
+                "region": "${MetricsRegion}",
+                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(10, sum by (\"model\")({\"ClaudeCoWork\", MetricName=\"cost.usage\"}))", "step": 60 }] }
+              }
+            },
+            {
+              "type": "metric",
+              "x": 0, "y": 31, "width": 6, "height": 4,
+              "properties": {
+                "title": "Active Users",
+                "view": "singleValue",
+                "region": "${MetricsRegion}",
+                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "count(group by (\"user_email\")({\"ClaudeCoWork\", MetricName=\"session.turns\"}))", "step": 60, "label": "Active Users" }] }
+              }
+            },
+            {
               "type": "log",
-              "x": 12, "y": 12, "width": 12, "height": 6,
+              "x": 6, "y": 31, "width": 18, "height": 6,
               "properties": {
                 "title": "Recent CoWork Events (Raw)",
                 "region": "${MetricsRegion}",
-                "query": "SOURCE '/aws/claude-cowork/events' | fields @timestamp, coalesce(body.name, body) as event_name, coalesce(attributes.user_id, body.attributes.user_id) as device_id, coalesce(body.attributes.model, attributes.model) as model, coalesce(body.attributes.input_tokens, attributes.input_tokens) as input_tokens, coalesce(body.attributes.output_tokens, attributes.output_tokens) as output_tokens, coalesce(body.attributes.total_cost_usd, attributes.cost_usd) as cost_usd | sort @timestamp desc | limit 20",
+                "query": "SOURCE '/aws/claude-cowork/events' | fields @timestamp, coalesce(body.name, body) as event_name, coalesce(attributes.user_email, body.attributes.user_email) as user_email, coalesce(attributes.user_id, body.attributes.user_id) as device_id, coalesce(body.attributes.model, attributes.model) as model, coalesce(body.attributes.input_tokens, attributes.input_tokens) as input_tokens, coalesce(body.attributes.output_tokens, attributes.output_tokens) as output_tokens, coalesce(body.attributes.total_cost_usd, attributes.cost_usd) as cost_usd | sort @timestamp desc | limit 20",
                 "view": "table"
               }
             }


### PR DESCRIPTION
## Why

The CoWork dashboard (`cowork-dashboard.yaml`) has no per-user visibility into cost or token usage — everything is aggregate-only. Meanwhile, the Claude Code dashboard already has "Top Users by Token Usage" and "Estimated Cost by User" panels.

The data is already there: metric filters added in #571 and #632 emit `user_email` and `model` as CloudWatch dimensions:

```yaml
# Already in cowork-dashboard.yaml (since #571/#632):
Dimensions:
  - Key: "user_email"
    Value: "$.attributes.user_email"
  - Key: "model"
    Value: "$.attributes.model"
```

The dashboard just never surfaced it with per-user panels.

## What

Added 6 new widgets to the DashboardBody (after aggregate panels, before log widget):

### Section header

```json
{ "type": "text", "properties": { "markdown": "## Per-User Breakdown\n*Desktop mode only — LAM events do not emit user_email*" } }
```

### Top Users by Token Usage

```json
"query": "topk(10, sum by (\"user_email\")({\"ClaudeCoWork\", MetricName=\"token.usage.input\"}))"
```

### Estimated Cost by User (USD)

```json
"query": "topk(10, sum by (\"user_email\")({\"ClaudeCoWork\", MetricName=\"cost.usage\"}))"
```

### Session Turns by User

```json
"query": "topk(10, sum by (\"user_email\")({\"ClaudeCoWork\", MetricName=\"session.turns\"}))"
```

### Cost by Model

```json
"query": "topk(10, sum by (\"model\")({\"ClaudeCoWork\", MetricName=\"cost.usage\"}))"
```

### Active Users (single-value)

```json
"query": "count(group by (\"user_email\")({\"ClaudeCoWork\", MetricName=\"session.turns\"}))"
```

Also enhanced the log widget to include `user_email` in the Logs Insights query output.

## Why it wasn't there before

The dimension-based metric filters were added in stages:
- **#548** (`a0d7ca2`) — First CoWork dashboard. Built entirely around the `lam_session_turn_completed` schema (original telemetry format)
- **#571** (`db71b02`) — Claude Desktop changed its telemetry schema to `claude_code.api_request` with top-level attributes. Added support for both schemas.
- **#632** (`3fd45e6`) — Removed DefaultValue to allow Dimensions (they're mutually exclusive in CloudWatch). This enabled per-user attribution.

The dashboard panels were never added after #632 landed — the aggregate widgets worked, but nobody went back to add per-user views.

## About "Local Agent Mode" (LAM)

The `lam_session_turn_completed` event name is Claude Desktop's **original/legacy telemetry schema**, not a runtime mode users toggle. The name "Local Agent Mode" was Anthropic's internal name for the Claude Desktop feature during early development (an AI agent running locally on the user's machine).

**Two schemas exist because Claude Desktop changed its telemetry format:**

| Schema | Event | Attributes | Has `user_email`? |
|--------|-------|-----------|-------------------|
| Legacy (LAM) | `body.name = "lam_session_turn_completed"` | Nested: `body.attributes.*` | ❌ No |
| Current | `body = "claude_code.api_request"` | Top-level: `attributes.*` | ✅ Yes |

Both emit to the same CloudWatch metrics (`ClaudeCoWork` namespace) for aggregate totals. But only the current schema has the `user_email` dimension — which is why per-user panels only reflect activity from the newer telemetry format.

Older Claude Desktop versions (or deployments that haven't updated) may still emit the LAM schema. Those events contribute to aggregate totals but won't appear in per-user breakdowns.

## Validation
- ✅ cfn-lint: clean
- ✅ pytest (8 CoWork contract tests): all pass
- ✅ No metric filter changes — only dashboard panels added

Closes #739