### PR TITLE
fix(otel): resolve OIDC provider type before --get-monitoring-token so silent bearer refresh works

### DIFF
--- a/source/go/cmd/credential-process/main.go
+++ b/source/go/cmd/credential-process/main.go
@@ -98,6 +98,25 @@ func main() {
 		runExplain(profile, cfg)
 	}
 
+	// Resolve OIDC provider type + redirect port BEFORE the flag dispatch below.
+	// The --get-monitoring-token and --get-mcp-auth-header handlers perform a
+	// silent refresh_token exchange that depends on app.providerType (to build the
+	// token endpoint URL and pick the Azure confidential-auth path) and, on
+	// fall-through to browser auth, on app.redirectPort. Historically both fields
+	// were set only after the dispatch block (in the OIDC run() path), so those
+	// handlers ran with providerType=="" (empty token URL + no client assertion →
+	// failed exchange that wiped the refresh_token) and redirectPort==0 (browser
+	// fallback opened http://localhost:0 → ERR_UNSAFE_PORT).
+	//
+	// Gated to real OIDC profiles only: resolveProviderType calls provider.Detect,
+	// which returns "oidc" (→ os.Exit(1)) for the empty provider_domain typical of
+	// IDC/none profiles. IDC/none never use this OIDC refresh path, so skip them
+	// here and let their own dispatch branches (IsIDC / !IsSsoEnabled) handle them.
+	if cfg.IsSsoEnabled() && !cfg.IsIDC() {
+		app.providerType = resolveProviderType(cfg)
+		app.redirectPort = resolveRedirectPort(cfg)
+	}
+
 	// Flag dispatch — must run before auth-type branching so IDC users
 	// can use --get-monitoring-token, --show-tags, etc.
 	if *clearCache {
@@ -148,18 +167,15 @@ func main() {
 		exitAfterNotifications(app.runPassthrough())
 	}
 
-	// OIDC path — resolve provider type and redirect port
-	providerType := resolveProviderType(cfg)
-	redirectPort := 8400
-	if envPort := os.Getenv("REDIRECT_PORT"); envPort != "" {
-		if p, err := strconv.Atoi(envPort); err == nil && p > 0 {
-			redirectPort = p
-		}
-	} else if cfg.RedirectPort > 0 {
-		redirectPort = cfg.RedirectPort
+	// OIDC path — provider type + redirect port were already resolved above
+	// (before the flag dispatch) for this OIDC profile; resolve defensively if
+	// somehow unset.
+	if app.providerType == "" {
+		app.providerType = resolveProviderType(cfg)
 	}
-	app.providerType = providerType
-	app.redirectPort = redirectPort
+	if app.redirectPort == 0 {
+		app.redirectPort = resolveRedirectPort(cfg)
+	}
 
 	if *refreshIfNeeded {
 		if cfg.CredentialStorage != "session" {
@@ -196,6 +212,21 @@ type credentialApp struct {
 	cfg          *config.ProfileConfig
 	providerType string
 	redirectPort int
+}
+
+// resolveRedirectPort returns the OAuth callback port for the browser flow:
+// REDIRECT_PORT env override → profile RedirectPort → default 8400. Never returns
+// 0 (which would open http://localhost:0 → ERR_UNSAFE_PORT).
+func resolveRedirectPort(cfg *config.ProfileConfig) int {
+	if envPort := os.Getenv("REDIRECT_PORT"); envPort != "" {
+		if p, err := strconv.Atoi(envPort); err == nil && p > 0 {
+			return p
+		}
+	}
+	if cfg.RedirectPort > 0 {
+		return cfg.RedirectPort
+	}
+	return 8400
 }
 
 func resolveProviderType(cfg *config.ProfileConfig) string {
@@ -752,8 +783,17 @@ func (a *credentialApp) tryRefreshToken() *federation.AWSCredentials {
 	tokenResp, err := oidc.RefreshTokenExchange(tokenURL, refreshToken, a.cfg.ClientID, confidential)
 	if err != nil {
 		debugPrint("Refresh token exchange failed: %v", err)
-		// Token may be revoked/expired — clear it so we don't retry next time
-		storage.ClearRefreshToken(a.profile)
+		// Only discard the refresh_token when the IdP definitively rejected it
+		// (invalid_grant / invalid_token). Transient failures — network/5xx/
+		// timeout, or a misconfiguration such as an unresolved provider type —
+		// must retain the token so a later cycle can retry; clearing on those was
+		// what permanently disabled silent renewal until the next browser login.
+		if oidc.IsDefinitiveRefreshFailure(err) {
+			debugPrint("Refresh_token rejected by IdP (invalid_grant); clearing stored token")
+			storage.ClearRefreshToken(a.profile)
+		} else {
+			debugPrint("Transient refresh failure; retaining refresh_token for next attempt")
+		}
 		return nil
 	}
 
@@ -835,8 +875,15 @@ func (a *credentialApp) refreshIDTokenOnly() string {
 	tokenResp, err := oidc.RefreshTokenExchange(tokenURL, refreshToken, a.cfg.ClientID, confidential)
 	if err != nil {
 		debugPrint("Refresh token exchange failed: %v", err)
-		// Token may be revoked/expired — clear it so we don't retry next time.
-		storage.ClearRefreshToken(a.profile)
+		// Clear only on a definitive rejection (invalid_grant / invalid_token);
+		// retain on transient failures so a later cycle can retry. See the twin
+		// guard in tryRefreshToken.
+		if oidc.IsDefinitiveRefreshFailure(err) {
+			debugPrint("Refresh_token rejected by IdP (invalid_grant); clearing stored token")
+			storage.ClearRefreshToken(a.profile)
+		} else {
+			debugPrint("Transient refresh failure; retaining refresh_token for next attempt")
+		}
 		return ""
 	}
 	if tokenResp.IDToken == "" {

--- a/source/go/cmd/credential-process/monitoring_refresh_test.go
+++ b/source/go/cmd/credential-process/monitoring_refresh_test.go
@@ -59,11 +59,14 @@ func TestGetMonitoringToken_RefreshTokenWiring(t *testing.T) {
 
 // TestGetMonitoringToken_RefreshTokenStoredCallsExchange exercises the path
 // that runs when a refresh_token IS stored. Without mocking the OIDC token
-// endpoint, the exchange itself will fail (test.example.com is unreachable).
-// What we verify is that the exchange is *attempted*: the failure path in
-// tryRefreshToken clears the refresh_token (because the IdP may have revoked
-// it). After calling tryRefreshToken with an unreachable token URL, the
-// stored refresh_token must be cleared.
+// endpoint, the exchange itself will fail (test.invalid.example.com is
+// unreachable). This is a *transient* failure (DNS/network), so tryRefreshToken
+// must RETAIN the refresh_token — clearing on a transient failure is exactly the
+// bug that permanently disabled silent renewal. We assert the token survives and
+// that the exchange was attempted (tryRefreshToken returns nil).
+//
+// The clear-on-failure path is covered separately by the invalid_grant test in
+// refresh_clear_test.go, which serves a real 400 {"error":"invalid_grant"}.
 func TestGetMonitoringToken_RefreshTokenStoredCallsExchange(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
@@ -88,15 +91,16 @@ func TestGetMonitoringToken_RefreshTokenStoredCallsExchange(t *testing.T) {
 	}
 	app := &credentialApp{profile: profile, cfg: cfg, providerType: "okta"}
 
-	// Exchange will fail (network or DNS); tryRefreshToken returns nil and
-	// clears the (presumed-revoked) refresh_token.
+	// Exchange will fail (network or DNS) — a transient failure. tryRefreshToken
+	// returns nil but must NOT clear the refresh_token.
 	if creds := app.tryRefreshToken(); creds != nil {
 		t.Fatalf("tryRefreshToken returned non-nil for unreachable IdP: %+v", creds)
 	}
 
-	// Clearing on failure is the contract — proves the exchange was attempted.
-	if got := storage.LoadRefreshToken(profile, "session"); got != "" {
-		t.Errorf("refresh_token not cleared after failed exchange (got %q); "+
-			"this means tryRefreshToken did NOT attempt the exchange — the wiring is broken", got)
+	// Retaining on a transient failure is the contract — a network blip must not
+	// permanently disable silent renewal.
+	if got := storage.LoadRefreshToken(profile, "session"); got != "rt_test_value" {
+		t.Errorf("refresh_token not retained after transient failure (got %q, want %q); "+
+			"a transient network failure must NOT clear the token", got, "rt_test_value")
 	}
 }

--- a/source/go/cmd/credential-process/quota_recheck_refresh_test.go
+++ b/source/go/cmd/credential-process/quota_recheck_refresh_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 
@@ -27,13 +29,24 @@ import (
 // is empty, attempt tryRefreshToken() to silently mint a fresh id_token
 // before giving up.
 //
-// This test proves the exchange is *attempted*: with a refresh_token stored
-// but an unreachable IdP, tryRefreshToken fails and clears the (presumed
-// revoked) refresh_token. Before the fix, performQuotaRecheck returned on the
-// empty-token check and NEVER touched the refresh_token, so it would remain
-// stored. The cleared-token assertion therefore fails without the fix and
-// passes with it.
+// This test proves the exchange is *attempted*: with a refresh_token stored and
+// an IdP that returns a definitive invalid_grant, tryRefreshToken fails and
+// clears the (revoked) refresh_token. Before the fix, performQuotaRecheck
+// returned on the empty-token check and NEVER touched the refresh_token, so it
+// would remain stored. The cleared-token assertion therefore fails without the
+// fix and passes with it.
+//
+// NOTE: the IdP must return invalid_grant (not merely be unreachable) — a
+// transient/unreachable failure now correctly RETAINS the token (that retention
+// is the OTEL-bearer undercount fix), so only a definitive rejection clears it.
 func TestPerformQuotaRecheck_AttemptsRefreshWhenTokenExpired(t *testing.T) {
+	// IdP that definitively rejects the refresh_token → tryRefreshToken clears it.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"revoked"}`))
+	}))
+	defer srv.Close()
+
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 	t.Setenv("USERPROFILE", tmpDir) // Windows
@@ -54,13 +67,13 @@ func TestPerformQuotaRecheck_AttemptsRefreshWhenTokenExpired(t *testing.T) {
 
 	cfg := &config.ProfileConfig{
 		ClientID:          "test-client",
-		ProviderDomain:    "test.invalid.example.com", // unreachable — exchange must fail
+		OIDCTokenEndpoint: srv.URL, // generic provider reads the endpoint directly
 		CredentialStorage: "session",
 		QuotaAPIEndpoint:  "https://quota.invalid.example.com",
 		QuotaFailMode:     "open",
 		QuotaCheckTimeout: 1,
 	}
-	app := &credentialApp{profile: profile, cfg: cfg, providerType: "okta"}
+	app := &credentialApp{profile: profile, cfg: cfg, providerType: "generic"}
 
 	// Exchange fails (unreachable IdP); with no usable token the recheck
 	// fails open and allows cached credentials through.
@@ -69,10 +82,10 @@ func TestPerformQuotaRecheck_AttemptsRefreshWhenTokenExpired(t *testing.T) {
 	}
 
 	// The core regression assertion: the refresh_token was consumed by a
-	// failed exchange. If it is still present, performQuotaRecheck never
-	// attempted the exchange — the fix is not wired in.
+	// definitive invalid_grant exchange. If it is still present, performQuotaRecheck
+	// never attempted the exchange — the fix is not wired in.
 	if got := storage.LoadRefreshToken(profile, "session"); got != "" {
-		t.Errorf("refresh_token not cleared after failed exchange (got %q); "+
+		t.Errorf("refresh_token not cleared after invalid_grant exchange (got %q); "+
 			"performQuotaRecheck did NOT attempt tryRefreshToken — quota recheck "+
 			"will silently fail open for over-quota users with expired id_tokens", got)
 	}

--- a/source/go/cmd/credential-process/refresh_clear_test.go
+++ b/source/go/cmd/credential-process/refresh_clear_test.go
@@ -1,0 +1,122 @@
+package main
+
+// ABOUTME: Regression tests for the OTEL-bearer undercount bug —
+// ABOUTME: refresh_token must survive transient failures and only clear on invalid_grant.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"ccwb-go/internal/config"
+	"ccwb-go/internal/storage"
+)
+
+// newRefreshApp builds a credentialApp whose refresh_token exchange targets a
+// test server. It uses providerType "generic" so tryRefreshToken reads the
+// endpoint straight from cfg.OIDCTokenEndpoint (no domain concatenation), and a
+// session-storage temp HOME so the refresh_token round-trips through a real file.
+func newRefreshApp(t *testing.T, profile, tokenURL string) *credentialApp {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	if err := os.MkdirAll(tmp+"/.claude-code-session", 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	t.Cleanup(func() { storage.ClearRefreshToken(profile) })
+
+	if err := storage.SaveRefreshToken(profile, "session", "rt_original"); err != nil {
+		t.Fatalf("SaveRefreshToken: %v", err)
+	}
+	cfg := &config.ProfileConfig{
+		ClientID:          "test-client",
+		OIDCTokenEndpoint: tokenURL,
+		CredentialStorage: "session",
+	}
+	return &credentialApp{profile: profile, cfg: cfg, providerType: "generic"}
+}
+
+// TestTryRefreshToken_InvalidGrantClearsToken: a definitive invalid_grant
+// rejection means the refresh_token is dead — it must be cleared.
+func TestTryRefreshToken_InvalidGrantClearsToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"revoked"}`))
+	}))
+	defer srv.Close()
+
+	profile := "test-refresh-invalid-grant"
+	app := newRefreshApp(t, profile, srv.URL)
+
+	if creds := app.tryRefreshToken(); creds != nil {
+		t.Fatalf("tryRefreshToken returned non-nil on invalid_grant: %+v", creds)
+	}
+	if got := storage.LoadRefreshToken(profile, "session"); got != "" {
+		t.Errorf("refresh_token = %q after invalid_grant, want cleared", got)
+	}
+}
+
+// TestTryRefreshToken_ServerErrorRetainsToken: a 5xx is transient — the
+// refresh_token must survive so a later cycle can retry. This is the core of the
+// undercount fix: a single server blip must NOT permanently disable silent
+// renewal (which previously forced a full browser login to recover).
+func TestTryRefreshToken_ServerErrorRetainsToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"server_error"}`))
+	}))
+	defer srv.Close()
+
+	profile := "test-refresh-server-error"
+	app := newRefreshApp(t, profile, srv.URL)
+
+	if creds := app.tryRefreshToken(); creds != nil {
+		t.Fatalf("tryRefreshToken returned non-nil on 500: %+v", creds)
+	}
+	if got := storage.LoadRefreshToken(profile, "session"); got != "rt_original" {
+		t.Errorf("refresh_token = %q after transient 500, want retained (%q)", got, "rt_original")
+	}
+}
+
+// TestRefreshIDTokenOnly_ServerErrorRetainsToken guards the twin clear site on
+// the MCP-auth-header path (refreshIDTokenOnly), which had the identical
+// clear-on-any-failure bug.
+func TestRefreshIDTokenOnly_ServerErrorRetainsToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`bad gateway`))
+	}))
+	defer srv.Close()
+
+	profile := "test-idtoken-only-server-error"
+	app := newRefreshApp(t, profile, srv.URL)
+
+	if tok := app.refreshIDTokenOnly(); tok != "" {
+		t.Fatalf("refreshIDTokenOnly returned non-empty on 502: %q", tok)
+	}
+	if got := storage.LoadRefreshToken(profile, "session"); got != "rt_original" {
+		t.Errorf("refresh_token = %q after transient 502, want retained (%q)", got, "rt_original")
+	}
+}
+
+// TestRefreshIDTokenOnly_InvalidGrantClearsToken confirms the MCP path still
+// clears on a definitive rejection.
+func TestRefreshIDTokenOnly_InvalidGrantClearsToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
+	}))
+	defer srv.Close()
+
+	profile := "test-idtoken-only-invalid-grant"
+	app := newRefreshApp(t, profile, srv.URL)
+
+	if tok := app.refreshIDTokenOnly(); tok != "" {
+		t.Fatalf("refreshIDTokenOnly returned non-empty on invalid_grant: %q", tok)
+	}
+	if got := storage.LoadRefreshToken(profile, "session"); got != "" {
+		t.Errorf("refresh_token = %q after invalid_grant, want cleared", got)
+	}
+}

