### PR TITLE
feat(package): add --prepare-offline flag for air-gapped builds

### DIFF
--- a/assets/docs/CLI_REFERENCE.md
+++ b/assets/docs/CLI_REFERENCE.md
@@ -257,34 +257,7 @@ poetry run ccwb package [options]
 2. Creates `config.json` with federation config read from the admin profile
 3. Creates `claude-settings/settings.json` with Bedrock model and OTel endpoint (or `managed-settings.json` if `--managed` was used during init)
 4. Creates installer scripts (`install.sh`, `install.bat`, `ccwb-install.ps1`)
-5. Copies any admin-defined **extra files** into the build folder (see below)
-6. Outputs to `dist/{profile}/{timestamp}/`
-
-**Extra Files:**
-
-You can ship additional files or folders on top of the generated package —
-preinstall/postinstall scripts, an OIDC signing certificate, a CA bundle, and
-so on. Configure them during `ccwb init` (the "Extra files" step); they are
-stored in your admin deployment profile, never in the runtime `config.json` and
-never delivered to end users' Claude Code config.
-
-Each entry has three fields:
-
-| Field | Meaning |
-|---|---|
-| `name` | path inside the package (relative — no `..` or absolute paths) |
-| `targets` | which machines receive it (see tokens below) |
-| `from` | source path on your machine (a file or a whole folder) |
-
-`targets` accepts `all`, a family (`macos`, `linux`, `windows`), an
-architecture (`macos-arm64`, `macos-intel`, `linux-x64`, `linux-arm64`), or a
-list such as `["macos", "linux"]`.
-
-`ccwb package` copies **all** extras into the build folder. `ccwb distribute`
-then filters them per platform — a `macos` extra lands in the macOS package but
-not the Windows one; an `all` extra lands in every package. `package` fails
-fast (non-zero exit) if a `from` source is missing or a `name` collides with a
-generated artifact, so a listed file is never silently dropped.
+5. Outputs to `dist/{profile}/{timestamp}/`
 
 **Build Modes:**
 
@@ -304,6 +277,22 @@ With `--go`, all 5 platforms are always available regardless of the admin's OS. 
 - **Windows x64**: Native PE with embedded version info (~14 MB, unstripped for Defender compatibility)
 
 **Offline Packaging:**
+
+`ccwb package` normally needs internet on the admin machine for three things: Go module downloads for `source/go`, the OCB (OpenTelemetry Collector Builder) binary from GitHub, and Go module downloads for the OCB-generated collector module (sidecar mode only). A `vendor/` directory cannot cover the collector build — OCB generates a fresh Go module in a temp directory on every run.
+
+For air-gapped environments, use `--prepare-offline` to pre-seed everything:
+
+```bash
+# On an internet-connected machine (same OS/arch and Go version as the offline box):
+poetry run ccwb package --prepare-offline
+# Transfer ccwb-offline-go-bundle.tar.gz to the offline machine, extract, then:
+tar xzf ccwb-offline-go-bundle.tar.gz
+./scripts/prepare-offline-go-bundle.sh install
+source ccwb-offline-go-bundle/offline-env.sh
+poetry run ccwb package
+```
+
+The bundle contains the pinned OCB binary (installed to `~/.cache/ocb/`, where `package.py` looks before downloading) and a pre-populated Go module cache covering both `source/go` and the collector. Because every `go`/`ocb` subprocess inherits the environment, `GOPROXY=off` plus the seeded `GOMODCACHE` satisfies all module resolution — including the `go mod tidy` OCB runs internally. The `prepare` step rehearses a fully offline collector build before archiving, so a bundle that ships is a bundle that works.
 
 **Legacy mode platform details (PyInstaller / Nuitka / Docker):**
 

