### PR TITLE
Fix/otel default department

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Guidance for Claude Code and Cowork on Amazon Bedrock
 
-[![Stable Release](https://img.shields.io/github/v/release/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock?style=for-the-badge&label=stable)](https://github.com/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock/releases/latest)
+[![Stable Release](https://img.shields.io/github/v/release/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock?style=for-the-badge&label=stable&filter=v*.*.*)](https://github.com/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock/releases/latest)
 [![Beta Release](https://img.shields.io/github/v/release/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock?style=for-the-badge&include_prereleases&label=beta)](https://github.com/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock/tree/beta)
 
 This guidance enables enterprise deployment of Claude Code and Claude Cowork on Amazon Bedrock across command-line (CLI) and desktop surfaces — with secure single sign-on (SSO), usage monitoring, and cost controls.

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -4224,7 +4224,7 @@ Available metrics include:
                     # already resolved to http://localhost:4318 above; in central
                     # mode it is the ALB address from the profile/CloudFormation.
                     resource_attrs = otel_resource_attributes or (
-                        "department=engineering,team.id=default,"
+                        "department=default,team.id=default,"
                         "cost_center=default,organization=default,"
                         "project=default"
                     )

--- a/source/claude_code_with_bedrock/cli/commands/package_cb.py
+++ b/source/claude_code_with_bedrock/cli/commands/package_cb.py
@@ -457,7 +457,7 @@ class PackageCbCommand(Command):
 
                     if endpoint:
                         resource_attrs = otel_resource_attributes or (
-                            "department=engineering,team.id=default,"
+                            "department=default,team.id=default,"
                             "cost_center=default,organization=default,"
                             "project=default"
                         )

--- a/source/pyproject.toml
+++ b/source/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "claude-code-with-bedrock"
-version = "2.5.1"
+version = "2.5.2"
 description = "Deploy and manage Claude Code on Amazon Bedrock"
 authors = ["Claude Code Team <claude-code@example.com>"]
 readme = "../README.md"

--- a/source/tests/cli/commands/test_package.py
+++ b/source/tests/cli/commands/test_package.py
@@ -201,3 +201,67 @@ class TestResolveFederation:
         assert identity_pool_id is None
         assert federated_role_arn is None
         mock_stack.assert_not_called()
+
+
+class TestPackageCommandOtelDefaults:
+    """Tests for the default OTEL_RESOURCE_ATTRIBUTES written into settings.json."""
+
+    def _make_monitoring_profile(self):
+        return Profile(
+            name="test",
+            provider_domain="test.okta.com",
+            client_id="test-client",
+            credential_storage="session",
+            aws_region="us-east-1",
+            identity_pool_name="test-pool",
+            allowed_bedrock_regions=["us-east-1"],
+            monitoring_enabled=True,
+            stack_names={"monitoring": "test-otel-collector"},
+        )
+
+    def _render_settings(self, otel_resource_attributes=None):
+        """Drive _create_claude_settings with a mocked monitoring stack endpoint."""
+        command = PackageCommand()
+        profile = self._make_monitoring_profile()
+
+        fake_outputs = json.dumps(
+            [{"OutputKey": "CollectorEndpoint", "OutputValue": "https://otel.example.com"}]
+        )
+        completed = MagicMock(returncode=0, stdout=fake_outputs)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            with patch(
+                "claude_code_with_bedrock.cli.commands.package.subprocess.run",
+                return_value=completed,
+            ):
+                command._create_claude_settings(
+                    output_dir,
+                    profile,
+                    include_coauthored_by=True,
+                    profile_name="test",
+                    otel_resource_attributes=otel_resource_attributes,
+                )
+
+            settings_path = output_dir / "claude-settings" / "settings.json"
+            with open(settings_path, encoding="utf-8") as f:
+                return json.load(f)
+
+    def test_default_department_is_default_not_engineering(self):
+        """Regression: the default department must be 'default', not 'engineering'.
+
+        'engineering' is not a safe assumption for every deployment, so the
+        baseline OTEL attributes should be neutral and overridable.
+        """
+        settings = self._render_settings()
+        attrs = settings["env"]["OTEL_RESOURCE_ATTRIBUTES"]
+
+        assert "department=default" in attrs
+        assert "department=engineering" not in attrs
+
+    def test_configured_attributes_override_default(self):
+        """An explicit OTEL_RESOURCE_ATTRIBUTES value takes precedence over the default."""
+        settings = self._render_settings(otel_resource_attributes="department=research,team.id=ml")
+        attrs = settings["env"]["OTEL_RESOURCE_ATTRIBUTES"]
+
+        assert attrs == "department=research,team.id=ml"


### PR DESCRIPTION
Why
When packaging Claude Code (ccwb package), the generated settings.json
falls back to a hardcoded set of default OTEL_RESOURCE_ATTRIBUTES whenever
the operator hasn't configured their own. That fallback shipped with
department=engineering.

engineering is not a safe default — most deployments are not exclusively
engineering teams, and the value silently mislabels OTEL telemetry and cost
attribution for any non-engineering user who never overrides it. Every other
attribute in the same default string is neutral (team.id=default,
cost_center=default, organization=default, project=default), so
department should match. Operators who do want a real department value can
still set OTEL_RESOURCE_ATTRIBUTES and that override continues to win.

What
Change the default department=engineering → department=default in the
fallback OTEL attributes.
Fix applies in both code paths that contain the duplicated default:
source/claude_code_with_bedrock/cli/commands/package.py (PackageCommand)
source/claude_code_with_bedrock/cli/commands/package_cb.py (PackageCbCommand)
Add a regression test (TestPackageCommandOtelDefaults) that:
drives _create_claude_settings with a mocked monitoring endpoint and
asserts the rendered default is department=default (and not
department=engineering);
asserts an explicit OTEL_RESOURCE_ATTRIBUTES value still overrides the
default.
Testing
cd source && poetry run pytest tests/ -q → 919 passed, 22 skipped.
New regression tests fail against the old default and pass with the fix.