### PR TITLE
fix(quota): aggregate token usage with sum_over_time, not increase (delta metric)

### DIFF
--- a/deployment/infrastructure/lambda-functions/quota_monitor/index.py
+++ b/deployment/infrastructure/lambda-functions/quota_monitor/index.py
@@ -81,22 +81,38 @@ TOKEN_TYPE_TO_RATE_KEY = {
 
 
 def fetch_usage_from_promql():
-    """Query PromQL for per-user token usage in the last aggregation window only."""
+    """Query PromQL for per-user token usage in the last aggregation window only.
+
+    Aggregation MUST use sum_over_time(), NOT increase(). Claude Code exports
+    ``claude_code.token.usage`` as an OpenTelemetry Counter with DELTA temporality
+    by default (OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta): each
+    datapoint is the tokens emitted since the last export, so the series steps up
+    AND down (a sawtooth). increase() assumes CUMULATIVE temporality (a monotonic
+    running total) and reads every down-step as a counter reset — it returns empty
+    or wildly understated results, which froze DynamoDB and surfaced as
+    "Daily Tokens: 0" in `ccwb quota usage`. sum_over_time() sums the per-interval
+    deltas in the window = tokens used in the last 15 minutes, matching how the
+    Athena/CloudWatch consumers compute usage.
+
+    Coupling: this is correct only while the metric is exported with delta
+    temporality. If a deployment sets the temporality preference to `cumulative`,
+    increase() would become the correct function instead.
+    """
     window = AGGREGATION_WINDOW
 
     # Delta tokens per user in the last window
     results = _promql_query(
-        f'sum by ("user.email")(increase({{"claude_code.token.usage"}}[{window}s]))'
+        f'sum by ("user.email")(sum_over_time({{"claude_code.token.usage"}}[{window}s]))'
     )
 
     # Delta token type AND model breakdown per user (for cost calculation)
     type_model_results = _promql_query(
-        f'sum by ("user.email", type, model)(increase({{"claude_code.token.usage"}}[{window}s]))'
+        f'sum by ("user.email", type, model)(sum_over_time({{"claude_code.token.usage"}}[{window}s]))'
     )
 
     # Delta token type breakdown per user (without model, for backward compat)
     type_results = _promql_query(
-        f'sum by ("user.email", type)(increase({{"claude_code.token.usage"}}[{window}s]))'
+        f'sum by ("user.email", type)(sum_over_time({{"claude_code.token.usage"}}[{window}s]))'
     )
 
     users = {}
@@ -149,11 +165,13 @@ def fetch_usage_from_promql():
     # per-user metrics into the ClaudeCoWork namespace with user_email dimension.
     # This ensures CoWork token consumption counts toward the same quota as Claude Code.
     try:
+        # CoWork metrics are MetricFilter-derived per-event token counts (delta,
+        # not cumulative) — use sum_over_time() for the same reason as above.
         cowork_input = _promql_query(
-            f'sum by ("user_email", "model")(increase({{"ClaudeCoWork","token.usage.input"}}[{window}s]))'
+            f'sum by ("user_email", "model")(sum_over_time({{"ClaudeCoWork","token.usage.input"}}[{window}s]))'
         )
         cowork_output = _promql_query(
-            f'sum by ("user_email", "model")(increase({{"ClaudeCoWork","token.usage.output"}}[{window}s]))'
+            f'sum by ("user_email", "model")(sum_over_time({{"ClaudeCoWork","token.usage.output"}}[{window}s]))'
         )
         cowork_count = 0
         for r in cowork_input + cowork_output:

--- a/source/tests/test_quota_monitor_lambda.py
+++ b/source/tests/test_quota_monitor_lambda.py
@@ -228,3 +228,67 @@ class TestCostEstimateTokenTypes:
         ]
         users = self._run_cost(mod, vector)
         assert users["a@b.com"]["cost_usd"] == pytest.approx(5.00 + 25.00 + 0.50 + 6.25)