--- a/scripts/prepare-offline-go-bundle.sh
+++ b/scripts/prepare-offline-go-bundle.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# ABOUTME: Prepares (on an internet-connected machine) and installs (on an offline
+# ABOUTME: machine) everything `ccwb package` needs to build Go binaries and the
+# ABOUTME: OTEL Collector sidecar without network access.
+#
+# The sidecar collector build (`_build_otelcol` in package.py) cannot use a
+# vendor/ directory: OCB generates a fresh Go module in a temp dir on every
+# run, then resolves its dependencies from the network. Instead, this script
+# pre-seeds the two artifacts that build consults before touching the network:
+#
+#   1. The OCB binary at ~/.cache/ocb/ocb_<ver>_<os>_<arch> — package.py only
+#      downloads it when that exact file is missing.
+#   2. A Go module cache (GOMODCACHE) containing every module needed by both
+#      source/go (credential-process, otel-helper) and the OCB-generated
+#      collector. With GOPROXY=off, all `go` invocations — including the
+#      `go mod tidy` OCB runs internally — resolve from this cache.
+#
+# Because every go/ocb subprocess in package.py inherits the parent
+# environment, no changes to ccwb itself are required.
+#
+# Usage:
+#   On a machine WITH internet (same OS/arch and Go version as the offline box):
+#       ./scripts/prepare-offline-go-bundle.sh prepare [bundle-dir]
+#   Transfer the resulting ccwb-offline-go-bundle.tar.gz, then on the OFFLINE box:
+#       tar xzf ccwb-offline-go-bundle.tar.gz
+#       ./scripts/prepare-offline-go-bundle.sh install [bundle-dir]
+#       source <bundle-dir>/offline-env.sh
+#       poetry run ccwb package --go
+#
+# Requirements on both machines: bash, Go >= 1.23 (ideally the same minor version).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PACKAGE_PY="$REPO_ROOT/source/claude_code_with_bedrock/cli/commands/package.py"
+MANIFEST="$REPO_ROOT/source/otel_helper/ocb-manifest.yaml"
+
+MODE="${1:-prepare}"
+BUNDLE_DIR="$(cd "$(dirname "${2:-$REPO_ROOT/ccwb-offline-go-bundle}")" 2>/dev/null && pwd)/$(basename "${2:-ccwb-offline-go-bundle}")"
+
+# OCB version is pinned in package.py — parse it so the bundle can never drift.
+OCB_VERSION="$(sed -n 's/.*OCB_VERSION = "\([0-9.]*\)".*/\1/p' "$PACKAGE_PY")"
+if [ -z "$OCB_VERSION" ]; then
+    echo "ERROR: could not parse OCB_VERSION from $PACKAGE_PY" >&2
+    exit 1
+fi
+
+case "$(uname -s)" in
+    Darwin) OCB_OS=darwin ;;
+    MINGW*|MSYS*|CYGWIN*) OCB_OS=windows ;;
+    *) OCB_OS=linux ;;
+esac
+case "$(uname -m)" in
+    arm64|aarch64) OCB_ARCH=arm64 ;;
+    *) OCB_ARCH=amd64 ;;
+esac
+OCB_SUFFIX=""
+[ "$OCB_OS" = "windows" ] && OCB_SUFFIX=".exe"
+OCB_NAME="ocb_${OCB_VERSION}_${OCB_OS}_${OCB_ARCH}${OCB_SUFFIX}"
+
+write_env_file() {
+    cat > "$BUNDLE_DIR/offline-env.sh" <<EOF
+# Source this before running 'ccwb package' on the offline machine.
+export GOMODCACHE="$BUNDLE_DIR/gomodcache"
+export GOPROXY=off
+export GOSUMDB=off
+export GOTOOLCHAIN=local
+EOF
+}
+
+prepare() {
+    command -v go >/dev/null || { echo "ERROR: Go is required" >&2; exit 1; }
+    mkdir -p "$BUNDLE_DIR/ocb" "$BUNDLE_DIR/gomodcache"
+    go version | awk '{print $3}' > "$BUNDLE_DIR/GO_VERSION"
+
+    echo "==> Downloading OCB v$OCB_VERSION ($OCB_OS/$OCB_ARCH)"
+    if [ ! -f "$BUNDLE_DIR/ocb/$OCB_NAME" ]; then
+        curl -fsSL -o "$BUNDLE_DIR/ocb/$OCB_NAME" \
+            "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/cmd%2Fbuilder%2Fv${OCB_VERSION}/${OCB_NAME}"
+        [ "$OCB_OS" != "windows" ] && chmod +x "$BUNDLE_DIR/ocb/$OCB_NAME"
+    fi
+
+    export GOMODCACHE="$BUNDLE_DIR/gomodcache" GOTOOLCHAIN=local
+
+    echo "==> Seeding module cache: source/go (credential-process, otel-helper)"
+    # Copy go.mod/go.sum to a temp module so 'download all' can't mutate the repo's go.sum.
+    tmp_mod="$(mktemp -d)"
+    cp "$REPO_ROOT/source/go/go.mod" "$REPO_ROOT/source/go/go.sum" "$tmp_mod/"
+    (cd "$tmp_mod" && go mod download all)
+    rm -rf "$tmp_mod"
+
+    echo "==> Seeding module cache: OCB-generated collector module"
+    build_dir="$(mktemp -d)"
+    sed "s|output_path: ./build/otelcol|output_path: $build_dir|" "$MANIFEST" > "$build_dir/manifest.yaml"
+    "$BUNDLE_DIR/ocb/$OCB_NAME" --config "$build_dir/manifest.yaml" --skip-compilation
+    (cd "$build_dir" && go mod download)
+
+    echo "==> Verifying: rebuilding collector with GOPROXY=off (offline rehearsal)"
+    verify_dir="$(mktemp -d)"
+    sed "s|output_path: ./build/otelcol|output_path: $verify_dir|" "$MANIFEST" > "$verify_dir/manifest.yaml"
+    (
+        export GOPROXY=off GOSUMDB=off
+        "$BUNDLE_DIR/ocb/$OCB_NAME" --config "$verify_dir/manifest.yaml" --skip-compilation
+        cd "$verify_dir" && go mod download
+        GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -trimpath -o /dev/null .
+    )
+    rm -rf "$build_dir" "$verify_dir"
+
+    write_env_file
+
+    echo "==> Creating archive"
+    tar -C "$(dirname "$BUNDLE_DIR")" -czf "$BUNDLE_DIR.tar.gz" "$(basename "$BUNDLE_DIR")"
+    echo ""
+    echo "Bundle ready: $BUNDLE_DIR.tar.gz ($(du -sh "$BUNDLE_DIR.tar.gz" | cut -f1))"
+    echo "Transfer it to the offline machine, extract, then run:"
+    echo "    ./scripts/prepare-offline-go-bundle.sh install <bundle-dir>"
+}
+
+install_bundle() {
+    [ -d "$BUNDLE_DIR" ] || { echo "ERROR: bundle dir not found: $BUNDLE_DIR" >&2; exit 1; }
+
+    if command -v go >/dev/null; then
+        local_go="$(go version | awk '{print $3}')"
+        bundled_go="$(cat "$BUNDLE_DIR/GO_VERSION" 2>/dev/null || echo unknown)"
+        if [ "$local_go" != "$bundled_go" ]; then
+            echo "WARNING: bundle was prepared with $bundled_go but this machine has $local_go." >&2
+            echo "         Module resolution is usually compatible, but prefer matching versions." >&2
+        fi
+    fi
+
+    echo "==> Installing OCB binary to ~/.cache/ocb/ (package.py skips its download when present)"
+    mkdir -p "$HOME/.cache/ocb"
+    cp "$BUNDLE_DIR/ocb/$OCB_NAME" "$HOME/.cache/ocb/$OCB_NAME"
+    [ "$OCB_OS" != "windows" ] && chmod +x "$HOME/.cache/ocb/$OCB_NAME"
+
+    write_env_file
+    echo ""
+    echo "Done. Before running 'ccwb package', activate the offline Go environment:"
+    echo "    source $BUNDLE_DIR/offline-env.sh"
+    echo "    poetry run ccwb package --go"
+}
+
+case "$MODE" in
+    prepare) prepare ;;
+    install) install_bundle ;;
+    *) echo "Usage: $0 {prepare|install} [bundle-dir]" >&2; exit 1 ;;
+esac

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -250,6 +250,11 @@ class PackageCommand(Command):
             description="Skip configuration validation checks",
             flag=True,
         ),
