### PR TITLE
fix(quota): enforce quota before STS exchange on silent refresh paths

### DIFF
--- a/.claude/rules/credential-flow.md
+++ b/.claude/rules/credential-flow.md
@@ -11,8 +11,8 @@ AWS SDK → credential-process [Go or Python]
   2. If valid + not expired → return immediately (fast path, ~5ms)
   3. If expired → try silent refresh (refresh_token exchange, no browser)
   4. If no refresh_token → OIDC browser flow (or IDC passthrough)
-  5. Exchange token → STS AssumeRoleWithWebIdentity → temporary credentials
-  6. Check quota (if configured) → blocked? exit non-zero
+  5. Check quota with the id_token (if configured) → blocked? exit non-zero
+  6. Exchange token → STS AssumeRoleWithWebIdentity → temporary credentials
   7. Save credentials to cache
   8. Emit OTEL attribution headers to cache file
   9. Print JSON to stdout → AWS SDK uses credentials
@@ -39,10 +39,14 @@ print(json.dumps(credentials))  # only JSON on stdout
 
 ## Quota Integration
 
-Quota check happens AFTER auth but BEFORE outputting credentials:
+Quota check happens AFTER auth (id_token in hand) but BEFORE the STS
+exchange — an over-quota user must never mint or cache fresh AWS
+credentials (#761):
 - If quota blocks → exit non-zero (credential-process contract: no JSON = failure)
 - If quota warns → print warning to stderr, still output credentials
 - Quota check uses the same token (OIDC: Bearer, IDC: SigV4)
+- Check with the in-scope id_token; never re-read it from storage and
+  silently skip when the read comes back empty (fail per quota_fail_mode)
 
 ## OTEL Attribution
 

--- a/.claude/rules/token-endpoint-single-builder.md
+++ b/.claude/rules/token-endpoint-single-builder.md
@@ -31,8 +31,9 @@ tokenURL = provider.TokenEndpointURL(providerType, oktaAuthServerID, providerDom
 
 ## Callers (must all use the shared builder)
 - `oidc/flow.go` — browser authorization-code exchange
-- `tryRefreshToken()` in main.go — silent refresh
-- `refreshIDTokenOnly()` — monitoring token refresh (when added)
+- `tryRefreshToken()` in main.go — the single silent refresh_token exchange
+  (serves credential refresh, monitoring token refresh, and the MCP auth
+  header path; the former `refreshIDTokenOnly()` twin was merged into it)
 - Any future token endpoint caller
 
 ## Related

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,8 +46,8 @@ AWS SDK calls credential-process
   → read cache → [valid?] → return cached credentials
   → [expired?] → try silent refresh (refresh_token)
   → [no token?] → OIDC browser flow or IDC passthrough
+  → check quota with id_token → [blocked?] → exit non-zero
   → STS AssumeRoleWithWebIdentity → credentials
-  → check quota → [blocked?] → exit non-zero
   → emit OTEL attribution headers → cache → stdout JSON
 ```
 

--- a/source/credential_provider/__main__.py
+++ b/source/credential_provider/__main__.py
@@ -1679,14 +1679,12 @@ class MultiProviderAuth:
                 except Exception:
                     pass  # nosec B110
 
-            # Get AWS credentials (we need them but won't output them)
-            self._debug_print("Exchanging token for AWS credentials...")
-            credentials = self.get_aws_credentials(id_token, token_claims)
-
-            # Cache credentials for future use
-            self.save_credentials(credentials)
-
-            # Save monitoring token
+            # Persist the monitoring token only. Deliberately NO AWS credential
+            # exchange here: this entrypoint serves OTEL attribution, and
+            # minting credentials on it would bypass quota enforcement (#761) —
+            # every credential-minting path must enforce quota first. A blocked
+            # user still gets a monitoring token so their telemetry stays
+            # attributed.
             self.save_monitoring_token(id_token, token_claims)
 
             # Return just the monitoring token
@@ -2268,29 +2266,43 @@ class MultiProviderAuth:
     # End Quota Check Methods
     # ===========================================
 
-    def _try_silent_refresh(self):
-        """Attempt to refresh AWS credentials using a cached, still-valid OIDC id_token.
+    def _get_cached_token_for_silent_refresh(self):
+        """Return (id_token, token_claims) from the cached monitoring token, or (None, None).
 
-        Returns:
-            Tuple of (credentials, id_token, token_claims) if successful, (None, None, None) otherwise.
+        Read-only: no STS exchange happens here so the caller can enforce
+        quota with the token BEFORE any credentials are minted.
         """
         try:
             id_token = self.get_monitoring_token()
             if not id_token:
                 self._debug_print("No valid cached id_token for silent refresh")
-                return None, None, None
-
-            self._debug_print("Found valid cached id_token, attempting silent credential refresh...")
+                return None, None
             token_claims = jwt.decode(id_token, options={"verify_signature": False})
+            return id_token, token_claims
+        except Exception as e:
+            self._debug_print(f"Could not load cached id_token for silent refresh: {e}")
+            return None, None
 
+    def _try_silent_refresh(self, id_token, token_claims):
+        """Exchange a quota-cleared cached id_token for AWS credentials and persist them.
+
+        Callers MUST run the quota check first — this method mints and caches
+        credentials, so calling it before quota clearance would hand an
+        over-quota user a full STS session.
+
+        Returns:
+            Credentials dict if successful, None otherwise (caller falls back to browser auth).
+        """
+        try:
+            self._debug_print("Found valid cached id_token, attempting silent credential refresh...")
             credentials = self.get_aws_credentials(id_token, token_claims)
             self.save_credentials(credentials)
             self.save_monitoring_token(id_token, token_claims)
             self._debug_print("Silent credential refresh succeeded")
-            return credentials, id_token, token_claims
+            return credentials
         except Exception as e:
             self._debug_print(f"Silent refresh failed, will require browser auth: {e}")
-            return None, None, None
+            return None
 
     def _run_passthrough(self):
         """Emit credentials from the ambient AWS credential chain (Identity Center, env vars, instance profile).
@@ -2417,21 +2429,23 @@ class MultiProviderAuth:
                     print(json.dumps(cached))  # noqa: S105
                     return 0
 
-                # Try silent refresh using cached id_token before opening browser
-                silent_creds, id_token, token_claims = self._try_silent_refresh()
-                if silent_creds:
-                    # Check quota if configured (reuse token/claims already fetched above)
+                # Try silent refresh using cached id_token before opening browser.
+                # Quota is enforced BEFORE the STS exchange, using the id_token
+                # already in hand, so an over-quota user never mints or caches
+                # fresh credentials on this path (#761).
+                id_token, token_claims = self._get_cached_token_for_silent_refresh()
+                if id_token:
                     if self._should_check_quota():
-                        if id_token and token_claims:
-                            quota_result = self._check_quota(token_claims, id_token)
-                            self._save_quota_check_timestamp()
-                            if not quota_result.get("allowed", True):
-                                return self._handle_quota_blocked(quota_result)
-                            else:
-                                self._handle_quota_warning(quota_result)
+                        quota_result = self._check_quota(token_claims, id_token)
+                        self._save_quota_check_timestamp()
+                        if not quota_result.get("allowed", True):
+                            return self._handle_quota_blocked(quota_result)
+                        self._handle_quota_warning(quota_result)
 
-                    print(json.dumps(silent_creds))
-                    return 0
+                    silent_creds = self._try_silent_refresh(id_token, token_claims)
+                    if silent_creds:
+                        print(json.dumps(silent_creds))
+                        return 0
 
                 # Authenticate with OIDC provider (browser popup - only when id_token is also expired).
                 # Hand the still-bound lock socket to the OAuth callback server so

--- a/source/go/cmd/credential-process/desktop_helper.go
+++ b/source/go/cmd/credential-process/desktop_helper.go
@@ -37,8 +37,15 @@ func (a *credentialApp) runDesktopHelper() int {
 	if creds == nil {
 		// No cached creds — try silent refresh
 		if a.cfg.IsSsoEnabled() && !a.cfg.IsIDC() {
-			// OIDC: try refresh token
-			creds = a.tryRefreshToken()
+			// OIDC: try refresh token. Quota is enforced on the fresh id_token
+			// BEFORE the STS exchange (#761) — previously this path minted
+			// credentials with no quota check at all.
+			if auth := a.tryRefreshToken(); auth != nil {
+				if !a.enforceQuota(auth.IDToken) {
+					return 1
+				}
+				creds = a.exchangeAndSaveCredentials(auth)
+			}
 		}
 
 		if creds == nil && allowInteractive {
@@ -69,9 +76,15 @@ func (a *credentialApp) runDesktopHelper() int {
 	// Check if credentials are expired
 	remaining := storage.ParseExpirationSeconds(creds.Expiration)
 	if remaining <= 30 {
-		// Expired — try refresh
+		// Expired — try refresh (same quota-before-STS ordering as above)
 		if a.cfg.IsSsoEnabled() && !a.cfg.IsIDC() {
-			creds = a.tryRefreshToken()
+			creds = nil
+			if auth := a.tryRefreshToken(); auth != nil {
+				if !a.enforceQuota(auth.IDToken) {
+					return 1
+				}
+				creds = a.exchangeAndSaveCredentials(auth)
+			}
 		}
 		if creds == nil || storage.ParseExpirationSeconds(creds.Expiration) <= 30 {
 			if allowInteractive {

--- a/source/go/cmd/credential-process/main.go
+++ b/source/go/cmd/credential-process/main.go
@@ -299,16 +299,13 @@ func (a *credentialApp) getMonitoringToken() int {
 	// token has aged past the 10-min buffer in storage.GetMonitoringToken
 	// while their refresh_token is still valid (typically 7-30 days).
 	//
-	// Note: trySilentRefresh() is intentionally not attempted here — its
-	// first step is storage.GetMonitoringToken(), which we just observed
-	// returns empty. Only refresh_token (separately stored) is meaningful.
-	if creds := a.tryRefreshToken(); creds != nil {
-		_ = creds // tryRefreshToken already saved AWS creds and the fresh monitoring token
-		if t, terr := storage.GetMonitoringToken(a.profile, a.cfg.CredentialStorage); terr == nil && t != "" {
-			fmt.Println(t)
-			return 0
-		}
-		debugPrint("refresh_token exchange succeeded but monitoring token unreadable; falling through to browser auth")
+	// Note: the cached-token path is intentionally not attempted here — we
+	// just observed storage.GetMonitoringToken() returns empty. Only
+	// refresh_token (separately stored) is meaningful. tryRefreshToken mints
+	// no AWS credentials, so this path cannot bypass quota enforcement.
+	if auth := a.tryRefreshToken(); auth != nil {
+		fmt.Println(auth.IDToken)
+		return 0
 	}
 
 	// No refresh_token available, refresh failed, or refresh produced no
@@ -330,15 +327,11 @@ func (a *credentialApp) getMonitoringToken() int {
 		return 1
 	}
 
-	// Get AWS creds (needed to complete the flow)
-	awsCreds, err := a.getAWSCredentials(authResult)
-	if err != nil {
-		debugPrint("Failed to get AWS credentials: %v", err)
-		return 1
-	}
-	_ = a.saveCredentials(awsCreds)
-
-	// Save monitoring token
+	// Persist the monitoring token only. Deliberately NO AWS credential
+	// exchange here: this entrypoint serves OTEL attribution, and minting
+	// credentials on it would bypass quota enforcement (#761) — every
+	// credential-minting path must enforce quota first. A blocked user
+	// still gets a monitoring token so their telemetry stays attributed.
 	a.saveMonitoringTokenAndHeaders(authResult.IDToken, map[string]interface{}(authResult.TokenClaims))
 
 	fmt.Println(authResult.IDToken)
@@ -361,13 +354,12 @@ func (a *credentialApp) getMCPAuthHeader() int {
 		// headersHelper can never drive an interactive login. Only attempt for
 		// OIDC; idc/none have no id_token.
 		//
-		// Use refreshIDTokenOnly (NOT tryRefreshToken): the gateway's CUSTOM_JWT
-		// authorizer only needs the id_token, so a successful refresh must NOT be
-		// thrown away just because the unrelated AWS STS/IAM credential exchange
-		// fails or times out. tryRefreshToken couples the two and would discard a
-		// perfectly valid refreshed id_token on a Cognito/STS hiccup.
-		if fresh := a.refreshIDTokenOnly(); fresh != "" {
-			token, err = fresh, nil
+		// tryRefreshToken performs only the token exchange (no AWS credential
+		// exchange), so a successful refresh is never thrown away because the
+		// unrelated AWS STS/IAM credential exchange fails or times out — the
+		// gateway's CUSTOM_JWT authorizer only needs the id_token.
+		if auth := a.tryRefreshToken(); auth != nil {
+			token, err = auth.IDToken, nil
 		}
 	}
 	if err != nil || token == "" {
@@ -540,42 +532,37 @@ func (a *credentialApp) run() int {
 		return 0
 	}
 
-	// Try silent refresh using cached id_token before opening browser
-	if creds := a.trySilentRefresh(); creds != nil {
-		if a.cfg.QuotaAPIEndpoint != "" {
-			token, _ := storage.GetMonitoringToken(a.profile, a.cfg.CredentialStorage)
-			if token != "" {
-				qr := quota.Check(a.cfg.QuotaAPIEndpoint, token, a.cfg.QuotaCheckTimeout, a.cfg.QuotaFailMode)
-				if !qr.Allowed {
-					printQuotaBlocked(qr)
-					return 1
-				}
-				printQuotaWarning(qr)
-				_ = storage.SaveQuotaState(a.profile)
-			}
+	// Try silent refresh using cached id_token before opening browser.
+	// Quota is enforced BEFORE the STS exchange, using the id_token already in
+	// hand, so an over-quota user never mints or caches fresh credentials and
+	// the check can never be skipped because a separate storage read came back
+	// empty (#761).
+	if auth := a.cachedTokenAuthResult(); auth != nil {
+		if !a.enforceQuota(auth.IDToken) {
+			return 1
 		}
-		outputJSON(creds)
-		return 0
+		if creds := a.exchangeAndSaveCredentials(auth); creds != nil {
+			debugPrint("Silent credential refresh succeeded")
+			outputJSON(creds)
+			return 0
+		}
+		debugPrint("Silent refresh failed, trying refresh_token exchange...")
 	}
 
 	// Try refresh_token exchange before falling back to browser auth.
 	// This enables Cowork 3P (Claude Desktop) to refresh silently even after
 	// the id_token expires, since Claude Desktop cannot open a browser popup.
-	if creds := a.tryRefreshToken(); creds != nil {
-		if a.cfg.QuotaAPIEndpoint != "" {
-			token, _ := storage.GetMonitoringToken(a.profile, a.cfg.CredentialStorage)
-			if token != "" {
-				qr := quota.Check(a.cfg.QuotaAPIEndpoint, token, a.cfg.QuotaCheckTimeout, a.cfg.QuotaFailMode)
-				if !qr.Allowed {
-					printQuotaBlocked(qr)
-					return 1
-				}
-				printQuotaWarning(qr)
-				_ = storage.SaveQuotaState(a.profile)
-			}
+	// Same ordering contract as above: quota first, credentials second.
+	if auth := a.tryRefreshToken(); auth != nil {
+		if !a.enforceQuota(auth.IDToken) {
+			return 1
 		}
-		outputJSON(creds)
-		return 0
+		if creds := a.exchangeAndSaveCredentials(auth); creds != nil {
+			debugPrint("Refresh token exchange succeeded — credentials renewed without browser")
+			outputJSON(creds)
+			return 0
+		}
+		debugPrint("AWS credential exchange after refresh failed, falling back to browser auth")
 	}
 
 	// Authenticate with OIDC provider (browser popup)
@@ -587,14 +574,8 @@ func (a *credentialApp) run() int {
 	}
 
 	// Quota check before issuing credentials
-	if a.cfg.QuotaAPIEndpoint != "" {
-		qr := quota.Check(a.cfg.QuotaAPIEndpoint, authResult.IDToken, a.cfg.QuotaCheckTimeout, a.cfg.QuotaFailMode)
-		if !qr.Allowed {
-			printQuotaBlocked(qr)
-			return 1
-		}
-		printQuotaWarning(qr)
-		_ = storage.SaveQuotaState(a.profile)
+	if !a.enforceQuota(authResult.IDToken) {
+		return 1
 	}
 
 	// Get AWS credentials
@@ -715,13 +696,45 @@ func (a *credentialApp) getAWSCredentials(auth *oidc.AuthResult) (*federation.AW
 	)
 }
 
-func (a *credentialApp) trySilentRefresh() *federation.AWSCredentials {
+// enforceQuota performs the pre-issuance quota check with the given id_token.
+// Returns false when credentials must NOT be issued. When a quota endpoint is
+// configured but no usable token is available, the outcome is decided by
+// quota_fail_mode — never silently skipped (#761).
+func (a *credentialApp) enforceQuota(idToken string) bool {
+	if a.cfg.QuotaAPIEndpoint == "" {
+		return true
+	}
+	if idToken == "" {
+		// The OIDC quota API expects a JWT. Never fall through to the SigV4
+		// path here — inside credential-process the default credential chain
+		// would recurse into ourselves.
+		if a.cfg.QuotaFailMode == "closed" {
+			fmt.Fprintln(os.Stderr, "Error: quota enforcement is configured but no identity token is available for the check (quota fail mode: closed).")
+			return false
+		}
+		debugPrint("Quota check has no identity token; allowing per fail mode 'open'")
+		return true
+	}
+	qr := quota.Check(a.cfg.QuotaAPIEndpoint, idToken, a.cfg.QuotaCheckTimeout, a.cfg.QuotaFailMode)
+	if !qr.Allowed {
+		printQuotaBlocked(qr)
+		return false
+	}
+	printQuotaWarning(qr)
+	_ = storage.SaveQuotaState(a.profile)
+	return true
+}
+
+// cachedTokenAuthResult builds an AuthResult from the cached monitoring
+// id_token, or returns nil when no valid unexpired token is cached. It makes
+// no network calls — the caller decides what to do with the token (quota
+// check first, then STS exchange).
+func (a *credentialApp) cachedTokenAuthResult() *oidc.AuthResult {
 	token, err := storage.GetMonitoringToken(a.profile, a.cfg.CredentialStorage)
 	if err != nil || token == "" {
 		debugPrint("No valid cached id_token for silent refresh")
 		return nil
 	}
-	debugPrint("Found valid cached id_token, attempting silent credential refresh...")
 	claims, err := jwt.DecodePayload(token)
 	if err != nil {
 		debugPrint("Failed to decode cached id_token: %v", err)
@@ -732,18 +745,26 @@ func (a *credentialApp) trySilentRefresh() *federation.AWSCredentials {
 		debugPrint("Cached id_token is expired, silent refresh not possible")
 		return nil
 	}
-	authResult := &oidc.AuthResult{IDToken: token, TokenClaims: claims}
-	creds, err := a.getAWSCredentials(authResult)
+	debugPrint("Found valid cached id_token, attempting silent credential refresh...")
+	return &oidc.AuthResult{IDToken: token, TokenClaims: claims}
+}
+
+// exchangeAndSaveCredentials exchanges a quota-cleared id_token for AWS
+// credentials and persists them plus the monitoring token. Callers MUST run
+// enforceQuota first — this is the only place the silent-refresh paths mint
+// credentials, which keeps the "quota before STS" ordering in one spot.
+// Returns nil on failure so callers can fall through to the next auth path.
+func (a *credentialApp) exchangeAndSaveCredentials(auth *oidc.AuthResult) *federation.AWSCredentials {
+	creds, err := a.getAWSCredentials(auth)
 	if err != nil {
-		debugPrint("Silent refresh failed, will require browser auth: %v", err)
+		debugPrint("AWS credential exchange failed: %v", err)
 		return nil
 	}
 	if saveErr := a.saveCredentials(creds); saveErr != nil {
-		debugPrint("Failed to save silently-refreshed credentials: %v", saveErr)
+		debugPrint("Failed to save credentials: %v", saveErr)
 	}
 	// Re-save monitoring token to refresh its expiry tracking
-	a.saveMonitoringTokenAndHeaders(token, map[string]interface{}(claims))
-	debugPrint("Silent credential refresh succeeded")
+	a.saveMonitoringTokenAndHeaders(auth.IDToken, map[string]interface{}(auth.TokenClaims))
 	return creds
 }
 
@@ -752,7 +773,12 @@ func (a *credentialApp) trySilentRefresh() *federation.AWSCredentials {
 // Cowork 3P (Claude Desktop): after the id_token expires, credential-process
 // can still silently refresh credentials as long as the refresh_token is valid
 // (typically 7-30 days depending on IdP configuration).
-func (a *credentialApp) tryRefreshToken() *federation.AWSCredentials {
+//
+// It persists the refreshed monitoring token and rotated refresh_token, but
+// deliberately does NOT exchange for AWS credentials: quota must be enforced
+// on the fresh id_token before any STS call (#761), and callers like
+// --get-mcp-auth-header and --get-monitoring-token only need the id_token.
+func (a *credentialApp) tryRefreshToken() *oidc.AuthResult {
 	refreshToken := storage.LoadRefreshToken(a.profile, a.cfg.CredentialStorage)
 	if refreshToken == "" {
 		debugPrint("No cached refresh_token, cannot refresh silently")
@@ -809,23 +835,6 @@ func (a *credentialApp) tryRefreshToken() *federation.AWSCredentials {
 		return nil
 	}
 
-	// Exchange for AWS credentials
-	authResult := &oidc.AuthResult{
-		IDToken:      tokenResp.IDToken,
-		RefreshToken: tokenResp.RefreshToken,
-		TokenClaims:  claims,
-	}
-	creds, err := a.getAWSCredentials(authResult)
-	if err != nil {
-		debugPrint("AWS credential exchange after refresh failed: %v", err)
-		return nil
-	}
-
-	// Save refreshed credentials
-	if saveErr := a.saveCredentials(creds); saveErr != nil {
-		debugPrint("Failed to save refresh-derived credentials: %v", saveErr)
-	}
-
 	// Update monitoring token with fresh id_token
 	a.saveMonitoringTokenAndHeaders(tokenResp.IDToken, map[string]interface{}(claims))
 
@@ -834,79 +843,12 @@ func (a *credentialApp) tryRefreshToken() *federation.AWSCredentials {
 		_ = storage.SaveRefreshToken(a.profile, a.cfg.CredentialStorage, tokenResp.RefreshToken)
 	}
 
-	debugPrint("Refresh token exchange succeeded — credentials renewed without browser")
-	return creds
-}
-
-// refreshIDTokenOnly performs the browserless refresh_token exchange and returns
-// a fresh id_token WITHOUT exchanging it for AWS credentials. It exists for the
-// MCP headersHelper path (--get-mcp-auth-header): the AgentCore CUSTOM_JWT gateway
-// authorizer validates only the id_token, so the header must still be emitted even
-// when the AWS STS/IAM credential exchange would fail or time out — a failure mode
-// unrelated to gateway auth. (tryRefreshToken couples the two and returns nil if
-// cred exchange fails, which would discard a valid refreshed id_token.)
-//
-// It mirrors tryRefreshToken's endpoint/confidential-auth resolution and persists
-// the refreshed monitoring token + rotated refresh_token so the next cache read
-// hits, but never opens a browser. Returns "" on any failure so the caller fails
-// cleanly. Only meaningful for OIDC (idc/none have no id_token).
-func (a *credentialApp) refreshIDTokenOnly() string {
-	refreshToken := storage.LoadRefreshToken(a.profile, a.cfg.CredentialStorage)
-	if refreshToken == "" {
-		debugPrint("No cached refresh_token, cannot refresh id_token silently")
-		return ""
+	debugPrint("id_token refreshed without browser")
+	return &oidc.AuthResult{
+		IDToken:      tokenResp.IDToken,
+		RefreshToken: tokenResp.RefreshToken,
+		TokenClaims:  claims,
 	}
-
-	// Resolve token endpoint URL — use shared builder from #666 to avoid
-	// Azure /v2.0 doubling and keep parity with tryRefreshToken.
-	var tokenURL string
-	if a.providerType == "generic" {
-		tokenURL = a.cfg.OIDCTokenEndpoint
-	} else {
-		tokenURL = provider.TokenEndpointURL(a.providerType, a.cfg.OktaAuthServerID, a.cfg.ProviderDomain)
-	}
-
-	confidential, err := a.resolveConfidentialAuth()
-	if err != nil {
-		debugPrint("Failed to resolve confidential auth for id_token refresh: %v", err)
-		return ""
-	}
-
-	tokenResp, err := oidc.RefreshTokenExchange(tokenURL, refreshToken, a.cfg.ClientID, confidential)
-	if err != nil {
-		debugPrint("Refresh token exchange failed: %v", err)
-		// Clear only on a definitive rejection (invalid_grant / invalid_token);
-		// retain on transient failures so a later cycle can retry. See the twin
-		// guard in tryRefreshToken.
-		if oidc.IsDefinitiveRefreshFailure(err) {
-			debugPrint("Refresh_token rejected by IdP (invalid_grant); clearing stored token")
-			storage.ClearRefreshToken(a.profile)
-		} else {
-			debugPrint("Transient refresh failure; retaining refresh_token for next attempt")
-		}
-		return ""
-	}
-	if tokenResp.IDToken == "" {
-		debugPrint("Refresh response did not contain an id_token")
-		return ""
-	}
-
-	claims, err := jwt.DecodePayload(tokenResp.IDToken)
-	if err != nil {
-		debugPrint("Failed to decode refreshed id_token: %v", err)
-		return ""
-	}
-
-	// Persist the refreshed monitoring token so the next cache read hits, and
-	// rotate the refresh_token (some IdPs rotate on every use). Deliberately no
-	// AWS credential exchange here — see the doc comment above.
-	a.saveMonitoringTokenAndHeaders(tokenResp.IDToken, map[string]interface{}(claims))
-	if tokenResp.RefreshToken != "" {
-		_ = storage.SaveRefreshToken(a.profile, a.cfg.CredentialStorage, tokenResp.RefreshToken)
-	}
-
-	debugPrint("id_token refreshed without browser (no AWS credential exchange)")
-	return tokenResp.IDToken
 }
 
 // saveMonitoringTokenAndHeaders persists the monitoring token and also writes
@@ -959,8 +901,8 @@ func (a *credentialApp) performQuotaRecheck() bool {
 		// getMonitoringToken() handler: try a silent refresh_token exchange to
 		// mint a fresh id_token before giving up, so an over-quota user is still
 		// warned/blocked on the cache-hit fast path instead of silently passing.
-		if creds := a.tryRefreshToken(); creds != nil {
-			token, _ = storage.GetMonitoringToken(a.profile, a.cfg.CredentialStorage)
+		if auth := a.tryRefreshToken(); auth != nil {
+			token = auth.IDToken
 		}
 	}
 	if token == "" {

--- a/source/go/cmd/credential-process/quota_enforcement_order_test.go
+++ b/source/go/cmd/credential-process/quota_enforcement_order_test.go
@@ -1,0 +1,466 @@
+package main
+
+// ABOUTME: Regression tests for #761 — quota must be enforced BEFORE the STS
+// ABOUTME: exchange on the silent-refresh and refresh-token paths, and the
+// ABOUTME: check must never be silently skipped when a quota endpoint is set.
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"ccwb-go/internal/config"
+	"ccwb-go/internal/federation"
+	"ccwb-go/internal/storage"
+)
+
+// stsRecorder is an httptest server that counts AssumeRoleWithWebIdentity
+// calls and returns a syntactically valid credentials response. run() reaches
+// it via AWS_ENDPOINT_URL_STS, which the SDK's config loader honors.
+func stsRecorder(t *testing.T) (*httptest.Server, *int32) {
+	t.Helper()
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "text/xml")
+		fmt.Fprint(w, `<AssumeRoleWithWebIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRoleWithWebIdentityResult>
+    <Credentials>
+      <AccessKeyId>ASIAMOCKSTS12345</AccessKeyId>
+      <SecretAccessKey>mock-secret</SecretAccessKey>
+      <SessionToken>mock-session-token</SessionToken>
+      <Expiration>2099-01-01T00:00:00Z</Expiration>
+    </Credentials>
+    <SubjectFromWebIdentityToken>user-123</SubjectFromWebIdentityToken>
+  </AssumeRoleWithWebIdentityResult>
+  <ResponseMetadata><RequestId>mock-request</RequestId></ResponseMetadata>
+</AssumeRoleWithWebIdentityResponse>`)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &hits
+}
+
+// quotaRecorder returns a quota API stub that counts /check calls and answers
+// with the given allowed value.
+func quotaRecorder(t *testing.T, allowed bool) (*httptest.Server, *int32) {
+	t.Helper()
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if allowed {
+			fmt.Fprint(w, `{"allowed": true, "reason": "within_limits", "message": "ok"}`)
+			return
+		}
+		fmt.Fprint(w, `{"allowed": false, "reason": "quota_exceeded", "message": "Usage quota exceeded."}`)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &hits
+}
+
+// freeLocalPort grabs an ephemeral port for run()'s port-lock acquisition so
+// parallel test runs never collide on the default 8400.
+func freeLocalPort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+	return port
+}
+
+// newQuotaOrderEnv isolates HOME/session storage and points the AWS SDK at the
+// mock STS server. Returns the temp home dir.
+func newQuotaOrderEnv(t *testing.T, stsURL string) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir) // Windows
+	t.Setenv("CLAUDE_CODE_MONITORING_TOKEN", "")
+	t.Setenv("AWS_ENDPOINT_URL_STS", stsURL)
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".claude-code-session"), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	return tmpDir
+}
+
+func directSTSConfig(quotaURL string, port int) *config.ProfileConfig {
+	return &config.ProfileConfig{
+		ClientID:           "test-client",
+		ProviderDomain:     "test.example.com",
+		CredentialStorage:  "session",
+		SsoEnabled:         boolPtr(true),
+		FederationType:     "direct",
+		FederatedRoleARN:   "arn:aws:iam::123456789012:role/TestRole",
+		AWSRegion:          "us-east-1",
+		MaxSessionDuration: 3600,
+		QuotaAPIEndpoint:   quotaURL,
+		QuotaFailMode:      "open",
+		QuotaCheckTimeout:  2,
+		RedirectPort:       port,
+	}
+}
+
+// assertNoSavedCredentials fails the test when real (non-dummy) credentials
+// were persisted for the profile.
+func assertNoSavedCredentials(t *testing.T, profile string) {
+	t.Helper()
+	creds, err := storage.ReadFromCredentialsFile(profile)
+	if err != nil || creds == nil || storage.IsExpiredDummy(creds) {
+		return
+	}
+	t.Errorf("credentials were saved for profile %q despite quota block: AccessKeyId=%s",
+		profile, creds.AccessKeyID)
+}
+
+// TestRun_SilentRefreshPath_QuotaBlockedBeforeSTS is the core regression test
+// for #761: with a valid cached id_token and a quota API that answers
+// allowed=false, run() must exit non-zero WITHOUT calling STS and WITHOUT
+// persisting credentials. Before the fix, trySilentRefresh() exchanged and
+// saved AWS credentials first and only then consulted the quota API.
+func TestRun_SilentRefreshPath_QuotaBlockedBeforeSTS(t *testing.T) {
+	setupNotificationTest(t)
+	stsSrv, stsHits := stsRecorder(t)
+	quotaSrv, quotaHits := quotaRecorder(t, false)
+	tmpDir := newQuotaOrderEnv(t, stsSrv.URL)
+
+	profile := "test-quota-order-silent-blocked"
+	idToken := fakeJWT(t, map[string]interface{}{
+		"sub": "user-123", "email": "test@example.com",
+		"exp": float64(time.Now().Unix() + 3600),
+	})
+	writeMonitoringToken(t, tmpDir, profile, idToken, time.Now().Unix()+3600)
+
+	app := &credentialApp{
+		profile:      profile,
+		cfg:          directSTSConfig(quotaSrv.URL, freeLocalPort(t)),
+		providerType: "okta",
+		redirectPort: 0,
+	}
+	app.redirectPort = app.cfg.RedirectPort
+
+	res := captureMCPStdout(t, app.run)
+	if res.code != 1 {
+		t.Fatalf("run() = %d, want 1 (quota blocked)", res.code)
+	}
+	if res.stdout != "" {
+		t.Errorf("run() printed to stdout despite quota block: %q", res.stdout)
+	}
+	if got := atomic.LoadInt32(quotaHits); got != 1 {
+		t.Errorf("quota API hits = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(stsHits); got != 0 {
+		t.Errorf("STS hits = %d, want 0 — credentials were exchanged before/despite the quota block", got)
+	}
+	assertNoSavedCredentials(t, profile)
+}
+
+// TestRun_RefreshTokenPath_QuotaBlockedBeforeSTS covers the refresh_token
+// (Cowork 3P) path: quota must be checked with the freshly-exchanged id_token
+// BEFORE any STS call, and a block must leave no credentials behind.
+func TestRun_RefreshTokenPath_QuotaBlockedBeforeSTS(t *testing.T) {
+	setupNotificationTest(t)
+	stsSrv, stsHits := stsRecorder(t)
+	quotaSrv, quotaHits := quotaRecorder(t, false)
+	newQuotaOrderEnv(t, stsSrv.URL)
+
+	profile := "test-quota-order-refresh-blocked"
+	t.Cleanup(func() { storage.ClearRefreshToken(profile) })
+
+	freshIDToken := fakeJWT(t, map[string]interface{}{
+		"sub": "user-123", "email": "test@example.com",
+		"exp": float64(time.Now().Unix() + 3600),
+	})
+	idpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"id_token": %q, "refresh_token": "rt_rotated", "token_type": "Bearer"}`, freshIDToken)
+	}))
+	defer idpSrv.Close()
+
+	if err := storage.SaveRefreshToken(profile, "session", "rt_original"); err != nil {
+		t.Fatalf("SaveRefreshToken: %v", err)
+	}
+
+	cfg := directSTSConfig(quotaSrv.URL, freeLocalPort(t))
+	cfg.OIDCTokenEndpoint = idpSrv.URL
+	app := &credentialApp{profile: profile, cfg: cfg, providerType: "generic", redirectPort: cfg.RedirectPort}
+
+	res := captureMCPStdout(t, app.run)
+	if res.code != 1 {
+		t.Fatalf("run() = %d, want 1 (quota blocked)", res.code)
+	}
+	if res.stdout != "" {
+		t.Errorf("run() printed to stdout despite quota block: %q", res.stdout)
+	}
+	if got := atomic.LoadInt32(quotaHits); got != 1 {
+		t.Errorf("quota API hits = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(stsHits); got != 0 {
+		t.Errorf("STS hits = %d, want 0 — credentials were exchanged before/despite the quota block", got)
+	}
+	assertNoSavedCredentials(t, profile)
+}
+
+// TestRun_RefreshTokenPath_ShortLivedTokenStillChecked pins the fix for the
+// silent-skip variant of #761: the pre-fix code re-read the monitoring token
+// from storage and skipped the quota check entirely when that read came back
+// empty. An IdP issuing id_tokens with a lifetime inside the 10-minute
+// storage buffer (exp - now <= 600s) made that skip systematic: credentials
+// were issued with the quota API never called. The fix checks quota with the
+// in-scope token, so the block must now fire.
+func TestRun_RefreshTokenPath_ShortLivedTokenStillChecked(t *testing.T) {
+	setupNotificationTest(t)
+	stsSrv, stsHits := stsRecorder(t)
+	quotaSrv, quotaHits := quotaRecorder(t, false)
+	newQuotaOrderEnv(t, stsSrv.URL)
+
+	profile := "test-quota-order-shortlived"
+	t.Cleanup(func() { storage.ClearRefreshToken(profile) })
+
+	// exp within the 600s buffer → storage.GetMonitoringToken returns ""
+	shortLivedToken := fakeJWT(t, map[string]interface{}{
+		"sub": "user-123", "email": "test@example.com",
+		"exp": float64(time.Now().Unix() + 300),
+	})
+	idpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"id_token": %q, "token_type": "Bearer"}`, shortLivedToken)
+	}))
+	defer idpSrv.Close()
+
+	if err := storage.SaveRefreshToken(profile, "session", "rt_original"); err != nil {
+		t.Fatalf("SaveRefreshToken: %v", err)
+	}
+
+	cfg := directSTSConfig(quotaSrv.URL, freeLocalPort(t))
+	cfg.OIDCTokenEndpoint = idpSrv.URL
+	app := &credentialApp{profile: profile, cfg: cfg, providerType: "generic", redirectPort: cfg.RedirectPort}
+
+	res := captureMCPStdout(t, app.run)
+	if res.code != 1 {
+		t.Fatalf("run() = %d, want 1 (quota blocked) — short-lived id_token must not skip the quota check", res.code)
+	}
+	if got := atomic.LoadInt32(quotaHits); got != 1 {
+		t.Errorf("quota API hits = %d, want 1 — the check was silently skipped", got)
+	}
+	if got := atomic.LoadInt32(stsHits); got != 0 {
+		t.Errorf("STS hits = %d, want 0", got)
+	}
+	assertNoSavedCredentials(t, profile)
+}
+
+// TestRun_SilentRefreshPath_QuotaAllowedIssuesCredentials proves the happy
+// path still works after the reordering: quota allows → STS is called →
+// credentials are printed and cached.
+func TestRun_SilentRefreshPath_QuotaAllowedIssuesCredentials(t *testing.T) {
+	setupNotificationTest(t)
+	stsSrv, stsHits := stsRecorder(t)
+	quotaSrv, quotaHits := quotaRecorder(t, true)
+	tmpDir := newQuotaOrderEnv(t, stsSrv.URL)
+
+	profile := "test-quota-order-allowed"
+	idToken := fakeJWT(t, map[string]interface{}{
+		"sub": "user-123", "email": "test@example.com",
+		"exp": float64(time.Now().Unix() + 3600),
+	})
+	writeMonitoringToken(t, tmpDir, profile, idToken, time.Now().Unix()+3600)
+
+	cfg := directSTSConfig(quotaSrv.URL, freeLocalPort(t))
+	app := &credentialApp{profile: profile, cfg: cfg, providerType: "okta", redirectPort: cfg.RedirectPort}
+
+	res := captureMCPStdout(t, app.run)
+	if res.code != 0 {
+		t.Fatalf("run() = %d, want 0 (quota allowed)", res.code)
+	}
+	if got := atomic.LoadInt32(quotaHits); got != 1 {
+		t.Errorf("quota API hits = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(stsHits); got != 1 {
+		t.Errorf("STS hits = %d, want 1", got)
+	}
+	creds, err := storage.ReadFromCredentialsFile(profile)
+	if err != nil || creds == nil {
+		t.Fatalf("expected saved credentials after allowed refresh, got err=%v", err)
+	}
+	if creds.AccessKeyID != "ASIAMOCKSTS12345" {
+		t.Errorf("saved AccessKeyId = %q, want mock STS value", creds.AccessKeyID)
+	}
+}
+
+// TestEnforceQuota_NoTokenHonorsFailMode pins the "never silently skip"
+// contract: with a quota endpoint configured but no token available, the
+// outcome is decided by quota_fail_mode instead of bypassing the check.
+func TestEnforceQuota_NoTokenHonorsFailMode(t *testing.T) {
+	cfgClosed := &config.ProfileConfig{QuotaAPIEndpoint: "https://quota.invalid.example.com", QuotaFailMode: "closed"}
+	appClosed := &credentialApp{profile: "test-enforce-closed", cfg: cfgClosed}
+	if appClosed.enforceQuota("") {
+		t.Errorf("enforceQuota(\"\") = true with fail mode 'closed', want false (fail closed)")
+	}
+
+	cfgOpen := &config.ProfileConfig{QuotaAPIEndpoint: "https://quota.invalid.example.com", QuotaFailMode: "open"}
+	appOpen := &credentialApp{profile: "test-enforce-open", cfg: cfgOpen}
+	if !appOpen.enforceQuota("") {
+		t.Errorf("enforceQuota(\"\") = false with fail mode 'open', want true")
+	}
+
+	cfgNone := &config.ProfileConfig{}
+	appNone := &credentialApp{profile: "test-enforce-none", cfg: cfgNone}
+	if !appNone.enforceQuota("") {
+		t.Errorf("enforceQuota(\"\") = false with no quota endpoint, want true")
+	}
+}
+
+// TestRunDesktopHelper_QuotaBlockedOnRefresh pins the desktop-helper (#761
+// follow-on): the --desktop silent refresh previously minted a Bedrock bearer
+// token with NO quota check at all. With CLAUDE_HELPER_CONTEXT=silent (no
+// interactive fallback), a quota block must exit 1 without touching STS and
+// without emitting a token.
+func TestRunDesktopHelper_QuotaBlockedOnRefresh(t *testing.T) {
+	setupNotificationTest(t)
+	stsSrv, stsHits := stsRecorder(t)
+	quotaSrv, quotaHits := quotaRecorder(t, false)
+	newQuotaOrderEnv(t, stsSrv.URL)
+	t.Setenv("CLAUDE_HELPER_CONTEXT", "silent")
+
+	profile := "test-desktop-quota-blocked"
+	t.Cleanup(func() { storage.ClearRefreshToken(profile) })
+
+	freshIDToken := fakeJWT(t, map[string]interface{}{
+		"sub": "user-123", "email": "test@example.com",
+		"exp": float64(time.Now().Unix() + 3600),
+	})
+	idpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"id_token": %q, "token_type": "Bearer"}`, freshIDToken)
+	}))
+	defer idpSrv.Close()
+
+	if err := storage.SaveRefreshToken(profile, "session", "rt_original"); err != nil {
+		t.Fatalf("SaveRefreshToken: %v", err)
+	}
+
+	cfg := directSTSConfig(quotaSrv.URL, freeLocalPort(t))
+	cfg.OIDCTokenEndpoint = idpSrv.URL
+	app := &credentialApp{profile: profile, cfg: cfg, providerType: "generic", redirectPort: cfg.RedirectPort}
+
+	res := captureMCPStdout(t, app.runDesktopHelper)
+	if res.code != 1 {
+		t.Fatalf("runDesktopHelper() = %d, want 1 (quota blocked)", res.code)
+	}
+	if res.stdout != "" {
+		t.Errorf("runDesktopHelper() emitted output despite quota block: %q", res.stdout)
+	}
+	if got := atomic.LoadInt32(quotaHits); got != 1 {
+		t.Errorf("quota API hits = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(stsHits); got != 0 {
+		t.Errorf("STS hits = %d, want 0 — desktop helper exchanged credentials despite quota block", got)
+	}
+	assertNoSavedCredentials(t, profile)
+}
+
+// TestRunDesktopHelper_QuotaAllowedEmitsToken proves the desktop happy path
+// still works with quota enforcement in place: allowed → STS exchange → a
+// Bedrock bearer token is emitted.
+func TestRunDesktopHelper_QuotaAllowedEmitsToken(t *testing.T) {
+	setupNotificationTest(t)
+	stsSrv, stsHits := stsRecorder(t)
+	quotaSrv, _ := quotaRecorder(t, true)
+	newQuotaOrderEnv(t, stsSrv.URL)
+	t.Setenv("CLAUDE_HELPER_CONTEXT", "silent")
+
+	profile := "test-desktop-quota-allowed"
+	t.Cleanup(func() { storage.ClearRefreshToken(profile) })
+
+	freshIDToken := fakeJWT(t, map[string]interface{}{
+		"sub": "user-123", "email": "test@example.com",
+		"exp": float64(time.Now().Unix() + 3600),
+	})
+	idpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"id_token": %q, "token_type": "Bearer"}`, freshIDToken)
+	}))
+	defer idpSrv.Close()
+
+	if err := storage.SaveRefreshToken(profile, "session", "rt_original"); err != nil {
+		t.Fatalf("SaveRefreshToken: %v", err)
+	}
+
+	cfg := directSTSConfig(quotaSrv.URL, freeLocalPort(t))
+	cfg.OIDCTokenEndpoint = idpSrv.URL
+	app := &credentialApp{profile: profile, cfg: cfg, providerType: "generic", redirectPort: cfg.RedirectPort}
+
+	res := captureMCPStdout(t, app.runDesktopHelper)
+	if res.code != 0 {
+		t.Fatalf("runDesktopHelper() = %d, want 0 (quota allowed)", res.code)
+	}
+	if got := atomic.LoadInt32(stsHits); got != 1 {
+		t.Errorf("STS hits = %d, want 1", got)
+	}
+	if !strings.Contains(res.stdout, `"token"`) {
+		t.Errorf("runDesktopHelper() stdout missing bearer token JSON: %q", res.stdout)
+	}
+}
+
+// TestPerformQuotaRecheck_ShortLivedTokenStillChecked pins the cache-hit
+// variant of the silent-skip fix: after a successful refresh_token exchange,
+// performQuotaRecheck must use the in-scope fresh id_token. The pre-fix code
+// re-read it from storage, where an id_token expiring inside the 10-minute
+// buffer reads back empty — so the recheck failed open and the blocked user
+// kept their cached credentials.
+func TestPerformQuotaRecheck_ShortLivedTokenStillChecked(t *testing.T) {
+	setupNotificationTest(t)
+	stsSrv, _ := stsRecorder(t)
+	quotaSrv, quotaHits := quotaRecorder(t, false)
+	newQuotaOrderEnv(t, stsSrv.URL)
+
+	profile := "test-recheck-shortlived"
+	t.Cleanup(func() { storage.ClearRefreshToken(profile) })
+
+	// exp within the 600s buffer → storage.GetMonitoringToken returns ""
+	shortLivedToken := fakeJWT(t, map[string]interface{}{
+		"sub": "user-123", "email": "test@example.com",
+		"exp": float64(time.Now().Unix() + 300),
+	})
+	idpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"id_token": %q, "token_type": "Bearer"}`, shortLivedToken)
+	}))
+	defer idpSrv.Close()
+
+	if err := storage.SaveRefreshToken(profile, "session", "rt_original"); err != nil {
+		t.Fatalf("SaveRefreshToken: %v", err)
+	}
+	// Seed cached credentials that the block must wipe.
+	seeded := &federation.AWSCredentials{
+		Version: 1, AccessKeyID: "ASIASEEDED", SecretAccessKey: "seed",
+		SessionToken: "seed", Expiration: time.Now().Add(time.Hour).Format(time.RFC3339),
+	}
+	if err := storage.SaveToCredentialsFile(seeded, profile); err != nil {
+		t.Fatalf("SaveToCredentialsFile: %v", err)
+	}
+
+	cfg := directSTSConfig(quotaSrv.URL, freeLocalPort(t))
+	cfg.OIDCTokenEndpoint = idpSrv.URL
+	app := &credentialApp{profile: profile, cfg: cfg, providerType: "generic", redirectPort: cfg.RedirectPort}
+
+	if allowed := app.performQuotaRecheck(); allowed {
+		t.Fatalf("performQuotaRecheck = true with a blocking quota response — short-lived id_token silently skipped the check")
+	}
+	if got := atomic.LoadInt32(quotaHits); got != 1 {
+		t.Errorf("quota API hits = %d, want 1", got)
+	}
+	if creds, err := storage.ReadFromCredentialsFile(profile); err == nil && creds != nil && !storage.IsExpiredDummy(creds) {
+		t.Errorf("cached credentials survived a quota block: AccessKeyId=%s", creds.AccessKeyID)
+	}
+}