--- a/source/go/cmd/credential-process/resolve_port_test.go
+++ b/source/go/cmd/credential-process/resolve_port_test.go
@@ -1,0 +1,41 @@
+package main
+
+// ABOUTME: Regression tests for resolveRedirectPort — the browser callback port
+// ABOUTME: must never be 0 (http://localhost:0 → ERR_UNSAFE_PORT).
+
+import (
+	"testing"
+
+	"ccwb-go/internal/config"
+)
+
+// TestResolveRedirectPort guards the ERR_UNSAFE_PORT regression: once the
+// --get-monitoring-token path resolves the provider type early and can fall
+// through to browser auth, an unset redirect port would open http://localhost:0.
+// resolveRedirectPort must always yield a usable port.
+func TestResolveRedirectPort(t *testing.T) {
+	tests := []struct {
+		name    string
+		env     string
+		cfgPort int
+		want    int
+	}{
+		{name: "default when unset", env: "", cfgPort: 0, want: 8400},
+		{name: "profile port used", env: "", cfgPort: 9001, want: 9001},
+		{name: "env overrides profile", env: "9200", cfgPort: 9001, want: 9200},
+		{name: "invalid env falls back to profile", env: "not-a-port", cfgPort: 9001, want: 9001},
+		{name: "zero env falls back to default", env: "0", cfgPort: 0, want: 8400},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("REDIRECT_PORT", tc.env)
+			cfg := &config.ProfileConfig{RedirectPort: tc.cfgPort}
+			if got := resolveRedirectPort(cfg); got != tc.want {
+				t.Errorf("resolveRedirectPort = %d, want %d", got, tc.want)
+			}
+			if got := resolveRedirectPort(cfg); got == 0 {
+				t.Error("resolveRedirectPort returned 0 — would open http://localhost:0 (ERR_UNSAFE_PORT)")
+			}
+		})
+	}
+}