+
+
+class TestPromQLAggregationFunction:
+    """Regression: token.usage is a Counter exported with DELTA temporality.
+
+    increase() assumes cumulative temporality and misreads the delta sawtooth's
+    down-steps as counter resets, returning empty/understated results. That froze
+    the DynamoDB row and surfaced as "Daily Tokens: 0" in `ccwb quota usage` while
+    Athena/CloudWatch (which sum the deltas) stayed correct. Aggregation MUST use
+    sum_over_time(). The existing tests mock fetch_usage_from_promql out entirely,
+    so the query construction — where the bug lived — was never exercised.
+    """
+
+    def _capture_queries(self, mod, primary_total="531643"):
+        """Monkeypatch _promql_query to record every query string it receives.
+
+        Returns the list that accumulates the queries. Only the primary
+        per-user total query gets a non-empty vector so the aggregation has
+        something to fold in; the rest return empty so cost/CoWork paths no-op.
+        """
+        captured = []
+
+        def fake_query(query, time_param=None):
+            captured.append(query)
+            is_primary = 'sum by ("user.email")' in query and ", type" not in query and ", model" not in query
+            if is_primary and "claude_code.token.usage" in query:
+                return [{"metric": {"user.email": "a@b.com"}, "value": [0, primary_total]}]
+            return []
+
+        mod._promql_query = fake_query
+        return captured
+
+    def test_claude_code_queries_use_sum_over_time_not_increase(self, base_env):
+        mod = _load_quota_monitor(base_env)
+        captured = self._capture_queries(mod)
+
+        mod.fetch_usage_from_promql()
+
+        cc_queries = [q for q in captured if "claude_code.token.usage" in q]
+        assert cc_queries, "expected at least one claude_code.token.usage query"
+        for q in cc_queries:
+            assert "sum_over_time(" in q, f"delta metric must use sum_over_time: {q}"
+            assert "increase(" not in q, f"increase() is wrong for a delta metric: {q}"
+
+    def test_cowork_queries_use_sum_over_time_not_increase(self, base_env):
+        mod = _load_quota_monitor(base_env)
+        captured = self._capture_queries(mod)
+
+        mod.fetch_usage_from_promql()
+
+        cowork_queries = [q for q in captured if "ClaudeCoWork" in q]
+        assert cowork_queries, "expected CoWork token.usage queries"
+        for q in cowork_queries:
+            assert "sum_over_time(" in q, f"CoWork delta metric must use sum_over_time: {q}"
+            assert "increase(" not in q, f"increase() is wrong for a delta metric: {q}"
+
+    def test_aggregated_total_flows_through(self, base_env):
+        """A non-empty primary vector must be recorded (not skipped as delta<=0)."""
+        mod = _load_quota_monitor(base_env)
+        self._capture_queries(mod, primary_total="531643")
+
+        users = mod.fetch_usage_from_promql()
+
+        assert users.get("a@b.com", {}).get("total_tokens") == 531643


### PR DESCRIPTION
## Description

The quota-monitor Lambda (`claude-code-quota-monitor`) aggregates per-user token usage every 15 minutes and writes it to the `UserQuotaMetrics` DynamoDB table that `ccwb quota usage` reads and that monthly/daily quota enforcement is based on. It was querying CloudWatch's PromQL-compatible API with `increase()` over `claude_code.token.usage`. This PR switches the aggregation to `sum_over_time()`.

## Why is this change needed

