### PR TITLE
feat(auth): attach existing IAM managed policies to the federated role

### DIFF
--- a/assets/docs/CLI_REFERENCE.md
+++ b/assets/docs/CLI_REFERENCE.md
@@ -85,6 +85,10 @@ poetry run ccwb init [options]
 - Prompts for authentication method selection:
   - Direct IAM: Uses IAM OIDC Provider for federation
   - Cognito: Uses Cognito Identity Pool for federation
+- Prompts for additional IAM managed policy ARNs to attach to the federated role (optional):
+  - Attach existing customer-managed guardrail policies (for example, an IP-restriction policy that denies requests unless `aws:SourceIp` matches your corporate CIDR ranges)
+  - Policies must already exist in the deployment account; they are attached alongside the stack-created Bedrock access policy
+  - IAM allows at most 10 managed policies per role by default (quota increase possible up to 20)
 - Configures AWS settings (region, stack names)
 - Prompts for Claude model selection (Opus, Sonnet, Haiku)
 - Configures cross-region inference profiles (US, Europe, APAC)

--- a/assets/docs/DEPLOYMENT.md
+++ b/assets/docs/DEPLOYMENT.md
@@ -36,6 +36,8 @@ The `ccwb` (Claude Code with Bedrock) CLI tool guides you through deployment wit
 
 The wizard asks you to choose an authentication method. You can select either Direct IAM federation or Cognito Identity Pool based on your organization's requirements. Both methods provide secure OIDC federation to AWS credentials.
 
+The wizard also lets you attach additional IAM managed policies to the federated role. If your organization requires extra guardrails — for example, an IP-restriction policy that denies access unless `aws:SourceIp` matches your corporate network ranges — create that policy in the deployment account first, then supply its ARN (comma-separate multiple ARNs) when prompted. The deploy step attaches the policies alongside the generated Bedrock access policy, so they stay managed by CloudFormation instead of manual console edits.
+
 Next, you'll select your Claude model and configure regional access. Choose from available Claude models (Opus, Sonnet, Haiku) and select a cross-region inference profile (US, Europe, or APAC) for optimal performance. The wizard will then prompt you to select a source region within your chosen profile for model inference. Finally, choose where to deploy the authentication infrastructure (typically your primary AWS region) and configure optional monitoring setup, which provides usage analytics and cost tracking through OpenTelemetry.
 
 Once configuration is complete, deploy the infrastructure with:

--- a/deployment/infrastructure/bedrock-auth-auth0.yaml
+++ b/deployment/infrastructure/bedrock-auth-auth0.yaml
@@ -57,7 +57,15 @@ Parameters:
       - 'false'
     Description: Enable CloudWatch monitoring for Bedrock usage
 
+  AdditionalManagedPolicyArns:
+    Type: String
+    Default: ''
+    Description: Comma-separated ARNs of existing IAM managed policies to attach to the federated role (e.g. an IP-restriction policy). Leave empty to skip.
+    AllowedPattern: '^$|^arn:[a-z-]+:iam::(\d{12}|aws):policy/\S+(,arn:[a-z-]+:iam::(\d{12}|aws):policy/\S+)*$'
+    ConstraintDescription: Must be empty or a comma-separated list of IAM managed policy ARNs
+
 Conditions:
+  HasAdditionalManagedPolicies: !Not [!Equals [!Ref AdditionalManagedPolicyArns, '']]
   UseDirectIAM: !Equals [!Ref FederationType, direct]
   UseCognitoIdentity: !Equals [!Ref FederationType, cognito]
   MonitoringEnabled: !Equals [!Ref EnableMonitoring, 'true']
@@ -171,8 +179,10 @@ Resources:
             Action:
               - 'sts:AssumeRoleWithWebIdentity'
               - 'sts:TagSession'
-      ManagedPolicyArns:
-        - !Ref BedrockAccessPolicy
+      ManagedPolicyArns: !If
+        - HasAdditionalManagedPolicies
+        - !Split [',', !Join [',', [!Ref BedrockAccessPolicy, !Ref AdditionalManagedPolicyArns]]]
+        - - !Ref BedrockAccessPolicy
       Tags:
         - Key: Purpose
           Value: Claude Code Direct IAM Authentication
@@ -231,8 +241,10 @@ Resources:
                     - IsGovCloudEast
                     - 'cognito-identity.us-gov-east-1.amazonaws.com:amr': authenticated
                     - 'cognito-identity.amazonaws.com:amr': authenticated
-      ManagedPolicyArns:
-        - !Ref BedrockAccessPolicy
+      ManagedPolicyArns: !If
+        - HasAdditionalManagedPolicies
+        - !Split [',', !Join [',', [!Ref BedrockAccessPolicy, !Ref AdditionalManagedPolicyArns]]]
+        - - !Ref BedrockAccessPolicy
       Tags:
         - Key: Purpose
           Value: Claude Code Cognito Authentication

--- a/deployment/infrastructure/bedrock-auth-azure.yaml
+++ b/deployment/infrastructure/bedrock-auth-azure.yaml
@@ -49,7 +49,15 @@ Parameters:
       - 'false'
     Description: Enable CloudWatch monitoring for Bedrock usage
 
+  AdditionalManagedPolicyArns:
+    Type: String
+    Default: ''
+    Description: Comma-separated ARNs of existing IAM managed policies to attach to the federated role (e.g. an IP-restriction policy). Leave empty to skip.
+    AllowedPattern: '^$|^arn:[a-z-]+:iam::(\d{12}|aws):policy/\S+(,arn:[a-z-]+:iam::(\d{12}|aws):policy/\S+)*$'
+    ConstraintDescription: Must be empty or a comma-separated list of IAM managed policy ARNs
+
 Conditions:
