### PR TITLE
fix(quota): price cache-write (cacheCreation) tokens in cost estimate

### DIFF
--- a/deployment/infrastructure/lambda-functions/quota_monitor/index.py
+++ b/deployment/infrastructure/lambda-functions/quota_monitor/index.py
@@ -67,6 +67,18 @@ def _promql_query(query, time_param=None):
 
 AGGREGATION_WINDOW = 900  # 15 minutes in seconds (matches EventBridge schedule)
 
+# Map the metric's `type` dimension values to pricing.py rate keys.
+# The CloudWatch `type` dimension is camelCase (input/output/cacheRead/
+# cacheCreation); the rate tables in shared/pricing.py are snake_case
+# (input/output/cache_read/cache_write). cacheCreation (cache-write) is usually
+# the majority of tokens, so a missing mapping silently drops most of the cost.
+TOKEN_TYPE_TO_RATE_KEY = {
+    "input": "input",
+    "output": "output",
+    "cacheRead": "cache_read",
+    "cacheCreation": "cache_write",
+}
+
 
 def fetch_usage_from_promql():
     """Query PromQL for per-user token usage in the last aggregation window only."""
@@ -123,7 +135,7 @@ def fetch_usage_from_promql():
                 u = users.setdefault(email, {})
                 family = resolve_model_family(model)
                 family_rates = rates.get(family, rates.get("sonnet", {}))
-                rate = family_rates.get(token_type.replace("cacheRead", "cache_read"), 0)
+                rate = family_rates.get(TOKEN_TYPE_TO_RATE_KEY.get(token_type, token_type), 0)
                 cost_delta = (val / 1_000_000) * rate
                 u["cost_usd"] = u.get("cost_usd", 0) + cost_delta
     except Exception as e:

--- a/source/tests/test_quota_monitor_lambda.py
+++ b/source/tests/test_quota_monitor_lambda.py
@@ -166,3 +166,65 @@ class TestStaleDailyReset:
         }
         entry = mod._build_usage_entry(item, _today())
         assert entry["daily_tokens"] == 3_355_533
+
+
+class TestCostEstimateTokenTypes:
+    """Regression: cost must price all four token types, including cacheCreation.
+
+    The metric's `type` dimension is camelCase (input/output/cacheRead/
+    cacheCreation) but the rate tables use snake_case keys (input/output/
+    cache_read/cache_write). The old code only rewrote cacheRead->cache_read, so
+    cacheCreation looked up a non-existent key and priced at $0 — dropping the
+    cache-write share of the cost, which is usually the majority of tokens.
+    """
+
+    def _run_cost(self, mod, type_model_vector):
+        """Drive fetch_usage_from_promql with a canned type+model breakdown.
+
+        Only the (user.email, type, model) query returns data; the primary
+        total, type-only, and CoWork queries return empty so we isolate the
+        cost calculation. Returns the users dict.
+        """
+
+        def fake_query(query, time_param=None):
+            if ", type, model)" in query and "claude_code.token.usage" in query:
+                return type_model_vector
+            return []
+
+        mod._promql_query = fake_query
+        return mod.fetch_usage_from_promql()
+
+    def test_cache_creation_is_priced(self, base_env):
+        """A cacheCreation-only breakdown must produce a non-zero cost."""
+        mod = _load_quota_monitor(base_env)
+        # opus cache_write rate = 6.25 / 1M tokens; 1,000,000 tokens -> $6.25
+        vector = [
+            {
+                "metric": {"user.email": "a@b.com", "type": "cacheCreation", "model": "claude-opus-4-8"},
+                "value": [0, "1000000"],
+            }
+        ]
+        users = self._run_cost(mod, vector)
+        assert users["a@b.com"]["cost_usd"] == pytest.approx(6.25)
+
+    def test_all_four_types_priced(self, base_env):
+        """input/output/cacheRead/cacheCreation each contribute to the cost."""
+        mod = _load_quota_monitor(base_env)
+        # opus rates per 1M: input 5.00, output 25.00, cache_read 0.50, cache_write 6.25
+        vector = [
+            {"metric": {"user.email": "a@b.com", "type": "input", "model": "claude-opus-4-8"}, "value": [0, "1000000"]},
+            {
+                "metric": {"user.email": "a@b.com", "type": "output", "model": "claude-opus-4-8"},
+                "value": [0, "1000000"],
+            },
+            {
+                "metric": {"user.email": "a@b.com", "type": "cacheRead", "model": "claude-opus-4-8"},
+                "value": [0, "1000000"],
+            },
+            {
+                "metric": {"user.email": "a@b.com", "type": "cacheCreation", "model": "claude-opus-4-8"},
+                "value": [0, "1000000"],
+            },
+        ]
+        users = self._run_cost(mod, vector)
+        assert users["a@b.com"]["cost_usd"] == pytest.approx(5.00 + 25.00 + 0.50 + 6.25)