`claude_code.token.usage` is an OpenTelemetry **Counter** that Claude Code exports with **DELTA temporality by default** (`OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta` — see [Claude Code monitoring docs](https://code.claude.com/docs/en/monitoring-usage)). With delta temporality, each exported datapoint is the tokens emitted **since the last export**, so the series steps up **and** down (a sawtooth) — it is *not* a cumulative running total.

`increase()` is only valid for series with **cumulative** temporality (a monotonically-increasing counter that resets to 0 on process restart). Fed a delta series, `increase()` interprets every down-step as a counter reset and applies bogus "reset compensation," so it returns **empty results or wildly understated values** depending on the exact arrangement of samples in the window. CloudWatch's PromQL API even returns an advisory warning for this exact case:

```
PromQL info: metric might not be a counter, name does not end in _total/_sum/_count/_bucket: "claude_code.token.usage"
```

### User-visible impact

When `increase()` returned empty/zero for a user in a given 15-minute cycle, `update_quota_metrics()` hit its `if delta <= 0: continue` guard and **skipped the DynamoDB write entirely**. That had two effects:

1. **`total_tokens` (monthly) froze** and was systematically undercounted — so monthly quota enforcement was too lax.
2. **`daily_date` was never advanced to the current day**, so the read path's stale-day guard (in both `quota.py` and the Lambda's `_build_usage_entry`) correctly zeroed the daily counter — surfacing as **`Daily Tokens: 0`** in `ccwb quota usage` even for an actively-used account.

Because `increase()`'s output depends on the shape of samples in the sliding window, the command's numbers appeared to update **intermittently** (a cycle that happened to land on a rising window would write a small value and refresh `daily_date`; the next cycle would write nothing) — which made the bug look flaky rather than systematic.

Meanwhile the other consumers were **correct the whole time**, because they sum the per-interval delta values directly:
- **Grafana dashboards** (via Athena — the OTEL logs exported to S3, `SUM(...)`)
- **CloudWatch metric** queried with the `Sum` statistic
- Claude Code's own `/usage`

Only the quota Lambda tried to reconstruct a total with `increase()`, and that was the sole broken link.

Fixes # <!-- link the tracking issue if one is opened -->

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `deployment/infrastructure/lambda-functions/quota_monitor/index.py`
  - Replaced `increase(...)` with `sum_over_time(...)` in all three `claude_code.token.usage` queries (per-user total; type+model breakdown for cost; type-only breakdown for input/output/cache).
  - Replaced `increase(...)` with `sum_over_time(...)` in both `ClaudeCoWork` `token.usage.input/output` queries (also delta, MetricFilter-derived per-event counts).
  - Added a docstring/comment explaining the delta-vs-cumulative temporality reasoning and the coupling caveat (see below).
- `source/tests/test_quota_monitor_lambda.py`
  - Added `TestPromQLAggregationFunction` with a regression test that monkeypatches `_promql_query` to capture the generated query strings and asserts `sum_over_time(` (never `increase(`) for both the Claude Code and CoWork metrics, plus a test that a non-empty vector flows through the aggregation.

## Additional Notes

**Temporality coupling (documented in-code):** `sum_over_time()` is correct **as long as** the metric is exported with delta temporality (Claude Code's default). If a deployment sets `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=cumulative`, then `increase()` would become the correct function instead. This is noted in the function docstring so the two never drift.

**Window-boundary tiling:** `sum_over_time([900s])` sums every datapoint in the trailing 900s window, and the EventBridge schedule is also `rate(15 minutes)`. Scheduler jitter (~sub-second) could in theory double-count or miss a datapoint at a window boundary; this is negligible (well under 1%) compared to the ~10x undercount being fixed. A follow-up could pin the query to a fixed grid via the already-present-but-unused `time_param` argument on `_promql_query()` if exact tiling is ever required.

**Existing data:** month-to-date `total_tokens` for existing deployments was undercounted while `increase()` was in effect. This PR fixes forward (correct going forward). Operators who want the historical month corrected can backfill the `MONTH#<month>` rows from Athena/CloudWatch (`SUM`/`sum_over_time` over the month) — out of scope for this PR.

**Diagnosis method (reproducible):** against a live account, the same 900s window returned an empty/tiny vector for `increase()` while `sum_over_time()` returned the real total that matched Grafana/CloudWatch. Anyone can reproduce with a SigV4-signed POST to `https://monitoring.<region>.amazonaws.com/api/v1/query`:

```bash
# understated / empty (old behavior):
query=sum by ("user.email")(increase({"claude_code.token.usage"}[900s]))
# correct (new behavior):
query=sum by ("user.email")(sum_over_time({"claude_code.token.usage"}[900s]))
```

## Testing Checklist

### What was tested

- [x] Unit/integration tests pass

### Special cases

- [x] n/a

## Testing Evidence

**Test Environment:** Python 3.12, macOS; PromQL diagnosis run against `us-east-1`.

**Test Results:**

Red/green verified — the new regression tests fail against the old `increase()` code and pass with the fix:

```text
# Against the ORIGINAL (increase()) code — new tests correctly FAIL:
FAILED tests/test_quota_monitor_lambda.py::TestPromQLAggregationFunction::test_claude_code_queries_use_sum_over_time_not_increase
FAILED tests/test_quota_monitor_lambda.py::TestPromQLAggregationFunction::test_cowork_queries_use_sum_over_time_not_increase
AssertionError: CoWork delta metric must use sum_over_time:
  sum by ("user_email", "model")(increase({"ClaudeCoWork","token.usage.input"}[900s]))

# With the fix applied — all pass:
$ poetry run pytest tests/test_quota_monitor_lambda.py -q
.......                                                                  [100%]
7 passed in 0.27s

$ ruff check tests/test_quota_monitor_lambda.py
All checks passed!
$ ruff format --check tests/test_quota_monitor_lambda.py
1 file already formatted
```
