### PR TITLE
feat(distribution): add IAM Identity Center auth to existing landing page

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -283,7 +283,8 @@
         "filename": "deployment/infrastructure/landing-page-distribution.yaml",
         "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
         "is_verified": false,
-        "line_number": 1070
+        "line_number": 1070,
+        "is_secret": false
       }
     ],
     "source/claude_code_with_bedrock/cli/utils/cowork_3p.py": [

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -183,7 +183,7 @@
         "filename": "deployment/infrastructure/bootstrap-device-code.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 172,
+        "line_number": 177,
         "is_secret": false
       }
     ],
@@ -277,13 +277,22 @@
         "is_secret": false
       }
     ],
+    "deployment/infrastructure/landing-page-distribution.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "deployment/infrastructure/landing-page-distribution.yaml",
+        "hashed_secret": "5ffe533b830f08a0326348a9160afafc8ada44db",
+        "is_verified": false,
+        "line_number": 1070
+      }
+    ],
     "source/claude_code_with_bedrock/cli/utils/cowork_3p.py": [
       {
         "type": "Base64 High Entropy String",
         "filename": "source/claude_code_with_bedrock/cli/utils/cowork_3p.py",
         "hashed_secret": "a0422442dba3fda71eda7b743f0e726ad8af17a5",
         "is_verified": false,
-        "line_number": 345,
+        "line_number": 596,
         "is_secret": false
       }
     ],
@@ -489,6 +498,15 @@
         "is_secret": false
       }
     ],
