### PR TITLE
feat(package): stamp settings_version into OTEL_RESOURCE_ATTRIBUTES

### DIFF
--- a/assets/docs/MONITORING.md
+++ b/assets/docs/MONITORING.md
@@ -130,6 +130,31 @@ are only populated for OIDC. IDC attributes `user.email` only. See
 [Cost Attribution](COST_ATTRIBUTION.md#idc-limitation) for the CUR/ABAC path to
 per-user team/department breakdowns under IDC.
 
+### Tracking deployed package versions (`settings_version`)
+
+`ccwb package` stamps the dist-folder timestamp (e.g. `2026-07-08-120000`) into
+the generated `settings.json` as a `settings_version` entry in
+`OTEL_RESOURCE_ATTRIBUTES`. Every user's telemetry then carries the version of
+the distribution package they installed, so you can see who is running an
+outdated package. Installs from packages built before this attribute existed
+simply report no `settings_version` — itself a signal that the user is on an
+old package.
+
+When the analytics pipeline is enabled, the `awsemf` exporter converts resource
+attributes to fields on every metric event in `/aws/claude-code/metrics`, so
+adoption is queryable in CloudWatch Logs Insights without any collector change:
+
+```
+fields @timestamp
+| stats count_distinct(`user.email`) as users by settings_version
+```
+
+To surface `settings_version` as a first-class CloudWatch metric dimension for
+dashboards or alarms, add a `metric_declarations` entry for it in
+`otel-collector.yaml` — scope it to a single metric (e.g.
+`claude_code.token.usage`) rather than `.*`, since every package release adds a
+new dimension value and broad declarations multiply custom-metric cost.
+
 ## Usage Quota Monitoring
 
 Quota monitoring uses the CloudWatch Prometheus-compatible API (`monitoring.<region>.amazonaws.com/api/v1/query`) to query per-user token usage via PromQL. The quota monitor Lambda runs every 15 minutes, fetches usage data via PromQL, writes results to a DynamoDB table (`UserQuotaMetrics`), and checks against quota policies.

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -804,6 +804,7 @@ class PackageCommand(Command):
             profile_name,
             otel_resource_attributes,
             is_idc_zero_binary=is_idc_zero_binary,
+            settings_version=timestamp,
         )
 
         # Generate CoWork 3P MDM configuration if enabled
@@ -2635,7 +2636,14 @@ RUN pyinstaller \
 
         # Regenerate Claude Code settings
         console.print("[cyan]Generating Claude Code settings...[/cyan]")
-        self._create_claude_settings(output_dir, profile, include_coauthored_by, profile_name, otel_resource_attributes)
+        self._create_claude_settings(
+            output_dir,
+            profile,
+            include_coauthored_by,
+            profile_name,
+            otel_resource_attributes,
+            settings_version=timestamp,
+        )
 
         # Summary
         console.print("\n[green]✓ Installers regenerated successfully![/green]")
@@ -4097,6 +4105,7 @@ Available metrics include:
         profile_name: str = "ClaudeCode",
         otel_resource_attributes: str | None = None,
         is_idc_zero_binary: bool = False,
+        settings_version: str | None = None,
     ) -> None:
         """Create Claude Code settings.json with Bedrock and optional monitoring configuration."""
         console = Console()
@@ -4335,6 +4344,13 @@ Available metrics include:
                     resource_attrs = otel_resource_attributes or (
                         "department=default,team.id=default,cost_center=default,organization=default,project=default"
                     )
+                    # Stamp the dist-folder timestamp so telemetry records which
+                    # packaged distribution each user runs. The collector's
+                    # resource_to_telemetry_conversion surfaces it as a field on
+                    # every EMF event in /aws/claude-code/metrics, so adoption is
+                    # queryable without any collector change.
+                    if settings_version:
+                        resource_attrs += f",settings_version={settings_version}"
 
                     settings["env"].update(
                         {

--- a/source/claude_code_with_bedrock/cli/commands/package_cb.py
+++ b/source/claude_code_with_bedrock/cli/commands/package_cb.py
@@ -276,7 +276,14 @@ class PackageCbCommand(Command):
                 pkg._create_documentation(output_dir, profile, timestamp)
 
         console.print("[cyan]Creating Claude Code settings...[/cyan]")
-        self._create_claude_settings(output_dir, profile, include_coauthored_by, profile_name, otel_resource_attributes)
+        self._create_claude_settings(
+            output_dir,
+            profile,
+            include_coauthored_by,
+            profile_name,
+            otel_resource_attributes,
+            settings_version=timestamp,
+        )
 
         # Show configuration
         console.print()
@@ -400,6 +407,7 @@ class PackageCbCommand(Command):
         include_coauthored_by: bool,
         profile_name: str,
         otel_resource_attributes: str | None = None,
+        settings_version: str | None = None,
     ) -> None:
         """Create Claude Code settings.json with Bedrock and optional monitoring configuration."""
         console = Console()
@@ -461,6 +469,11 @@ class PackageCbCommand(Command):
                             "cost_center=default,organization=default,"
                             "project=default"
                         )
