### PR TITLE
fix(package): make install.bat actually merge existing Claude settings

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -3658,7 +3658,7 @@ REM external command" and silently drops all metrics, so we fail the install
 REM loudly rather than leave a broken telemetry config.
 if exist "otel-helper.cmd" (
     copy /Y "otel-helper.cmd" "%USERPROFILE%\\claude-code-with-bedrock\\otel-helper.cmd" >nul
-    if %errorlevel% neq 0 (
+    if !errorlevel! neq 0 (
         echo ERROR: Failed to copy otel-helper.cmd
         pause
         exit /b 1
@@ -3676,7 +3676,7 @@ if exist "otel-helper.cmd" (
 )
 if exist "otel-helper.ps1" (
     copy /Y "otel-helper.ps1" "%USERPROFILE%\\claude-code-with-bedrock\\otel-helper.ps1" >nul
-    if %errorlevel% neq 0 (
+    if !errorlevel! neq 0 (
         echo ERROR: Failed to copy otel-helper.ps1
         pause
         exit /b 1
@@ -3741,7 +3741,7 @@ if exist "claude-settings" (
 
         REM Check for Administrator privileges
         net session >nul 2>&1
-        if %errorlevel% neq 0 (
+        if !errorlevel! neq 0 (
             echo ERROR: Managed settings require Administrator privileges.
             echo        Right-click install.bat and select "Run as administrator"
             echo        [Target: C:\\Program Files\\ClaudeCode\\managed-settings.json]
@@ -3760,25 +3760,31 @@ if exist "claude-settings" (
 
     REM Copy user-scope settings.json if present (with merge support)
     if exist "claude-settings\\settings.json" (
-        set SKIP_SETTINGS=false
+        set WRITE_SETTINGS=false
         if exist "%USERPROFILE%\\.claude\\settings.json" (
             echo Existing Claude Code settings found - merging...
 
-            REM Merge new settings into existing (preserves user customizations)
-            powershell -NoProfile -Command "$otelPath = ($env:USERPROFILE + '\\claude-code-with-bedrock\\otel-helper.cmd').Replace('\\','\\\\'); $credPath = $env:USERPROFILE + '\\claude-code-with-bedrock\\credential-process.exe' -replace '\\\\', '/'; $existing = Get-Content (Join-Path $env:USERPROFILE '.claude\\settings.json') | ConvertFrom-Json; $incoming = (Get-Content 'claude-settings\\settings.json') -replace '__OTEL_HELPER_PATH__', $otelPath -replace '__CREDENTIAL_PROCESS_PATH__', $credPath | ConvertFrom-Json; foreach ($prop in $incoming.PSObject.Properties) {{{{ $existing | Add-Member -MemberType NoteProperty -Name $prop.Name -Value $prop.Value -Force }}}}; $existing | ConvertTo-Json -Depth 10 | Set-Content (Join-Path $env:USERPROFILE '.claude\\settings.json')"
-            if %errorlevel% equ 0 (
+            REM Merge new settings into existing. Top-level keys from the new
+            REM settings win, but the 'env' object is DEEP-merged so custom env
+            REM vars the user added survive. $ErrorActionPreference=Stop plus
+            REM the catch/exit 1 makes any failure visible via !errorlevel!.
+            powershell -NoProfile -Command "$ErrorActionPreference = 'Stop'; try {{ $otelPath = ($env:USERPROFILE + '\\claude-code-with-bedrock\\otel-helper.cmd').Replace('\\','\\\\'); $credPath = $env:USERPROFILE + '\\claude-code-with-bedrock\\credential-process.exe' -replace '\\\\', '/'; $settingsPath = Join-Path $env:USERPROFILE '.claude\\settings.json'; $existing = Get-Content $settingsPath -Raw | ConvertFrom-Json; $incoming = (Get-Content 'claude-settings\\settings.json' -Raw) -replace '__OTEL_HELPER_PATH__', $otelPath -replace '__CREDENTIAL_PROCESS_PATH__', $credPath | ConvertFrom-Json; foreach ($prop in $incoming.PSObject.Properties) {{ if ($prop.Name -eq 'env' -and $existing.PSObject.Properties['env']) {{ foreach ($envProp in $prop.Value.PSObject.Properties) {{ $existing.env | Add-Member -MemberType NoteProperty -Name $envProp.Name -Value $envProp.Value -Force }} }} else {{ $existing | Add-Member -MemberType NoteProperty -Name $prop.Name -Value $prop.Value -Force }} }}; $existing | ConvertTo-Json -Depth 10 | Set-Content $settingsPath }} catch {{ Write-Error $_; exit 1 }}"
+            if !errorlevel! equ 0 (
                 echo OK Claude Code settings merged [user settings preserved]
             ) else (
                 set /p OVERWRITE="Merge failed. Overwrite with new settings? (y/n): "
-                if /i not "%OVERWRITE%"=="y" (
+                if /i "!OVERWRITE!"=="y" (
+                    set WRITE_SETTINGS=true
+                ) else (
                     echo Skipping Claude Code settings...
-                    set SKIP_SETTINGS=true
                 )
             )
+        ) else (
+            set WRITE_SETTINGS=true
         )
 
-        if not "%SKIP_SETTINGS%"=="true" if not exist "%USERPROFILE%\\.claude\\settings.json" (
-            REM No existing settings - write directly
+        if "!WRITE_SETTINGS!"=="true" (
+            REM No existing settings [or user chose overwrite] - write directly
             powershell -Command "$otelPath = ($env:USERPROFILE + '\\claude-code-with-bedrock\\otel-helper.cmd').Replace('\\','\\\\'); $credPath = $env:USERPROFILE + '\\claude-code-with-bedrock\\credential-process.exe' -replace '\\\\', '/'; (Get-Content 'claude-settings\\settings.json') -replace '__OTEL_HELPER_PATH__', $otelPath -replace '__CREDENTIAL_PROCESS_PATH__', $credPath | Set-Content (Join-Path $env:USERPROFILE '.claude\\settings.json')"
             echo OK Claude Code settings configured
         )

--- a/source/tests/cli/commands/test_installer_launcher.py
+++ b/source/tests/cli/commands/test_installer_launcher.py
@@ -16,6 +16,8 @@ with the launcher as optional, and, for bash, that both the installer and the
 launcher it writes are syntactically valid shell.
 """
 
+import json
+import os
 import shutil
 import subprocess
 import sys
@@ -185,3 +187,105 @@ class TestWindowsInstallerLauncher:
         assert "claude-bedrock.cmd" in content
         # The old "run the launcher, NOT 'claude' directly" framing must be gone.
         assert "NOT 'claude' directly" not in content
+
+
+class TestWindowsInstallerSettingsMerge:
+    """Regression tests for merging claude-settings/settings.json into an
+    existing %USERPROFILE%\\.claude\\settings.json.
+
+    The original merge one-liner rendered with DOUBLED braces (f-string
+    `{{{{` -> `{{` in the .bat), so PowerShell parsed the foreach body as a
+    scriptblock LITERAL that was never invoked — the existing file was
+    rewritten unchanged and the new settings were silently dropped.
+    """
+
+    def _generate(self) -> str:
+        cmd = PackageCommand()
+        out = Path(tempfile.mkdtemp())
+        path = cmd._create_windows_installer(out, _idc_profile())
+        return path.read_text(encoding="utf-8")
+
+    def _merge_command(self, content: str) -> str:
+        """Extract the PowerShell merge command from the generated install.bat."""
+        for line in content.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("powershell") and "$ErrorActionPreference" in stripped:
+                # Strip `powershell -NoProfile -Command "` prefix and closing quote.
+                # The command body uses only single-quoted strings, so the outer
+                # double quotes delimit it unambiguously.
+                start = stripped.index('"') + 1
+                return stripped[start:-1]
+        raise AssertionError("merge powershell command not found in install.bat")
+
+    def test_merge_command_has_no_doubled_braces(self):
+        """`{{` in the emitted batch means the foreach body is a scriptblock
+        literal (a no-op) — the exact bug that made the merge do nothing."""
+        content = self._generate()
+        assert "{{" not in content, "install.bat must not contain doubled braces (PowerShell no-op scriptblock)"
+        merge = self._merge_command(content)
+        assert "foreach ($prop in $incoming.PSObject.Properties) {" in merge
+
+    def test_merge_deep_merges_env(self):
+        """Top-level Add-Member -Force would replace the whole `env` object,
+        wiping user-added env vars. The merge must descend into `env`."""
+        merge = self._merge_command(self._generate())
+        assert "$existing.env | Add-Member" in merge
+
+    def test_merge_failure_is_detectable(self):
+        """The merge runs inside a parenthesized batch block, where %errorlevel%
+        expands at PARSE time (always the pre-block value). The check must use
+        delayed expansion, and the command must exit non-zero on failure."""
+        content = self._generate()
+        assert "if !errorlevel! equ 0 (" in content
+        merge = self._merge_command(content)
+        assert "$ErrorActionPreference = 'Stop'" in merge
+        assert "exit 1" in merge
+
+    def test_overwrite_choice_actually_overwrites(self):
+        """Answering 'y' to 'Merge failed. Overwrite?' previously did nothing:
+        the write branch also required the settings file to NOT exist. The
+        rewritten flow funnels both paths through a delayed-expansion flag."""
+        content = self._generate()
+        assert 'if "!WRITE_SETTINGS!"=="true" (' in content
+        assert 'if /i "!OVERWRITE!"=="y" (' in content
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="executes the merge under real PowerShell")
+    def test_merge_executes_and_preserves_user_settings(self, tmp_path):
+        """Functional check on Windows CI: run the extracted merge command and
+        assert (1) new keys land, (2) placeholders are resolved, (3) the user's
+        pre-existing top-level keys and custom env vars survive."""
+        merge = self._merge_command(self._generate())
+
+        userprofile = tmp_path / "home"
+        (userprofile / ".claude").mkdir(parents=True)
+        existing = {"model": "opus", "env": {"MY_CUSTOM_VAR": "keep-me"}}
+        (userprofile / ".claude" / "settings.json").write_text(json.dumps(existing), encoding="utf-8")
+
+        workdir = tmp_path / "package"
+        (workdir / "claude-settings").mkdir(parents=True)
+        incoming = {
+            "env": {"CLAUDE_CODE_USE_BEDROCK": "1", "AWS_PROFILE": "idc-test"},
+            "otelHeadersHelper": "__OTEL_HELPER_PATH__ --profile idc-test",
+            "awsAuthRefresh": "__CREDENTIAL_PROCESS_PATH__ --login --profile idc-test",
+        }
+        (workdir / "claude-settings" / "settings.json").write_text(json.dumps(incoming), encoding="utf-8")
+
+        env = dict(os.environ, USERPROFILE=str(userprofile))
+        result = subprocess.run(
+            ["powershell", "-NoProfile", "-Command", merge],
+            cwd=workdir,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"merge command failed: {result.stderr}"
+
+        merged = json.loads((userprofile / ".claude" / "settings.json").read_text(encoding="utf-8"))
+        # New settings applied (the original bug: nothing changed at all).
+        assert merged["env"]["CLAUDE_CODE_USE_BEDROCK"] == "1"
+        assert "otel-helper.cmd --profile idc-test" in merged["otelHeadersHelper"].replace("\\\\", "\\")
+        assert "__OTEL_HELPER_PATH__" not in merged["otelHeadersHelper"]
+        assert "__CREDENTIAL_PROCESS_PATH__" not in merged["awsAuthRefresh"]
+        # User customizations preserved (top-level and inside env).
+        assert merged["model"] == "opus"
+        assert merged["env"]["MY_CUSTOM_VAR"] == "keep-me"


### PR DESCRIPTION
## Why
On Windows, running `install.bat` with an existing `~/.claude/settings.json` silently applies **nothing**. The PowerShell merge one-liner is generated from an f-string with over-escaped braces (`{{{{` -> `{{`), so PowerShell parses the `foreach` body as a scriptblock *literal* that is never invoked — the user's file is rewritten unchanged, and the Bedrock env, credential process, and telemetry settings are never configured. The failure is also undetectable: `%errorlevel%` inside a parenthesized batch block expands at parse time, so the error branch can never fire.

## What
- Emit single braces so the merge loop actually executes
- Deep-merge the `env` object (incoming keys win; user-added env vars survive) instead of replacing it wholesale
- Run the merge under `$ErrorActionPreference = 'Stop'` with `catch { exit 1 }`, and check `!errorlevel!` / `!OVERWRITE!` / `!WRITE_SETTINGS!` with delayed expansion so failures surface
- Fix the dead overwrite path: answering `y` to "Merge failed. Overwrite?" previously did nothing because the write branch also required the settings file to not exist

## Testing
- New `TestWindowsInstallerSettingsMerge` regression tests: static assertions (no doubled braces, deep env merge, delayed-expansion checks) run on every platform; a functional test extracts the generated merge command and executes it under real PowerShell on Windows CI, asserting new keys land, placeholders resolve, and user customizations (top-level keys and custom env vars) survive
- Full suite passes on Linux (1688 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)