+    "source/tests/test_google_client_secret.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "source/tests/test_google_client_secret.py",
+        "hashed_secret": "f9dd974b5c6991911f4016ae36a17a0c29c16bdd",
+        "is_verified": false,
+        "line_number": 109
+      }
+    ],
     "source/tests/test_oidc_discovery.py": [
       {
         "type": "Hex High Entropy String",
@@ -518,5 +536,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-02T22:06:59Z"
+  "generated_at": "2026-07-18T02:06:29Z"
 }

--- a/deployment/infrastructure/landing-page-distribution.yaml
+++ b/deployment/infrastructure/landing-page-distribution.yaml
@@ -178,11 +178,28 @@ Parameters:
     Default: 'initial'
     Description: Timestamp to force custom resource re-execution on every deployment (auto-populated by deploy command)
 
+  AuthType:
+    Type: String
+    Default: 'oidc'
+    AllowedValues: ['oidc', 'idc']
+    Description: Authentication type. 'oidc' for direct OIDC IdPs, 'idc' for IAM Identity Center via SAML.
+
+  SamlMetadataUrl:
+    Type: String
+    Default: ''
+    Description: SAML metadata URL from IAM Identity Center (required when AuthType=idc)
+
 Conditions:
+  IsIdcAuth: !Equals [!Ref AuthType, 'idc']
+  IsOidcAuth: !Not [!Condition IsIdcAuth]
   IsOkta: !Equals [!Ref IdPProvider, 'okta']
   IsAzure: !Equals [!Ref IdPProvider, 'azure']
   IsAuth0: !Equals [!Ref IdPProvider, 'auth0']
-  IsCognito: !Equals [!Ref IdPProvider, 'cognito']
+  IsCognitoProvider: !Equals [!Ref IdPProvider, 'cognito']
+  # IsCognito requires both Cognito provider AND OIDC auth type (not IDC)
+  IsCognito: !And
+    - !Condition IsCognitoProvider
+    - !Condition IsOidcAuth
   # Note: 'generic' is the terminal fallback in the AuthenticateOidcConfig !If chains
   # (the else branch after Okta/Azure/Auth0/Cognito), so no named condition is needed.
   HasRoute53Zone: !Not [!Equals [!Ref HostedZoneId, '']]
@@ -913,9 +930,10 @@ Resources:
         - Key: Application
           Value: ClaudeCodeWithBedrock
 
-  # HTTPS Listener with OIDC Authentication (REQUIRED - uses custom domain)
+  # HTTPS Listener with OIDC Authentication (only when AuthType=oidc)
   HTTPSListener:
     Type: AWS::ElasticLoadBalancingV2::Listener
+    Condition: IsOidcAuth
     Properties:
       LoadBalancerArn: !Ref DistributionALB
       Port: 443
@@ -1007,6 +1025,83 @@ Resources:
                     - !Sub '{{resolve:secretsmanager:${CognitoClientSecretArn}:SecretString}}'
                     - !Sub '{{resolve:secretsmanager:${GenericClientSecretArn}:SecretString}}'
             SessionTimeout: 43200  # 12 hours
+            Scope: 'openid email profile'
+            OnUnauthenticatedRequest: authenticate
+        # Forward to Lambda
+        - Type: forward
+          Order: 2
+          TargetGroupArn: !Ref LambdaTargetGroup
+
+  # ============================================================
+  # IAM Identity Center (IDC) SAML Authentication Resources
+  # These resources are only created when AuthType=idc
+  # ============================================================
+
+  # Cognito User Pool for IDC SAML federation
+  IdcUserPool:
+    Type: AWS::Cognito::UserPool
+    Condition: IsIdcAuth
+    Properties:
+      UserPoolName: !Sub '${AWS::StackName}-idc-pool'
+
+  # SAML Identity Provider (links to IAM Identity Center)
+  IdcSamlProvider:
+    Type: AWS::Cognito::UserPoolIdentityProvider
+    Condition: IsIdcAuth
+    Properties:
+      UserPoolId: !Ref IdcUserPool
+      ProviderName: IAMIdentityCenter
+      ProviderType: SAML
+      ProviderDetails:
+        MetadataURL: !Ref SamlMetadataUrl
+      AttributeMapping:
+        email: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress
+        given_name: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname
+        family_name: http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname
+
+  # App client for the ALB to use with Cognito/IDC
+  IdcUserPoolClient:
+    Type: AWS::Cognito::UserPoolClient
+    Condition: IsIdcAuth
+    DependsOn: IdcSamlProvider
+    Properties:
+      UserPoolId: !Ref IdcUserPool
+      GenerateSecret: true
+      AllowedOAuthFlowsUserPoolClient: true
+      AllowedOAuthFlows: [code]
+      AllowedOAuthScopes: [openid, email, profile]
+      SupportedIdentityProviders: [IAMIdentityCenter]
+      CallbackURLs:
+        - !Sub 'https://${CustomDomainName}/oauth2/idpresponse'
+
+  # Cognito domain for hosted UI (IDC)
+  IdcUserPoolDomain:
+    Type: AWS::Cognito::UserPoolDomain
+    Condition: IsIdcAuth
+    Properties:
+      UserPoolId: !Ref IdcUserPool
+      Domain: !Sub '${AWS::StackName}-idc'
+
+  # HTTPS Listener with Cognito/IDC Authentication (only when AuthType=idc)
+  IdcHTTPSListener:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Condition: IsIdcAuth
+    Properties:
+      LoadBalancerArn: !Ref DistributionALB
+      Port: 443
+      Protocol: HTTPS
+      SslPolicy: ELBSecurityPolicy-TLS13-1-2-2021-06
+      Certificates:
+        - CertificateArn: !Ref Certificate
+      DefaultActions:
+        # Cognito Authentication Action (SAML via IDC)
+        - Type: authenticate-cognito
+          Order: 1
+          AuthenticateCognitoConfig:
+            UserPoolArn: !GetAtt IdcUserPool.Arn
+            UserPoolClientId: !Ref IdcUserPoolClient
+            UserPoolDomain: !Sub '${AWS::StackName}-idc'
+            SessionTimeout: 43200
             Scope: 'openid email profile'
             OnUnauthenticatedRequest: authenticate
         # Forward to Lambda
@@ -1204,3 +1299,8 @@ Outputs:
     Value: !GetAtt DistributionBucket.Arn
     Export:
       Name: !Sub '${AWS::StackName}-DistributionBucketArn'
+
+  IdcLoginUrl:
+    Condition: IsIdcAuth
+    Description: IDC login URL (users visit this to sign in via IAM Identity Center)
+    Value: !Sub 'https://${CustomDomainName}'

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -1063,6 +1063,13 @@ class DeployCommand(Command):
                     if profile.distribution_hosted_zone_id:
                         params.append(f"HostedZoneId={profile.distribution_hosted_zone_id}")
 
+                    # Add IDC/SAML auth parameters when auth_type is idc
+                    if profile.effective_auth_type == "idc":
+                        params.append("AuthType=idc")
+                        saml_url = getattr(profile, 'distribution_saml_metadata_url', None)
+                        if saml_url:
+                            params.append(f"SamlMetadataUrl={saml_url}")
+
                     # Add deployment timestamp to force custom resource re-execution
                     from datetime import datetime, timezone
 

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -1077,7 +1077,7 @@ class DeployCommand(Command):
                     # Add IDC/SAML auth parameters when auth_type is idc
                     if profile.effective_auth_type == "idc":
                         params.append("AuthType=idc")
-                        saml_url = getattr(profile, 'distribution_saml_metadata_url', None)
+                        saml_url = getattr(profile, "distribution_saml_metadata_url", None)
                         if saml_url:
                             params.append(f"SamlMetadataUrl={saml_url}")
 

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1683,325 +1683,424 @@ class InitCommand(Command):
             # when AWS setup was skipped (skip_aws=True), so region is bound for all IdP providers.
             region = config.get("aws", {}).get("region", get_current_region())
 
-            # IdP provider selection
-            idp_choices = [
-                questionary.Choice("Okta", value="okta"),
-                questionary.Choice("Azure AD / Entra ID", value="azure"),
-                questionary.Choice("Auth0", value="auth0"),
-                questionary.Choice("AWS Cognito User Pool", value="cognito"),
-                questionary.Choice("Google", value="google"),
-                questionary.Choice("Generic OIDC (PingFederate, Keycloak, ForgeRock, etc.)", value="generic"),
-            ]
+            # IDC/SAML auth path: skip OIDC IdP config, prompt for SAML metadata URL
+            auth_type = config.get("auth_type", "oidc")
+            if auth_type == "idc":
+                console.print("\n[bold]IAM Identity Center (SAML) Configuration[/bold]")
+                console.print("[dim]IAM Identity Center requires a SAML metadata URL.[/dim]")
+                console.print("[dim]Create a Custom SAML 2.0 application in IAM Identity Center first.[/dim]")
+                console.print("[dim]Set the ACS URL to: https://<your-domain>/oauth2/idpresponse[/dim]")
 
-            idp_provider = questionary.select(
-                "Identity provider for web authentication:",
-                choices=idp_choices,
-                default=config.get("distribution", {}).get("idp_provider", "okta"),
-            ).ask()
+                saml_url = questionary.text(
+                    "SAML metadata URL from IAM Identity Center:",
+                    validate=lambda x: x.startswith("https://") or "URL must start with https://",
+                    default=config.get("distribution", {}).get("saml_metadata_url") or "",
+                ).ask()
+                if saml_url is None:
+                    return None
 
-            # Auto-detection for Cognito User Pool
-            cognito_auto_configured = False
-            if idp_provider == "cognito":
-                from claude_code_with_bedrock.cli.utils.aws import (
-                    detect_cognito_stack,
-                    validate_cognito_stack_for_distribution,
-                )
+                config.setdefault("distribution", {})["saml_metadata_url"] = saml_url.strip()
 
-                console.print("\n[bold]Cognito Configuration Detection[/bold]")
-                console.print("Searching for deployed Cognito User Pool stack...")
+                # Custom domain (REQUIRED for authenticated landing page)
+                console.print("\n[bold]Custom Domain Configuration (REQUIRED)[/bold]")
+                console.print("[yellow]⚠️  Custom domain with HTTPS is required for ALB authentication[/yellow]")
+                console.print("You will need:")
+                console.print("  • A custom domain (e.g., downloads.company.com)")
+                console.print("  • An ACM certificate for this domain in the same region")
 
-                # Try to auto-detect Cognito stack (region resolved at top of landing-page block)
-                cognito_stack_info = detect_cognito_stack(region)
+                custom_domain = questionary.text(
+                    "Custom domain (e.g., downloads.company.com):",
+                    default=config.get("distribution", {}).get("custom_domain") or "",
+                    validate=lambda text: (
+                        len(text.strip()) > 0 or "Custom domain is required for authenticated landing page"
+                    ),
+                ).ask()
+                if custom_domain is None:
+                    return None
 
-                if cognito_stack_info:
-                    console.print(f"[green]✓[/green] Found Cognito stack: {cognito_stack_info['stack_name']}")
+                # Check for Route53 hosted zones
+                console.print("\n[bold]Route53 Configuration[/bold]")
+                console.print("Looking for Route53 hosted zones...")
 
-                    # Validate it has distribution support
-                    is_valid, message = validate_cognito_stack_for_distribution(
-                        cognito_stack_info["stack_name"], region
-                    )
+                hosted_zone_id = None
+                try:
+                    import boto3
 
-                    if is_valid:
-                        console.print(f"[green]✓[/green] {message}")
+                    route53_client = boto3.client("route53")
+                    zones_response = route53_client.list_hosted_zones()
+                    hosted_zones = zones_response.get("HostedZones", [])
 
-                        # Show detected values
-                        outputs = cognito_stack_info["outputs"]
-                        console.print("\n[cyan]Detected Configuration:[/cyan]")
-                        console.print(f"  • User Pool ID: {outputs.get('UserPoolId', 'N/A')}")
+                    if hosted_zones:
+                        console.print(f"Found {len(hosted_zones)} hosted zone(s)")
 
-                        # Extract domain prefix from full domain
-                        full_domain = outputs.get("UserPoolDomain", "")
-                        domain_prefix = full_domain.split(".")[0] if full_domain else "N/A"
-                        console.print(f"  • Domain: {domain_prefix}")
+                        existing_zone_id = config.get("distribution", {}).get("hosted_zone_id")
 
-                        console.print(f"  • Client ID: {outputs.get('DistributionWebClientId', 'N/A')}")
-                        console.print(f"  • Secret ARN: {outputs.get('DistributionWebClientSecretArn', 'N/A')}")
-
-                        use_detected = questionary.confirm("\nUse these detected values?", default=True).ask()
-
-                        if use_detected:
-                            # Auto-populate configuration
-                            idp_domain = domain_prefix
-                            idp_client_id = outputs["DistributionWebClientId"]
-                            secret_arn = outputs["DistributionWebClientSecretArn"]
-
-                            # Store in config immediately
-                            config.setdefault("distribution", {}).update(
-                                {
-                                    "idp_provider": "cognito",
-                                    "idp_domain": idp_domain,
-                                    "idp_client_id": idp_client_id,
-                                    "idp_client_secret_arn": secret_arn,
-                                }
+                        zone_choices = [
+                            questionary.Choice(
+                                f"{zone['Name']} (ID: {zone['Id'].split('/')[-1]})",
+                                value=zone["Id"].split("/")[-1],
                             )
+                            for zone in hosted_zones
+                        ]
+                        zone_choices.append(questionary.Choice("Skip (no Route53 managed domain)", value=None))
 
-                            # Also store Cognito User Pool ID for auth
-                            if "cognito_user_pool_id" not in config:
-                                config["cognito_user_pool_id"] = outputs["UserPoolId"]
+                        default_choice = None
+                        if existing_zone_id:
+                            for choice in zone_choices:
+                                if choice.value == existing_zone_id:
+                                    default_choice = choice
+                                    break
 
-                            console.print("[green]✓[/green] Configuration auto-populated from stack outputs")
-                            cognito_auto_configured = True
-                        else:
-                            console.print("[yellow]Manual configuration selected[/yellow]")
+                        hosted_zone_id = questionary.select(
+                            "Select Route53 hosted zone:",
+                            choices=zone_choices,
+                            default=default_choice if default_choice else zone_choices[0],
+                        ).ask()
                     else:
-                        console.print(f"[yellow]⚠[/yellow] {message}")
-                        console.print("[yellow]Falling back to manual configuration...[/yellow]")
-                else:
-                    console.print("[yellow]No Cognito User Pool stack detected[/yellow]")
-                    console.print("You can either:")
-                    console.print("  1. Deploy the Cognito stack first")
-                    console.print("  2. Enter configuration manually")
-
-            # Only prompt for manual configuration if not auto-configured
-            if not cognito_auto_configured:
-                # IdP domain
-                # Use `or ""`, not just the .get default: a reloaded profile stores these
-                # keys with an explicit None (see _build_config_from_profile), so the key
-                # is present and .get returns None — and questionary.text(default=None)
-                # crashes with "object of type 'NoneType' has no len()".
-                idp_domain = questionary.text(
-                    "IdP domain (e.g., company.okta.com for Okta, company.auth0.com for Auth0):",
-                    default=config.get("distribution", {}).get("idp_domain") or "",
-                ).ask()
-
-                # Web app client ID
-                idp_client_id = questionary.text(
-                    "Web application client ID (separate from CLI native app):",
-                    default=config.get("distribution", {}).get("idp_client_id") or "",
-                ).ask()
-
-                # Web app client secret
-                idp_client_secret = questionary.password(
-                    "Web application client secret:",
-                ).ask()
-
-            # Generic OIDC providers (PingFederate, Keycloak, ForgeRock, custom IdP) can't have
-            # their ALB authenticate-oidc endpoints derived from a single domain the way
-            # Okta/Azure/Auth0/Cognito can, so collect each one explicitly. Try OIDC discovery
-            # first (mirrors the SSO generic flow) and fall back to manual entry.
-            dist_oidc_issuer = None
-            dist_oidc_authorization_endpoint = None
-            dist_oidc_token_endpoint = None
-            dist_oidc_userinfo_endpoint = None
-            if idp_provider == "generic":
-                from claude_code_with_bedrock.cli.utils.oidc_discovery import (
-                    OidcDiscoveryError,
-                    discover_oidc_endpoints,
-                )
-
-                console.print("\n[bold]Generic OIDC Landing Page Configuration[/bold]")
-                console.print(
-                    "[dim]We'll try to auto-discover endpoints via the standard well-known URL,[/dim]\n"
-                    "[dim]and fall back to manual entry if your IdP doesn't expose one.[/dim]\n"
-                )
-
-                # Use the domain entered above as the default issuer; let the user override.
-                default_issuer = (
-                    idp_domain
-                    if idp_domain and idp_domain.startswith(("http://", "https://"))
-                    else (f"https://{idp_domain}" if idp_domain else "")
-                ).rstrip("/")
-
-                dist_oidc_issuer = questionary.text(
-                    "OIDC issuer URL:",
-                    validate=lambda x: x.startswith("https://") or "Issuer must start with https://",
-                    default=config.get("distribution", {}).get("idp_issuer", default_issuer),
-                    instruction="(must match the 'iss' claim in tokens)",
-                ).ask()
-                if not dist_oidc_issuer:
-                    return None
-                dist_oidc_issuer = dist_oidc_issuer.rstrip("/")
-
-                discovered: dict[str, str] = {}
-                console.print(f"[dim]Querying {dist_oidc_issuer}/.well-known/openid-configuration ...[/dim]")
-                try:
-                    discovered = discover_oidc_endpoints(dist_oidc_issuer)
-                    console.print("[green]✓ Discovery succeeded.[/green]")
-                except OidcDiscoveryError as e:
-                    console.print(f"[yellow]Discovery failed: {e}[/yellow]")
-                    console.print("[dim]Falling back to manual entry.[/dim]")
-
-                dist_oidc_authorization_endpoint = questionary.text(
-                    "Authorization endpoint:",
-                    validate=lambda x: bool(x) or "Authorization endpoint cannot be empty",
-                    default=(
-                        discovered.get("authorization_endpoint")
-                        or config.get("distribution", {}).get("idp_authorization_endpoint")
-                        or f"{dist_oidc_issuer}/as/authorization.oauth2"
-                    ),
-                    instruction="(full URL)",
-                ).ask()
-                if not dist_oidc_authorization_endpoint:
-                    return None
-
-                dist_oidc_token_endpoint = questionary.text(
-                    "Token endpoint:",
-                    validate=lambda x: bool(x) or "Token endpoint cannot be empty",
-                    default=(
-                        discovered.get("token_endpoint")
-                        or config.get("distribution", {}).get("idp_token_endpoint")
-                        or f"{dist_oidc_issuer}/as/token.oauth2"
-                    ),
-                    instruction="(full URL)",
-                ).ask()
-                if not dist_oidc_token_endpoint:
-                    return None
-
-                dist_oidc_userinfo_endpoint = questionary.text(
-                    "UserInfo endpoint:",
-                    validate=lambda x: bool(x) or "UserInfo endpoint cannot be empty",
-                    default=(
-                        discovered.get("userinfo_endpoint")
-                        or config.get("distribution", {}).get("idp_userinfo_endpoint")
-                        or f"{dist_oidc_issuer}/idp/userinfo.openid"
-                    ),
-                    instruction="(full URL)",
-                ).ask()
-                if not dist_oidc_userinfo_endpoint:
-                    return None
-
-            # Store secret in AWS Secrets Manager (only if not auto-configured)
-            import boto3
-
-            if not cognito_auto_configured:
-                try:
-                    secrets_client = boto3.client("secretsmanager", region_name=region)
-                    account_id = boto3.client("sts").get_caller_identity()["Account"]
-
-                    secret_name = f"{config['aws']['identity_pool_name']}-distribution-idp-secret"
-
-                    secret_arn = self._store_idp_secret(
-                        secrets_client,
-                        secret_name,
-                        idp_client_secret,
-                        description=f"IdP client secret for "
-                        f"{config['aws']['identity_pool_name']} distribution landing page",
-                    )
-
-                    console.print(f"[green]✓[/green] IdP client secret stored in Secrets Manager: {secret_name}")
+                        console.print("[yellow]No Route53 hosted zones found in this account[/yellow]")
+                        console.print("You can still use custom domain if it's managed externally")
 
                 except Exception as e:
-                    console.print(f"[red]Error storing secret in Secrets Manager: {e}[/red]")
-                    console.print("[yellow]You'll need to configure the secret manually before deployment[/yellow]")
-                    # Storing failed, so we have no API response. Recover the real
-                    # ARN (with its random suffix) via describe_secret if the secret
-                    # exists; only fall back to a hand-built ARN as a last resort.
-                    try:
-                        secret_arn = secrets_client.describe_secret(SecretId=secret_name)["ARN"]
-                    except Exception:
-                        # Partition-aware so the fallback ARN is valid in GovCloud
-                        # (aws-us-gov) and China (aws-cn), not just commercial AWS.
-                        from claude_code_with_bedrock.utils.partition import aws_partition_for_region
+                    console.print(f"[yellow]Could not list Route53 zones: {e}[/yellow]")
 
-                        partition = aws_partition_for_region(region)
-                        secret_arn = f"arn:{partition}:secretsmanager:{region}:{account_id}:secret:{secret_name}"  # allow-handbuilt-arn
-
-            # Custom domain (REQUIRED for authenticated landing page)
-            console.print("\n[bold]Custom Domain Configuration (REQUIRED)[/bold]")
-            console.print("[yellow]⚠️  Custom domain with HTTPS is required for ALB OIDC authentication[/yellow]")
-            console.print("You will need:")
-            console.print("  • A custom domain (e.g., downloads.company.com)")
-            console.print("  • An ACM certificate for this domain in the same region")
-
-            custom_domain = questionary.text(
-                "Custom domain (e.g., downloads.company.com):",
-                default=config.get("distribution", {}).get("custom_domain") or "",
-                validate=lambda text: (
-                    len(text.strip()) > 0 or "Custom domain is required for authenticated landing page"
-                ),
-            ).ask()
-
-            # Check for Route53 hosted zones
-            console.print("\n[bold]Route53 Configuration[/bold]")
-            console.print("Looking for Route53 hosted zones...")
-
-            hosted_zone_id = None
-            try:
-                route53_client = boto3.client("route53")
-                zones_response = route53_client.list_hosted_zones()
-                hosted_zones = zones_response.get("HostedZones", [])
-
-                if hosted_zones:
-                    console.print(f"Found {len(hosted_zones)} hosted zone(s)")
-
-                    # Get existing hosted zone if configured
-                    existing_zone_id = config.get("distribution", {}).get("hosted_zone_id")
-
-                    # Create zone choices
-                    zone_choices = [
-                        questionary.Choice(
-                            f"{zone['Name']} (ID: {zone['Id'].split('/')[-1]})", value=zone["Id"].split("/")[-1]
-                        )
-                        for zone in hosted_zones
-                    ]
-                    zone_choices.append(questionary.Choice("Skip (no Route53 managed domain)", value=None))
-
-                    # Find the default choice based on existing zone
-                    default_choice = None
-                    if existing_zone_id:
-                        for choice in zone_choices:
-                            if choice.value == existing_zone_id:
-                                default_choice = choice
-                                break
-
-                    hosted_zone_id = questionary.select(
-                        "Select Route53 hosted zone:",
-                        choices=zone_choices,
-                        default=default_choice if default_choice else zone_choices[0],
-                    ).ask()
-                else:
-                    console.print("[yellow]No Route53 hosted zones found in this account[/yellow]")
-                    console.print("You can still use custom domain if it's managed externally")
-                    hosted_zone_id = None
-
-            except Exception as e:
-                console.print(f"[yellow]Could not list Route53 zones: {e}[/yellow]")
-                hosted_zone_id = None
-
-            # Save landing page configuration
-            config["distribution"].update(
-                {
-                    "idp_provider": idp_provider,
-                    "idp_domain": idp_domain,
-                    "idp_client_id": idp_client_id,
-                    "idp_client_secret_arn": secret_arn,
-                    "custom_domain": custom_domain,
-                    "hosted_zone_id": hosted_zone_id,
-                }
-            )
-
-            # Generic OIDC: persist the explicit endpoints (only set for provider == "generic")
-            if idp_provider == "generic":
+                # Save IDC landing page configuration
                 config["distribution"].update(
                     {
-                        "idp_issuer": dist_oidc_issuer,
-                        "idp_authorization_endpoint": dist_oidc_authorization_endpoint,
-                        "idp_token_endpoint": dist_oidc_token_endpoint,
-                        "idp_userinfo_endpoint": dist_oidc_userinfo_endpoint,
+                        "type": "landing-page",
+                        "enabled": True,
+                        "custom_domain": custom_domain,
+                        "hosted_zone_id": hosted_zone_id,
+                        "saml_metadata_url": saml_url.strip(),
                     }
                 )
 
-            console.print("\n[green]✓[/green] Landing page distribution will be deployed with IdP authentication")
+                console.print(
+                    "\n[green]✓[/green] Landing page distribution will be deployed "
+                    "with IAM Identity Center (SAML) authentication"
+                )
+
+            else:
+                # OIDC auth path: existing IdP configuration flow
+
+                # IdP provider selection
+                idp_choices = [
+                    questionary.Choice("Okta", value="okta"),
+                    questionary.Choice("Azure AD / Entra ID", value="azure"),
+                    questionary.Choice("Auth0", value="auth0"),
+                    questionary.Choice("AWS Cognito User Pool", value="cognito"),
+                    questionary.Choice("Google", value="google"),
+                    questionary.Choice("Generic OIDC (PingFederate, Keycloak, ForgeRock, etc.)", value="generic"),
+                ]
+    
+                idp_provider = questionary.select(
+                    "Identity provider for web authentication:",
+                    choices=idp_choices,
+                    default=config.get("distribution", {}).get("idp_provider", "okta"),
+                ).ask()
+    
+                # Auto-detection for Cognito User Pool
+                cognito_auto_configured = False
+                if idp_provider == "cognito":
+                    from claude_code_with_bedrock.cli.utils.aws import (
+                        detect_cognito_stack,
+                        validate_cognito_stack_for_distribution,
+                    )
+    
+                    console.print("\n[bold]Cognito Configuration Detection[/bold]")
+                    console.print("Searching for deployed Cognito User Pool stack...")
+    
+                    # Try to auto-detect Cognito stack (region resolved at top of landing-page block)
+                    cognito_stack_info = detect_cognito_stack(region)
+    
+                    if cognito_stack_info:
+                        console.print(f"[green]✓[/green] Found Cognito stack: {cognito_stack_info['stack_name']}")
+    
+                        # Validate it has distribution support
+                        is_valid, message = validate_cognito_stack_for_distribution(
+                            cognito_stack_info["stack_name"], region
+                        )
+    
+                        if is_valid:
+                            console.print(f"[green]✓[/green] {message}")
+    
+                            # Show detected values
+                            outputs = cognito_stack_info["outputs"]
+                            console.print("\n[cyan]Detected Configuration:[/cyan]")
+                            console.print(f"  • User Pool ID: {outputs.get('UserPoolId', 'N/A')}")
+    
+                            # Extract domain prefix from full domain
+                            full_domain = outputs.get("UserPoolDomain", "")
+                            domain_prefix = full_domain.split(".")[0] if full_domain else "N/A"
+                            console.print(f"  • Domain: {domain_prefix}")
+    
+                            console.print(f"  • Client ID: {outputs.get('DistributionWebClientId', 'N/A')}")
+                            console.print(f"  • Secret ARN: {outputs.get('DistributionWebClientSecretArn', 'N/A')}")
+    
+                            use_detected = questionary.confirm("\nUse these detected values?", default=True).ask()
+    
+                            if use_detected:
+                                # Auto-populate configuration
+                                idp_domain = domain_prefix
+                                idp_client_id = outputs["DistributionWebClientId"]
+                                secret_arn = outputs["DistributionWebClientSecretArn"]
+    
+                                # Store in config immediately
+                                config.setdefault("distribution", {}).update(
+                                    {
+                                        "idp_provider": "cognito",
+                                        "idp_domain": idp_domain,
+                                        "idp_client_id": idp_client_id,
+                                        "idp_client_secret_arn": secret_arn,
+                                    }
+                                )
+    
+                                # Also store Cognito User Pool ID for auth
+                                if "cognito_user_pool_id" not in config:
+                                    config["cognito_user_pool_id"] = outputs["UserPoolId"]
+    
+                                console.print("[green]✓[/green] Configuration auto-populated from stack outputs")
+                                cognito_auto_configured = True
+                            else:
+                                console.print("[yellow]Manual configuration selected[/yellow]")
+                        else:
+                            console.print(f"[yellow]⚠[/yellow] {message}")
+                            console.print("[yellow]Falling back to manual configuration...[/yellow]")
+                    else:
+                        console.print("[yellow]No Cognito User Pool stack detected[/yellow]")
+                        console.print("You can either:")
+                        console.print("  1. Deploy the Cognito stack first")
+                        console.print("  2. Enter configuration manually")
+    
+                # Only prompt for manual configuration if not auto-configured
+                if not cognito_auto_configured:
+                    # IdP domain
+                    # Use `or ""`, not just the .get default: a reloaded profile stores these
+                    # keys with an explicit None (see _build_config_from_profile), so the key
+                    # is present and .get returns None — and questionary.text(default=None)
+                    # crashes with "object of type 'NoneType' has no len()".
+                    idp_domain = questionary.text(
+                        "IdP domain (e.g., company.okta.com for Okta, company.auth0.com for Auth0):",
+                        default=config.get("distribution", {}).get("idp_domain") or "",
+                    ).ask()
+    
+                    # Web app client ID
+                    idp_client_id = questionary.text(
+                        "Web application client ID (separate from CLI native app):",
+                        default=config.get("distribution", {}).get("idp_client_id") or "",
+                    ).ask()
+    
+                    # Web app client secret
+                    idp_client_secret = questionary.password(
+                        "Web application client secret:",
+                    ).ask()
+    
+                # Generic OIDC providers (PingFederate, Keycloak, ForgeRock, custom IdP) can't have
+                # their ALB authenticate-oidc endpoints derived from a single domain the way
+                # Okta/Azure/Auth0/Cognito can, so collect each one explicitly. Try OIDC discovery
+                # first (mirrors the SSO generic flow) and fall back to manual entry.
+                dist_oidc_issuer = None
+                dist_oidc_authorization_endpoint = None
+                dist_oidc_token_endpoint = None
+                dist_oidc_userinfo_endpoint = None
+                if idp_provider == "generic":
+                    from claude_code_with_bedrock.cli.utils.oidc_discovery import (
+                        OidcDiscoveryError,
+                        discover_oidc_endpoints,
+                    )
+    
+                    console.print("\n[bold]Generic OIDC Landing Page Configuration[/bold]")
+                    console.print(
+                        "[dim]We'll try to auto-discover endpoints via the standard well-known URL,[/dim]\n"
+                        "[dim]and fall back to manual entry if your IdP doesn't expose one.[/dim]\n"
+                    )
+    
+                    # Use the domain entered above as the default issuer; let the user override.
+                    default_issuer = (
+                        idp_domain
+                        if idp_domain and idp_domain.startswith(("http://", "https://"))
+                        else (f"https://{idp_domain}" if idp_domain else "")
+                    ).rstrip("/")
+    
+                    dist_oidc_issuer = questionary.text(
+                        "OIDC issuer URL:",
+                        validate=lambda x: x.startswith("https://") or "Issuer must start with https://",
+                        default=config.get("distribution", {}).get("idp_issuer", default_issuer),
+                        instruction="(must match the 'iss' claim in tokens)",
+                    ).ask()
+                    if not dist_oidc_issuer:
+                        return None
+                    dist_oidc_issuer = dist_oidc_issuer.rstrip("/")
+    
+                    discovered: dict[str, str] = {}
+                    console.print(f"[dim]Querying {dist_oidc_issuer}/.well-known/openid-configuration ...[/dim]")
+                    try:
+                        discovered = discover_oidc_endpoints(dist_oidc_issuer)
+                        console.print("[green]✓ Discovery succeeded.[/green]")
+                    except OidcDiscoveryError as e:
+                        console.print(f"[yellow]Discovery failed: {e}[/yellow]")
+                        console.print("[dim]Falling back to manual entry.[/dim]")
+    
+                    dist_oidc_authorization_endpoint = questionary.text(
+                        "Authorization endpoint:",
+                        validate=lambda x: bool(x) or "Authorization endpoint cannot be empty",
+                        default=(
+                            discovered.get("authorization_endpoint")
+                            or config.get("distribution", {}).get("idp_authorization_endpoint")
+                            or f"{dist_oidc_issuer}/as/authorization.oauth2"
+                        ),
+                        instruction="(full URL)",
+                    ).ask()
+                    if not dist_oidc_authorization_endpoint:
+                        return None
+    
+                    dist_oidc_token_endpoint = questionary.text(
+                        "Token endpoint:",
+                        validate=lambda x: bool(x) or "Token endpoint cannot be empty",
+                        default=(
+                            discovered.get("token_endpoint")
+                            or config.get("distribution", {}).get("idp_token_endpoint")
+                            or f"{dist_oidc_issuer}/as/token.oauth2"
+                        ),
+                        instruction="(full URL)",
+                    ).ask()
+                    if not dist_oidc_token_endpoint:
+                        return None
+    
+                    dist_oidc_userinfo_endpoint = questionary.text(
+                        "UserInfo endpoint:",
+                        validate=lambda x: bool(x) or "UserInfo endpoint cannot be empty",
+                        default=(
+                            discovered.get("userinfo_endpoint")
+                            or config.get("distribution", {}).get("idp_userinfo_endpoint")
+                            or f"{dist_oidc_issuer}/idp/userinfo.openid"
+                        ),
+                        instruction="(full URL)",
+                    ).ask()
+                    if not dist_oidc_userinfo_endpoint:
+                        return None
+    
+                # Store secret in AWS Secrets Manager (only if not auto-configured)
+                import boto3
+    
+                if not cognito_auto_configured:
+                    try:
+                        secrets_client = boto3.client("secretsmanager", region_name=region)
+                        account_id = boto3.client("sts").get_caller_identity()["Account"]
+    
+                        secret_name = f"{config['aws']['identity_pool_name']}-distribution-idp-secret"
+    
+                        secret_arn = self._store_idp_secret(
+                            secrets_client,
+                            secret_name,
+                            idp_client_secret,
+                            description=f"IdP client secret for "
+                            f"{config['aws']['identity_pool_name']} distribution landing page",
+                        )
+    
+                        console.print(f"[green]✓[/green] IdP client secret stored in Secrets Manager: {secret_name}")
+    
+                    except Exception as e:
+                        console.print(f"[red]Error storing secret in Secrets Manager: {e}[/red]")
+                        console.print("[yellow]You'll need to configure the secret manually before deployment[/yellow]")
+                        # Storing failed, so we have no API response. Recover the real
+                        # ARN (with its random suffix) via describe_secret if the secret
+                        # exists; only fall back to a hand-built ARN as a last resort.
+                        try:
+                            secret_arn = secrets_client.describe_secret(SecretId=secret_name)["ARN"]
+                        except Exception:
+                            # Partition-aware so the fallback ARN is valid in GovCloud
+                            # (aws-us-gov) and China (aws-cn), not just commercial AWS.
+                            from claude_code_with_bedrock.utils.partition import aws_partition_for_region
+    
+                            partition = aws_partition_for_region(region)
+                            secret_arn = f"arn:{partition}:secretsmanager:{region}:{account_id}:secret:{secret_name}"  # allow-handbuilt-arn
+    
+                # Custom domain (REQUIRED for authenticated landing page)
+                console.print("\n[bold]Custom Domain Configuration (REQUIRED)[/bold]")
+                console.print("[yellow]⚠️  Custom domain with HTTPS is required for ALB OIDC authentication[/yellow]")
+                console.print("You will need:")
+                console.print("  • A custom domain (e.g., downloads.company.com)")
+                console.print("  • An ACM certificate for this domain in the same region")
+    
+                custom_domain = questionary.text(
+                    "Custom domain (e.g., downloads.company.com):",
+                    default=config.get("distribution", {}).get("custom_domain") or "",
+                    validate=lambda text: (
+                        len(text.strip()) > 0 or "Custom domain is required for authenticated landing page"
+                    ),
+                ).ask()
+    
+                # Check for Route53 hosted zones
+                console.print("\n[bold]Route53 Configuration[/bold]")
+                console.print("Looking for Route53 hosted zones...")
+    
+                hosted_zone_id = None
+                try:
+                    route53_client = boto3.client("route53")
+                    zones_response = route53_client.list_hosted_zones()
+                    hosted_zones = zones_response.get("HostedZones", [])
+    
+                    if hosted_zones:
+                        console.print(f"Found {len(hosted_zones)} hosted zone(s)")
+    
+                        # Get existing hosted zone if configured
+                        existing_zone_id = config.get("distribution", {}).get("hosted_zone_id")
+    
+                        # Create zone choices
+                        zone_choices = [
+                            questionary.Choice(
+                                f"{zone['Name']} (ID: {zone['Id'].split('/')[-1]})", value=zone["Id"].split("/")[-1]
+                            )
+                            for zone in hosted_zones
+                        ]
+                        zone_choices.append(questionary.Choice("Skip (no Route53 managed domain)", value=None))
+    
+                        # Find the default choice based on existing zone
+                        default_choice = None
+                        if existing_zone_id:
+                            for choice in zone_choices:
+                                if choice.value == existing_zone_id:
+                                    default_choice = choice
+                                    break
+    
+                        hosted_zone_id = questionary.select(
+                            "Select Route53 hosted zone:",
+                            choices=zone_choices,
+                            default=default_choice if default_choice else zone_choices[0],
+                        ).ask()
+                    else:
+                        console.print("[yellow]No Route53 hosted zones found in this account[/yellow]")
+                        console.print("You can still use custom domain if it's managed externally")
+                        hosted_zone_id = None
+    
+                except Exception as e:
+                    console.print(f"[yellow]Could not list Route53 zones: {e}[/yellow]")
+                    hosted_zone_id = None
+    
+                # Save landing page configuration
+                config["distribution"].update(
+                    {
+                        "idp_provider": idp_provider,
+                        "idp_domain": idp_domain,
+                        "idp_client_id": idp_client_id,
+                        "idp_client_secret_arn": secret_arn,
+                        "custom_domain": custom_domain,
+                        "hosted_zone_id": hosted_zone_id,
+                    }
+                )
+    
+                # Generic OIDC: persist the explicit endpoints (only set for provider == "generic")
+                if idp_provider == "generic":
+                    config["distribution"].update(
+                        {
+                            "idp_issuer": dist_oidc_issuer,
+                            "idp_authorization_endpoint": dist_oidc_authorization_endpoint,
+                            "idp_token_endpoint": dist_oidc_token_endpoint,
+                            "idp_userinfo_endpoint": dist_oidc_userinfo_endpoint,
+                        }
+                    )
+    
+                console.print("\n[green]✓[/green] Landing page distribution will be deployed with IdP authentication")
 
         elif distribution_type == "presigned-s3":
             console.print("[green]✓[/green] Presigned S3 distribution will be deployed")
@@ -2814,6 +2913,7 @@ class InitCommand(Command):
             ),
             "distribution_idp_token_endpoint": config_data.get("distribution", {}).get("idp_token_endpoint"),
             "distribution_idp_userinfo_endpoint": config_data.get("distribution", {}).get("idp_userinfo_endpoint"),
+            "distribution_saml_metadata_url": config_data.get("distribution", {}).get("saml_metadata_url"),
             "quota_monitoring_enabled": (
                 config_data.get("quota", {}).get("enabled", False)
                 if config_data.get("monitoring", {}).get("enabled")
@@ -3236,6 +3336,7 @@ class InitCommand(Command):
                     "idp_authorization_endpoint": getattr(profile, "distribution_idp_authorization_endpoint", None),
                     "idp_token_endpoint": getattr(profile, "distribution_idp_token_endpoint", None),
                     "idp_userinfo_endpoint": getattr(profile, "distribution_idp_userinfo_endpoint", None),
+                    "saml_metadata_url": getattr(profile, "distribution_saml_metadata_url", None),
                 }
 
             # Add quota monitoring configuration if present.

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1812,7 +1812,7 @@ class InitCommand(Command):
                             )
                             for zone in hosted_zones
                         ]