--- a/source/go/cmd/credential-process/refresh_clear_test.go
+++ b/source/go/cmd/credential-process/refresh_clear_test.go
@@ -80,43 +80,7 @@ func TestTryRefreshToken_ServerErrorRetainsToken(t *testing.T) {
 	}
 }
 
-// TestRefreshIDTokenOnly_ServerErrorRetainsToken guards the twin clear site on
-// the MCP-auth-header path (refreshIDTokenOnly), which had the identical
-// clear-on-any-failure bug.
-func TestRefreshIDTokenOnly_ServerErrorRetainsToken(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusBadGateway)
-		_, _ = w.Write([]byte(`bad gateway`))
-	}))
-	defer srv.Close()
-
-	profile := "test-idtoken-only-server-error"
-	app := newRefreshApp(t, profile, srv.URL)
-
-	if tok := app.refreshIDTokenOnly(); tok != "" {
-		t.Fatalf("refreshIDTokenOnly returned non-empty on 502: %q", tok)
-	}
-	if got := storage.LoadRefreshToken(profile, "session"); got != "rt_original" {
-		t.Errorf("refresh_token = %q after transient 502, want retained (%q)", got, "rt_original")
-	}
-}
-
-// TestRefreshIDTokenOnly_InvalidGrantClearsToken confirms the MCP path still
-// clears on a definitive rejection.
-func TestRefreshIDTokenOnly_InvalidGrantClearsToken(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
-	}))
-	defer srv.Close()
-
-	profile := "test-idtoken-only-invalid-grant"
-	app := newRefreshApp(t, profile, srv.URL)
-
-	if tok := app.refreshIDTokenOnly(); tok != "" {
-		t.Fatalf("refreshIDTokenOnly returned non-empty on invalid_grant: %q", tok)
-	}
-	if got := storage.LoadRefreshToken(profile, "session"); got != "" {
-		t.Errorf("refresh_token = %q after invalid_grant, want cleared", got)
-	}
-}
+// NOTE: the former refreshIDTokenOnly twin tests were removed when that
+// function was consolidated into tryRefreshToken (which no longer performs an
+// AWS credential exchange). The two tests above now cover the single
+// clear-vs-retain site for every caller, including the MCP-auth-header path.

