### PR TITLE
feat: declarative extra_files for package + distribute

### DIFF
--- a/assets/docs/CLI_REFERENCE.md
+++ b/assets/docs/CLI_REFERENCE.md
@@ -257,7 +257,34 @@ poetry run ccwb package [options]
 2. Creates `config.json` with federation config read from the admin profile
 3. Creates `claude-settings/settings.json` with Bedrock model and OTel endpoint (or `managed-settings.json` if `--managed` was used during init)
 4. Creates installer scripts (`install.sh`, `install.bat`, `ccwb-install.ps1`)
-5. Outputs to `dist/{profile}/{timestamp}/`
+5. Copies any admin-defined **extra files** into the build folder (see below)
+6. Outputs to `dist/{profile}/{timestamp}/`
+
+**Extra Files:**
+
+You can ship additional files or folders on top of the generated package —
+preinstall/postinstall scripts, an OIDC signing certificate, a CA bundle, and
+so on. Configure them during `ccwb init` (the "Extra files" step); they are
+stored in your admin deployment profile, never in the runtime `config.json` and
+never delivered to end users' Claude Code config.
+
+Each entry has three fields:
+
+| Field | Meaning |
+|---|---|
+| `name` | path inside the package (relative — no `..` or absolute paths) |
+| `targets` | which machines receive it (see tokens below) |
+| `from` | source path on your machine (a file or a whole folder) |
+
+`targets` accepts `all`, a family (`macos`, `linux`, `windows`), an
+architecture (`macos-arm64`, `macos-intel`, `linux-x64`, `linux-arm64`), or a
+list such as `["macos", "linux"]`.
+
+`ccwb package` copies **all** extras into the build folder. `ccwb distribute`
+then filters them per platform — a `macos` extra lands in the macOS package but
+not the Windows one; an `all` extra lands in every package. `package` fails
+fast (non-zero exit) if a `from` source is missing or a `name` collides with a
+generated artifact, so a listed file is never silently dropped.
 
 **Build Modes:**
 

--- a/source/claude_code_with_bedrock/cli/commands/distribute.py
+++ b/source/claude_code_with_bedrock/cli/commands/distribute.py
@@ -726,6 +726,12 @@ class DistributeCommand(Command):
                                     f"claude-code-package/{rel_path.as_posix()}", self._read_file_with_retry(file)
                                 )
 
+                    # Add matching extras. "all-platforms" takes everything
+                    # (token=None); each family zip filters by its landing token
+                    # (mac/linux/windows).
+                    extra_token = None if platform == "all-platforms" else platform
+                    self._add_extra_files_to_zip(zipf, package_path, getattr(profile, "extra_files", None), extra_token)
+
                 # Upload to S3 at packages/{platform}/latest.zip
                 s3_key = f"packages/{platform}/latest.zip"
                 try:
@@ -996,7 +1002,7 @@ class DistributeCommand(Command):
         ) as progress:
             # Create archive
             task = progress.add_task("Creating distribution archive...", total=None)
-            archive_path = self._create_archive(package_path)
+            archive_path = self._create_archive(package_path, getattr(profile, "extra_files", None))
 
             # Calculate checksum
             progress.update(task, description="Calculating checksum...")
@@ -1241,7 +1247,7 @@ class DistributeCommand(Command):
         """Create and distribute separate packages per OS platform."""
         console.print("\n[cyan]Creating per-OS distribution packages...[/cyan]\n")
 
-        archives = self._create_per_os_archives(package_path)
+        archives = self._create_per_os_archives(package_path, getattr(profile, "extra_files", None))
         if not archives:
             console.print("[red]No platform binaries found to package.[/red]")
             return 1
@@ -1425,12 +1431,48 @@ class DistributeCommand(Command):
                         continue
                 raise
 
-    def _create_archive(self, package_path: Path) -> Path:
+    def _add_extra_files_to_zip(self, zf, package_path: Path, entries, platform_token) -> None:
+        """Add admin-defined extra files to an open zip, filtered by platform.
+
+        Extras were already copied into ``package_path`` by ``package`` (distribute
+        never re-reads the ``from`` source), so this reads plain files/dirs from the
+        build folder and writes them under the ``claude-code-package/`` prefix using
+        ``writestr()`` + ``_read_file_with_retry()`` (no temp files — SSL/AV invariant).
+
+        ``platform_token=None`` includes every extra (the all-OS archive). Otherwise
+        an entry is included only when its ``targets`` match ``platform_token`` via
+        ``extra_applies_to`` (per-OS zips and landing-family zips).
+        """
+        from claude_code_with_bedrock.extra_files import extra_applies_to, validate_extra_files
+
+        if not entries or validate_extra_files(entries):
+            # No extras, or an invalid config — package already fails fast on
+            # invalid entries, so skip silently rather than shipping garbage.
+            return
+
+        for entry in entries:
+            if platform_token is not None and not extra_applies_to(entry["targets"], platform_token):
+                continue
+            name = entry["name"]
+            src = package_path / name
+            if not src.exists():
+                continue
+            if src.is_dir():
+                for f in src.rglob("*"):
+                    if f.is_file():
+                        rel = f.relative_to(package_path)
+                        zf.writestr(f"claude-code-package/{rel.as_posix()}", self._read_file_with_retry(f))
+            else:
+                zf.writestr(f"claude-code-package/{name}", self._read_file_with_retry(src))
+
+    def _create_archive(self, package_path: Path, extra_files=None) -> Path:
         """Create a zip archive of the package directory.
 
         Builds the ZIP directly from source files using writestr() to avoid
         temp directory operations that fail on Windows with spaces in paths
         or when antivirus locks newly-written files.
+
+        ``extra_files`` (admin-defined) are added unconditionally (all-OS archive).
         """
         import zipfile
 
@@ -1489,6 +1531,9 @@ class DistributeCommand(Command):
                         rel_path = f.relative_to(package_path)
                         zf.writestr(f"claude-code-package/{rel_path.as_posix()}", self._read_file_with_retry(f))
 
+            # All-OS archive gets every extra file (platform_token=None).
+            self._add_extra_files_to_zip(zf, package_path, extra_files, None)
+
         return archive_path
 
     # Platform-to-files mapping for per-OS packages
@@ -1520,11 +1565,14 @@ class DistributeCommand(Command):
         },
     }
 
-    def _create_per_os_archives(self, package_path: Path) -> list[tuple[str, Path]]:
+    def _create_per_os_archives(self, package_path: Path, extra_files=None) -> list[tuple[str, Path]]:
         """Create separate zip archives per OS platform. Returns list of (platform_label, archive_path).
 
         Builds ZIPs directly from source files using writestr() to avoid
         temp directory operations that fail on Windows with spaces in paths.
+
+        ``extra_files`` are filtered per platform via the per-OS token (``macos-arm64``,
+        ``windows``, ``linux-x64``, …) so a ``macos`` extra never lands in the Windows zip.
         """
         import zipfile
 