-                        zone_choices.append(questionary.Choice("Skip (no Route53 managed domain)", value=None))
+                        zone_choices.append(questionary.Choice("Skip (no Route53 managed domain)", value=_CHOICE_NONE))
 
                         default_choice = None
                         if existing_zone_id:
@@ -1826,6 +1826,8 @@ class InitCommand(Command):
                             choices=zone_choices,
                             default=default_choice if default_choice else zone_choices[0],
                         ).ask()
+                        if hosted_zone_id == _CHOICE_NONE:
+                            hosted_zone_id = None
                     else:
                         console.print("[yellow]No Route53 hosted zones found in this account[/yellow]")
                         console.print("You can still use custom domain if it's managed externally")
@@ -2123,7 +2125,7 @@ class InitCommand(Command):
                             )
                             for zone in hosted_zones
                         ]
-                        zone_choices.append(questionary.Choice("Skip (no Route53 managed domain)", value=None))
+                        zone_choices.append(questionary.Choice("Skip (no Route53 managed domain)", value=_CHOICE_NONE))
 
                         # Find the default choice based on existing zone
                         default_choice = None
@@ -2138,6 +2140,8 @@ class InitCommand(Command):
                             choices=zone_choices,
                             default=default_choice if default_choice else zone_choices[0],
                         ).ask()