+  HasAdditionalManagedPolicies: !Not [!Equals [!Ref AdditionalManagedPolicyArns, '']]
   UseDirectIAM: !Equals [!Ref FederationType, direct]
   UseCognitoIdentity: !Equals [!Ref FederationType, cognito]
   MonitoringEnabled: !Equals [!Ref EnableMonitoring, 'true']
@@ -163,8 +171,10 @@ Resources:
             Action:
               - 'sts:AssumeRoleWithWebIdentity'
               - 'sts:TagSession'
-      ManagedPolicyArns:
-        - !Ref BedrockAccessPolicy
+      ManagedPolicyArns: !If
+        - HasAdditionalManagedPolicies
+        - !Split [',', !Join [',', [!Ref BedrockAccessPolicy, !Ref AdditionalManagedPolicyArns]]]
+        - - !Ref BedrockAccessPolicy
       Tags:
         - Key: Purpose
           Value: Claude Code Direct IAM Authentication
@@ -223,8 +233,10 @@ Resources:
                     - IsGovCloudEast
                     - 'cognito-identity.us-gov-east-1.amazonaws.com:amr': authenticated
                     - 'cognito-identity.amazonaws.com:amr': authenticated
-      ManagedPolicyArns:
-        - !Ref BedrockAccessPolicy
+      ManagedPolicyArns: !If
+        - HasAdditionalManagedPolicies
+        - !Split [',', !Join [',', [!Ref BedrockAccessPolicy, !Ref AdditionalManagedPolicyArns]]]
+        - - !Ref BedrockAccessPolicy
       Tags:
         - Key: Purpose
           Value: Claude Code Cognito Authentication

--- a/deployment/infrastructure/bedrock-auth-cognito-pool.yaml
+++ b/deployment/infrastructure/bedrock-auth-cognito-pool.yaml
@@ -55,7 +55,15 @@ Parameters:
       - 'false'
     Description: Enable CloudWatch monitoring for Bedrock usage
 
+  AdditionalManagedPolicyArns:
+    Type: String
+    Default: ''
+    Description: Comma-separated ARNs of existing IAM managed policies to attach to the federated role (e.g. an IP-restriction policy). Leave empty to skip.
+    AllowedPattern: '^$|^arn:[a-z-]+:iam::(\d{12}|aws):policy/\S+(,arn:[a-z-]+:iam::(\d{12}|aws):policy/\S+)*$'
+    ConstraintDescription: Must be empty or a comma-separated list of IAM managed policy ARNs
+
 Conditions:
+  HasAdditionalManagedPolicies: !Not [!Equals [!Ref AdditionalManagedPolicyArns, '']]
   UseDirectIAM: !Equals [!Ref FederationType, direct]
   UseCognitoIdentity: !Equals [!Ref FederationType, cognito]
   MonitoringEnabled: !Equals [!Ref EnableMonitoring, 'true']
@@ -173,8 +181,10 @@ Resources:
             Action:
               - 'sts:AssumeRoleWithWebIdentity'
               - 'sts:TagSession'
-      ManagedPolicyArns:
-        - !Ref BedrockAccessPolicy
+      ManagedPolicyArns: !If
+        - HasAdditionalManagedPolicies
+        - !Split [',', !Join [',', [!Ref BedrockAccessPolicy, !Ref AdditionalManagedPolicyArns]]]
+        - - !Ref BedrockAccessPolicy
       Tags:
         - Key: Purpose
           Value: Claude Code Direct IAM Authentication
@@ -239,8 +249,10 @@ Resources:
                     - IsGovCloudEast
                     - 'cognito-identity.us-gov-east-1.amazonaws.com:amr': authenticated
                     - 'cognito-identity.amazonaws.com:amr': authenticated
-      ManagedPolicyArns:
-        - !Ref BedrockAccessPolicy
+      ManagedPolicyArns: !If
+        - HasAdditionalManagedPolicies
+        - !Split [',', !Join [',', [!Ref BedrockAccessPolicy, !Ref AdditionalManagedPolicyArns]]]
+        - - !Ref BedrockAccessPolicy
       Tags:
         - Key: Purpose
           Value: Claude Code Cognito Authentication

--- a/deployment/infrastructure/bedrock-auth-generic.yaml
+++ b/deployment/infrastructure/bedrock-auth-generic.yaml
@@ -53,7 +53,15 @@ Parameters:
       - 'false'
     Description: Enable CloudWatch monitoring for Bedrock usage
 
+  AdditionalManagedPolicyArns:
+    Type: String
+    Default: ''
+    Description: Comma-separated ARNs of existing IAM managed policies to attach to the federated role (e.g. an IP-restriction policy). Leave empty to skip.
+    AllowedPattern: '^$|^arn:[a-z-]+:iam::(\d{12}|aws):policy/\S+(,arn:[a-z-]+:iam::(\d{12}|aws):policy/\S+)*$'
+    ConstraintDescription: Must be empty or a comma-separated list of IAM managed policy ARNs
+
 Conditions:
+  HasAdditionalManagedPolicies: !Not [!Equals [!Ref AdditionalManagedPolicyArns, '']]
   UseDirectIAM: !Equals [!Ref FederationType, direct]
   UseCognitoIdentity: !Equals [!Ref FederationType, cognito]
   MonitoringEnabled: !Equals [!Ref EnableMonitoring, 'true']
@@ -170,8 +178,10 @@ Resources:
             Action:
               - 'sts:AssumeRoleWithWebIdentity'
               - 'sts:TagSession'