### PR DESCRIPTION
## Description

The quota-monitor Lambda (`claude-code-quota-monitor`) estimates per-user cost from the model-aware token breakdown it pulls from CloudWatch. This PR fixes a token-type→rate-key mapping bug that caused **cache-write (`cacheCreation`) tokens to be priced at $0**, understating `estimated_cost` / `daily_cost_usd`.

## Why is this change needed

The `claude_code.token.usage` metric's `type` dimension uses camelCase values — `input`, `output`, `cacheRead`, `cacheCreation` — while the rate tables in `shared/pricing.py` use snake_case keys — `input`, `output`, `cache_read`, `cache_write`.

The cost loop mapped between them with a single string replace:

```python
rate = family_rates.get(token_type.replace("cacheRead", "cache_read"), 0)
```

That only handles `cacheRead → cache_read`. `cacheCreation` was passed through unchanged, so `family_rates.get("cacheCreation", 0)` missed (the key is `cache_write`) and defaulted the rate to **0**. Every other type was priced correctly; only cache-write silently contributed nothing.

Cache-write is typically the **majority** of a session's tokens (cache creation dominates in agentic/coding workloads), so the cost estimate was understated by the cache-write share. Worked example for an ~23K-token opus request (≈77% cache-write):

| type | tokens | correct $ | old (buggy) $ |
|---|--:|--:|--:|
| input | 3,710 | 0.0186 | 0.0186 |
| output | 1,600 | 0.0400 | 0.0400 |
| cacheRead | 0 | 0.0000 | 0.0000 |
| **cacheCreation** | 17,910 | **0.1119** | **0.0000** ❌ |
| **total** | | **$0.170** | **$0.059** (≈34% — missing ~66%) |

The token *quota* counter (`total_tokens`) was never affected — that query has no `type` filter and sums all four types. This bug is isolated to the **cost** figure, which is informational today but would be materially wrong if cost-based enforcement were enabled.

Fixes # <!-- link the tracking issue if one is opened -->

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `deployment/infrastructure/lambda-functions/quota_monitor/index.py`
  - Added an explicit `TOKEN_TYPE_TO_RATE_KEY` mapping (`input→input`, `output→output`, `cacheRead→cache_read`, `cacheCreation→cache_write`).
  - Used it for the per-type rate lookup in the cost calculation, replacing the `cacheRead`-only string replace.
- `source/tests/test_quota_monitor_lambda.py`
  - Added `TestCostEstimateTokenTypes`: feeds a `type+model` breakdown (including `cacheCreation`) through the real cost loop and asserts (a) a `cacheCreation`-only breakdown produces a non-zero cost and (b) all four token types contribute to `cost_usd`.

## Additional Notes

- The CoWork 3P cost path only handles `input`/`output` (its metrics have no cache dimensions), so it is unaffected.
- Not touched here: the informational per-type breakdown attributes (`input_tokens`/`output_tokens`/`cache_tokens`) still omit a dedicated cache-write field. That is cosmetic — the enforced `total_tokens` already includes cache-write — and out of scope for this cost fix.

## Testing Checklist

### What was tested

- [x] Unit/integration tests pass

## Testing Evidence

**Test Environment:** Python 3.12, macOS.

**Test Results:**

Red/green verified — the new tests fail against the old mapping and pass with the fix:

```text
# Against the ORIGINAL code (cacheCreation -> rate 0) — new tests correctly FAIL:
FAILED tests/test_quota_monitor_lambda.py::TestCostEstimateTokenTypes::test_cache_creation_is_priced
FAILED tests/test_quota_monitor_lambda.py::TestCostEstimateTokenTypes::test_all_four_types_priced
  assert 30.5 == 36.75 ± 3.7e-05     # missing the $6.25 opus cache-write rate

# With the fix applied — all pass:
$ poetry run pytest tests/test_quota_monitor_lambda.py -q
......                                                                   [100%]
6 passed in 0.22s

$ ruff check tests/test_quota_monitor_lambda.py     # All checks passed!
$ ruff format --check tests/test_quota_monitor_lambda.py     # already formatted
```
