### PR TITLE
fix(package): filter extra_files by --target-platform

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -811,11 +811,11 @@ class PackageCommand(Command):
             console.print("\n[cyan]Generating CoWork 3P MDM configuration...[/cyan]")
             self._generate_cowork_3p_mdm_config(output_dir, profile, profile_name)
 
-        # Copy admin-defined extra files into the build folder (superset; per-OS
-        # filtering happens in distribute at zip time). Fail fast on a missing
-        # source or a validation error — a listed cert the admin expects shipped
-        # must not be silently skipped.
-        copied_extra_files = self._copy_extra_files(profile, output_dir, console)
+        # Copy admin-defined extra files into the build folder, filtered to the
+        # platforms actually being built (distribute filters again per-OS at zip
+        # time). Fail fast on a missing source or a validation error — a listed
+        # cert the admin expects shipped must not be silently skipped.
+        copied_extra_files = self._copy_extra_files(profile, output_dir, console, platforms_to_build)
         if copied_extra_files is None:
             return 1
 
@@ -878,17 +878,21 @@ class PackageCommand(Command):
 
         return 0
 
-    def _copy_extra_files(self, profile, output_dir: Path, console: Console) -> list[tuple[str, str]] | None:
+    def _copy_extra_files(
+        self, profile, output_dir: Path, console: Console, platforms_to_build: list[str] | None = None
+    ) -> list[tuple[str, str]] | None:
         """Copy admin-defined extra files into the build folder.
 
-        Copies the full superset of entries (per-OS filtering happens later at
-        zip time in distribute). Returns a list of ``(name, targets)`` tuples for
-        the package summary, or ``None`` to signal a fatal error (missing source
-        or validation failure) — the caller must return a non-zero exit code.
+        Copies only the entries whose ``targets`` apply to at least one platform
+        in ``platforms_to_build`` (``None`` disables filtering and copies every
+        entry). Distribute filters again per-OS at zip time. Returns a list of
+        ``(name, targets)`` tuples for the package summary, or ``None`` to signal
+        a fatal error (missing source or validation failure) — the caller must
+        return a non-zero exit code.
         """
         import shutil
 
-        from claude_code_with_bedrock.extra_files import validate_extra_files
+        from claude_code_with_bedrock.extra_files import extra_applies_to_any, validate_extra_files
 
         entries = getattr(profile, "extra_files", []) or []
         if not entries:
@@ -905,6 +909,9 @@ class PackageCommand(Command):
         copied: list[tuple[str, str]] = []
         for entry in entries:
             name = entry["name"]
+            if platforms_to_build is not None and not extra_applies_to_any(entry["targets"], platforms_to_build):
+                console.print(f"  [dim]– {name} skipped (not targeted for this build)[/dim]")
+                continue
             src = Path(entry["from"]).expanduser()
             if not src.exists():
                 console.print(f"[red]Extra file source not found for '{name}': {src}[/red]")

--- a/source/claude_code_with_bedrock/extra_files.py
+++ b/source/claude_code_with_bedrock/extra_files.py
@@ -8,7 +8,8 @@ bundles, etc.) to ship *on top of* the generated package. The list lives in the
 admin-side deployment profile (never in the runtime ``config.json`` and never
 synced to the Go credential-process) and is consumed by two commands:
 
-- ``package`` copies the full superset of extras into the build folder.
+- ``package`` copies the extras that apply to at least one platform being
+  built (``--target-platform``) into the build folder.
 - ``distribute`` filters extras per-OS across its three archive builders.
 
 Each entry is a plain dict with three keys::
@@ -134,6 +135,25 @@ def extra_applies_to(targets: Any, platform_token: str) -> bool:
         if token_family and plat in _LANDING_FAMILY and _LANDING_FAMILY[plat] == token_family:
             return True
     return False