+                        if hosted_zone_id == _CHOICE_NONE:
+                            hosted_zone_id = None
                     else:
                         console.print("[yellow]No Route53 hosted zones found in this account[/yellow]")
                         console.print("You can still use custom domain if it's managed externally")

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1861,13 +1861,13 @@ class InitCommand(Command):
                     questionary.Choice("Google", value="google"),
                     questionary.Choice("Generic OIDC (PingFederate, Keycloak, ForgeRock, etc.)", value="generic"),
                 ]
-    
+
                 idp_provider = questionary.select(
                     "Identity provider for web authentication:",
                     choices=idp_choices,
                     default=config.get("distribution", {}).get("idp_provider", "okta"),
                 ).ask()
-    
+
                 # Auto-detection for Cognito User Pool
                 cognito_auto_configured = False
                 if idp_provider == "cognito":
@@ -1875,45 +1875,45 @@ class InitCommand(Command):
                         detect_cognito_stack,
                         validate_cognito_stack_for_distribution,
                     )
-    
+
                     console.print("\n[bold]Cognito Configuration Detection[/bold]")
                     console.print("Searching for deployed Cognito User Pool stack...")
-    
+
                     # Try to auto-detect Cognito stack (region resolved at top of landing-page block)
                     cognito_stack_info = detect_cognito_stack(region)