+        option(
+            "prepare-offline",
+            description="Prepare an offline bundle (OCB binary + Go module cache) for air-gapped builds",
+            flag=True,
+        ),
     ]
 
     def handle(self) -> int:
@@ -268,6 +273,10 @@ class PackageCommand(Command):
             console.print("  • [cyan]poetry run ccwb builds --status latest[/cyan]    (check latest build)")
             console.print("\nRedirecting to builds command...\n")
             return self._check_build_status(self.option("status"), console)
+
+        # Prepare offline bundle for air-gapped environments
+        if self.option("prepare-offline"):
+            return self._prepare_offline_bundle(console)
 
         # Load configuration first (needed to check CodeBuild status)
         config = Config.load()
@@ -1161,7 +1170,15 @@ class PackageCommand(Command):
                 f"cmd%2Fbuilder%2Fv{OCB_VERSION}/ocb_{OCB_VERSION}_{ocb_os}_{ocb_arch}{ocb_suffix}"
             )
             console.print(f"[dim]Downloading OCB v{OCB_VERSION}...[/dim]")
-            urllib.request.urlretrieve(url, ocb_path)  # noqa: S310 (trusted GitHub release URL)
+            try:
+                urllib.request.urlretrieve(url, ocb_path)  # noqa: S310 (trusted GitHub release URL)
+            except (urllib.error.URLError, OSError) as e:
+                console.print(f"[red]Failed to download OCB: {e}[/red]")
+                console.print(
+                    "[yellow]For air-gapped environments, run "
+                    "'ccwb package --prepare-offline' on a connected machine first.[/yellow]"
+                )
+                raise
             if ocb_os != "windows":
                 ocb_path.chmod(0o755)
 