+
+
+def extra_applies_to_any(targets: Any, platform_tokens: Any) -> bool:
+    """True if an entry with ``targets`` applies to at least one platform in
+    ``platform_tokens``.
+
+    ``platform_tokens`` uses the ``platforms_to_build`` vocabulary from the
+    ``package`` command: per-OS arch tokens (``macos-arm64``, ``windows``, …)
+    plus the generic family tokens ``macos`` / ``linux`` that the non-Go build
+    path can produce. A family token is expanded to its arches so an
+    arch-targeted extra (e.g. ``macos-arm64``) still ships in a generic
+    ``macos`` build.
+    """
+    expanded: set[str] = set()
+    for p in platform_tokens or []:
+        tok = str(p).strip().lower()
+        expanded.add(tok)
+        expanded.update(arch for arch, family in _FAMILY_OF.items() if family == tok)
+    return any(extra_applies_to(targets, tok) for tok in expanded)
 
 
 def _name_errors(name: Any) -> list[str]:

--- a/source/tests/cli/commands/test_package.py
+++ b/source/tests/cli/commands/test_package.py
@@ -340,3 +340,63 @@ class TestCopyExtraFiles:
         result = PackageCommand()._copy_extra_files(profile, out, MagicMock())
         assert result is not None
         assert (out / "hooks" / "pre.sh").read_text() == "hook"
+
+    def test_target_platform_filters_non_matching_extras(self, tmp_path):
+        """Regression: --target-platform macos must not copy windows-only extras."""
+        for fname in ("hook-win.bat", "hook-mac.sh", "ca.pem"):
+            (tmp_path / fname).write_text(fname)
+        out = tmp_path / "out"
+        out.mkdir()
+        profile = self._profile(
+            [
+                {"name": "ca.pem", "targets": "all", "from": str(tmp_path / "ca.pem")},
+                {
+                    "name": "hook-mac.sh",
+                    "targets": ["macos", "macos-arm64", "macos-intel"],
+                    "from": str(tmp_path / "hook-mac.sh"),
+                },
+                {
+                    "name": "hook-win.bat",
+                    "targets": ["windows"],
+                    "from": str(tmp_path / "hook-win.bat"),
+                },
+            ]
+        )
+
+        result = PackageCommand()._copy_extra_files(profile, out, MagicMock(), ["macos-arm64"])
+
+        assert result is not None
+        assert (out / "ca.pem").exists()
+        assert (out / "hook-mac.sh").exists()
+        assert not (out / "hook-win.bat").exists()
+        names = {name for name, _ in result}
+        assert names == {"ca.pem", "hook-mac.sh"}
+
+    def test_skipped_extra_does_not_require_source(self, tmp_path):
+        """A filtered-out entry's missing 'from' source must not fail the build."""
+        out = tmp_path / "out"
+        out.mkdir()
+        profile = self._profile(
+            [{"name": "win-only.bat", "targets": "windows", "from": str(tmp_path / "does-not-exist.bat")}]
+        )
+        result = PackageCommand()._copy_extra_files(profile, out, MagicMock(), ["macos-arm64"])
+        assert result == []
+
+    def test_applicable_extra_missing_source_still_fails(self, tmp_path):
+        out = tmp_path / "out"
+        out.mkdir()
+        profile = self._profile(
+            [{"name": "mac-only.sh", "targets": "macos", "from": str(tmp_path / "does-not-exist.sh")}]
+        )
+        result = PackageCommand()._copy_extra_files(profile, out, MagicMock(), ["macos-arm64"])
+        assert result is None
+
+    def test_no_platform_filter_copies_everything(self, tmp_path):
+        """platforms_to_build=None keeps the pre-filter superset behavior."""
+        (tmp_path / "w.bat").write_text("w")
+        out = tmp_path / "out"
+        out.mkdir()
+        profile = self._profile([{"name": "w.bat", "targets": "windows", "from": str(tmp_path / "w.bat")}])
+        result = PackageCommand()._copy_extra_files(profile, out, MagicMock())
+        assert result is not None
+        assert (out / "w.bat").exists()

