### PR TITLE
fix(quota): cost-based enforcement reads correct DDB attributes

### DIFF
--- a/deployment/infrastructure/lambda-functions/quota_check/index.py
+++ b/deployment/infrastructure/lambda-functions/quota_check/index.py
@@ -36,6 +36,7 @@ policies_table = dynamodb.Table(POLICIES_TABLE)
 
 class DecimalEncoder(json.JSONEncoder):
     """JSON encoder that handles Decimal types."""
+
     def default(self, obj):
         if isinstance(obj, Decimal):
             return float(obj)
@@ -88,43 +89,50 @@ def lambda_handler(event, context):
             # Neither JWT nor IAM identity resolved
             print(f"No user identity found. JWT claims: {list(jwt_claims.keys())}")
             allow_missing_email = MISSING_EMAIL_ENFORCEMENT != "block"
-            return build_response(200, {
-                "error": "No user identity found (no JWT email claim or IAM session name)",
-                "allowed": allow_missing_email,
-                "reason": "missing_identity",
-                "message": "Could not resolve user identity" + (" - quota check skipped" if allow_missing_email else " - access denied for security")
-            })
+            return build_response(
+                200,
+                {
+                    "error": "No user identity found (no JWT email claim or IAM session name)",
+                    "allowed": allow_missing_email,
+                    "reason": "missing_identity",
+                    "message": "Could not resolve user identity"
+                    + (" - quota check skipped" if allow_missing_email else " - access denied for security"),
+                },
+            )
 
         # 1. Resolve the effective quota policy for this user
         policy = resolve_quota_for_user(email, groups)
 
         if policy is None:
             # No policy = unlimited (quota monitoring disabled)
-            return build_response(200, {
-                "allowed": True,
-                "reason": "no_policy",
-                "enforcement_mode": None,
-                "usage": None,
-                "policy": None,
-                "unblock_status": None,
-                "message": "No quota policy configured - unlimited access"
-            })
+            return build_response(
+                200,
+                {
+                    "allowed": True,
+                    "reason": "no_policy",
+                    "enforcement_mode": None,
+                    "usage": None,
+                    "policy": None,
+                    "unblock_status": None,
+                    "message": "No quota policy configured - unlimited access",
+                },
+            )
 
         # 2. Check for active unblock override
         unblock_status = get_unblock_status(email)
         if unblock_status and unblock_status.get("is_unblocked"):