+                        # Stamp the dist-folder timestamp so telemetry records
+                        # which packaged distribution each user runs (mirrors
+                        # package.py — keep both in sync).
+                        if settings_version:
+                            resource_attrs += f",settings_version={settings_version}"
                         settings["env"].update(
                             {
                                 "CLAUDE_CODE_ENABLE_TELEMETRY": "1",

--- a/source/tests/cli/commands/test_package.py
+++ b/source/tests/cli/commands/test_package.py
@@ -219,7 +219,7 @@ class TestPackageCommandOtelDefaults:
             stack_names={"monitoring": "test-otel-collector"},
         )
 
-    def _render_settings(self, otel_resource_attributes=None):
+    def _render_settings(self, otel_resource_attributes=None, settings_version=None):
         """Drive _create_claude_settings with a mocked monitoring stack endpoint."""
         command = PackageCommand()
         profile = self._make_monitoring_profile()
@@ -239,6 +239,7 @@ class TestPackageCommandOtelDefaults:
                     include_coauthored_by=True,
                     profile_name="test",
                     otel_resource_attributes=otel_resource_attributes,
+                    settings_version=settings_version,
                 )
 
             settings_path = output_dir / "claude-settings" / "settings.json"
@@ -263,6 +264,62 @@ class TestPackageCommandOtelDefaults:
         attrs = settings["env"]["OTEL_RESOURCE_ATTRIBUTES"]
 
         assert attrs == "department=research,team.id=ml"
+
+    def test_settings_version_appended_to_default_attributes(self):
+        """The dist-folder timestamp is stamped as settings_version for telemetry."""
+        settings = self._render_settings(settings_version="2026-07-08-120000")
+        attrs = settings["env"]["OTEL_RESOURCE_ATTRIBUTES"]
+
+        assert attrs.endswith(",settings_version=2026-07-08-120000")
+        assert "department=default" in attrs
+
+    def test_settings_version_appended_to_custom_attributes(self):
+        """settings_version is stamped even when the admin customizes attributes."""
+        settings = self._render_settings(
+            otel_resource_attributes="department=research,team.id=ml",
+            settings_version="2026-07-08-120000",
+        )
+        attrs = settings["env"]["OTEL_RESOURCE_ATTRIBUTES"]
+
+        assert attrs == "department=research,team.id=ml,settings_version=2026-07-08-120000"
+
+    def test_no_settings_version_omits_attribute(self):
+        """Without a version (backward compat), the attribute is absent entirely."""
+        settings = self._render_settings()
+        attrs = settings["env"]["OTEL_RESOURCE_ATTRIBUTES"]
+
+        assert "settings_version" not in attrs
+
+    def test_cowork_package_stamps_settings_version(self):
+        """Parity: the CodeBuild package variant stamps settings_version too."""
+        from claude_code_with_bedrock.cli.commands.package_cb import PackageCbCommand
+
+        command = PackageCbCommand()
+        profile = self._make_monitoring_profile()
+
+        fake_outputs = json.dumps([{"OutputKey": "CollectorEndpoint", "OutputValue": "https://otel.example.com"}])
+        completed = MagicMock(returncode=0, stdout=fake_outputs)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            with patch(
+                "claude_code_with_bedrock.cli.commands.package_cb.subprocess.run",
+                return_value=completed,
+            ):
+                command._create_claude_settings(
+                    output_dir,
+                    profile,
+                    include_coauthored_by=True,
+                    profile_name="test",
+                    settings_version="2026-07-08-120000",
+                )
+
+            settings_path = output_dir / "claude-settings" / "settings.json"
+            with open(settings_path, encoding="utf-8") as f:
+                settings = json.load(f)
+
+        attrs = settings["env"]["OTEL_RESOURCE_ATTRIBUTES"]
+        assert attrs.endswith(",settings_version=2026-07-08-120000")
 
 
 class TestCopyExtraFiles:


### PR DESCRIPTION
## Why

Admins distribute packages from timestamped dist folders (`dist/<profile>/<timestamp>`), but once installed there is no way to tell which distribution each user is actually running. When settings change (new model defaults, telemetry config, quota wiring), there's no signal for who has upgraded and who is still on an old package.

## What

`ccwb package` now stamps the dist-folder timestamp into the generated `settings.json` as a `settings_version` entry in `OTEL_RESOURCE_ATTRIBUTES`, so every user's telemetry carries the version of the package they installed.

- Applied in both the standard package command and the CodeBuild variant, including the regenerate-installers path (which stamps its new output-dir timestamp, matching the regenerated `config.json`).
- Admin-customized telemetry attributes from the wizard still get the version appended.
- Packages built before this change simply report no `settings_version` — itself an outdated-package signal.
- Works identically across OIDC, IDC, and none auth modes and both collector modes — it's a plain env var attached by Claude Code's OTLP export, not part of the auth/attribution chain.

With the analytics pipeline enabled, the `awsemf` exporter's `resource_to_telemetry_conversion` surfaces the attribute as a field on every metric event in `/aws/claude-code/metrics`, so adoption is queryable in Logs Insights with no collector change:

```
fields @timestamp
| stats count_distinct(`user.email`) as users by settings_version
```

Deployments that want `settings_version` as a first-class CloudWatch dimension can add a scoped `metric_declarations` entry in `otel-collector.yaml`; the docs note the cardinality/cost caveat (each release adds a new dimension value).

## Notes

- No new `Profile` field — the version derives from the timestamp already in scope, so no Go `ProfileConfig` mirror or `--explain` change is needed.
- Docs updated in `assets/docs/MONITORING.md` (new section under per-user attribution).

## Testing

- Four new tests in `tests/cli/commands/test_package.py`: version appended to default attributes, appended to custom attributes, omitted when absent (backward compat), and a parity test for the CodeBuild variant.
- Full suite: 1673 passed, 27 skipped.
- Verified locally: generated `claude-settings/settings.json` ends with `,settings_version=<dist folder timestamp>`.