--- a/source/tests/test_silent_refresh.py
+++ b/source/tests/test_silent_refresh.py
@@ -101,7 +101,7 @@ def auth_instance(tmp_path):
 
 
 class TestSilentRefresh:
-    """Tests for _try_silent_refresh method."""
+    """Tests for the two-phase silent refresh (token load, then exchange)."""
 
     def test_silent_refresh_succeeds_with_valid_id_token(self, auth_instance):
         """When a valid id_token is cached, silent refresh should return new AWS creds."""
@@ -114,12 +114,14 @@ class TestSilentRefresh:
             patch.object(auth_instance, "save_credentials") as mock_save,
             patch.object(auth_instance, "save_monitoring_token") as mock_save_token,
         ):
-            creds, returned_token, returned_claims = auth_instance._try_silent_refresh()
+            returned_token, returned_claims = auth_instance._get_cached_token_for_silent_refresh()
+            assert returned_token == id_token
+            assert returned_claims["sub"] == claims["sub"]
+
+            creds = auth_instance._try_silent_refresh(returned_token, returned_claims)
 
             assert creds is not None
             assert creds["AccessKeyId"] == aws_creds["AccessKeyId"]
-            assert returned_token == id_token
-            assert returned_claims["sub"] == claims["sub"]
             mock_get_creds.assert_called_once()
             mock_save.assert_called_once_with(aws_creds)
             # Verify the id_token is re-persisted so the next refresh also works