--- a/source/tests/test_extra_files.py
+++ b/source/tests/test_extra_files.py
@@ -10,6 +10,7 @@ import pytest
 from claude_code_with_bedrock.extra_files import (
     VALID_TARGET_TOKENS,
     extra_applies_to,
+    extra_applies_to_any,
     normalize_targets,
     validate_extra_files,
 )
@@ -104,6 +105,40 @@ class TestExtraAppliesToList:
 
     def test_empty_targets_matches_nothing(self):
         assert extra_applies_to([], "windows") is False
+
+
+class TestExtraAppliesToAny:
+    """Matcher used by ``package`` to filter extras against --target-platform.
+
+    Regression: a windows-only extra must not land in a macos-only build."""
+
+    def test_windows_extra_excluded_from_macos_build(self):
+        assert extra_applies_to_any("windows", ["macos-arm64"]) is False
+        assert extra_applies_to_any(["windows"], ["macos-arm64", "macos-intel"]) is False
+
+    def test_all_matches_any_build(self):
+        assert extra_applies_to_any("all", ["macos-arm64"]) is True
+        assert extra_applies_to_any("all", ["windows"]) is True
+
+    def test_family_target_matches_arch_build(self):
+        assert extra_applies_to_any("macos", ["macos-arm64"]) is True
+        assert extra_applies_to_any(["macos", "macos-arm64", "macos-intel"], ["macos-arm64"]) is True
+
+    def test_arch_target_matches_generic_family_build(self):
+        # The non-Go build path can produce generic "macos"/"linux" tokens;
+        # arch-targeted extras must still ship in those builds.
+        assert extra_applies_to_any("macos-arm64", ["macos"]) is True
+        assert extra_applies_to_any("linux-arm64", ["linux"]) is True
+
+    def test_arch_target_excluded_from_sibling_arch_build(self):
+        assert extra_applies_to_any("macos-intel", ["macos-arm64"]) is False
+
+    def test_matches_when_any_platform_applies(self):
+        assert extra_applies_to_any("windows", ["macos-arm64", "windows"]) is True
+
+    def test_empty_platforms_matches_nothing(self):
+        assert extra_applies_to_any("all", []) is False
+        assert extra_applies_to_any("all", None) is False
 
 
 class TestValidateExtraFiles:


### PR DESCRIPTION
## Why

`ccwb package --target-platform macos` copied **every** `extra_files` entry into the build folder, including windows-targeted ones — so a single-platform package shipped files intended only for other platforms. The superset design from #744 assumed `distribute` always filters later at zip time, but the package folder itself is the deliverable when admins share it directly.

## What

- **extra_files.py**: new `extra_applies_to_any()` matcher that resolves an entry's `targets` against the `platforms_to_build` vocabulary. Generic family tokens (`macos`/`linux`, produced by the non-Go build path) are expanded to their arches so an arch-targeted extra (`macos-arm64`) still ships in a generic `macos` build.
- **package.py**: `_copy_extra_files` now receives `platforms_to_build` and skips entries that don't apply to any platform being built (with a dim "skipped (not targeted for this build)" note). A skipped entry's missing `from` source no longer fails the build; applicable entries still fail fast with a non-zero exit.
- No change to `distribute`: per-OS zip filtering already works correctly. Since non-target extras now never reach the package folder, distribute archives can't include them either (missing files are skipped at zip time).

## Backward compatibility

- `--target-platform all` (and the non-Go "all" expansion) behaves exactly as before — every extra applies to some built platform.
- Users without `extra_files` configured are untouched — the early-return on an empty list is unchanged.
- `platforms_to_build=None` preserves the unfiltered superset behavior for any direct caller.

## Testing

- Regression test: windows-targeted extra + `platforms_to_build=["macos-arm64"]` → not copied; `all`/family-targeted entries still copied.
- Skipped entry with a missing `from` source no longer fails; an applicable entry with a missing source still returns a fatal error.
- Matcher truth table for `extra_applies_to_any` including family-token expansion and sibling-arch exclusion.
- All tests are self-contained (`tmp_path` fixtures, in-memory profiles) — no dependence on host files.

```
1680 passed, 27 skipped, 1 xfailed, 1 xpassed
```