--- a/source/go/internal/oidc/refresh_error_test.go
+++ b/source/go/internal/oidc/refresh_error_test.go
@@ -1,0 +1,111 @@
+package oidc
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestRefreshTokenExchange_ErrorClassification verifies that RefreshTokenExchange
+// distinguishes a definitively-rejected refresh_token (invalid_grant /
+// invalid_token → discard) from transient failures (5xx, unexpected 4xx, bad
+// URL → retain). Clearing on a transient failure is the bug that permanently
+// disabled silent OTEL-bearer renewal until the next browser login.
+func TestRefreshTokenExchange_ErrorClassification(t *testing.T) {
+	tests := []struct {
+		name           string
+		status         int
+		body           string
+		wantDefinitive bool
+		wantOAuthCode  string
+	}{
+		{
+			name:           "invalid_grant is definitive",
+			status:         http.StatusBadRequest,
+			body:           `{"error":"invalid_grant","error_description":"Token expired or revoked"}`,
+			wantDefinitive: true,
+			wantOAuthCode:  "invalid_grant",
+		},
+		{
+			name:           "invalid_token is definitive",
+			status:         http.StatusUnauthorized,
+			body:           `{"error":"invalid_token"}`,
+			wantDefinitive: true,
+			wantOAuthCode:  "invalid_token",
+		},
+		{
+			name:           "500 server error is transient",
+			status:         http.StatusInternalServerError,
+			body:           `{"error":"server_error"}`,
+			wantDefinitive: false,
+			wantOAuthCode:  "server_error",
+		},
+		{
+			name:           "temporarily_unavailable is transient",
+			status:         http.StatusServiceUnavailable,
+			body:           `{"error":"temporarily_unavailable"}`,
+			wantDefinitive: false,
+			wantOAuthCode:  "temporarily_unavailable",
+		},
+		{
+			name:           "unexpected 400 without invalid_grant is transient",
+			status:         http.StatusBadRequest,
+			body:           `{"error":"invalid_request","error_description":"malformed"}`,
+			wantDefinitive: false,
+			wantOAuthCode:  "invalid_request",
+		},
+		{
+			name:           "non-JSON error body is transient",
+			status:         http.StatusBadGateway,
+			body:           `<html>502 Bad Gateway</html>`,
+			wantDefinitive: false,
+			wantOAuthCode:  "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			_, err := RefreshTokenExchange(srv.URL, "rt_value", "client", nil)
+			if err == nil {
+				t.Fatalf("expected an error for status %d, got nil", tc.status)
+			}
+			if got := IsDefinitiveRefreshFailure(err); got != tc.wantDefinitive {
+				t.Errorf("IsDefinitiveRefreshFailure = %v, want %v (err=%v)", got, tc.wantDefinitive, err)
+			}
+		})
+	}
+}
+
+// TestRefreshTokenExchange_EmptyURLIsTransient verifies the defense-in-depth
+// guard: an empty/relative token endpoint URL (the symptom of an unresolved
+// provider type) must fail as a transient error, never as a definitive rejection
+// that would discard the refresh_token.
+func TestRefreshTokenExchange_EmptyURLIsTransient(t *testing.T) {
+	for _, url := range []string{"", "login.microsoftonline.com/tenant/oauth2/v2.0/token"} {
+		_, err := RefreshTokenExchange(url, "rt_value", "client", nil)
+		if err == nil {
+			t.Fatalf("expected an error for URL %q, got nil", url)
+		}
+		if IsDefinitiveRefreshFailure(err) {
+			t.Errorf("empty/relative URL %q classified as definitive; must be transient", url)
+		}
+	}
+}
+
+// TestIsDefinitiveRefreshFailure_NilAndOther confirms the helper is safe for
+// a nil error and for unrelated error types (both → not definitive, so the
+// caller retains the token by default).
+func TestIsDefinitiveRefreshFailure_NilAndOther(t *testing.T) {
+	if IsDefinitiveRefreshFailure(nil) {
+		t.Error("nil error must not be definitive")
+	}
+	if IsDefinitiveRefreshFailure(http.ErrServerClosed) {
+		t.Error("unrelated error must not be definitive")
+	}
+}

