### PR TITLE
fix: cowork-dashboard deploy fails — PromQL widgets typed as "metric" not "chart"

### DIFF
--- a/deployment/infrastructure/cowork-dashboard.yaml
+++ b/deployment/infrastructure/cowork-dashboard.yaml
@@ -324,13 +324,14 @@ Resources:
               }
             },
             {
-              "type": "metric",
+              "type": "chart",
               "x": 12, "y": 12, "width": 12, "height": 6,
               "properties": {
                 "title": "Avg Cost Per Turn (USD)",
-                "view": "timeSeries",
+                "view": "line",
                 "region": "${MetricsRegion}",
-                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"ClaudeCoWork\", MetricName=\"cost.usage\"}) / sum({\"ClaudeCoWork\", MetricName=\"session.turns\"})", "step": 60, "label": "$/turn" }] }
+                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"ClaudeCoWork\", MetricName=\"cost.usage\"}) / sum({\"ClaudeCoWork\", MetricName=\"session.turns\"})", "step": 60, "label": "$/turn" }] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
@@ -339,57 +340,58 @@ Resources:
               "properties": { "markdown": "## Per-User Breakdown\n*Desktop mode only — LAM events do not emit user_email*" }
             },
             {
-              "type": "metric",
+              "type": "chart",
               "x": 0, "y": 19, "width": 12, "height": 6,
               "properties": {
                 "title": "Top Users by Token Usage",
-                "view": "timeSeries",
-                "stacked": true,
+                "view": "line",
                 "region": "${MetricsRegion}",
-                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(10, sum by (\"user_email\")({\"ClaudeCoWork\", MetricName=\"token.usage.input\"}))", "step": 60 }] }
+                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(10, sum by (\"user_email\")({\"ClaudeCoWork\", MetricName=\"token.usage.input\"}))", "step": 60 }] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": true, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
-              "type": "metric",
+              "type": "chart",
               "x": 12, "y": 19, "width": 12, "height": 6,
               "properties": {
                 "title": "Estimated Cost by User (USD)",
-                "view": "timeSeries",
-                "stacked": true,
+                "view": "line",
                 "region": "${MetricsRegion}",
-                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(10, sum by (\"user_email\")({\"ClaudeCoWork\", MetricName=\"cost.usage\"}))", "step": 60 }] }
+                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(10, sum by (\"user_email\")({\"ClaudeCoWork\", MetricName=\"cost.usage\"}))", "step": 60 }] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": true, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
-              "type": "metric",
+              "type": "chart",
               "x": 0, "y": 25, "width": 12, "height": 6,
               "properties": {
                 "title": "Session Turns by User",
-                "view": "timeSeries",
-                "stacked": true,
+                "view": "line",
                 "region": "${MetricsRegion}",
-                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(10, sum by (\"user_email\")({\"ClaudeCoWork\", MetricName=\"session.turns\"}))", "step": 60 }] }
+                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(10, sum by (\"user_email\")({\"ClaudeCoWork\", MetricName=\"session.turns\"}))", "step": 60 }] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": true, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
-              "type": "metric",
+              "type": "chart",
               "x": 12, "y": 25, "width": 12, "height": 6,
               "properties": {
                 "title": "Cost by Model",
-                "view": "timeSeries",
-                "stacked": true,
+                "view": "line",
                 "region": "${MetricsRegion}",
-                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(10, sum by (\"model\")({\"ClaudeCoWork\", MetricName=\"cost.usage\"}))", "step": 60 }] }
+                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(10, sum by (\"model\")({\"ClaudeCoWork\", MetricName=\"cost.usage\"}))", "step": 60 }] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": true, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
-              "type": "metric",
+              "type": "chart",
               "x": 0, "y": 31, "width": 6, "height": 4,
               "properties": {
                 "title": "Active Users",
-                "view": "singleValue",
+                "view": "number",
                 "region": "${MetricsRegion}",
-                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "count(group by (\"user_email\")({\"ClaudeCoWork\", MetricName=\"session.turns\"}))", "step": 60, "label": "Active Users" }] }
+                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "count(group by (\"user_email\")({\"ClaudeCoWork\", MetricName=\"session.turns\"}))", "step": 60, "label": "Active Users" }] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {

--- a/source/tests/e2e/test_cowork_dashboard_filters.py
+++ b/source/tests/e2e/test_cowork_dashboard_filters.py
@@ -3,6 +3,8 @@
 
 """Tests for CoWork dashboard metric filter schema coverage."""
 
+import json
+import re
 from pathlib import Path
 
 import pytest
@@ -133,4 +135,83 @@ class TestCoWorkDashboardMetricFilters:
             for transform in res["Properties"]["MetricTransformations"]:
                 assert transform["MetricNamespace"] == "ClaudeCoWork", (
                     f"{name}: expected ClaudeCoWork namespace, got {transform['MetricNamespace']}"
+                )
+
+
+class TestCoWorkDashboardBody:
+    """Verify the CloudWatch DashboardBody widgets pass CloudWatch validation.
+
+    Regression: PromQL queries (properties.data.queries) are only valid for the
+    newer "chart" widget type. When such a query lived on a "metric" widget,
+    CloudWatch rejected the dashboard with "Should have required property
+    'metrics'" (18 validation errors), breaking `ccwb deploy` of the
+    cowork-dashboard stack.
+    """
+
+    @pytest.fixture(autouse=True)
+    def load_body(self):
+        text = DASHBOARD_PATH.read_text()
+        # Extract the DashboardBody block that follows `DashboardBody: !Sub |`
+        marker = "DashboardBody: !Sub |"
+        block = text[text.index(marker) :].splitlines()[1:]
+        body_lines = []
+        for line in block:
+            if line.strip() == "":
+                body_lines.append("")
+            elif line.startswith("        "):
+                body_lines.append(line[8:])
+            else:
+                break
+        raw = "\n".join(body_lines)
+        # Neutralize the !Sub variable so the block is parseable JSON.
+        raw = re.sub(r"\$\{[^}]+\}", "us-east-1", raw)
+        self.body = json.loads(raw)
+        self.widgets = self.body["widgets"]
+
+    def test_body_is_valid_json(self):
+        """DashboardBody must be valid JSON (this fixture would raise otherwise)."""
+        assert isinstance(self.widgets, list) and self.widgets
+
+    def test_promql_queries_only_on_chart_widgets(self):
+        """PromQL data.queries are only valid on 'chart' widgets, never 'metric'.
+
+        A 'metric' widget carrying data.queries has neither a `metrics` array
+        nor `annotations`, which CloudWatch rejects at deploy time.
+        """
+        for i, widget in enumerate(self.widgets):
+            props = widget.get("properties", {})
+            if "data" in props and "queries" in props["data"]:
+                assert widget["type"] == "chart", (
+                    f"widget {i} ({props.get('title')!r}) uses data.queries (PromQL) "
+                    f"but has type {widget['type']!r}; PromQL requires type 'chart'"
+                )
+
+    def test_metric_widgets_have_metrics_array(self):
+        """Every 'metric' widget must define a metrics array (CloudWatch requirement)."""
+        for i, widget in enumerate(self.widgets):
+            if widget["type"] == "metric":
+                props = widget.get("properties", {})
+                assert "metrics" in props, (
+                    f"widget {i} ({props.get('title')!r}) is a metric widget without a "
+                    "'metrics' array; CloudWatch will reject the dashboard"
+                )
+
+    def test_chart_widgets_do_not_use_metric_only_view_or_stacked(self):
+        """Chart widgets use chart views (line/number/pie/bar), not metric-only keys.
+
+        `singleValue`/`timeSeries` views and the top-level `stacked` flag belong to
+        'metric' widgets; on a chart widget they are the fingerprint of a
+        mis-typed PromQL widget.
+        """
+        metric_only_views = {"singleValue", "timeSeries"}
+        for i, widget in enumerate(self.widgets):
+            if widget["type"] == "chart":
+                props = widget.get("properties", {})
+                assert props.get("view") not in metric_only_views, (
+                    f"widget {i} ({props.get('title')!r}) is a chart widget using "
+                    f"metric-only view {props.get('view')!r}"
+                )
+                assert "stacked" not in props, (
+                    f"widget {i} ({props.get('title')!r}) uses top-level 'stacked'; "
+                    "chart widgets stack via plotOptions.style.lineOptions.stacked"
                 )


### PR DESCRIPTION
## Why

`ccwb deploy` fails on the `cowork-dashboard` stack. CloudWatch rejects the dashboard body with **18 validation errors** and the stack rolls back, so admins never get the CoWork telemetry dashboard.

```
✗ Failed to deploy cowork-dashboard stack: AWS::CloudWatch::Dashboard (Dashboard):
The dashboard body is invalid, there are 18 validation errors:
  /widgets/8/properties  → Should have required property 'metrics'
  /widgets/8/properties  → The metric widget should have specified a region and a data source or an alarm annotation
  /widgets/8/properties  → Should have required property 'annotations'
  ... (same 3 errors for widgets 10, 11, 12, 13, 14)
(Service: CloudWatch, Status Code: 400)
```

## Root cause

Six widgets in `deployment/infrastructure/cowork-dashboard.yaml` use PromQL queries in `properties.data.queries` but are declared as `"type": "metric"`. PromQL `data.queries` is only valid on the newer `"type": "chart"` widget — CloudWatch validates a `metric` widget against the classic schema, which requires a `metrics` array or `annotations` (3 errors each × 6 widgets = 18).

The sibling `claude-code-dashboard.yaml` deploys fine because its PromQL widgets are correctly typed `chart` — that was the tell.

## What

- Convert the 6 PromQL widgets (Avg Cost Per Turn, Top Users by Token Usage, Estimated Cost by User, Session Turns by User, Cost by Model, Active Users) from `metric` → `chart`:
  - `view: timeSeries` → `line`; `view: singleValue` → `number`
  - Drop the top-level `stacked` (invalid on charts); stack via `plotOptions.style.lineOptions.stacked`
  - Add the `plotOptions` block each chart widget needs
- The 7 non-PromQL `metric` widgets and the text/log widgets are correct and untouched.
- Add `TestCoWorkDashboardBody` regression tests: PromQL only on chart widgets, every metric widget has a `metrics` array, chart widgets never use metric-only `view`/`stacked` keys.

## Testing

- DashboardBody parses as valid JSON; all PromQL widgets are now `chart`
- `cfn-lint deployment/infrastructure/cowork-dashboard.yaml` passes
- `poetry run pytest tests/e2e/test_cowork_dashboard_filters.py -q` → **12 passed**

Note: a previously failed deploy may leave the stack in `ROLLBACK_COMPLETE`, which must be deleted before redeploying.

Fixes #759