@@ -1566,6 +1614,9 @@ class DistributeCommand(Command):
                         if f.is_file():
                             rel_path = f.relative_to(package_path)
                             zf.writestr(f"claude-code-package/{rel_path.as_posix()}", self._read_file_with_retry(f))
+
+                # Add matching extras for this per-OS token (e.g. macos-arm64).
+                self._add_extra_files_to_zip(zf, package_path, extra_files, platform)
 
             archives.append((platform, pconfig["label"], archive_path))
 

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -2286,7 +2286,138 @@ class InitCommand(Command):
         else:
             config["tags"] = config.get("tags", {})
 
+        # Extra files (optional) — admin-defined files/folders shipped on top of
+        # the generated package. Preserves the existing list on cancel.
+        config["extra_files"] = self._configure_extra_files(config.get("extra_files", []))
+
         return config
+
+    def _configure_extra_files(self, existing: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Interactively add/edit/remove admin-defined extra files.
+
+        Extra files are copied on top of the generated package by `package` and
+        filtered per-OS by `distribute`. Returns the (possibly unchanged) list.
+
+        Non-interactive / cancel safety: any prompt returning None (Ctrl+C or no
+        TTY) leaves the existing list untouched — the wizard never crashes and
+        never silently drops configured entries.
+        """
+        from claude_code_with_bedrock.extra_files import VALID_TARGET_TOKENS, validate_extra_files
+
+        console = Console()
+        # Work on a copy so a mid-loop cancel can fall back to the original.
+        entries: list[dict[str, Any]] = [dict(e) for e in (existing or [])]
+
+        console.print("\n[bold]Extra Files (Optional)[/bold]")
+        console.print("[dim]Ship extra files/folders on top of the package (preinstall scripts, certs, etc.).[/dim]")
+
+        want = questionary.confirm(
+            "Add or edit extra files to include in the package?",
+            default=bool(entries),
+        ).ask()
+        if want is None:
+            return existing or []
+        if not want:
+            return entries
+
+        # Sorted for a stable checkbox order in the Add prompt.
+        token_choices = sorted(VALID_TARGET_TOKENS)
+
+        while True:
+            if entries:
+                console.print("\n[dim]Current extra files:[/dim]")
+                for i, e in enumerate(entries, 1):
+                    targets = e.get("targets")
+                    targets_str = ", ".join(targets) if isinstance(targets, list) else str(targets)
+                    console.print(f"  {i}. {e.get('name')}  → {targets_str}  ← {e.get('from')}")
+            else:
+                console.print("\n[dim]No extra files configured yet.[/dim]")
+
+            action = questionary.select(
+                "Extra files:",
+                choices=["Add", "Edit", "Remove", "Done"] if entries else ["Add", "Done"],
+            ).ask()
+            if action is None or action == "Done":
+                break
+
+            if action == "Remove":
+                idx = self._pick_extra_file_index(entries, "Remove which entry?")
+                if idx is not None:
+                    removed = entries.pop(idx)
+                    console.print(f"[yellow]✗[/yellow] Removed: {removed.get('name')}")
+                continue
+
+            # Add or Edit both gather the same three fields.
+            current = None
+            if action == "Edit":
+                idx = self._pick_extra_file_index(entries, "Edit which entry?")
+                if idx is None:
+                    continue
+                current = entries[idx]
+
+            src = questionary.text(
+                "Source path (file or folder) on this machine:",
+                default=(current.get("from") if current else "") or "",
+            ).ask()
+            if src is None or not src.strip():
+                console.print("[dim]Cancelled.[/dim]")
+                continue
+            src = src.strip()
+
+            default_name = (current.get("name") if current else "") or Path(src).expanduser().name
+            name = questionary.text(
+                "Name inside the package:",
+                default=default_name,
+            ).ask()
+            if name is None or not name.strip():
+                console.print("[dim]Cancelled.[/dim]")
+                continue
+            name = name.strip()
+
+            # Pre-check the entry's current targets when editing; nothing on Add.
+            # Save exactly what the admin checks — "all" is just another token and
+            # can be combined with specific platforms (the matcher treats "all" as
+            # matching everything, so extra picks alongside it are harmless).
+            current_targets = current.get("targets", []) if current else []
+            if isinstance(current_targets, str):
+                current_targets = [current_targets]
+            targets = questionary.checkbox(
+                "Which machines get this? (space to select, enter to confirm)",
+                choices=[questionary.Choice(t, value=t, checked=(t in current_targets)) for t in token_choices],
+            ).ask()
+            if targets is None or not targets:
+                console.print("[yellow]![/yellow] No targets selected — entry not saved.")
+                continue
+
+            entry = {"name": name, "targets": targets, "from": src}
+            errors = validate_extra_files([entry])
+            if errors:
+                for err in errors:
+                    console.print(f"[red]✗ {err}[/red]")
+                console.print("[dim]Entry not saved — fix the issue and try again.[/dim]")
+                continue
+
+            # Warn (don't block) if the source doesn't exist yet — the admin may
+            # create it before running `package`. Build time enforces presence.
+            if not Path(src).expanduser().exists():
+                console.print(f"[yellow]![/yellow] Source not found yet: {src} (must exist at package time)")
+
+            if current is not None:
+                entries[idx] = entry
+                console.print(f"[green]✓[/green] Updated: {name}")
+            else:
+                entries.append(entry)
+                console.print(f"[green]✓[/green] Added: {name}")
+
+        return entries
+
+    @staticmethod
+    def _pick_extra_file_index(entries: list[dict[str, Any]], prompt: str) -> int | None:
+        """Prompt for an entry by name; return its index or None if cancelled."""
+        if not entries:
+            return None
+        choices = [questionary.Choice(f"{e.get('name')} ← {e.get('from')}", value=i) for i, e in enumerate(entries)]
+        return questionary.select(prompt, choices=choices).ask()
 
     @staticmethod
     def _store_idp_secret(secrets_client, secret_name: str, secret_value: str, description: str = "") -> str:
@@ -2432,6 +2563,11 @@ class InitCommand(Command):
         extra_keys = config.get("cowork_3p", {}).get("extra_keys", {})
         if extra_keys:
             table.add_row("Custom MDM Keys", ", ".join(f"{k}={v}" for k, v in extra_keys.items()))
+
+        # Show admin-defined extra files
+        extra_files = config.get("extra_files", [])
+        if extra_files:
+            table.add_row("Extra Files", ", ".join(str(e.get("name", "?")) for e in extra_files))
 
         console.print(table)
 
@@ -2707,6 +2843,7 @@ class InitCommand(Command):
             "lock_default_model": config_data.get("lock_default_model", False),
             "tags": config_data.get("tags", {}),
             "redirect_port": config_data.get("redirect_port"),
+            "extra_files": config_data.get("extra_files", []),
         }
 
         if existing_profile:
@@ -3140,6 +3277,9 @@ class InitCommand(Command):
             # Add resource tags if present
             if hasattr(profile, "tags") and profile.tags:
                 existing_config["tags"] = profile.tags
+
+            # Restore admin-defined extra files so re-running init shows them.
+            existing_config["extra_files"] = getattr(profile, "extra_files", [])
 
             return existing_config
 

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -802,6 +802,14 @@ class PackageCommand(Command):
             console.print("\n[cyan]Generating CoWork 3P MDM configuration...[/cyan]")
             self._generate_cowork_3p_mdm_config(output_dir, profile, profile_name)
 
+        # Copy admin-defined extra files into the build folder (superset; per-OS
+        # filtering happens in distribute at zip time). Fail fast on a missing
+        # source or a validation error — a listed cert the admin expects shipped
+        # must not be silently skipped.
+        copied_extra_files = self._copy_extra_files(profile, output_dir, console)
+        if copied_extra_files is None:
+            return 1
+
         # Summary
         console.print("\n[green]✓ Package created successfully![/green]")
         console.print(f"\nOutput directory: [cyan]{output_dir}[/cyan]")
@@ -832,6 +840,8 @@ class PackageCommand(Command):
                 console.print("  • cowork-3p.mobileconfig - CoWork 3P MDM profile (macOS)")
             if (output_dir / "cowork-3p.reg").exists():
                 console.print("  • cowork-3p.reg - CoWork 3P registry file (Windows)")
+        for name, targets in copied_extra_files:
+            console.print(f"  • {name} - Extra file (targets: {targets})")
 
         # Next steps
         console.print("\n[bold]Distribution steps:[/bold]")
@@ -858,6 +868,53 @@ class PackageCommand(Command):
             return 1
 
         return 0
+
+    def _copy_extra_files(self, profile, output_dir: Path, console: Console) -> list[tuple[str, str]] | None:
+        """Copy admin-defined extra files into the build folder.
+
+        Copies the full superset of entries (per-OS filtering happens later at
+        zip time in distribute). Returns a list of ``(name, targets)`` tuples for
+        the package summary, or ``None`` to signal a fatal error (missing source
+        or validation failure) — the caller must return a non-zero exit code.
+        """
+        import shutil
+
+        from claude_code_with_bedrock.extra_files import validate_extra_files
+
+        entries = getattr(profile, "extra_files", []) or []
+        if not entries:
+            return []
+
+        errors = validate_extra_files(entries)
+        if errors:
+            console.print("[red]Invalid extra_files configuration:[/red]")
+            for err in errors:
+                console.print(f"  [red]• {err}[/red]")
+            return None
+
+        console.print("\n[cyan]Copying extra files...[/cyan]")
+        copied: list[tuple[str, str]] = []
+        for entry in entries:
+            name = entry["name"]
+            src = Path(entry["from"]).expanduser()
+            if not src.exists():
+                console.print(f"[red]Extra file source not found for '{name}': {src}[/red]")
+                console.print("[red]Fix the 'from' path or remove the entry, then re-run.[/red]")
+                return None
+
+            dst = output_dir / name
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            if src.is_dir():
+                shutil.copytree(src, dst, dirs_exist_ok=True)
+            else:
+                shutil.copy2(src, dst)
+
+            targets = entry["targets"]
+            targets_label = ", ".join(targets) if isinstance(targets, list) else str(targets)
+            copied.append((name, targets_label))
+            console.print(f"  [green]✓[/green] {name} ← {src} (targets: {targets_label})")
+
+        return copied
 
     def _check_build_status(self, build_id: str, console: Console) -> int:
         """Check the status of a CodeBuild build."""

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -179,6 +179,12 @@ class Profile:
     websearch_domain_denylist: list[str] = field(default_factory=list)  # Optional domains to exclude from results
     websearch_headers_helper_path: str = ""  # Absolute path override for the Cowork headersHelper (default: ~/claude-code-with-bedrock/websearch-headers)
 
+    # Admin-only extra files copied into the package on top of generated artifacts.
+    # Consumed ONLY by `package`/`distribute` — deliberately NOT mirrored in the Go
+    # ProfileConfig (config-sync.md) and NOT written to the runtime config.json.
+    # Each entry: {"name": str, "targets": str | list[str], "from": str}
+    extra_files: list[dict[str, Any]] = field(default_factory=list)
+
     # Legacy field support
     @property
     def okta_domain(self) -> str:

--- a/source/claude_code_with_bedrock/extra_files.py
+++ b/source/claude_code_with_bedrock/extra_files.py
@@ -1,0 +1,210 @@
+# ABOUTME: Declarative extra-files list shared by the package and distribute commands
+# ABOUTME: Provides OS-token matching and validation for admin-defined extra files
+
+"""Admin-defined extra files for packaging and distribution.
+
+Admins can list extra files/folders (preinstall scripts, certificates, CA
+bundles, etc.) to ship *on top of* the generated package. The list lives in the
+admin-side deployment profile (never in the runtime ``config.json`` and never
+synced to the Go credential-process) and is consumed by two commands:
+
+- ``package`` copies the full superset of extras into the build folder.
+- ``distribute`` filters extras per-OS across its three archive builders.
+
+Each entry is a plain dict with three keys::
+
+    {"name": "certs", "targets": "all", "from": "~/secure/azure-oidc-certs"}
+
+- ``name``    — path inside the package (relative, no traversal).
+- ``targets`` — which machines get it: a single token or a list of tokens.
+- ``from``    — source path on the admin's machine (a file or a whole folder).
+
+The ``targets`` tokens form a hierarchy ``all`` > family > arch so that a single
+list can be resolved against three different platform vocabularies (see
+``extra_applies_to``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Arch-specific tokens mapped to their OS family.
+_FAMILY_OF: dict[str, str] = {
+    "macos-arm64": "macos",
+    "macos-intel": "macos",
+    "linux-x64": "linux",
+    "linux-arm64": "linux",
+    "windows": "windows",
+}
+
+# All family tokens.
+_FAMILIES: frozenset[str] = frozenset(_FAMILY_OF.values())
+
+# Every token an admin may put in ``targets``.
+VALID_TARGET_TOKENS: frozenset[str] = frozenset({"all"}) | _FAMILIES | frozenset(_FAMILY_OF)
+
+# Landing-page family tokens -> internal family. The landing page groups by
+# family only (no arch split), so ``mac`` maps to the ``macos`` family.
+_LANDING_FAMILY: dict[str, str] = {"mac": "macos", "linux": "linux", "windows": "windows"}
+
+# Generated artifacts and reserved directories that an extra file's ``name``
+# must never collide with — clobbering these would silently break the package.
+RESERVED_NAMES: frozenset[str] = frozenset(
+    {
+        "config.json",
+        "install.sh",
+        "install.bat",
+        "ccwb-install.ps1",
+        "readme.md",
+        "collector-config.yaml",
+        "otel-helper.sh",
+        "otel-helper.ps1",
+        "otel-helper.cmd",
+        "cowork-3p.reg",
+        "cowork-3p.mobileconfig",
+        "cowork-3p-config.json",
+    }
+)
+
+# Reserved top-level directory names (an extra must not shadow these).
+RESERVED_DIRS: frozenset[str] = frozenset({"claude-settings"})
+
+# Prefixes of generated binaries an extra's top-level name must not collide with.
+_RESERVED_PREFIXES: tuple[str, ...] = (
+    "credential-process-",
+    "otel-helper-",
+    "otelcol-",
+)
+
+
+def normalize_targets(targets: Any) -> list[str]:
+    """Return ``targets`` as a lowercased list of tokens.
+
+    Accepts a single string or a list of strings. Non-string members are
+    coerced defensively but validation (``validate_extra_files``) is what
+    rejects unknown tokens.
+    """
+    if isinstance(targets, str):
+        raw = [targets]
+    elif isinstance(targets, (list, tuple)):
+        raw = list(targets)
+    else:
+        return []
+    return [str(t).strip().lower() for t in raw]
+
+
+def extra_applies_to(targets: Any, platform_token: str) -> bool:
+    """True if an entry with ``targets`` should be included for ``platform_token``.
+
+    ``platform_token`` is one of:
+
+    - a per-OS token: ``windows``, ``linux-x64``, ``linux-arm64``,
+      ``macos-arm64``, ``macos-intel`` (used by ``_create_per_os_archives``);
+    - a landing family: ``mac``, ``linux``, ``windows`` (used by
+      ``_upload_landing_page_packages``).
+
+    The all-OS archive (``_create_archive``) does not call this — it includes
+    every extra unconditionally.
+
+    Matching rules (hierarchy ``all`` > family > arch):
+
+    - ``all`` matches everything.
+    - An exact token match always applies.
+    - A family target (``macos``) matches any arch in that family and the
+      family/landing token.
+    - An arch target (``macos-arm64``) matches its own per-OS token and its
+      landing family (``mac``) — the landing family has no arch split, so any
+      arch-specific extra for that family must appear in it.
+    """
+    plat = platform_token.strip().lower()
+    # Resolve the platform to its family, whether it's a per-OS token,
+    # an arch token, or a landing-family token.
+    plat_family = _LANDING_FAMILY.get(plat) or _FAMILY_OF.get(plat) or (plat if plat in _FAMILIES else None)
+
+    for token in normalize_targets(targets):
+        if token == "all":
+            return True
+        if token == plat:
+            return True
+        # Family target matches any platform in that family.
+        if token in _FAMILIES and token == plat_family:
+            return True
+        # Arch target matches its landing family (family has no arch split).
+        token_family = _FAMILY_OF.get(token)
+        if token_family and plat in _LANDING_FAMILY and _LANDING_FAMILY[plat] == token_family:
+            return True
+    return False
+
+
+def _name_errors(name: Any) -> list[str]:
+    """Validate the ``name`` field for path safety and reserved collisions."""
+    errors: list[str] = []
+    if not isinstance(name, str) or not name.strip():
+        return ["extra_files: 'name' must be a non-empty string"]
+
+    # Reject absolute paths and Windows drive letters (e.g. "C:\\x").
+    if name.startswith(("/", "\\")) or (len(name) >= 2 and name[1] == ":"):
+        errors.append(f"extra_files: 'name' must be a relative path, got '{name}'")
+
+    # Reject traversal in either separator style. Splitting on both catches
+    # "a/../b" and "a\\..\\b" regardless of the host OS.
+    segments = name.replace("\\", "/").split("/")
+    if ".." in segments:
+        errors.append(f"extra_files: 'name' must not contain '..' path segments, got '{name}'")
+
+    # Reserved-name / reserved-dir collision on the FIRST path segment
+    # (case-insensitive). The first segment is what lands at the package root.
+    top = segments[0].lower() if segments else ""
+    if top in RESERVED_NAMES or top in RESERVED_DIRS:
+        errors.append(f"extra_files: 'name' collides with a generated artifact: '{name}'")
+    elif top.startswith(_RESERVED_PREFIXES):
+        errors.append(f"extra_files: 'name' collides with a generated binary: '{name}'")
+
+    return errors
+
+
+def validate_extra_files(entries: Any) -> list[str]:
+    """Validate an ``extra_files`` list; return human-readable error strings.
+
+    An empty list (or non-error input) returns ``[]``. Presence of the ``from``
+    source path is intentionally NOT checked here — that is a build-time concern
+    handled by ``package`` (fail-fast). This validates shape, ``name`` safety,
+    ``targets`` tokens, and that ``from`` is a non-empty string.
+    """
+    if entries in (None, []):
+        return []
+    if not isinstance(entries, list):
+        return ["extra_files: must be a list of entries"]
+
+    errors: list[str] = []
+    for i, entry in enumerate(entries):
+        prefix = f"extra_files[{i}]"
+        if not isinstance(entry, dict):
+            errors.append(f"{prefix}: must be an object with 'name', 'targets', 'from'")
+            continue
+
+        expected = {"name", "targets", "from"}
+        keys = set(entry)
+        missing = expected - keys
+        extra = keys - expected
+        if missing:
+            errors.append(f"{prefix}: missing key(s): {', '.join(sorted(missing))}")
+        if extra:
+            errors.append(f"{prefix}: unexpected key(s): {', '.join(sorted(extra))}")
+
+        for err in _name_errors(entry.get("name")):
+            errors.append(f"{prefix}: {err.split(': ', 1)[-1]}")
+
+        tokens = normalize_targets(entry.get("targets"))
+        if not tokens:
+            errors.append(f"{prefix}: 'targets' must be a token or list of tokens")
+        else:
+            unknown = [t for t in tokens if t not in VALID_TARGET_TOKENS]
+            if unknown:
+                errors.append(f"{prefix}: unknown target(s) {unknown}; valid: {', '.join(sorted(VALID_TARGET_TOKENS))}")
+
+        src = entry.get("from")
+        if not isinstance(src, str) or not src.strip():
+            errors.append(f"{prefix}: 'from' must be a non-empty source path")
+
+    return errors

--- a/source/tests/cli/commands/test_init_extra_files.py
+++ b/source/tests/cli/commands/test_init_extra_files.py
@@ -1,0 +1,226 @@
+# ABOUTME: Tests for the init wizard extra_files step and its round-trip wiring
+# ABOUTME: Covers add/edit/remove/cancel flows and _check_existing_deployment restore
+
+"""Tests for the `ccwb init` extra_files step.
+
+The wizard step (`_configure_extra_files`) must:
+- add, edit, and remove entries;
+- validate each entry and reject bad ones without saving;
+- preserve the existing list on cancel / non-interactive (prompt returns None);
+- round-trip through save (_save_configuration) and reload
+  (_check_existing_deployment) without drift.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+# ruff: noqa: E402
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+from claude_code_with_bedrock.cli.commands.init import InitCommand
+from claude_code_with_bedrock.config import Config, Profile
+
+
+class _FakeAsk:
+    """Stand-in for a questionary object whose .ask() returns a queued value."""
+
+    def __init__(self, value):
+        self._value = value
+
+    def ask(self):
+        return self._value
+
+
+def _make_profile(extra_files=None) -> Profile:
+    return Profile(
+        name="test",
+        provider_domain="example.okta.com",
+        client_id="0oa1234567890",
+        identity_pool_name="claude-code-auth",
+        credential_storage="keyring",
+        aws_region="us-east-1",
+        extra_files=extra_files or [],
+    )
+
+
+def _rebuild_config(profile: Profile) -> dict:
+    command = InitCommand()
+    fake_config = Config()
+    with (
+        patch.object(Config, "load", return_value=fake_config),
+        patch.object(fake_config, "get_profile", return_value=profile),
+        patch.object(InitCommand, "_stack_exists", side_effect=Exception("no creds")),
+    ):
+        return command._check_existing_deployment("test")
+
+
+class TestExtraFilesRoundTrip:
+    """_check_existing_deployment must restore extra_files from the profile."""
+
+    def test_rerun_preserves_extra_files(self):
+        entries = [
+            {"name": "certs", "targets": "all", "from": "~/secure/certs"},
+            {"name": "pre.sh", "targets": ["macos"], "from": "~/x/pre.sh"},
+        ]
+        rebuilt = _rebuild_config(_make_profile(entries))
+        assert rebuilt["extra_files"] == entries
+
+    def test_rerun_empty_extra_files(self):
+        rebuilt = _rebuild_config(_make_profile([]))
+        assert rebuilt["extra_files"] == []
+
+
+class TestConfigureExtraFiles:
+    """Drive the interactive loop with mocked questionary prompts."""
+
+    def _run(self, existing, confirm, selects, texts, checkboxes):
+        """Run _configure_extra_files with queued prompt responses.
+
+        confirm    -> the single top-level questionary.confirm value
+        selects    -> queued questionary.select return values (actions + pickers)
+        texts      -> queued questionary.text return values (from, name)
+        checkboxes -> queued questionary.checkbox return values (targets)
+        """
+        command = InitCommand()
+        select_iter = iter(selects)
+        text_iter = iter(texts)
+        checkbox_iter = iter(checkboxes)
+        # Record the choices passed to each checkbox call so tests can assert
+        # the pre-checked state (the real Add-vs-Edit default bug).
+        self.checkbox_choices = []
+
+        def _capture_checkbox(*a, **k):
+            self.checkbox_choices.append(k.get("choices", []))
+            return _FakeAsk(next(checkbox_iter))
+
+        with (
+            patch("questionary.confirm", return_value=_FakeAsk(confirm)),
+            patch("questionary.select", side_effect=lambda *a, **k: _FakeAsk(next(select_iter))),
+            patch("questionary.text", side_effect=lambda *a, **k: _FakeAsk(next(text_iter))),
+            patch("questionary.checkbox", side_effect=_capture_checkbox),
+            # Source-exists warning must not depend on the filesystem.
+            patch.object(Path, "exists", return_value=True),
+        ):
+            return command._configure_extra_files(existing)
+
+    def test_decline_keeps_existing(self):
+        existing = [{"name": "certs", "targets": "all", "from": "~/c"}]
+        result = self._run(existing, confirm=False, selects=[], texts=[], checkboxes=[])
+        assert result == existing
+
+    def test_confirm_none_keeps_existing(self):
+        existing = [{"name": "certs", "targets": "all", "from": "~/c"}]
+        result = self._run(existing, confirm=None, selects=[], texts=[], checkboxes=[])
+        assert result == existing
+
+    def test_add_entry(self):
+        result = self._run(
+            existing=[],
+            confirm=True,
+            selects=["Add", "Done"],
+            texts=["~/ccwb-extras/pre.sh", "pre.sh"],
+            checkboxes=[["macos"]],
+        )
+        assert result == [{"name": "pre.sh", "targets": ["macos"], "from": "~/ccwb-extras/pre.sh"}]
+
+    def test_add_prechecks_nothing(self):
+        """Regression: a new Add must start with no target pre-checked, so a
+        sticky 'all' default can't silently subsume the admin's selection."""
+        self._run(
+            existing=[],
+            confirm=True,
+            selects=["Add", "Done"],
+            texts=["~/x/pre.sh", "pre.sh"],
+            checkboxes=[["macos"]],
+        )
+        choices = self.checkbox_choices[0]
+        assert all(not c.checked for c in choices), "Add must not pre-check any target"
+
+    def test_edit_prechecks_existing_targets(self):
+        """Editing pre-checks exactly the entry's current targets."""
+        existing = [{"name": "certs", "targets": ["macos", "linux"], "from": "~/c"}]
+        self._run(
+            existing=existing,
+            confirm=True,
+            selects=["Edit", 0, "Done"],
+            texts=["~/c", "certs"],
+            checkboxes=[["macos", "linux"]],
+        )
+        checked = {c.value for c in self.checkbox_choices[0] if c.checked}
+        assert checked == {"macos", "linux"}
+
+    def test_add_saves_checked_targets_verbatim(self):
+        """Regression: selections are saved exactly as checked, with no collapse.
+
+        The earlier bug flattened any selection containing 'all' down to ['all'],
+        discarding the specific platforms the admin had also checked.
+        """
+        result = self._run(
+            existing=[],
+            confirm=True,
+            selects=["Add", "Done"],
+            texts=["~/secure/certs", "certs"],
+            checkboxes=[["all", "macos", "linux", "windows"]],
+        )
+        assert result == [{"name": "certs", "targets": ["all", "macos", "linux", "windows"], "from": "~/secure/certs"}]
+
+    def test_add_specific_platforms_only(self):
+        """Checking specific platforms (no 'all') saves exactly those."""
+        result = self._run(
+            existing=[],
+            confirm=True,
+            selects=["Add", "Done"],
+            texts=["~/x/pre.sh", "pre.sh"],
+            checkboxes=[["macos", "windows"]],
+        )
+        assert result == [{"name": "pre.sh", "targets": ["macos", "windows"], "from": "~/x/pre.sh"}]
+
+    def test_invalid_entry_not_saved(self):
+        """A zip-slip name is rejected; nothing is added."""
+        result = self._run(
+            existing=[],
+            confirm=True,
+            selects=["Add", "Done"],
+            texts=["~/x", "../escape"],
+            checkboxes=[["all"]],
+        )
+        assert result == []
+
+    def test_remove_entry(self):
+        existing = [
+            {"name": "certs", "targets": "all", "from": "~/c"},
+            {"name": "pre.sh", "targets": ["macos"], "from": "~/p"},
+        ]
+        # confirm=True, then select "Remove", picker returns index 0, then "Done".
+        result = self._run(
+            existing=existing,
+            confirm=True,
+            selects=["Remove", 0, "Done"],
+            texts=[],
+            checkboxes=[],
+        )
+        assert result == [{"name": "pre.sh", "targets": ["macos"], "from": "~/p"}]
+
+    def test_edit_entry(self):
+        existing = [{"name": "certs", "targets": "all", "from": "~/c"}]
+        # "Edit", picker index 0, new from/name, new targets.
+        result = self._run(
+            existing=existing,
+            confirm=True,
+            selects=["Edit", 0, "Done"],
+            texts=["~/new/certs", "certs"],
+            checkboxes=[["linux", "macos"]],
+        )
+        assert result == [{"name": "certs", "targets": ["linux", "macos"], "from": "~/new/certs"}]
+
+    def test_add_cancel_source_keeps_list(self):
+        """Cancelling the source prompt (None) drops back to the menu."""
+        result = self._run(
+            existing=[],
+            confirm=True,
+            selects=["Add", "Done"],
+            texts=[None],
+            checkboxes=[],
+        )
+        assert result == []

--- a/source/tests/cli/commands/test_package.py
+++ b/source/tests/cli/commands/test_package.py
@@ -265,3 +265,78 @@ class TestPackageCommandOtelDefaults:
         attrs = settings["env"]["OTEL_RESOURCE_ATTRIBUTES"]
 
         assert attrs == "department=research,team.id=ml"
+class TestCopyExtraFiles:
+    """Tests for _copy_extra_files — the package-side extra-files copy step."""
+
+    def _profile(self, extra_files):
+        return Profile(
+            name="test",
+            provider_domain="test.okta.com",
+            client_id="test-client-id",
+            credential_storage="keyring",
+            aws_region="us-east-1",
+            identity_pool_name="test-pool",
+            monitoring_enabled=False,
+            extra_files=extra_files,
+        )
+
+    def test_empty_list_returns_empty(self, tmp_path):
+        command = PackageCommand()
+        profile = self._profile([])
+        result = command._copy_extra_files(profile, tmp_path, MagicMock())
+        assert result == []
+
+    def test_copies_file_and_folder(self, tmp_path):
+        # Source file
+        src_file = tmp_path / "src" / "preinstall.sh"
+        src_file.parent.mkdir(parents=True)
+        src_file.write_text("#!/bin/bash\necho hi")
+        # Source folder
+        src_dir = tmp_path / "src" / "certs"
+        src_dir.mkdir()
+        (src_dir / "ca.pem").write_text("CERT")
+
+        out = tmp_path / "out"
+        out.mkdir()
+        profile = self._profile(
+            [
+                {"name": "preinstall.sh", "targets": "macos", "from": str(src_file)},
+                {"name": "certs", "targets": "all", "from": str(src_dir)},
+            ]
+        )
+
+        result = PackageCommand()._copy_extra_files(profile, out, MagicMock())
+
+        assert (out / "preinstall.sh").read_text() == "#!/bin/bash\necho hi"
+        assert (out / "certs" / "ca.pem").read_text() == "CERT"
+        names = {name for name, _ in result}
+        assert names == {"preinstall.sh", "certs"}
+
+    def test_missing_source_fails(self, tmp_path):
+        out = tmp_path / "out"
+        out.mkdir()
+        profile = self._profile([{"name": "missing.sh", "targets": "all", "from": str(tmp_path / "nope.sh")}])
+        result = PackageCommand()._copy_extra_files(profile, out, MagicMock())
+        assert result is None
+        assert not (out / "missing.sh").exists()
+
+    def test_validation_error_fails_and_copies_nothing(self, tmp_path):
+        src = tmp_path / "cfg"
+        src.write_text("x")
+        out = tmp_path / "out"
+        out.mkdir()
+        # 'config.json' collides with a generated artifact → validation error
+        profile = self._profile([{"name": "config.json", "targets": "all", "from": str(src)}])
+        result = PackageCommand()._copy_extra_files(profile, out, MagicMock())
+        assert result is None
+        assert not (out / "config.json").exists()
+
+    def test_nested_name_creates_parent_dirs(self, tmp_path):
+        src = tmp_path / "hook.sh"
+        src.write_text("hook")
+        out = tmp_path / "out"
+        out.mkdir()
+        profile = self._profile([{"name": "hooks/pre.sh", "targets": "all", "from": str(src)}])
+        result = PackageCommand()._copy_extra_files(profile, out, MagicMock())
+        assert result is not None
+        assert (out / "hooks" / "pre.sh").read_text() == "hook"

--- a/source/tests/test_config.py
+++ b/source/tests/test_config.py
@@ -224,6 +224,55 @@ class TestCodebuildRegionField:
         assert restored.codebuild_prior_regions == ["ap-southeast-2", "eu-west-1"]
 
 
+class TestExtraFilesField:
+    """Tests for the admin-only extra_files field."""
+
+    def test_defaults_to_empty_list(self):
+        """New field defaults to [] so old profiles load unchanged."""
+        profile = Profile(
+            name="t",
+            provider_domain="test.okta.com",
+            client_id="x",
+            credential_storage="session",
+            aws_region="us-east-1",
+            identity_pool_name="tp",
+        )
+        assert profile.extra_files == []
+        assert "extra_files" in profile.to_dict()
+
+    def test_legacy_config_without_extra_files_loads(self):
+        """A profile.json saved before this field existed loads with []."""
+        profile = Profile.from_dict(
+            {
+                "name": "t",
+                "provider_domain": "test.okta.com",
+                "client_id": "x",
+                "credential_storage": "session",
+                "aws_region": "us-east-1",
+                "identity_pool_name": "tp",
+            }
+        )
+        assert profile.extra_files == []
+
+    def test_round_trip_preserves_entries(self):
+        """extra_files survives a to_dict -> from_dict round-trip."""
+        entries = [
+            {"name": "certs", "targets": "all", "from": "~/secure/certs"},
+            {"name": "preinstall-mac.sh", "targets": ["macos"], "from": "~/x/pre.sh"},
+        ]
+        profile = Profile(
+            name="t",
+            provider_domain="test.okta.com",
+            client_id="x",
+            credential_storage="session",
+            aws_region="us-east-1",
+            identity_pool_name="tp",
+            extra_files=entries,
+        )
+        restored = Profile.from_dict(profile.to_dict())
+        assert restored.extra_files == entries
+
+
 class TestConfigManager:
     """Tests for the Config manager."""
 

--- a/source/tests/test_distribute.py
+++ b/source/tests/test_distribute.py
@@ -270,6 +270,78 @@ class TestCreatePerOsArchives:
         assert archives[0][0] == "linux-x64"
 
 
+class TestExtraFilesInArchives:
+    """Tests for admin-defined extra_files across the three archive builders."""
+
+    @pytest.fixture
+    def package_with_extras(self, package_dir):
+        """Add extra files (a folder + two OS-specific scripts) into the build dir."""
+        certs = package_dir / "certs"
+        certs.mkdir()
+        (certs / "ca.pem").write_text("CERT")
+        (package_dir / "preinstall-mac.sh").write_text("#!/bin/bash")
+        (package_dir / "preinstall-windows.ps1").write_text("# ps1")
+        return package_dir
+
+    _EXTRAS = [
+        {"name": "certs", "targets": "all", "from": "~/x/certs"},
+        {"name": "preinstall-mac.sh", "targets": "macos", "from": "~/x/pre.sh"},
+        {"name": "preinstall-windows.ps1", "targets": "windows", "from": "~/x/pre.ps1"},
+    ]
+
+    def test_all_os_archive_contains_every_extra(self, cmd, package_with_extras):
+        archive = cmd._create_archive(package_with_extras, self._EXTRAS)
+        with zipfile.ZipFile(archive, "r") as zf:
+            names = zf.namelist()
+        assert "claude-code-package/certs/ca.pem" in names
+        assert "claude-code-package/preinstall-mac.sh" in names
+        assert "claude-code-package/preinstall-windows.ps1" in names
+
+    def test_all_os_archive_without_extras_unchanged(self, cmd, package_with_extras):
+        """No extra_files arg → extras present in the build dir are NOT auto-added."""
+        archive = cmd._create_archive(package_with_extras)
+        with zipfile.ZipFile(archive, "r") as zf:
+            names = zf.namelist()
+        assert "claude-code-package/certs/ca.pem" not in names
+        assert "claude-code-package/preinstall-mac.sh" not in names
+
+    def test_per_os_filters_by_platform(self, cmd, package_with_extras):
+        archives = cmd._create_per_os_archives(package_with_extras, self._EXTRAS)
+        by_platform = {p: a for p, _label, a in archives}
+
+        with zipfile.ZipFile(by_platform["macos-arm64"], "r") as zf:
+            mac_names = zf.namelist()
+        assert "claude-code-package/certs/ca.pem" in mac_names  # all
+        assert "claude-code-package/preinstall-mac.sh" in mac_names  # macos
+        assert "claude-code-package/preinstall-windows.ps1" not in mac_names  # windows excluded
+
+        with zipfile.ZipFile(by_platform["windows"], "r") as zf:
+            win_names = zf.namelist()
+        assert "claude-code-package/certs/ca.pem" in win_names  # all
+        assert "claude-code-package/preinstall-windows.ps1" in win_names  # windows
+        assert "claude-code-package/preinstall-mac.sh" not in win_names  # macos excluded
+
+    def test_per_os_arch_target_lands_in_family_zip(self, cmd, package_dir):
+        """An arch-specific target (macos-arm64) belongs in the macos-arm64 per-OS zip."""
+        (package_dir / "arm-only.sh").write_text("arm")
+        entries = [{"name": "arm-only.sh", "targets": "macos-arm64", "from": "~/x"}]
+        archives = cmd._create_per_os_archives(package_dir, entries)
+        by_platform = {p: a for p, _label, a in archives}
+
+        with zipfile.ZipFile(by_platform["macos-arm64"], "r") as zf:
+            assert "claude-code-package/arm-only.sh" in zf.namelist()
+        with zipfile.ZipFile(by_platform["macos-intel"], "r") as zf:
+            assert "claude-code-package/arm-only.sh" not in zf.namelist()
+
+    def test_invalid_entries_skipped_silently(self, cmd, package_with_extras):
+        """A colliding/invalid entry must not crash or ship — package fails fast upstream."""
+        bad = [{"name": "config.json", "targets": "all", "from": "~/x"}]
+        archive = cmd._create_archive(package_with_extras, bad)
+        with zipfile.ZipFile(archive, "r") as zf:
+            # config.json is the generated one, not clobbered by the extra
+            assert "claude-code-package/config.json" in zf.namelist()
+
+
 class TestCalculateChecksum:
     """Tests for _calculate_checksum."""
 

--- a/source/tests/test_extra_files.py
+++ b/source/tests/test_extra_files.py
@@ -1,0 +1,185 @@
+"""Unit tests for the declarative extra_files matcher and validator.
+
+The matcher (`extra_applies_to`) is the highest-risk piece of the feature: it
+reconciles three different platform vocabularies (per-OS arch tokens, landing
+families, and the all-OS archive). These tests pin the full truth table.
+"""
+
+import pytest
+
+from claude_code_with_bedrock.extra_files import (
+    VALID_TARGET_TOKENS,
+    extra_applies_to,
+    normalize_targets,
+    validate_extra_files,
+)
+
+# Every token used by _create_per_os_archives (PLATFORM_FILES keys).
+PER_OS_TOKENS = ["windows", "linux-x64", "linux-arm64", "macos-arm64", "macos-intel"]
+# Every token used by _upload_landing_page_packages.
+LANDING_TOKENS = ["windows", "linux", "mac"]
+
+
+class TestNormalizeTargets:
+    def test_single_string(self):
+        assert normalize_targets("macos") == ["macos"]
+
+    def test_list(self):
+        assert normalize_targets(["macos", "LINUX"]) == ["macos", "linux"]
+
+    def test_whitespace_and_case(self):
+        assert normalize_targets("  Windows ") == ["windows"]
+
+    def test_invalid_type(self):
+        assert normalize_targets(None) == []
+        assert normalize_targets(42) == []
+
+
+class TestExtraAppliesToAll:
+    @pytest.mark.parametrize("platform", PER_OS_TOKENS + LANDING_TOKENS)
+    def test_all_matches_every_platform(self, platform):
+        assert extra_applies_to("all", platform) is True
+
+    @pytest.mark.parametrize("platform", PER_OS_TOKENS + LANDING_TOKENS)
+    def test_all_in_list_matches(self, platform):
+        assert extra_applies_to(["all", "windows"], platform) is True
+
+
+class TestExtraAppliesToExact:
+    @pytest.mark.parametrize("token", PER_OS_TOKENS)
+    def test_exact_per_os(self, token):
+        assert extra_applies_to(token, token) is True
+
+    def test_windows_exact(self):
+        assert extra_applies_to("windows", "windows") is True
+
+
+class TestExtraAppliesToFamily:
+    def test_macos_family_matches_both_arches(self):
+        assert extra_applies_to("macos", "macos-arm64") is True
+        assert extra_applies_to("macos", "macos-intel") is True
+
+    def test_linux_family_matches_both_arches(self):
+        assert extra_applies_to("linux", "linux-x64") is True
+        assert extra_applies_to("linux", "linux-arm64") is True
+
+    def test_macos_family_matches_landing_mac(self):
+        assert extra_applies_to("macos", "mac") is True
+
+    def test_linux_family_matches_landing_linux(self):
+        assert extra_applies_to("linux", "linux") is True
+
+    def test_family_does_not_cross_families(self):
+        assert extra_applies_to("macos", "linux-x64") is False
+        assert extra_applies_to("linux", "macos-arm64") is False
+        assert extra_applies_to("macos", "windows") is False
+
+
+class TestExtraAppliesToArch:
+    def test_arch_matches_own_per_os(self):
+        assert extra_applies_to("macos-arm64", "macos-arm64") is True
+
+    def test_arch_excludes_sibling_arch_per_os(self):
+        # An arch-specific extra must NOT land in the sibling arch's per-os zip.
+        assert extra_applies_to("macos-arm64", "macos-intel") is False
+        assert extra_applies_to("linux-x64", "linux-arm64") is False
+
+    def test_arch_matches_landing_family(self):
+        # Landing families have no arch split, so an arch extra must appear there.
+        assert extra_applies_to("macos-arm64", "mac") is True
+        assert extra_applies_to("linux-arm64", "linux") is True
+
+    def test_arch_excludes_wrong_landing_family(self):
+        assert extra_applies_to("macos-arm64", "windows") is False
+        assert extra_applies_to("linux-x64", "mac") is False
+
+
+class TestExtraAppliesToList:
+    def test_list_of_families(self):
+        targets = ["macos", "linux"]
+        assert extra_applies_to(targets, "macos-arm64") is True
+        assert extra_applies_to(targets, "linux-x64") is True
+        assert extra_applies_to(targets, "windows") is False
+        assert extra_applies_to(targets, "mac") is True
+
+    def test_empty_targets_matches_nothing(self):
+        assert extra_applies_to([], "windows") is False
+
+
+class TestValidateExtraFiles:
+    def test_empty_is_valid(self):
+        assert validate_extra_files([]) == []
+        assert validate_extra_files(None) == []
+
+    def test_valid_entries(self):
+        entries = [
+            {"name": "certs", "targets": "all", "from": "~/secure/certs"},
+            {"name": "preinstall-mac.sh", "targets": ["macos"], "from": "~/x/pre.sh"},
+        ]
+        assert validate_extra_files(entries) == []
+
+    def test_not_a_list(self):
+        assert validate_extra_files({"name": "x"}) != []
+
+    def test_entry_not_a_dict(self):
+        errors = validate_extra_files(["nope"])
+        assert any("must be an object" in e for e in errors)
+
+    def test_missing_keys(self):
+        errors = validate_extra_files([{"name": "x"}])
+        assert any("missing key" in e for e in errors)
+
+    def test_unexpected_key(self):
+        errors = validate_extra_files([{"name": "x", "targets": "all", "from": "~/x", "mode": "755"}])
+        assert any("unexpected key" in e for e in errors)
+
+    def test_unknown_target_token(self):
+        errors = validate_extra_files([{"name": "x", "targets": "solaris", "from": "~/x"}])
+        assert any("unknown target" in e for e in errors)
+
+    def test_empty_from(self):
+        errors = validate_extra_files([{"name": "x", "targets": "all", "from": ""}])
+        assert any("'from'" in e for e in errors)
+
+    @pytest.mark.parametrize(
+        "bad_name",
+        ["../escape", "/etc/passwd", "C:\\Windows\\x", "a/../../b", "sub\\..\\evil"],
+    )
+    def test_zip_slip_names_rejected(self, bad_name):
+        errors = validate_extra_files([{"name": bad_name, "targets": "all", "from": "~/x"}])
+        assert errors, f"expected {bad_name!r} to be rejected"
+
+    @pytest.mark.parametrize(
+        "reserved",
+        ["config.json", "install.sh", "install.bat", "README.md", "collector-config.yaml"],
+    )
+    def test_reserved_name_collision(self, reserved):
+        errors = validate_extra_files([{"name": reserved, "targets": "all", "from": "~/x"}])
+        assert any("collides" in e for e in errors)
+
+    def test_reserved_dir_collision(self):
+        errors = validate_extra_files([{"name": "claude-settings/foo.json", "targets": "all", "from": "~/x"}])
+        assert any("collides" in e for e in errors)
+
+    def test_reserved_binary_prefix_collision(self):
+        errors = validate_extra_files([{"name": "credential-process-macos-arm64", "targets": "all", "from": "~/x"}])
+        assert any("collides" in e for e in errors)
+
+    def test_nested_name_allowed(self):
+        # A safe nested path that does not collide is fine.
+        assert validate_extra_files([{"name": "certs/ca.pem", "targets": "all", "from": "~/x"}]) == []
+
+
+class TestTokenSet:
+    def test_valid_tokens_are_stable(self):
+        # Guards against accidental token-set drift.
+        assert VALID_TARGET_TOKENS == {
+            "all",
+            "macos",
+            "linux",
+            "windows",
+            "macos-arm64",
+            "macos-intel",
+            "linux-x64",
+            "linux-arm64",
+        }


### PR DESCRIPTION
## Why

Admins sometimes need to ship files *on top of* the generated package —
preinstall/postinstall scripts, an OIDC signing certificate, a CA bundle, etc.
Today that means hand-editing `package.py` and the three archive builders in
`distribute.py`, which doesn't survive a rebase onto upstream, drifts across the
four hardcoded file inventories (the exact problem `distribution-manifest-parity.md`
warns about), and can't express "this file only goes to Windows".

This adds a single declarative list — `extra_files` — read by both `package`
and `distribute`. It is **additive**: it never re-declares the binaries,
`config.json`, `install.sh`, or `managed-settings.json`; those keep working
exactly as they do today. The list lives in the admin-side deployment profile,
so it never reaches the runtime `config.json` and is never synced to the Go
credential-process.

## What

- **config:** new `extra_files` field on the `Profile` dataclass (default `[]`,
  so old profiles load unchanged) plus a shared `extra_files.py` module with the
  OS-token matcher (`extra_applies_to`) and validator (`validate_extra_files`).
- **init:** wizard step to add/edit/remove entries, with round-trip save/reload
  wiring so re-running `init` shows the saved list.
- **package:** copies the full superset of extras into the build folder; fails
  fast (non-zero exit) on a missing `from` source or a `name` that collides with
  a generated artifact — a listed file is never silently dropped.
- **distribute:** a shared `_add_extra_files_to_zip` helper filters extras
  per-OS across all three archive builders (all-OS = every extra, per-OS token
  filter, landing-family filter). Distribute reads from the already-built
  package folder, never the `from` source, keeping the two commands decoupled.
- **docs:** Extra Files subsection in the CLI reference.

Each entry has three fields: `name` (path inside the package), `targets`
(`all` / family / arch / list), and `from` (source path on the admin's machine).

## Backward compatibility

- New field defaults to `[]` — old `profile.json` files load without error.
- Not synced to Go config; not written to runtime `config.json`.
- No change to existing package/distribute behavior when `extra_files` is empty.

## Testing

137 tests across `test_extra_files.py` (matcher truth table + validator),
`test_config.py` (round-trip), `test_package.py` (copy, missing source,
validation), and `test_distribute.py` (all-OS / per-OS filtering, arch-in-family).

```
137 passed
```

Path safety (`name`) rejects absolute paths, `..` traversal, Windows drive
letters, and collisions with generated artifacts — the zip-slip surface, since
`name` becomes a zip entry path.