-            return build_response(200, {
-                "allowed": True,
-                "reason": "unblocked",
-                "enforcement_mode": policy.get("enforcement_mode", "alert"),
-                "usage": get_user_usage_summary(email, policy),
-                "policy": {
-                    "type": policy.get("policy_type"),
-                    "identifier": policy.get("identifier")
+            return build_response(
+                200,
+                {
+                    "allowed": True,
+                    "reason": "unblocked",
+                    "enforcement_mode": policy.get("enforcement_mode", "alert"),
+                    "usage": get_user_usage_summary(email, policy),
+                    "policy": {"type": policy.get("policy_type"), "identifier": policy.get("identifier")},
+                    "unblock_status": unblock_status,
+                    "message": f"Access granted - temporarily unblocked until {unblock_status.get('expires_at')}",
                 },
-                "unblock_status": unblock_status,
-                "message": f"Access granted - temporarily unblocked until {unblock_status.get('expires_at')}"
-            })
+            )
 
         # 3. Get current usage
         usage = get_user_usage(email)
@@ -135,23 +143,23 @@ def lambda_handler(event, context):
 
         if enforcement_mode != "block":
             # Alert-only mode - always allow
-            return build_response(200, {
-                "allowed": True,
-                "reason": "within_quota",
-                "enforcement_mode": enforcement_mode,
-                "usage": usage_summary,
-                "policy": {
-                    "type": policy.get("policy_type"),
-                    "identifier": policy.get("identifier")
+            return build_response(
+                200,
+                {
+                    "allowed": True,
+                    "reason": "within_quota",
+                    "enforcement_mode": enforcement_mode,
+                    "usage": usage_summary,
+                    "policy": {"type": policy.get("policy_type"), "identifier": policy.get("identifier")},
+                    "unblock_status": {"is_unblocked": False},
+                    "message": "Access granted - enforcement mode is alert-only",
                 },
-                "unblock_status": {"is_unblocked": False},
-                "message": "Access granted - enforcement mode is alert-only"
-            })
+            )
 
         # 5. Check limits (monthly, daily) — supports both token and cost modes
         monthly_tokens = usage.get("total_tokens", 0)
         daily_tokens = usage.get("daily_tokens", 0)
-        monthly_cost = float(usage.get("cost_usd", 0))
+        monthly_cost = float(usage.get("estimated_cost", 0))
         daily_cost = float(usage.get("daily_cost_usd", 0))
 
         monthly_limit = policy.get("monthly_token_limit", 0)
@@ -161,98 +169,102 @@ def lambda_handler(event, context):
 
         # Cost-based enforcement (takes precedence when configured)
         if monthly_cost_limit > 0 and monthly_cost >= monthly_cost_limit:
-            return build_response(200, {
-                "allowed": False,
-                "reason": "monthly_cost_exceeded",
-                "enforcement_mode": enforcement_mode,
-                "usage": usage_summary,
-                "policy": {
-                    "type": policy.get("policy_type"),
-                    "identifier": policy.get("identifier")
+            return build_response(
+                200,
+                {
+                    "allowed": False,
+                    "reason": "monthly_cost_exceeded",
+                    "enforcement_mode": enforcement_mode,
+                    "usage": usage_summary,
+                    "policy": {"type": policy.get("policy_type"), "identifier": policy.get("identifier")},
+                    "unblock_status": {"is_unblocked": False},
+                    "message": f"Monthly spend limit exceeded: ${monthly_cost:.2f} / ${monthly_cost_limit:.2f} ({monthly_cost / monthly_cost_limit * 100:.1f}%). Contact your administrator.",
                 },
-                "unblock_status": {"is_unblocked": False},
-                "message": f"Monthly spend limit exceeded: ${monthly_cost:.2f} / ${monthly_cost_limit:.2f} ({monthly_cost/monthly_cost_limit*100:.1f}%). Contact your administrator."
-            })
+            )
 
         if daily_cost_limit > 0 and daily_cost >= daily_cost_limit:
             daily_mode = policy.get("daily_enforcement_mode", "alert")
             if daily_mode == "block":
-                return build_response(200, {
-                    "allowed": False,
-                    "reason": "daily_cost_exceeded",
-                    "enforcement_mode": enforcement_mode,
-                    "usage": usage_summary,
-                    "policy": {
-                        "type": policy.get("policy_type"),
-                        "identifier": policy.get("identifier")
+                return build_response(
+                    200,
+                    {
+                        "allowed": False,
+                        "reason": "daily_cost_exceeded",
+                        "enforcement_mode": enforcement_mode,
+                        "usage": usage_summary,
+                        "policy": {"type": policy.get("policy_type"), "identifier": policy.get("identifier")},
+                        "unblock_status": {"is_unblocked": False},
+                        "message": f"Daily spend limit exceeded: ${daily_cost:.2f} / ${daily_cost_limit:.2f}. Resets at UTC midnight.",
                     },
-                    "unblock_status": {"is_unblocked": False},
-                    "message": f"Daily spend limit exceeded: ${daily_cost:.2f} / ${daily_cost_limit:.2f}. Resets at UTC midnight."
-                })
+                )
 
         # Token-based enforcement (existing behavior)
         # Check monthly token limit
         if monthly_limit > 0 and monthly_tokens >= monthly_limit:
-            return build_response(200, {
-                "allowed": False,
-                "reason": "monthly_exceeded",
-                "enforcement_mode": enforcement_mode,
-                "usage": usage_summary,
-                "policy": {
-                    "type": policy.get("policy_type"),
-                    "identifier": policy.get("identifier")
+            return build_response(
+                200,
+                {
+                    "allowed": False,
+                    "reason": "monthly_exceeded",
+                    "enforcement_mode": enforcement_mode,
+                    "usage": usage_summary,
+                    "policy": {"type": policy.get("policy_type"), "identifier": policy.get("identifier")},
+                    "unblock_status": {"is_unblocked": False},
+                    "message": f"Monthly quota exceeded: {int(monthly_tokens):,} / {int(monthly_limit):,} tokens ({monthly_tokens / monthly_limit * 100:.1f}%). Contact your administrator for assistance.",
                 },
-                "unblock_status": {"is_unblocked": False},
-                "message": f"Monthly quota exceeded: {int(monthly_tokens):,} / {int(monthly_limit):,} tokens ({monthly_tokens/monthly_limit*100:.1f}%). Contact your administrator for assistance."
-            })
+            )
 
         # Check daily token limit (if configured)
         if daily_limit and daily_limit > 0 and daily_tokens >= daily_limit:
             daily_mode = policy.get("daily_enforcement_mode", "alert")
             if daily_mode == "block":
-                return build_response(200, {
-                    "allowed": False,
-                    "reason": "daily_exceeded",
-                    "enforcement_mode": enforcement_mode,
-                    "usage": usage_summary,
-                    "policy": {
-                        "type": policy.get("policy_type"),
-                        "identifier": policy.get("identifier")
+                return build_response(
+                    200,
+                    {
+                        "allowed": False,
+                        "reason": "daily_exceeded",
+                        "enforcement_mode": enforcement_mode,
+                        "usage": usage_summary,
+                        "policy": {"type": policy.get("policy_type"), "identifier": policy.get("identifier")},
+                        "unblock_status": {"is_unblocked": False},
+                        "message": f"Daily quota exceeded: {int(daily_tokens):,} / {int(daily_limit):,} tokens ({daily_tokens / daily_limit * 100:.1f}%). Quota resets at UTC midnight.",
                     },
-                    "unblock_status": {"is_unblocked": False},
-                    "message": f"Daily quota exceeded: {int(daily_tokens):,} / {int(daily_limit):,} tokens ({daily_tokens/daily_limit*100:.1f}%). Quota resets at UTC midnight."
-                })
+                )
 
         # All checks passed - access allowed
-        return build_response(200, {
-            "allowed": True,
-            "reason": "within_quota",
-            "enforcement_mode": enforcement_mode,
-            "usage": usage_summary,
-            "policy": {
-                "type": policy.get("policy_type"),
-                "identifier": policy.get("identifier")
+        return build_response(
+            200,
+            {
+                "allowed": True,
+                "reason": "within_quota",
+                "enforcement_mode": enforcement_mode,
+                "usage": usage_summary,
+                "policy": {"type": policy.get("policy_type"), "identifier": policy.get("identifier")},
+                "unblock_status": {"is_unblocked": False},
+                "message": "Access granted - within quota limits",
             },
-            "unblock_status": {"is_unblocked": False},
-            "message": "Access granted - within quota limits"
-        })
+        )
 
     except Exception as e:
         print(f"Error during quota check: {str(e)}")
         import traceback
+
         traceback.print_exc()
 
         # Security: Honor error handling mode - default to fail-closed for security
         allow_on_error = ERROR_HANDLING_MODE != "fail_closed"
-        return build_response(200, {
-            "allowed": allow_on_error,
-            "reason": "check_failed",
-            "enforcement_mode": None,
-            "usage": None,
-            "policy": None,
-            "unblock_status": None,
-            "message": f"Quota check failed ({ERROR_HANDLING_MODE}): {str(e)}"
-        })
+        return build_response(
+            200,
+            {
+                "allowed": allow_on_error,
+                "reason": "check_failed",
+                "enforcement_mode": None,
+                "usage": None,
+                "policy": None,
+                "unblock_status": None,
+                "message": f"Quota check failed ({ERROR_HANDLING_MODE}): {str(e)}",
+            },
+        )
 
 
 def build_response(status_code: int, body: dict) -> dict:
@@ -263,9 +275,9 @@ def build_response(status_code: int, body: dict) -> dict:
             "Content-Type": "application/json",
             "Access-Control-Allow-Origin": "*",
             "Access-Control-Allow-Methods": "GET, OPTIONS",
-            "Access-Control-Allow-Headers": "Content-Type, Authorization"
+            "Access-Control-Allow-Headers": "Content-Type, Authorization",
         },
-        "body": json.dumps(body, cls=DecimalEncoder)
+        "body": json.dumps(body, cls=DecimalEncoder),
     }
 
 
@@ -376,6 +388,8 @@ def get_policy(policy_type: str, identifier: str) -> dict | None:
             "identifier": item.get("identifier"),
             "monthly_token_limit": int(item.get("monthly_token_limit", 0)),
             "daily_token_limit": int(item.get("daily_token_limit", 0)) if item.get("daily_token_limit") else None,
+            "monthly_cost_limit": float(item.get("monthly_cost_limit", 0)),
+            "daily_cost_limit": float(item.get("daily_cost_limit", 0)),
             "warning_threshold_80": int(item.get("warning_threshold_80", 0)),
             "warning_threshold_90": int(item.get("warning_threshold_90", 0)),
             "enforcement_mode": item.get("enforcement_mode", "alert"),
@@ -412,7 +426,7 @@ def get_unblock_status(email: str) -> dict:
             "unblocked_by": item.get("unblocked_by"),
             "unblocked_at": item.get("unblocked_at"),
             "reason": item.get("reason"),
-            "duration_type": item.get("duration_type")
+            "duration_type": item.get("duration_type"),
         }
     except Exception as e:
         print(f"Error checking unblock status for {email}: {e}")
@@ -439,7 +453,9 @@ def get_user_usage(email: str) -> dict:
                 "daily_date": current_date,
                 "input_tokens": 0,
                 "output_tokens": 0,
-                "cache_tokens": 0
+                "cache_tokens": 0,
+                "estimated_cost": 0,
+                "daily_cost_usd": 0,
             }
 
         # Check if daily tokens need to be reset (different day)
@@ -456,7 +472,9 @@ def get_user_usage(email: str) -> dict:
             "daily_date": daily_date,
             "input_tokens": float(item.get("input_tokens", 0)),
             "output_tokens": float(item.get("output_tokens", 0)),
-            "cache_tokens": float(item.get("cache_tokens", 0))
+            "cache_tokens": float(item.get("cache_tokens", 0)),
+            "estimated_cost": float(item.get("estimated_cost", 0)),
+            "daily_cost_usd": float(item.get("daily_cost_usd", 0)) if daily_date == current_date else 0,
         }
     except Exception as e:
         print(f"Error getting usage for {email}: {e}")
@@ -466,7 +484,9 @@ def get_user_usage(email: str) -> dict:
             "daily_date": current_date,
             "input_tokens": 0,
             "output_tokens": 0,
-            "cache_tokens": 0
+            "cache_tokens": 0,
+            "estimated_cost": 0,
+            "daily_cost_usd": 0,
         }
 
 
@@ -482,7 +502,7 @@ def build_usage_summary(usage: dict, policy: dict) -> dict:
         "monthly_tokens": int(monthly_tokens),
         "monthly_limit": monthly_limit,
         "monthly_percent": round(monthly_tokens / monthly_limit * 100, 1) if monthly_limit > 0 else 0,
-        "daily_tokens": int(daily_tokens)
+        "daily_tokens": int(daily_tokens),
     }
 
     if daily_limit:

--- a/source/tests/test_quota_check_lambda.py
+++ b/source/tests/test_quota_check_lambda.py
@@ -581,3 +581,99 @@ class TestIdcUsernameIdentity:
         # Non-SSO role without email should be blocked
         assert body.get("reason") == "missing_identity"
         assert body["allowed"] is False
+
+
+class TestCostBasedEnforcement:
+    """Tests that cost-based quota enforcement reads the correct DDB attributes.
+
+    Regression tests for issue #746: monthly cost enforcement was broken because:
+    1. get_user_usage() didn't include cost fields in its return dict
+    2. get_policy() didn't include monthly_cost_limit/daily_cost_limit
+    3. The lookup key was 'cost_usd' but DDB attribute is 'estimated_cost'
+    """
+
+    def _make_module(self, base_env):
+        env = {
+            **base_env,
+            "ENABLE_FINEGRAINED_QUOTAS": "true",
+        }
+        return _load_quota_check(env)
+
+    def _patch_tables(
+        self,
+        mod,
+        estimated_cost: float,
+        monthly_cost_limit: float,
+        daily_cost_usd: float = 0,
+        daily_cost_limit: float = 0,
+    ):
+        """Mock both quota_table and policies_table with correct call sequence."""
+        from datetime import datetime, timezone
+
+        current_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+        mod.quota_table = MagicMock()
+        # Call 1: get_unblock_status -> no unblock
+        # Call 2: get_user_usage -> usage with estimated_cost
+        mod.quota_table.get_item.side_effect = [
+            {},  # unblock check: no item
+            {
+                "Item": {
+                    "total_tokens": 100000,
+                    "daily_tokens": 1000,
+                    "daily_date": current_date,
+                    "input_tokens": 60000,
+                    "output_tokens": 40000,
+                    "cache_tokens": 0,
+                    "estimated_cost": estimated_cost,
+                    "daily_cost_usd": daily_cost_usd,
+                }
+            },
+        ]
+
+        mod.policies_table = MagicMock()
+        mod.policies_table.get_item.return_value = {
+            "Item": {
+                "pk": "POLICY#default#default",
+                "sk": "CURRENT",
+                "policy_type": "default",
+                "identifier": "default",
+                "monthly_token_limit": 0,
+                "monthly_cost_limit": monthly_cost_limit,
+                "daily_cost_limit": daily_cost_limit,
+                "enforcement_mode": "block",
+                "daily_enforcement_mode": "block",
+                "enabled": True,
+            }
+        }
+
+    def test_monthly_cost_blocks_when_exceeded(self, base_env):
+        """When estimated_cost exceeds monthly_cost_limit, access must be denied."""
+        mod = self._make_module(base_env)
+        self._patch_tables(mod, estimated_cost=95.0, monthly_cost_limit=90.0)
+
+        body = _parse(mod.lambda_handler(_build_event(), None))
+        assert body["allowed"] is False, (
+            "Monthly cost enforcement failed: estimated_cost ($95) > limit ($90) but access was allowed. "
+            "Check that get_user_usage includes 'estimated_cost' and get_policy includes 'monthly_cost_limit'."
+        )
+        assert body["reason"] == "monthly_cost_exceeded"
+
+    def test_monthly_cost_allows_when_within_limit(self, base_env):
+        """When estimated_cost is below monthly_cost_limit, access is granted."""
+        mod = self._make_module(base_env)
+        self._patch_tables(mod, estimated_cost=45.0, monthly_cost_limit=90.0)
+
+        body = _parse(mod.lambda_handler(_build_event(), None))
+        assert body["allowed"] is True
+
+    def test_daily_cost_blocks_when_exceeded(self, base_env):
+        """When daily_cost_usd exceeds daily_cost_limit, access must be denied."""
+        mod = self._make_module(base_env)
+        self._patch_tables(
+            mod, estimated_cost=10.0, monthly_cost_limit=90.0, daily_cost_usd=12.0, daily_cost_limit=10.0
+        )
+
+        body = _parse(mod.lambda_handler(_build_event(), None))
+        assert body["allowed"] is False
+        assert body["reason"] == "daily_cost_exceeded"