@@ -2456,6 +2473,41 @@ RUN pyinstaller \
             raise RuntimeError(f"Nuitka build failed for OTEL helper: {result.stderr}")
 
         return output_dir / binary_name
+
+    def _prepare_offline_bundle(self, console: Console) -> int:
+        """Prepare an offline bundle for air-gapped Go and OTEL collector builds.
+
+        Downloads the OCB binary and pre-seeds the Go module cache so that
+        `ccwb package` can run without network access. The bundle is saved
+        to `ccwb-offline-go-bundle/` in the repo root.
+        """
+        import subprocess
+
+        script_path = Path(__file__).resolve().parents[4] / "scripts" / "prepare-offline-go-bundle.sh"
+        if not script_path.exists():
+            console.print(f"[red]Offline bundle script not found at {script_path}[/red]")
+            return 1
+
+        console.print("[bold]Preparing offline bundle...[/bold]")
+        console.print("[dim]This downloads OCB + Go modules and verifies the bundle with a test build.[/dim]\n")
+
+        try:
+            result = subprocess.run(
+                ["bash", str(script_path), "prepare"],
+                cwd=script_path.parent.parent,
+            )
+            if result.returncode == 0:
+                console.print("\n[green]✓ Offline bundle ready.[/green]")
+                console.print("\n[bold]Next steps:[/bold]")
+                console.print("  1. Transfer [cyan]ccwb-offline-go-bundle.tar.gz[/cyan] to the air-gapped machine")
+                console.print("  2. Extract: [cyan]tar xzf ccwb-offline-go-bundle.tar.gz[/cyan]")
+                console.print("  3. Install: [cyan]./scripts/prepare-offline-go-bundle.sh install[/cyan]")
+                console.print("  4. Source env: [cyan]source ccwb-offline-go-bundle/offline-env.sh[/cyan]")
+                console.print("  5. Build: [cyan]poetry run ccwb package[/cyan]")
+            return result.returncode
+        except FileNotFoundError:
+            console.print("[red]bash not found. This command requires a Unix-like environment.[/red]")
+            return 1
 
     def _regenerate_installers(self, profile, profile_name: str, console: Console) -> int:
         """Regenerate installer scripts using existing binaries from the latest dist folder."""