@@ -127,14 +129,13 @@ class TestSilentRefresh:
 
     def test_silent_refresh_returns_none_when_id_token_expired(self, auth_instance):
         """When cached id_token is within the 60-second expiry buffer, get_monitoring_token
-        returns None and silent refresh must not attempt an STS exchange."""
+        returns None and the token-load phase must not surface a token."""
         with (
             patch.object(auth_instance, "get_monitoring_token", return_value=None) as mock_get_token,
             patch.object(auth_instance, "get_aws_credentials") as mock_get_creds,
         ):
-            creds, id_token, token_claims = auth_instance._try_silent_refresh()
+            id_token, token_claims = auth_instance._get_cached_token_for_silent_refresh()
 
-            assert creds is None
             assert id_token is None
             assert token_claims is None
             mock_get_token.assert_called_once()
@@ -142,25 +143,19 @@ class TestSilentRefresh:
             mock_get_creds.assert_not_called()
 
     def test_silent_refresh_returns_none_when_no_cached_token(self, auth_instance):
-        """When no id_token is cached, silent refresh should return None."""
+        """When no id_token is cached, the token-load phase should return None."""
         with patch.object(auth_instance, "get_monitoring_token", return_value=None):
-            creds, id_token, token_claims = auth_instance._try_silent_refresh()
-            assert creds is None
+            id_token, token_claims = auth_instance._get_cached_token_for_silent_refresh()
             assert id_token is None
             assert token_claims is None
 
     def test_silent_refresh_returns_none_when_sts_exchange_fails(self, auth_instance):
         """When id_token is valid but STS exchange fails, should return None (fallback to browser)."""
-        id_token, _ = _make_id_token(exp_offset=3600)
+        id_token, claims = _make_id_token(exp_offset=3600)
 
-        with (
-            patch.object(auth_instance, "get_monitoring_token", return_value=id_token),
-            patch.object(auth_instance, "get_aws_credentials", side_effect=Exception("STS error")),
-        ):
-            creds, returned_token, returned_claims = auth_instance._try_silent_refresh()
+        with patch.object(auth_instance, "get_aws_credentials", side_effect=Exception("STS error")):
+            creds = auth_instance._try_silent_refresh(id_token, claims)
             assert creds is None
-            assert returned_token is None
-            assert returned_claims is None
 
     def test_silent_refresh_not_called_when_aws_creds_valid(self, auth_instance):
         """When AWS credentials are still valid, silent refresh should not be attempted."""
@@ -168,6 +163,7 @@ class TestSilentRefresh:
 
         with (
             patch.object(auth_instance, "get_cached_credentials", return_value=aws_creds),
+            patch.object(auth_instance, "_get_cached_token_for_silent_refresh") as mock_load_token,
             patch.object(auth_instance, "_try_silent_refresh") as mock_silent,
             patch.object(auth_instance, "_should_recheck_quota", return_value=False),
         ):
@@ -175,16 +171,19 @@ class TestSilentRefresh:
             with patch("builtins.print"):
                 auth_instance.run()
 
+            mock_load_token.assert_not_called()
             mock_silent.assert_not_called()
 
     def test_run_uses_silent_refresh_before_browser(self, auth_instance):
         """When AWS creds expired but id_token valid, run() should use silent refresh."""
+        id_token, claims = _make_id_token(exp_offset=3600)
         aws_creds = _make_aws_credentials(exp_offset=3600)
 
         with (
             patch.object(auth_instance, "get_cached_credentials", return_value=None),
             patch("socket.socket") as mock_socket_cls,
-            patch.object(auth_instance, "_try_silent_refresh", return_value=(aws_creds, None, None)),
+            patch.object(auth_instance, "_get_cached_token_for_silent_refresh", return_value=(id_token, claims)),
+            patch.object(auth_instance, "_try_silent_refresh", return_value=aws_creds),
             patch.object(auth_instance, "_should_check_quota", return_value=False),
             patch.object(auth_instance, "authenticate_oidc") as mock_browser,
             patch("builtins.print"),
@@ -206,7 +205,7 @@ class TestSilentRefresh:
         with (
             patch.object(auth_instance, "get_cached_credentials", return_value=None),
             patch("socket.socket") as mock_socket_cls,
-            patch.object(auth_instance, "_try_silent_refresh", return_value=(None, None, None)),
+            patch.object(auth_instance, "_get_cached_token_for_silent_refresh", return_value=(None, None)),
             patch.object(auth_instance, "authenticate_oidc", return_value=(id_token, claims)) as mock_browser,
             patch.object(auth_instance, "_should_check_quota", return_value=False),
             patch.object(auth_instance, "get_aws_credentials", return_value=aws_creds),
@@ -221,3 +220,70 @@ class TestSilentRefresh:
 
             assert result == 0
             mock_browser.assert_called_once()
+
+
+class TestQuotaBeforeSTSOnSilentRefresh:
+    """Regression tests for #761: quota must be enforced BEFORE the STS
+    exchange on the silent-refresh path, so an over-quota user never mints
+    or caches fresh credentials."""
+
+    def test_quota_blocked_prevents_sts_exchange(self, auth_instance):
+        """Quota blocked → run() must exit via the blocked handler WITHOUT
+        calling get_aws_credentials or save_credentials. Before the fix,
+        _try_silent_refresh exchanged and saved credentials first."""
+        id_token, claims = _make_id_token(exp_offset=3600)
+
+        with (
+            patch.object(auth_instance, "get_cached_credentials", return_value=None),
+            patch("socket.socket") as mock_socket_cls,
+            patch.object(auth_instance, "get_monitoring_token", return_value=id_token),
+            patch.object(auth_instance, "_should_check_quota", return_value=True),
+            patch.object(auth_instance, "_check_quota", return_value={"allowed": False, "reason": "quota_exceeded"}),
+            patch.object(auth_instance, "_save_quota_check_timestamp"),
+            patch.object(auth_instance, "_handle_quota_blocked", return_value=1) as mock_blocked,
+            patch.object(auth_instance, "get_aws_credentials") as mock_get_creds,
+            patch.object(auth_instance, "save_credentials") as mock_save,
+            patch.object(auth_instance, "authenticate_oidc") as mock_browser,
+            patch("builtins.print"),
+        ):
+            mock_socket = MagicMock()
+            mock_socket_cls.return_value = mock_socket
+
+            result = auth_instance.run()
+
+            assert result == 1
+            mock_blocked.assert_called_once()
+            # The heart of #761: no STS exchange, no cached credentials, no browser
+            mock_get_creds.assert_not_called()
+            mock_save.assert_not_called()
+            mock_browser.assert_not_called()
+
+    def test_quota_allowed_proceeds_to_sts_exchange(self, auth_instance):
+        """Quota allowed → the exchange runs and credentials are emitted."""
+        id_token, claims = _make_id_token(exp_offset=3600)
+        aws_creds = _make_aws_credentials()
+
+        with (
+            patch.object(auth_instance, "get_cached_credentials", return_value=None),
+            patch("socket.socket") as mock_socket_cls,
+            patch.object(auth_instance, "get_monitoring_token", return_value=id_token),
+            patch.object(auth_instance, "_should_check_quota", return_value=True),
+            patch.object(auth_instance, "_check_quota", return_value={"allowed": True}) as mock_quota,
+            patch.object(auth_instance, "_save_quota_check_timestamp"),
+            patch.object(auth_instance, "_handle_quota_warning"),
+            patch.object(auth_instance, "get_aws_credentials", return_value=aws_creds) as mock_get_creds,
+            patch.object(auth_instance, "save_credentials") as mock_save,
+            patch.object(auth_instance, "save_monitoring_token"),
+            patch.object(auth_instance, "authenticate_oidc") as mock_browser,
+            patch("builtins.print"),
+        ):
+            mock_socket = MagicMock()
+            mock_socket_cls.return_value = mock_socket
+
+            result = auth_instance.run()
+
+            assert result == 0
+            mock_quota.assert_called_once()
+            mock_get_creds.assert_called_once()
+            mock_save.assert_called_once_with(aws_creds)
+            mock_browser.assert_not_called()


### PR DESCRIPTION
## Why

Fixes #761. With `block` enforcement configured, over-quota users could still receive fresh AWS credentials:

1. **Ordering inversion:** on the silent-refresh and refresh_token paths, `trySilentRefresh()`/`tryRefreshToken()` exchanged the id_token for STS credentials and **saved them to cache** before `run()` performed the quota check. A block arrived after the credentials already existed, and the saved credentials could still be served from cache until the next recheck interval.
2. **Silent skip:** the quota check on those paths re-read the monitoring token from storage and was skipped entirely when that read came back empty (`if token != ""`), ignoring `quota_fail_mode`. IdPs issuing id_tokens with lifetimes inside the 10-minute storage buffer made this a systematic bypass.
3. **Same class, other entrypoints:** the desktop helper (`--desktop`) silent refresh minted a Bedrock bearer token with no quota check at all, and the `--get-monitoring-token` browser fallback (Go and Python) minted and cached credentials as a side effect with no quota check.

## What

- `run()` refresh paths now obtain the id_token first (`cachedTokenAuthResult()` / `tryRefreshToken()`), enforce quota with that in-scope token, and only then exchange for and persist credentials (`exchangeAndSaveCredentials()`). Blocked → exit 1 with nothing minted or cached.
- New `enforceQuota()` is the single pre-issuance check used by the browser, silent-refresh, refresh-token, and desktop paths. A configured endpoint with no usable token resolves via `quota_fail_mode` (closed → block; open → allow with a debug note) instead of being silently skipped. It never falls through to the SigV4 path with an empty token (credential recursion).
- `tryRefreshToken()` now performs only the token exchange (absorbing the former `refreshIDTokenOnly()` twin, which was line-for-line identical) — no caller can mint credentials without passing quota enforcement first. `performQuotaRecheck()` uses the fresh in-scope id_token instead of re-reading storage, closing the same silent fail-open on the cache-hit fast path.
- `--get-monitoring-token` (Go + Python) persists only the monitoring token after browser auth, so blocked users keep OTEL attribution without gaining credentials. Its consumers (otel-helper, `ccwb test`, install scripts) read only stdout, verified unaffected.
- Python `_try_silent_refresh` split into token-load + exchange phases with the quota check between them — Go/Python parity preserved (Python has no refresh_token store, so only the silent path applies).
- Docs: `credential-flow.md`, `token-endpoint-single-builder.md`, and the root `CLAUDE.md` flow updated to the quota-before-STS ordering.

## Behavior notes

- Browser-auth path ordering is unchanged (it already checked quota before STS).
- A quota block on a refresh path exits 1 **without** clearing the refresh_token, so users resume silently once quota resets (matches browser-path behavior).
- `--get-monitoring-token` no longer fails when the STS exchange would fail — more correct for a telemetry entrypoint, and matches the pre-existing Python behavior.
- In degraded STS conditions one invocation may check quota more than once as it falls through silent-refresh → refresh_token → browser; each path independently enforces before minting.

## Regression tests

Go (`quota_enforcement_order_test.go`, mock IdP + quota API + STS via `AWS_ENDPOINT_URL_STS`):
- Silent-refresh path, quota blocked → exit 1, **0 STS calls**, nothing cached (fails pre-fix: STS was called first and credentials saved)
- refresh_token path, quota blocked → same assertions
- Short-lived id_token (inside the 10-min buffer) → quota API still called and block enforced (fails pre-fix: check silently skipped, credentials issued)
- Quota allowed → STS called once, credentials issued and cached (happy path preserved)
- `enforceQuota("")` honors fail mode closed/open; no-endpoint no-op
- Desktop helper: blocked → exit 1, 0 STS calls, no token emitted; allowed → bearer token emitted
- `performQuotaRecheck` with short-lived fresh token → blocked and cached credentials wiped (fails pre-fix: fail-open)

Python (`test_silent_refresh.py`): quota blocked on silent refresh → blocked handler invoked, `get_aws_credentials`/`save_credentials` never called; quota allowed → exchange proceeds. Existing tests updated to the two-phase API.

Consolidating `refreshIDTokenOnly` into `tryRefreshToken` removed its two twin tests; the surviving `TestTryRefreshToken_*` pair now covers the single clear-vs-retain site for all callers, and `TestGetMCPAuthHeader_RefreshSucceedsWithoutAWSCreds` still pins the decoupling contract (fresh id_token survives STS failure).

## Verification

- `cd source/go && go build ./... && go vet ./... && go test ./... -race -count=1` — all pass
- `GOOS=windows GOARCH=amd64 go build ./...` and `GOOS=linux GOARCH=amd64 go build ./...` — clean
- `cd source && poetry run pytest tests/ -q` — 1669 passed, 27 skipped
- `ruff check` / `ruff format --check` / `gofmt` — clean

## Out of scope (pre-existing, noted during review)

- The desktop helper's cached-credentials fast path has no periodic quota recheck (unlike `run()`); a user crossing quota keeps working until cached credentials expire.
- Credential Tier 1 files touched: tested with OIDC flows end-to-end via mocks; IDC and passthrough entrypoints are untouched by this change (separate code paths, verified by their existing tests).