### PR DESCRIPTION
## Summary

Fixes **three bugs** that made monthly/daily cost-based quota enforcement silently fail — cost limits were configured but never enforced.

Closes #746 (reported by @jerehops)

## Root Cause Analysis

**Bug 1 — `get_user_usage()` strips cost fields:**
The function reads the DDB item but only returns token fields in its dict. `estimated_cost` and `daily_cost_usd` were never included in the return value, so the enforcement code always saw `0`.

**Bug 2 — `get_policy()` strips cost limit fields:**
Similarly, `monthly_cost_limit` and `daily_cost_limit` were never included in the policy return dict, even when stored in DynamoDB.

**Bug 3 — Wrong attribute name (`cost_usd` vs `estimated_cost`):**
`quota_monitor` writes monthly cumulative cost as DDB attribute `estimated_cost` (via `ADD estimated_cost :cost`). But `quota_check` was reading `cost_usd` — which is only an in-memory variable name in `quota_monitor`, never a DDB attribute.

## Fix

| File | Change |
|------|--------|
| `quota_check/index.py` L154 | `usage.get("cost_usd")` → `usage.get("estimated_cost")` |
| `quota_check/index.py` `get_user_usage()` | Include `estimated_cost` and `daily_cost_usd` in return dict |
| `quota_check/index.py` `get_policy()` | Include `monthly_cost_limit` and `daily_cost_limit` in return dict |

## Testing

3 new regression tests in `test_quota_check_lambda.py::TestCostBasedEnforcement`:
- `test_monthly_cost_blocks_when_exceeded` — verifies block at $95/$90 limit
- `test_monthly_cost_allows_when_within_limit` — verifies allow at $45/$90 limit
- `test_daily_cost_blocks_when_exceeded` — verifies daily cost enforcement

All 29 tests in the file pass.

## Impact

- **Before:** Cost-based enforcement was silently broken. All cost checks defaulted to $0, making `monthly_cost_limit` and `daily_cost_limit` unenforceable regardless of configuration.
- **After:** Cost limits are correctly read from DDB and enforced. No changes needed for existing token-based quotas (backward compatible).