-      ManagedPolicyArns:
-        - !Ref BedrockAccessPolicy
+      ManagedPolicyArns: !If
+        - HasAdditionalManagedPolicies
+        - !Split [',', !Join [',', [!Ref BedrockAccessPolicy, !Ref AdditionalManagedPolicyArns]]]
+        - - !Ref BedrockAccessPolicy
       Tags:
         - Key: Purpose
           Value: Claude Code Direct IAM Authentication
@@ -230,8 +240,10 @@ Resources:
                     - IsGovCloudEast
                     - 'cognito-identity.us-gov-east-1.amazonaws.com:amr': authenticated
                     - 'cognito-identity.amazonaws.com:amr': authenticated
-      ManagedPolicyArns:
-        - !Ref BedrockAccessPolicy
+      ManagedPolicyArns: !If
+        - HasAdditionalManagedPolicies
+        - !Split [',', !Join [',', [!Ref BedrockAccessPolicy, !Ref AdditionalManagedPolicyArns]]]
+        - - !Ref BedrockAccessPolicy
       Tags:
         - Key: Purpose
           Value: Claude Code Cognito Authentication

--- a/deployment/infrastructure/bedrock-auth-google.yaml
+++ b/deployment/infrastructure/bedrock-auth-google.yaml
@@ -50,7 +50,15 @@ Parameters:
       - 'false'
     Description: Enable CloudWatch monitoring for Bedrock usage
 
+  AdditionalManagedPolicyArns:
+    Type: String
+    Default: ''
+    Description: Comma-separated ARNs of existing IAM managed policies to attach to the federated role (e.g. an IP-restriction policy). Leave empty to skip.
+    AllowedPattern: '^$|^arn:[a-z-]+:iam::(\d{12}|aws):policy/\S+(,arn:[a-z-]+:iam::(\d{12}|aws):policy/\S+)*$'
+    ConstraintDescription: Must be empty or a comma-separated list of IAM managed policy ARNs
+
 Conditions:
+  HasAdditionalManagedPolicies: !Not [!Equals [!Ref AdditionalManagedPolicyArns, '']]
   UseDirectIAM: !Equals [!Ref FederationType, direct]
   UseCognitoIdentity: !Equals [!Ref FederationType, cognito]
   MonitoringEnabled: !Equals [!Ref EnableMonitoring, 'true']
@@ -176,8 +184,10 @@ Resources:
             Condition:
               StringEquals:
                 'accounts.google.com:aud': !Ref GoogleClientId
-      ManagedPolicyArns:
-        - !Ref BedrockAccessPolicy
+      ManagedPolicyArns: !If
+        - HasAdditionalManagedPolicies
+        - !Split [',', !Join [',', [!Ref BedrockAccessPolicy, !Ref AdditionalManagedPolicyArns]]]
+        - - !Ref BedrockAccessPolicy
       Tags:
         - Key: Purpose
           Value: Claude Code Direct IAM Authentication
@@ -236,8 +246,10 @@ Resources:
                     - IsGovCloudEast
                     - 'cognito-identity.us-gov-east-1.amazonaws.com:amr': authenticated
                     - 'cognito-identity.amazonaws.com:amr': authenticated
-      ManagedPolicyArns:
-        - !Ref BedrockAccessPolicy
+      ManagedPolicyArns: !If
+        - HasAdditionalManagedPolicies
+        - !Split [',', !Join [',', [!Ref BedrockAccessPolicy, !Ref AdditionalManagedPolicyArns]]]
+        - - !Ref BedrockAccessPolicy
       Tags:
         - Key: Purpose
           Value: Claude Code Cognito Authentication

--- a/deployment/infrastructure/bedrock-auth-idc.yaml
+++ b/deployment/infrastructure/bedrock-auth-idc.yaml
@@ -22,7 +22,15 @@ Parameters:
     AllowedValues: ['true', 'false']
     Description: Enable monitoring and logging capabilities
 
+  AdditionalManagedPolicyArns:
+    Type: String
+    Default: ''
+    Description: Comma-separated ARNs of existing IAM managed policies to attach to the federated role (e.g. an IP-restriction policy). Leave empty to skip.
+    AllowedPattern: '^$|^arn:[a-z-]+:iam::(\d{12}|aws):policy/\S+(,arn:[a-z-]+:iam::(\d{12}|aws):policy/\S+)*$'
+    ConstraintDescription: Must be empty or a comma-separated list of IAM managed policy ARNs
+
 Conditions:
+  HasAdditionalManagedPolicies: !Not [!Equals [!Ref AdditionalManagedPolicyArns, '']]
   MonitoringEnabled: !Equals [!Ref EnableMonitoring, 'true']
 
 Resources:
@@ -92,8 +100,10 @@ Resources:
             Condition:
               ArnLike:
                 'aws:PrincipalArn': !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/*'
-      ManagedPolicyArns:
-        - !Ref BedrockAccessPolicy
+      ManagedPolicyArns: !If
+        - HasAdditionalManagedPolicies
+        - !Split [',', !Join [',', [!Ref BedrockAccessPolicy, !Ref AdditionalManagedPolicyArns]]]
+        - - !Ref BedrockAccessPolicy
       # Optional CloudWatch access for monitoring
       Policies: !If
         - MonitoringEnabled

--- a/deployment/infrastructure/bedrock-auth-okta.yaml
+++ b/deployment/infrastructure/bedrock-auth-okta.yaml
@@ -59,7 +59,15 @@ Parameters:
       - 'false'
     Description: Enable CloudWatch monitoring for Bedrock usage
 
+  AdditionalManagedPolicyArns:
+    Type: String
+    Default: ''
+    Description: Comma-separated ARNs of existing IAM managed policies to attach to the federated role (e.g. an IP-restriction policy). Leave empty to skip.
+    AllowedPattern: '^$|^arn:[a-z-]+:iam::(\d{12}|aws):policy/\S+(,arn:[a-z-]+:iam::(\d{12}|aws):policy/\S+)*$'
+    ConstraintDescription: Must be empty or a comma-separated list of IAM managed policy ARNs
+
 Conditions:
+  HasAdditionalManagedPolicies: !Not [!Equals [!Ref AdditionalManagedPolicyArns, '']]
   UseDirectIAM: !Equals [!Ref FederationType, direct]
   UseCognitoIdentity: !Equals [!Ref FederationType, cognito]
   MonitoringEnabled: !Equals [!Ref EnableMonitoring, 'true']
@@ -172,8 +180,10 @@ Resources:
             Action:
               - 'sts:AssumeRoleWithWebIdentity'
               - 'sts:TagSession'
-      ManagedPolicyArns:
-        - !Ref BedrockAccessPolicy
+      ManagedPolicyArns: !If
+        - HasAdditionalManagedPolicies
+        - !Split [',', !Join [',', [!Ref BedrockAccessPolicy, !Ref AdditionalManagedPolicyArns]]]
+        - - !Ref BedrockAccessPolicy
       Tags:
         - Key: Purpose
           Value: Claude Code Direct IAM Authentication
@@ -232,8 +242,10 @@ Resources:
                     - IsGovCloudEast
                     - 'cognito-identity.us-gov-east-1.amazonaws.com:amr': authenticated
                     - 'cognito-identity.amazonaws.com:amr': authenticated
-      ManagedPolicyArns:
-        - !Ref BedrockAccessPolicy
+      ManagedPolicyArns: !If
+        - HasAdditionalManagedPolicies
+        - !Split [',', !Join [',', [!Ref BedrockAccessPolicy, !Ref AdditionalManagedPolicyArns]]]
+        - - !Ref BedrockAccessPolicy
       Tags:
         - Key: Purpose
           Value: Claude Code Cognito Authentication

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -846,6 +846,9 @@ class DeployCommand(Command):
                         f"AllowedBedrockRegions={','.join(bedrock_regions)}",
                         f"EnableMonitoring={str(profile.monitoring_enabled).lower()}",
                     ]
+                    extra_policies = getattr(profile, "additional_managed_policy_arns", None) or []
+                    if extra_policies:
+                        params.append(f"AdditionalManagedPolicyArns={','.join(extra_policies)}")
                     return deploy_with_cf(
                         template,
                         stack_name,
@@ -955,6 +958,9 @@ class DeployCommand(Command):
                         f"EnableMonitoring={str(profile.monitoring_enabled).lower()}",
                     ]
                 )
+                extra_policies = getattr(profile, "additional_managed_policy_arns", None) or []
+                if extra_policies:
+                    params.append(f"AdditionalManagedPolicyArns={','.join(extra_policies)}")
 
                 return deploy_with_cf(
                     template,
@@ -1602,6 +1608,7 @@ class DeployCommand(Command):
 
             stack_name = profile.stack_names.get("auth", f"{profile.identity_pool_name}-stack")
             auth_type = profile.effective_auth_type
+            extra_policies = getattr(profile, "additional_managed_policy_arns", None) or []
 
             if auth_type == "idc":
                 template = project_root / "deployment" / "infrastructure" / "bedrock-auth-idc.yaml"
@@ -1612,6 +1619,8 @@ class DeployCommand(Command):
                     f"AllowedBedrockRegions={','.join(bedrock_regions)}",
                     f"EnableMonitoring={str(profile.monitoring_enabled).lower()}",
                 ]
+                if extra_policies:
+                    params.append(f"AdditionalManagedPolicyArns={','.join(extra_policies)}")
                 print_deploy_cmd(template, stack_name, params, ["CAPABILITY_NAMED_IAM"])
             else:
                 provider_type = profile.provider_type or "okta"
@@ -1653,6 +1662,8 @@ class DeployCommand(Command):
                         f"EnableMonitoring={str(profile.monitoring_enabled).lower()}",
                     ]
                 )
+                if extra_policies:
+                    params.append(f"AdditionalManagedPolicyArns={','.join(extra_policies)}")
                 print_deploy_cmd(template, stack_name, params, ["CAPABILITY_NAMED_IAM"])
 
         elif stack_type == "networking":

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -27,6 +27,7 @@ from claude_code_with_bedrock.cli.utils.aws import (
 )
 from claude_code_with_bedrock.cli.utils.progress import WizardProgress
 from claude_code_with_bedrock.cli.utils.validators import (
+    validate_managed_policy_arns,
     validate_oidc_provider_domain,
 )
 from claude_code_with_bedrock.config import WEBSEARCH_SUPPORTED_REGIONS, Config, Profile
@@ -436,6 +437,9 @@ class InitCommand(Command):
             if permission_set is None:
                 return None
             config["idc_permission_set_name"] = permission_set.strip()
+
+            # Optional guardrail policies on the federated role
+            self._prompt_additional_policy_arns(config)
 
             console.print("\n[green]✓[/green] IAM Identity Center configured")
             console.print(f"  Start URL: {config['idc_start_url']}")
@@ -894,6 +898,9 @@ class InitCommand(Command):
                 default=str(_default_duration),
             ).ask()
             config["max_session_duration"] = int(duration_str) if duration_str else _default_duration
+
+            # Optional guardrail policies on the federated role
+            self._prompt_additional_policy_arns(config)
 
             # Save progress
             progress.save_step("oidc_complete", config)
@@ -2292,6 +2299,31 @@ class InitCommand(Command):
 
         return config
 
+    def _prompt_additional_policy_arns(self, config: dict) -> None:
+        """Prompt for existing IAM managed policy ARNs to attach to the federated role.
+
+        Optional guardrail hook (e.g. an IP-restriction policy). The policies
+        must already exist in the deployment account; deploy passes them to the
+        auth stack, which attaches them alongside the stack-created Bedrock
+        access policy. Cancel / non-interactive keeps the existing list.
+        """
+        console = Console()
+        existing = config.get("additional_managed_policy_arns", []) or []
+
+        console.print("\n[cyan]Additional IAM Policies[/cyan]")
+        console.print(
+            "Attach existing customer-managed policies to the federated role "
+            "(e.g. an IP-restriction policy). Leave empty to attach none."
+        )
+        answer = questionary.text(
+            "Additional managed policy ARNs (comma-separated, optional):",
+            default=",".join(existing),
+            validate=validate_managed_policy_arns,
+        ).ask()
+        if answer is None:
+            return  # cancelled — keep the existing list untouched
+        config["additional_managed_policy_arns"] = [a.strip() for a in answer.split(",") if a.strip()]
+
     def _configure_extra_files(self, existing: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Interactively add/edit/remove admin-defined extra files.
 
@@ -2788,6 +2820,7 @@ class InitCommand(Command):
             "oidc_thumbprint": config_data.get("oidc_thumbprint"),
             "federation_type": config_data.get("federation_type", "cognito"),
             "max_session_duration": config_data.get("max_session_duration", 28800),
+            "additional_managed_policy_arns": config_data.get("additional_managed_policy_arns", []),
             "sso_enabled": config_data.get("sso_enabled", True),
             "auth_type": config_data.get("auth_type", "oidc"),
             "idc_start_url": config_data.get("idc_start_url"),
@@ -3155,6 +3188,9 @@ class InitCommand(Command):
             # Add max session duration if present
             if hasattr(profile, "max_session_duration") and profile.max_session_duration:
                 existing_config["max_session_duration"] = profile.max_session_duration
+
+            # Restore additional managed policy ARNs (unconditional — empty list is valid)
+            existing_config["additional_managed_policy_arns"] = getattr(profile, "additional_managed_policy_arns", [])
 
             # Add Cognito User Pool ID if present
             if hasattr(profile, "cognito_user_pool_id") and profile.cognito_user_pool_id:

--- a/source/claude_code_with_bedrock/cli/utils/validators.py
+++ b/source/claude_code_with_bedrock/cli/utils/validators.py
@@ -90,3 +90,23 @@ def validate_client_id(client_id: str) -> bool:
     # - Google: 123456789012-abcdefghijklmnopqrstuvwxyz1234.apps.googleusercontent.com
     pattern = r"^[a-zA-Z0-9][a-zA-Z0-9.\-_]+$"
     return bool(re.match(pattern, client_id))
+
+
+# Partition-agnostic (aws, aws-us-gov, aws-cn); "aws" account segment allows
+# AWS-managed policies. Must stay in sync with the AdditionalManagedPolicyArns
+# AllowedPattern in deployment/infrastructure/bedrock-auth-*.yaml.
+_MANAGED_POLICY_ARN_PATTERN = r"^arn:[a-z-]+:iam::(\d{12}|aws):policy/\S+$"
+
+
+def validate_managed_policy_arns(value: str) -> bool | str:
+    """Validate a comma-separated list of IAM managed policy ARNs.
+
+    Empty input is valid (feature is optional). Returns True or an error
+    message naming the first invalid entry (questionary validator contract).
+    """
+    if not value.strip():
+        return True
+    for arn in (a.strip() for a in value.split(",") if a.strip()):
+        if not re.match(_MANAGED_POLICY_ARN_PATTERN, arn):
+            return f"Invalid IAM managed policy ARN: {arn}"
+    return True

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -109,6 +109,9 @@ class Profile:
     federation_type: str = "cognito"  # "cognito" or "direct"
     federated_role_arn: str | None = None  # ARN for Direct STS federation
     max_session_duration: int = 28800  # 8 hours default, 43200 (12 hours) for Direct STS
+    # Existing customer-managed policy ARNs attached to the federated role at deploy
+    # time (e.g. an IP-restriction policy). Empty = only the stack-created policy.
+    additional_managed_policy_arns: list[str] = field(default_factory=list)
     sso_enabled: bool = True  # Enable SSO authentication (Okta, Auth0, Azure, Cognito)
 
     # Authentication type — explicit three-way classification

--- a/source/go/internal/config/config.go
+++ b/source/go/internal/config/config.go
@@ -19,6 +19,9 @@ type ProfileConfig struct {
 	// Federation - Direct STS
 	FederatedRoleARN string `json:"federated_role_arn"`
 	FederationType   string `json:"federation_type"`
+	// Deploy-time only (mirrors Python Profile): extra managed policies attached
+	// to the federated role by CloudFormation. Unused by credential-process.
+	AdditionalManagedPolicyARNs []string `json:"additional_managed_policy_arns,omitempty"`
 
 	// Federation - Cognito
 	IdentityPoolID    string `json:"identity_pool_id"`

--- a/source/tests/cli/commands/test_deploy_additional_policies.py
+++ b/source/tests/cli/commands/test_deploy_additional_policies.py
@@ -1,0 +1,82 @@
+# ABOUTME: Tests that deploy passes AdditionalManagedPolicyArns to the auth stack
+# ABOUTME: Covers OIDC and IDC paths, present-when-set and absent-when-empty
+
+"""`ccwb deploy` must forward additional_managed_policy_arns to CloudFormation.
+
+The parameter is only appended when the profile sets it — omitting it lets the
+template's Default ('') keep existing deployments unchanged.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+# ruff: noqa: E402
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+from rich.console import Console
+
+from claude_code_with_bedrock.cli.commands.deploy import DeployCommand
+from claude_code_with_bedrock.config import Profile
+
+POLICY_ARNS = [
+    "arn:aws:iam::123456789012:policy/corp-ip-restriction",
+    "arn:aws:iam::123456789012:policy/extra-guardrail",
+]
+
+
+def _make_profile(auth_type: str, policy_arns: list[str]) -> Profile:
+    fields = {
+        "name": "test",
+        "provider_domain": "example.okta.com",
+        "client_id": "0oa1234567890",
+        "identity_pool_name": "claude-code-auth",
+        "credential_storage": "keyring",
+        "aws_region": "us-east-1",
+        "provider_type": "okta",
+        "auth_type": auth_type,
+        "additional_managed_policy_arns": policy_arns,
+    }
+    if auth_type == "idc":
+        fields.update(
+            {
+                "idc_start_url": "https://example.awsapps.com/start",
+                "idc_account_id": "123456789012",
+                "idc_permission_set_name": "BedrockDeveloperAccess",
+                "sso_region": "us-east-1",
+            }
+        )
+    return Profile(**fields)
+
+
+def _deploy_auth_params(profile: Profile) -> list[dict]:
+    """Run the real auth-stack deploy path and capture the boto3 parameters."""
+    command = DeployCommand()
+    cf_manager = Mock()
+    cf_manager.deploy_stack.return_value = Mock(success=True)
+
+    rc = command._deploy_stack("auth", profile, Console(file=None, quiet=True), cf_manager)
+    assert rc == 0
+    return cf_manager.deploy_stack.call_args.kwargs["parameters"]
+
+
+def _param_value(params: list[dict], key: str):
+    for p in params:
+        if p["ParameterKey"] == key:
+            return p["ParameterValue"]
+    return None
+
+
+@pytest.mark.parametrize("auth_type", ["oidc", "idc"])
+def test_param_present_when_policies_configured(auth_type):
+    params = _deploy_auth_params(_make_profile(auth_type, list(POLICY_ARNS)))
+    assert _param_value(params, "AdditionalManagedPolicyArns") == ",".join(POLICY_ARNS)
+
+
+@pytest.mark.parametrize("auth_type", ["oidc", "idc"])
+def test_param_absent_when_no_policies(auth_type):
+    """Empty list → parameter omitted → template Default keeps old behavior."""
+    params = _deploy_auth_params(_make_profile(auth_type, []))
+    assert _param_value(params, "AdditionalManagedPolicyArns") is None

--- a/source/tests/cli/commands/test_init_additional_policies_roundtrip.py
+++ b/source/tests/cli/commands/test_init_additional_policies_roundtrip.py
@@ -1,0 +1,114 @@
+# ABOUTME: Regression tests for additional_managed_policy_arns init round-trip
+# ABOUTME: Guards save/reload parity, old-config compat, and the ARN list validator
+
+"""Re-running `ccwb init` must preserve additional managed policy ARNs.
+
+`_check_existing_deployment` rebuilds the wizard config dict from the saved
+Profile; any field it omits silently resets on re-run (see PRs #436, #619,
+#624). Old profiles without the field must load with an empty list.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+# ruff: noqa: E402
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+from claude_code_with_bedrock.cli.commands.init import InitCommand
+from claude_code_with_bedrock.cli.utils.validators import validate_managed_policy_arns
+from claude_code_with_bedrock.config import Config, Profile
+
+POLICY_ARNS = [
+    "arn:aws:iam::123456789012:policy/corp-ip-restriction",
+    "arn:aws:iam::123456789012:policy/extra-guardrail",
+]
+
+
+def _make_profile(**overrides) -> Profile:
+    fields = {
+        "name": "test",
+        "provider_domain": "example.okta.com",
+        "client_id": "0oa1234567890",
+        "identity_pool_name": "claude-code-auth",
+        "credential_storage": "keyring",
+        "aws_region": "us-east-1",
+    }
+    fields.update(overrides)
+    return Profile(**fields)
+
+
+def _rebuild_config(profile: Profile) -> dict:
+    """Run _check_existing_deployment with AWS interaction stubbed out."""
+    command = InitCommand()
+    fake_config = Config()
+    with (
+        patch.object(Config, "load", return_value=fake_config),
+        patch.object(fake_config, "get_profile", return_value=profile),
+        patch.object(InitCommand, "_stack_exists", side_effect=Exception("no creds")),
+    ):
+        return command._check_existing_deployment("test")
+
+
+def test_rerun_preserves_additional_policy_arns():
+    profile = _make_profile(additional_managed_policy_arns=list(POLICY_ARNS))
+    rebuilt = _rebuild_config(profile)
+    assert rebuilt["additional_managed_policy_arns"] == POLICY_ARNS
+
+
+def test_rerun_defaults_to_empty_list():
+    rebuilt = _rebuild_config(_make_profile())
+    assert rebuilt["additional_managed_policy_arns"] == []
+
+
+def test_old_config_without_field_loads_with_default():
+    """Backward compat: profiles saved before this field existed still load."""
+    old_data = {
+        "name": "legacy",
+        "provider_domain": "example.okta.com",
+        "client_id": "0oa1234567890",
+        "identity_pool_name": "claude-code-auth",
+        "aws_region": "us-east-1",
+    }
+    profile = Profile.from_dict(old_data)
+    assert profile.additional_managed_policy_arns == []
+
+
+def test_field_round_trips_through_serialization():
+    profile = _make_profile(additional_managed_policy_arns=list(POLICY_ARNS))
+    reloaded = Profile.from_dict(profile.to_dict())
+    assert reloaded.additional_managed_policy_arns == POLICY_ARNS
+
+
+class TestManagedPolicyArnValidator:
+    def test_empty_is_valid(self):
+        assert validate_managed_policy_arns("") is True
+        assert validate_managed_policy_arns("   ") is True
+
+    def test_single_customer_arn(self):
+        assert validate_managed_policy_arns("arn:aws:iam::123456789012:policy/corp-ip-restriction") is True
+
+    def test_comma_separated_arns_with_spaces(self):
+        assert validate_managed_policy_arns(", ".join(POLICY_ARNS)) is True
+
+    def test_aws_managed_and_govcloud_arns(self):
+        assert validate_managed_policy_arns("arn:aws:iam::aws:policy/ReadOnlyAccess") is True
+        assert validate_managed_policy_arns("arn:aws-us-gov:iam::123456789012:policy/corp-ip-restriction") is True
+
+    def test_path_prefixed_policy(self):
+        assert validate_managed_policy_arns("arn:aws:iam::123456789012:policy/guardrails/ip-restrict") is True
+
+    def test_invalid_arn_names_the_entry(self):
+        result = validate_managed_policy_arns("not-an-arn")
+        assert result != True  # noqa: E712 — questionary contract returns str on failure
+        assert "not-an-arn" in result
+
+    def test_role_arn_rejected(self):
+        result = validate_managed_policy_arns("arn:aws:iam::123456789012:role/some-role")
+        assert isinstance(result, str)
+
+    def test_one_bad_entry_fails_the_list(self):
+        value = POLICY_ARNS[0] + ",bogus"
+        result = validate_managed_policy_arns(value)
+        assert isinstance(result, str)
+        assert "bogus" in result

--- a/source/tests/test_cloudformation_additional_policies.py
+++ b/source/tests/test_cloudformation_additional_policies.py
@@ -1,0 +1,102 @@
+# ABOUTME: Tests that all bedrock-auth templates support AdditionalManagedPolicyArns
+# ABOUTME: Guards the parameter, condition, and ManagedPolicyArns wiring on federated roles
+
+"""Every auth template must accept AdditionalManagedPolicyArns.
+
+The parameter lets admins attach existing customer-managed policies (e.g. an
+IP-restriction policy) to the federated role without manual console edits.
+It must default to '' (backwards compatible) and feed the role's
+ManagedPolicyArns through the HasAdditionalManagedPolicies condition.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tests.test_cloudformation import CloudFormationLoader
+
+INFRA_DIR = Path(__file__).parent.parent.parent / "deployment" / "infrastructure"
+
+AUTH_TEMPLATES = [
+    "bedrock-auth-auth0.yaml",
+    "bedrock-auth-azure.yaml",
+    "bedrock-auth-cognito-pool.yaml",
+    "bedrock-auth-generic.yaml",
+    "bedrock-auth-google.yaml",
+    "bedrock-auth-idc.yaml",
+    "bedrock-auth-okta.yaml",
+]
+
+# Federated roles that must honor the parameter (per template)
+FEDERATED_ROLES = {
+    "bedrock-auth-idc.yaml": ["BedrockIDCRole"],
+    # All OIDC templates define both federation modes
+    "default": ["DirectIAMRole", "CognitoAuthenticatedRole"],
+}
+
+
+def load_template(name: str) -> dict:
+    with open(INFRA_DIR / name, encoding="utf-8") as f:
+        return yaml.load(f, Loader=CloudFormationLoader)
+
+
+@pytest.mark.parametrize("template_name", AUTH_TEMPLATES)
+def test_parameter_exists_with_safe_default(template_name):
+    """Parameter must exist and default to '' so existing stacks update cleanly."""
+    template = load_template(template_name)
+    params = template.get("Parameters", {})
+
+    assert "AdditionalManagedPolicyArns" in params
+    param = params["AdditionalManagedPolicyArns"]
+    assert param["Type"] == "String"
+    assert param["Default"] == ""
+    # Empty must be allowed by the validation pattern
+    assert param["AllowedPattern"].startswith("^$|")
+
+
+@pytest.mark.parametrize("template_name", AUTH_TEMPLATES)
+def test_condition_exists(template_name):
+    template = load_template(template_name)
+    conditions = template.get("Conditions", {})
+    assert "HasAdditionalManagedPolicies" in conditions
+
+
+@pytest.mark.parametrize("template_name", AUTH_TEMPLATES)
+def test_federated_roles_append_additional_policies(template_name):
+    """ManagedPolicyArns must keep BedrockAccessPolicy and append the extra ARNs."""
+    template = load_template(template_name)
+    resources = template.get("Resources", {})
+    role_names = FEDERATED_ROLES.get(template_name, FEDERATED_ROLES["default"])
+
+    for role_name in role_names:
+        assert role_name in resources, f"{template_name}: missing {role_name}"
+        policy_arns = resources[role_name]["Properties"]["ManagedPolicyArns"]
+
+        # Wired through the condition
+        assert isinstance(policy_arns, dict) and "Fn::If" in policy_arns, (
+            f"{template_name}/{role_name}: ManagedPolicyArns must use Fn::If"
+        )
+        condition, with_extra, without_extra = policy_arns["Fn::If"]
+        assert condition == "HasAdditionalManagedPolicies"
+
+        # False branch: unchanged behavior — only the stack-created policy
+        assert without_extra == [{"Ref": "BedrockAccessPolicy"}]
+
+        # True branch: base policy joined with the parameter, then split
+        rendered = str(with_extra)
+        assert "Fn::Split" in rendered
+        assert "BedrockAccessPolicy" in rendered
+        assert "AdditionalManagedPolicyArns" in rendered
+
+
+@pytest.mark.parametrize("template_name", AUTH_TEMPLATES)
+def test_unauthenticated_roles_not_extended(template_name):
+    """The extra policies must never reach the unauthenticated Cognito role."""
+    template = load_template(template_name)
+    resources = template.get("Resources", {})
+    unauth = resources.get("CognitoUnauthenticatedRole")
+    if unauth is None:
+        return
+    rendered = str(unauth["Properties"].get("ManagedPolicyArns", ""))
+    assert "AdditionalManagedPolicyArns" not in rendered


### PR DESCRIPTION
## Why

Enterprises deploying this guidance over the internet (no PrivateLink/VPN requirement) frequently need network-level guardrails on the Bedrock federated role. The canonical example: a customer-managed IP-restriction policy that denies all actions unless `aws:SourceIp` falls within corporate CIDR ranges, so leaked or replayed federated credentials are useless outside the corporate network.

Today the auth stacks hardcode the federated role's `ManagedPolicyArns` to the single stack-created `BedrockAccessPolicy`, so the only way to add such a guardrail is attaching the policy manually in the IAM console. That has real operational costs:

- **Configuration drift** — the attachment lives outside CloudFormation, invisible to stack updates and drift detection.
- **Not repeatable** — every account/environment needs the same manual step, and nothing enforces it during rollout.
- **Fragile** — if the role is ever replaced (rename, stack recreation), the attachment is silently lost and Bedrock access is un-guarded until someone notices.
- **Blocks clean teardown** — out-of-band attachments can interfere with stack deletion.

## What

Admins can now supply existing customer-managed policy ARNs during `ccwb init`; `ccwb deploy` forwards them to the auth stack, which attaches them alongside the stack-created Bedrock access policy — fully managed by CloudFormation.

- **Templates** (all 7 `bedrock-auth-*.yaml`): new `AdditionalManagedPolicyArns` parameter (`Type: String`, `Default: ''`, ARN-list `AllowedPattern`) and a positive `HasAdditionalManagedPolicies` condition. Each federated role (`DirectIAMRole`, `CognitoAuthenticatedRole`, `BedrockIDCRole`) builds `ManagedPolicyArns` via `!If` — base policy only when empty, base + supplied ARNs when set. `CognitoUnauthenticatedRole` is deliberately untouched.
- **Init wizard**: optional prompt in both the OIDC and IDC flows (comma-separated ARNs, validated per entry, cancel/non-interactive safe). Field is persisted to the profile and restored on re-run (`_save_configuration` ↔ `_check_existing_deployment` parity).
- **Deploy**: parameter is appended only when configured — omitted otherwise so the template default keeps existing behavior. Covered in the real deploy path (IDC + OIDC) and the `--show-commands` dry-run path.
- **Config**: `additional_managed_policy_arns: list[str] = []` on the Python `Profile`, mirrored as `AdditionalManagedPolicyARNs` in the Go `ProfileConfig` (deploy-time only; not added to `--explain` since it never affects resolved runtime config).

Example usage during init:

```
Additional managed policy ARNs (comma-separated, optional): arn:aws:iam::123456789012:policy/corp-ip-restriction
```

## Auth mode coverage

| Mode | Behavior |
|------|----------|
| OIDC (all providers) | Parameter wired into `DirectIAMRole` and `CognitoAuthenticatedRole` |
| IDC | Parameter wired into `BedrockIDCRole` |
| none | No federated-role stack deployed — naturally a no-op |

## Backwards compatibility

- Parameter defaults to `''` — existing stacks update in place with no change.
- Profiles saved before this field existed load with an empty list (regression-tested).
- No new required CLI arguments; non-interactive runs are unaffected.

## Testing

- `poetry run pytest tests/ -q` — 1706 passed, 28 skipped
- `cfn-lint deployment/infrastructure/bedrock-auth-*.yaml` — clean
- `ruff check` / `ruff format --check` — clean
- New tests:
  - `test_cloudformation_additional_policies.py` — parameter, condition, and `ManagedPolicyArns` wiring asserted across all 7 templates, including that the unauthenticated Cognito role is not extended
  - `test_deploy_additional_policies.py` — exercises the real `_deploy_stack` auth path (OIDC + IDC): parameter present when configured, absent when empty
  - `test_init_additional_policies_roundtrip.py` — init re-run round-trip, old-config backward compat, serialization round-trip, and ARN-list validator cases (GovCloud partition, AWS-managed policies, path-prefixed policies, invalid entries)
- Dry-run verified manually: `--show-commands` output includes `AdditionalManagedPolicyArns=...` only when the profile sets it

## Notes for reviewers

- IAM allows 10 managed policies per role by default (quota-raisable to 20); documented in `CLI_REFERENCE.md`.
- The supplied policies must already exist in the deployment account — CloudFormation fails the stack operation with a clear error if an ARN doesn't resolve, rather than silently ignoring it.