-    
+
                     if cognito_stack_info:
                         console.print(f"[green]✓[/green] Found Cognito stack: {cognito_stack_info['stack_name']}")
-    
+
                         # Validate it has distribution support
                         is_valid, message = validate_cognito_stack_for_distribution(
                             cognito_stack_info["stack_name"], region
                         )
-    
+
                         if is_valid:
                             console.print(f"[green]✓[/green] {message}")
-    
+
                             # Show detected values
                             outputs = cognito_stack_info["outputs"]
                             console.print("\n[cyan]Detected Configuration:[/cyan]")
                             console.print(f"  • User Pool ID: {outputs.get('UserPoolId', 'N/A')}")
-    
+
                             # Extract domain prefix from full domain
                             full_domain = outputs.get("UserPoolDomain", "")
                             domain_prefix = full_domain.split(".")[0] if full_domain else "N/A"
                             console.print(f"  • Domain: {domain_prefix}")
-    
+
                             console.print(f"  • Client ID: {outputs.get('DistributionWebClientId', 'N/A')}")
                             console.print(f"  • Secret ARN: {outputs.get('DistributionWebClientSecretArn', 'N/A')}")
-    
+
                             use_detected = questionary.confirm("\nUse these detected values?", default=True).ask()
-    
+
                             if use_detected:
                                 # Auto-populate configuration
                                 idp_domain = domain_prefix
                                 idp_client_id = outputs["DistributionWebClientId"]
                                 secret_arn = outputs["DistributionWebClientSecretArn"]