--- a/source/go/internal/oidc/token.go
+++ b/source/go/internal/oidc/token.go
@@ -2,6 +2,7 @@ package oidc
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -9,6 +10,53 @@ import (
 	"strings"
 	"time"
 )
+
+// RefreshExchangeError describes a failed refresh_token exchange.
+//
+// Definitive is true ONLY when the IdP explicitly rejected the refresh_token
+// itself (OAuth 2.0 error "invalid_grant" / "invalid_token", RFC 6749 §5.2) —
+// i.e. the token is revoked/expired and a full re-authentication is required, so
+// the stored refresh_token should be discarded. For every other failure
+// (network error, 5xx, timeout, empty/misconfigured token URL, unparseable
+// body) Definitive is false and the caller MUST retain the refresh_token so a
+// later cycle can retry. Clearing on a transient failure is what permanently
+// disabled silent renewal until the next browser login (see the OTEL bearer
+// undercount bug).
+type RefreshExchangeError struct {
+	Definitive bool   // true only for invalid_grant / invalid_token
+	OAuthCode  string // parsed OAuth "error" field, if any
+	StatusCode int    // HTTP status, if the request completed
+	err        error  // underlying formatted error (preserves the old message)
+}
+
+func (e *RefreshExchangeError) Error() string { return e.err.Error() }
+
+func (e *RefreshExchangeError) Unwrap() error { return e.err }
+
+// IsDefinitiveRefreshFailure reports whether err from RefreshTokenExchange means
+// the refresh_token itself was rejected (invalid_grant / invalid_token) and must
+// be discarded. Any other error — including a nil error — is treated as transient
+// (retain the token). Callers use this to decide whether to ClearRefreshToken.
+func IsDefinitiveRefreshFailure(err error) bool {
+	var re *RefreshExchangeError
+	if errors.As(err, &re) {
+		return re.Definitive
+	}
+	return false
+}
+
+// parseOAuthErrorCode extracts the OAuth 2.0 "error" field from a token-endpoint
+// error body (e.g. {"error":"invalid_grant","error_description":"..."}). Returns
+// "" when the body is empty or not the expected JSON shape.
+func parseOAuthErrorCode(body []byte) string {
+	var e struct {
+		Error string `json:"error"`
+	}
+	if json.Unmarshal(body, &e) == nil {
+		return e.Error
+	}
+	return ""
+}
 
 // TokenResponse holds the OIDC token endpoint response.
 type TokenResponse struct {
@@ -67,13 +115,27 @@ func ExchangeCode(tokenURL, code, redirectURI, clientID, codeVerifier string, co
 // id_token (and possibly a rotated refresh_token). Falls back gracefully:
 // callers should treat any error as "refresh unavailable, try browser auth."
 func RefreshTokenExchange(tokenURL, refreshToken, clientID string, confidential *ConfidentialAuth) (*TokenResponse, error) {
+	// Guard against an empty/relative token URL. This should never happen once
+	// the provider type is resolved, but if it slips through (as it did on the
+	// --get-monitoring-token path before the provider type was resolved) the POST
+	// below would fail in a way that must NOT be mistaken for a revoked token —
+	// so surface it as an explicit, transient error (Definitive=false).
+	if !strings.HasPrefix(tokenURL, "https://") && !strings.HasPrefix(tokenURL, "http://") {
+		return nil, &RefreshExchangeError{
+			Definitive: false,
+			err:        fmt.Errorf("refresh token exchange: invalid token endpoint URL %q (provider type not resolved?)", tokenURL),
+		}
+	}
+
 	form := map[string]string{
 		"grant_type":    "refresh_token",
 		"refresh_token": refreshToken,
 		"client_id":     clientID,
 	}
 	if err := confidential.apply(form, tokenURL, clientID); err != nil {
-		return nil, err
+		// Failing to build the client assertion (missing cert, etc.) is a local
+		// misconfiguration, not a revoked token — retain the refresh_token.
+		return nil, &RefreshExchangeError{Definitive: false, err: err}
 	}
 	data := url.Values{}
 	for k, v := range form {
@@ -83,22 +145,33 @@ func RefreshTokenExchange(tokenURL, refreshToken, clientID string, confidential 
 	client := &http.Client{Timeout: 30 * time.Second}
 	resp, err := client.Post(tokenURL, "application/x-www-form-urlencoded", strings.NewReader(data.Encode()))
 	if err != nil {
-		return nil, fmt.Errorf("refresh token request failed: %w", err)
+		// Network/DNS/timeout — transient, retain the token.
+		return nil, &RefreshExchangeError{Definitive: false, err: fmt.Errorf("refresh token request failed: %w", err)}
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("reading refresh response: %w", err)
+		return nil, &RefreshExchangeError{Definitive: false, StatusCode: resp.StatusCode, err: fmt.Errorf("reading refresh response: %w", err)}
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("refresh token exchange failed (HTTP %d): %s", resp.StatusCode, string(body))
+		// Only invalid_grant / invalid_token mean the refresh_token is dead.
+		// Everything else (5xx, throttling, unexpected 4xx) is treated as
+		// transient so we don't discard a still-valid token on a server blip.
+		oauthCode := parseOAuthErrorCode(body)
+		definitive := oauthCode == "invalid_grant" || oauthCode == "invalid_token"
+		return nil, &RefreshExchangeError{
+			Definitive: definitive,
+			OAuthCode:  oauthCode,
+			StatusCode: resp.StatusCode,
+			err:        fmt.Errorf("refresh token exchange failed (HTTP %d): %s", resp.StatusCode, string(body)),
+		}
 	}
 
 	var tokenResp TokenResponse
 	if err := json.Unmarshal(body, &tokenResp); err != nil {
-		return nil, fmt.Errorf("parsing refresh response: %w", err)
+		return nil, &RefreshExchangeError{Definitive: false, StatusCode: resp.StatusCode, err: fmt.Errorf("parsing refresh response: %w", err)}
 	}
 
 	return &tokenResp, nil


### PR DESCRIPTION
## Why

On **OIDC + central collector**, a user's telemetry silently stops being counted **~50 minutes after each login** while Bedrock inference keeps working. The result is that `ccwb quota usage` (and the CloudWatch `ClaudeCode` metrics) read materially **lower** than Claude Code's own `/usage`, because metric batches are dropped at the collector ALB with **401** and OTLP/HTTP exporters do not retry on 401.

This was reproduced live on a production OIDC profile (Azure, `azure_auth_mode=certificate`, keyring storage) and traced to a concrete ordering bug in `credential-process`.

## Root cause

`otel-helper` runs `credential-process --get-monitoring-token` on every OTEL export to obtain the monitoring bearer (the OIDC `id_token`). That flag handler dispatches in `main()` **before** the OIDC provider type is resolved:

- `--get-monitoring-token` (and `--get-mcp-auth-header`) dispatch early in `main()`.
- `app.providerType` / `app.redirectPort` were assigned only later, in the OIDC `run()` path.

So the silent `refresh_token` exchange on that path ran with `providerType == ""`, which caused a cascade:

1. `provider.TokenEndpointURL("", …)` returns an **empty URL** (`ConfigFor("")` is a zero-value `Config`).
2. `resolveConfidentialAuth()` is gated on `providerType == "azure"`, so with an empty type it skipped the **Azure client-assertion / certificate** entirely.
3. `RefreshTokenExchange` POSTed an unsigned `grant_type=refresh_token` to an empty URL → failed.
4. On that failure, `tryRefreshToken` called `ClearRefreshToken` — **deleting the still-valid refresh_token**.
5. The next cycle had no refresh_token at all, so the only recovery was a full interactive browser login.

Once the bearer crossed its 10-minute pre-expiry buffer (in `storage.GetMonitoringToken`), `otel-helper` emitted attribution headers **without an `authorization` header**, and the collector ALB's `jwt-validation` action returned **401 before forwarding** to the collector. No retry, no buffer → the batch is lost.

**Observed debug trace (before the fix):**

```
Debug: Found cached refresh_token, attempting token exchange...
Debug: Refresh token exchange failed: refresh token request failed: Post "": unsupported protocol scheme ""
Debug: OIDC authentication not available: unknown provider type:
```

Note `Post ""` — the empty token endpoint URL — and `unknown provider type:` (empty string) reaching the auth layer.

## The fix

1. **Resolve provider type + redirect port before the flag dispatch**, gated to real OIDC profiles (`IsSsoEnabled() && !IsIDC()`). This is important for IDC-safety: `resolveProviderType` calls `provider.Detect`, which returns `"oidc"` (→ `os.Exit(1)`) for the empty `provider_domain` typical of IDC/none profiles. Those profiles never use this OIDC refresh path, so they are explicitly skipped and continue to dispatch via their own `IsIDC()` / `!IsSsoEnabled()` branches.

2. **Only clear the stored `refresh_token` on a definitive IdP rejection** (`invalid_grant` / `invalid_token`, RFC 6749 §5.2). Transient failures — network/5xx/timeout, an empty/misconfigured token URL, or a missing client assertion — now **retain** the token so a later cycle can retry. Clearing on a transient failure was what turned a recoverable blip into a permanent silent-refresh outage until the next browser login. Applied to **both** `tryRefreshToken` and `refreshIDTokenOnly` (the MCP `--get-mcp-auth-header` path had the identical bug).

3. `RefreshTokenExchange` now returns a typed `RefreshExchangeError{Definitive}` (with `errors.As` helper `IsDefinitiveRefreshFailure`) and guards against an empty/relative token endpoint URL as defense-in-depth.

4. `resolveRedirectPort()` never returns `0`. Once this path can reach browser auth (previously it always died at `unknown provider type`), an unset port would have opened `http://localhost:0` → `ERR_UNSAFE_PORT`.

## Verification

**Live, after the fix** — the `--get-monitoring-token` refresh now reaches the **real** Azure token endpoint and classifies the response correctly (here with a deliberately-invalid token, hence `invalid_grant`; a valid refresh_token returns HTTP 200 and is rotated):

```
Debug: Found cached refresh_token, attempting token exchange...
Debug: Refresh token exchange failed (HTTP 400): {"error":"invalid_grant","error_description":"AADSTS9002313: ..."}
Debug: Refresh_token rejected by IdP (invalid_grant); clearing stored token
```

No more `Post ""` / `unknown provider type`, and a valid token is no longer wiped by a transient failure.

**Probe evidence** — a local probe ran the real `otel-helper` on a fixed interval, took the bearer it emitted, and POSTed to the real collector endpoint, recording the ALB status. `auth=False` cycles (bearer past the 10-min buffer, silent refresh unavailable) are exactly the dropped batches. `egress_ip` scrubbed:

```
time (UTC)            auth   exp_min  export  reason     drop
---------------------------------------------------------------------
2026-07-06T16:13:19Z  True   10.8     200     ok
2026-07-06T16:15:26Z  False  None     401     auth_401   <<< DROP
2026-07-06T16:17:34Z  False  None     401     auth_401   <<< DROP
   … (18 consecutive auth_401 drops over ~37 min) …
2026-07-06T16:52:46Z  False  None     401     auth_401   <<< DROP
2026-07-06T16:54:53Z  True   59.8     200     ok         (only after a fresh browser login)
---------------------------------------------------------------------
export status counts: {'200': 65, '401': 27}
DROP RATE (auth_401/total): 27/92 = 29.3%
cycles where helper emitted NO bearer: 27
```

The signature is a periodic square wave: ~50 min of `200`s after each login, then a hard wall of `auth_401` that only a new browser login clears. With the fix, silent refresh keeps the bearer alive across that boundary instead of failing and wiping the refresh_token.

## Tests

- `internal/oidc`: `RefreshTokenExchange` error classification — `invalid_grant`/`invalid_token` are definitive; 5xx, unexpected 4xx, non-JSON body, and empty/relative URL are transient. `IsDefinitiveRefreshFailure` safe for `nil` and unrelated errors.
- `cmd/credential-process`: `refresh_token` is cleared on `invalid_grant` but **retained** on a transient failure, for **both** `tryRefreshToken` and `refreshIDTokenOnly`; `resolveRedirectPort` never returns 0. Updated two existing tests that asserted the old clear-on-any-failure behavior.
- Full suite green: `go test ./... -race -count=1`, `go vet ./...`, `gofmt` clean.

## Auth-mode coverage & parity

- **OIDC**: fixed path (provider type resolved early; silent refresh works).
- **IDC / none**: explicitly skipped by the `IsSsoEnabled() && !IsIDC()` gate — no regression, no `os.Exit(1)`.
- **Python parity**: the Python provider already resolves `provider_type` in `__init__` and performs no refresh on the monitoring path (a documented Go/Python asymmetry), so no Python change is needed.

## Scope

Client-side `credential-process` (Go) only — **no CloudFormation / collector / ALB changes**. Rollout is `ccwb package` → `ccwb distribute` → re-install. Tier 1 critical files touched (`credential-process/main.go`, `internal/oidc/token.go`); regression tests included per the review-tiers policy.