@@ -4281,9 +4333,7 @@ Available metrics include:
                     # already resolved to http://localhost:4318 above; in central
                     # mode it is the ALB address from the profile/CloudFormation.
                     resource_attrs = otel_resource_attributes or (
-                        "department=default,team.id=default,"
-                        "cost_center=default,organization=default,"
-                        "project=default"
+                        "department=default,team.id=default,cost_center=default,organization=default,project=default"
                     )
 
                     settings["env"].update(

--- a/source/tests/cli/commands/test_package.py
+++ b/source/tests/cli/commands/test_package.py
@@ -224,9 +224,7 @@ class TestPackageCommandOtelDefaults:
         command = PackageCommand()
         profile = self._make_monitoring_profile()
 
-        fake_outputs = json.dumps(
-            [{"OutputKey": "CollectorEndpoint", "OutputValue": "https://otel.example.com"}]
-        )
+        fake_outputs = json.dumps([{"OutputKey": "CollectorEndpoint", "OutputValue": "https://otel.example.com"}])
         completed = MagicMock(returncode=0, stdout=fake_outputs)
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -265,6 +263,8 @@ class TestPackageCommandOtelDefaults:
         attrs = settings["env"]["OTEL_RESOURCE_ATTRIBUTES"]
 
         assert attrs == "department=research,team.id=ml"
+
+
 class TestCopyExtraFiles:
     """Tests for _copy_extra_files — the package-side extra-files copy step."""
 


### PR DESCRIPTION
## Summary

Adds `ccwb package --prepare-offline` for admins building in air-gapped/offline environments. This makes the offline bundling workflow discoverable via `--help` instead of requiring knowledge of a standalone script.

## What it does

`ccwb package` requires internet for two things:
1. **OCB binary** — downloaded from GitHub Releases if not cached
2. **Go modules** — OCB generates a fresh Go module at build time and runs `go mod tidy` (cannot be pre-vendored)

The `--prepare-offline` flag (run on a connected machine) prepares a bundle that pre-seeds both:
- OCB binary at `~/.cache/ocb/` (where `package.py` checks before downloading)
- Complete Go module cache with `GOPROXY=off` verification

On the air-gapped machine, extracting the bundle + sourcing `offline-env.sh` makes `ccwb package` work with zero network access.

## Changes

- **`package.py`**: New `--prepare-offline` flag + `_prepare_offline_bundle()` method (thin wrapper calling the script). Also adds network-error hint when OCB download fails.
- **`scripts/prepare-offline-go-bundle.sh`**: Standalone script implementing prepare/install workflow with self-verifying test build.
- **`CLI_REFERENCE.md`**: Updated docs showing the flag-based workflow.

## Testing

- All 1658 tests pass (0 failures)
- Purely additive — no changes to existing build paths
- Online builds are completely unaffected

## Credits

Based on the work by @wantmys2000 in #750, with the following improvements:
- Exposed as `--prepare-offline` flag for discoverability (vs standalone script only)
- Added error hint when OCB download fails suggesting the flag
- Supersedes #750

Co-authored-by: wantmys2000 <wantmys2000@users.noreply.github.com>