-    
+
                                 # Store in config immediately
                                 config.setdefault("distribution", {}).update(
                                     {
@@ -1923,11 +1923,11 @@ class InitCommand(Command):
                                         "idp_client_secret_arn": secret_arn,
                                     }
                                 )
-    
+
                                 # Also store Cognito User Pool ID for auth
                                 if "cognito_user_pool_id" not in config:
                                     config["cognito_user_pool_id"] = outputs["UserPoolId"]
-    
+
                                 console.print("[green]✓[/green] Configuration auto-populated from stack outputs")
                                 cognito_auto_configured = True
                             else:
@@ -1940,7 +1940,7 @@ class InitCommand(Command):
                         console.print("You can either:")
                         console.print("  1. Deploy the Cognito stack first")
                         console.print("  2. Enter configuration manually")
-    
+
                 # Only prompt for manual configuration if not auto-configured
                 if not cognito_auto_configured:
                     # IdP domain
@@ -1952,18 +1952,18 @@ class InitCommand(Command):
                         "IdP domain (e.g., company.okta.com for Okta, company.auth0.com for Auth0):",
                         default=config.get("distribution", {}).get("idp_domain") or "",
                     ).ask()
-    
+
                     # Web app client ID
                     idp_client_id = questionary.text(
                         "Web application client ID (separate from CLI native app):",
                         default=config.get("distribution", {}).get("idp_client_id") or "",
                     ).ask()
-    
+
                     # Web app client secret
                     idp_client_secret = questionary.password(
                         "Web application client secret:",
                     ).ask()
-    
+
                 # Generic OIDC providers (PingFederate, Keycloak, ForgeRock, custom IdP) can't have
                 # their ALB authenticate-oidc endpoints derived from a single domain the way
                 # Okta/Azure/Auth0/Cognito can, so collect each one explicitly. Try OIDC discovery
@@ -1977,20 +1977,20 @@ class InitCommand(Command):
                         OidcDiscoveryError,
                         discover_oidc_endpoints,
                     )
-    
+
                     console.print("\n[bold]Generic OIDC Landing Page Configuration[/bold]")
                     console.print(
                         "[dim]We'll try to auto-discover endpoints via the standard well-known URL,[/dim]\n"
                         "[dim]and fall back to manual entry if your IdP doesn't expose one.[/dim]\n"
                     )
-    
+
                     # Use the domain entered above as the default issuer; let the user override.
                     default_issuer = (
                         idp_domain
                         if idp_domain and idp_domain.startswith(("http://", "https://"))
                         else (f"https://{idp_domain}" if idp_domain else "")
                     ).rstrip("/")
-    
+
                     dist_oidc_issuer = questionary.text(
                         "OIDC issuer URL:",
                         validate=lambda x: x.startswith("https://") or "Issuer must start with https://",
@@ -2000,7 +2000,7 @@ class InitCommand(Command):
                     if not dist_oidc_issuer:
                         return None
                     dist_oidc_issuer = dist_oidc_issuer.rstrip("/")
-    
+
                     discovered: dict[str, str] = {}
                     console.print(f"[dim]Querying {dist_oidc_issuer}/.well-known/openid-configuration ...[/dim]")
                     try:
@@ -2009,7 +2009,7 @@ class InitCommand(Command):
                     except OidcDiscoveryError as e:
                         console.print(f"[yellow]Discovery failed: {e}[/yellow]")
                         console.print("[dim]Falling back to manual entry.[/dim]")
-    
+
                     dist_oidc_authorization_endpoint = questionary.text(
                         "Authorization endpoint:",
                         validate=lambda x: bool(x) or "Authorization endpoint cannot be empty",
@@ -2022,7 +2022,7 @@ class InitCommand(Command):
                     ).ask()
                     if not dist_oidc_authorization_endpoint:
                         return None
-    
+
                     dist_oidc_token_endpoint = questionary.text(
                         "Token endpoint:",
                         validate=lambda x: bool(x) or "Token endpoint cannot be empty",
@@ -2035,7 +2035,7 @@ class InitCommand(Command):
                     ).ask()
                     if not dist_oidc_token_endpoint:
                         return None
-    
+
                     dist_oidc_userinfo_endpoint = questionary.text(
                         "UserInfo endpoint:",
                         validate=lambda x: bool(x) or "UserInfo endpoint cannot be empty",
@@ -2048,17 +2048,17 @@ class InitCommand(Command):
                     ).ask()
                     if not dist_oidc_userinfo_endpoint:
                         return None
-    
+
                 # Store secret in AWS Secrets Manager (only if not auto-configured)
                 import boto3
-    
+
                 if not cognito_auto_configured:
                     try:
                         secrets_client = boto3.client("secretsmanager", region_name=region)
                         account_id = boto3.client("sts").get_caller_identity()["Account"]
-    
+
                         secret_name = f"{config['aws']['identity_pool_name']}-distribution-idp-secret"
-    
+
                         secret_arn = self._store_idp_secret(
                             secrets_client,
                             secret_name,
@@ -2066,9 +2066,9 @@ class InitCommand(Command):
                             description=f"IdP client secret for "
                             f"{config['aws']['identity_pool_name']} distribution landing page",
                         )
-    
+
                         console.print(f"[green]✓[/green] IdP client secret stored in Secrets Manager: {secret_name}")
-    
+
                     except Exception as e:
                         console.print(f"[red]Error storing secret in Secrets Manager: {e}[/red]")
                         console.print("[yellow]You'll need to configure the secret manually before deployment[/yellow]")
@@ -2081,17 +2081,17 @@ class InitCommand(Command):
                             # Partition-aware so the fallback ARN is valid in GovCloud
                             # (aws-us-gov) and China (aws-cn), not just commercial AWS.
                             from claude_code_with_bedrock.utils.partition import aws_partition_for_region
-    
+
                             partition = aws_partition_for_region(region)
                             secret_arn = f"arn:{partition}:secretsmanager:{region}:{account_id}:secret:{secret_name}"  # allow-handbuilt-arn
-    
+
                 # Custom domain (REQUIRED for authenticated landing page)
                 console.print("\n[bold]Custom Domain Configuration (REQUIRED)[/bold]")
                 console.print("[yellow]⚠️  Custom domain with HTTPS is required for ALB OIDC authentication[/yellow]")
                 console.print("You will need:")
                 console.print("  • A custom domain (e.g., downloads.company.com)")
                 console.print("  • An ACM certificate for this domain in the same region")
-    
+
                 custom_domain = questionary.text(
                     "Custom domain (e.g., downloads.company.com):",
                     default=config.get("distribution", {}).get("custom_domain") or "",
@@ -2099,23 +2099,23 @@ class InitCommand(Command):
                         len(text.strip()) > 0 or "Custom domain is required for authenticated landing page"
                     ),
                 ).ask()
-    
+
                 # Check for Route53 hosted zones
                 console.print("\n[bold]Route53 Configuration[/bold]")
                 console.print("Looking for Route53 hosted zones...")
-    
+
                 hosted_zone_id = None
                 try:
                     route53_client = boto3.client("route53")
                     zones_response = route53_client.list_hosted_zones()
                     hosted_zones = zones_response.get("HostedZones", [])
-    
+
                     if hosted_zones:
                         console.print(f"Found {len(hosted_zones)} hosted zone(s)")
-    
+
                         # Get existing hosted zone if configured
                         existing_zone_id = config.get("distribution", {}).get("hosted_zone_id")
-    
+
                         # Create zone choices
                         zone_choices = [
                             questionary.Choice(
@@ -2124,7 +2124,7 @@ class InitCommand(Command):
                             for zone in hosted_zones
                         ]
                         zone_choices.append(questionary.Choice("Skip (no Route53 managed domain)", value=None))
-    
+
                         # Find the default choice based on existing zone
                         default_choice = None
                         if existing_zone_id:
@@ -2132,7 +2132,7 @@ class InitCommand(Command):
                                 if choice.value == existing_zone_id:
                                     default_choice = choice
                                     break
-    
+
                         hosted_zone_id = questionary.select(
                             "Select Route53 hosted zone:",
                             choices=zone_choices,
@@ -2142,11 +2142,11 @@ class InitCommand(Command):
                         console.print("[yellow]No Route53 hosted zones found in this account[/yellow]")
                         console.print("You can still use custom domain if it's managed externally")
                         hosted_zone_id = None
-    
+
                 except Exception as e:
                     console.print(f"[yellow]Could not list Route53 zones: {e}[/yellow]")
                     hosted_zone_id = None
-    
+
                 # Save landing page configuration
                 config["distribution"].update(
                     {
@@ -2158,7 +2158,7 @@ class InitCommand(Command):
                         "hosted_zone_id": hosted_zone_id,
                     }
                 )
-    
+
                 # Generic OIDC: persist the explicit endpoints (only set for provider == "generic")
                 if idp_provider == "generic":
                     config["distribution"].update(
@@ -2169,7 +2169,7 @@ class InitCommand(Command):
                             "idp_userinfo_endpoint": dist_oidc_userinfo_endpoint,
                         }
                     )
-    
+
                 console.print("\n[green]✓[/green] Landing page distribution will be deployed with IdP authentication")
 
         elif distribution_type == "presigned-s3":

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -85,6 +85,9 @@ class Profile:
     distribution_idp_token_endpoint: str | None = None  # Full token endpoint URL
     distribution_idp_userinfo_endpoint: str | None = None  # Full userinfo endpoint URL
 
+    # IDC/SAML distribution config (only populated when auth_type == "idc" and distribution_type == "landing-page")
+    distribution_saml_metadata_url: str | None = None  # SAML metadata URL from IAM Identity Center
+
     # Quota monitoring configuration
     quota_monitoring_enabled: bool = False  # Enable per-user token quota monitoring
     monthly_token_limit: int = 225000000  # Monthly token limit per user (225M default)


### PR DESCRIPTION
Extends the existing landing page with optional IDC/SAML auth — no new stack needed.

## What

When `AuthType=idc`, deploys:
- Cognito User Pool with SAML provider (IAM Identity Center)
- ALB uses `authenticate-cognito` action instead of `authenticate-oidc`

Existing OIDC flow unchanged (default).

## Why

Consolidates IDC support into the existing template rather than maintaining a separate landing page (as proposed in #751). One landing page, different auth backends.

## Backwards compatible

- Default `AuthType=oidc` — zero change for existing deployments
- New Cognito resources are conditional (`IsIdcAuth`)
- Existing OIDC listener rules unaffected

Extracted from #751. Credit to @duttaabh for the IDC integration design.

Co-authored-by: duttaabh <duttaabh@users.noreply.github.com>