### PR TITLE
fix(otel): honor supplied --profile across all otel-helper variants

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -4390,7 +4390,10 @@ Available metrics include:
                     _is_idc = getattr(profile, "effective_auth_type", profile.auth_type) == "idc"
                     _idc_zero_binary = _is_idc and not bool(getattr(profile, "quota_api_endpoint", None))
                     if not _idc_zero_binary:
-                        settings["otelHeadersHelper"] = "__OTEL_HELPER_PATH__"
+                        # Pass the profile explicitly (same as AWS_CREDENTIAL_PROCESS /
+                        # awsAuthRefresh above) so the helper serves THIS profile even
+                        # when AWS_PROFILE in the helper's environment points elsewhere.
+                        settings["otelHeadersHelper"] = f"__OTEL_HELPER_PATH__ --profile {profile_name}"
 
                     is_https = endpoint.startswith("https://")
                     console.print(f"[dim]Added monitoring with {'HTTPS' if is_https else 'HTTP'} endpoint[/dim]")

--- a/source/claude_code_with_bedrock/cli/commands/package_cb.py
+++ b/source/claude_code_with_bedrock/cli/commands/package_cb.py
@@ -487,7 +487,10 @@ class PackageCbCommand(Command):
                                 "OTEL_RESOURCE_ATTRIBUTES": resource_attrs,
                             }
                         )
-                        settings["otelHeadersHelper"] = "__OTEL_HELPER_PATH__"
+                        # Pass the profile explicitly (same as the credential-process
+                        # settings) so the helper serves THIS profile even when
+                        # AWS_PROFILE in the helper's environment points elsewhere.
+                        settings["otelHeadersHelper"] = f"__OTEL_HELPER_PATH__ --profile {profile_name}"
 
                         is_https = endpoint.startswith("https://")
                         console.print(f"[dim]Added monitoring with {'HTTPS' if is_https else 'HTTP'} endpoint[/dim]")

--- a/source/go/cmd/otel-helper/main.go
+++ b/source/go/cmd/otel-helper/main.go
@@ -60,6 +60,7 @@ func main() {
 	verboseFlag := flag.Bool("verbose", false, "Show verbose output")
 	versionFlag := flag.Bool("version", false, "Show version")
 	statusFlag := flag.Bool("status", false, "Print current otel-helper status as JSON and exit (proxy running? port? mode?)")
+	profileFlag := flag.String("profile", "", "Profile name (overrides CCWB_PROFILE/AWS_PROFILE environment variables)")
 	proxyMode := flag.Bool("proxy", false, "Run as SigV4 signing proxy for CoWork OTLP logs")
 	proxyPort := flag.Int("proxy-port", defaultProxyPort, "Port for the signing proxy (default 4318)")
 	proxyRegion := flag.String("proxy-region", "", "AWS region for CloudWatch OTLP (default: AWS_REGION env)")
@@ -70,18 +71,16 @@ func main() {
 		os.Exit(0)
 	}
 
-	if *statusFlag {
-		os.Exit(runStatus(*proxyPort))
-	}
-
 	verbose = *verboseFlag || *testMode
 	debug = os.Getenv("DEBUG_MODE") != "" || verbose
 
+	profile := resolveProfile(*profileFlag)
+
+	if *statusFlag {
+		os.Exit(runStatus(*proxyPort, profile))
+	}
+
 	if *proxyMode {
-		profile := os.Getenv("AWS_PROFILE")
-		if profile == "" {
-			profile = "ClaudeCode"
-		}
 		os.Exit(startProxy(proxyConfig{
 			port:    *proxyPort,
 			region:  *proxyRegion,
@@ -89,15 +88,32 @@ func main() {
 		}))
 	}
 
-	os.Exit(run(*testMode))
+	os.Exit(run(*testMode, profile))
 }
 
-func run(testMode bool) int {
-	profile := os.Getenv("AWS_PROFILE")
-	if profile == "" {
-		profile = "ClaudeCode"
+// resolveProfile determines which named profile this invocation serves.
+// Precedence: explicit --profile flag > CCWB_PROFILE env var (the ccwb-specific
+// override, same convention as credential-process) > AWS_PROFILE env var
+// (legacy behaviour — Claude Code settings export it) > "ClaudeCode".
+// When the flag is supplied it is also exported to AWS_PROFILE so everything
+// downstream — credential-process subprocesses and the AWS SDK credential
+// chain in proxy mode — resolves the SAME profile from one place.
+func resolveProfile(flagValue string) string {
+	if flagValue != "" {
+		os.Setenv("AWS_PROFILE", flagValue)
+		return flagValue
 	}
+	if p := os.Getenv("CCWB_PROFILE"); p != "" {
+		os.Setenv("AWS_PROFILE", p)
+		return p
+	}
+	if p := os.Getenv("AWS_PROFILE"); p != "" {
+		return p
+	}
+	return "ClaudeCode"
+}
 
+func run(testMode bool, profile string) int {
 	// Layer 1: Serve attribution from the file cache. The cache stores
 	// attribution headers only, never the token, so the Bearer is still
 	// resolved below (env var, then credential-process). credential-process

--- a/source/go/cmd/otel-helper/main_test.go
+++ b/source/go/cmd/otel-helper/main_test.go
@@ -57,7 +57,7 @@ func TestRun_NoToken_EmitsEmptyHeadersAndExitsZero(t *testing.T) {
 	// No credential-process binary exists under tmpDir/claude-code-with-bedrock,
 	// so getTokenViaCredentialProcess returns an error -> emitEmptyHeaders.
 
-	if code := run(false); code != 0 {
+	if code := run(false, "ClaudeCode"); code != 0 {
 		t.Fatalf("run() exit code = %d, want 0", code)
 	}
 
@@ -95,7 +95,7 @@ func TestRun_TestMode_NoToken_DoesNotWriteCache(t *testing.T) {
 	t.Setenv("AWS_PROFILE", "ClaudeCode")
 	t.Setenv("CLAUDE_CODE_MONITORING_TOKEN", "")
 
-	if code := run(true); code != 0 {
+	if code := run(true, "ClaudeCode"); code != 0 {
 		t.Fatalf("run(testMode) exit code = %d, want 0", code)
 	}
 
@@ -129,7 +129,7 @@ func TestRun_FreshEmptyCache_ServedViaLayer1(t *testing.T) {
 		t.Fatalf("seed cache: %v", err)
 	}
 
-	if code := run(false); code != 0 {
+	if code := run(false, "ClaudeCode"); code != 0 {
 		t.Fatalf("run() exit code = %d, want 0", code)
 	}
 
@@ -172,7 +172,7 @@ func TestRun_PopulatedExpiredEntry_ServedNotRewritten(t *testing.T) {
 		t.Fatalf("seed cache: %v", err)
 	}
 
-	if code := run(false); code != 0 {
+	if code := run(false, "ClaudeCode"); code != 0 {
 		t.Fatalf("run() exit code = %d, want 0", code)
 	}
 
@@ -212,7 +212,7 @@ func TestRun_WithToken_IncludesBearerHeader(t *testing.T) {
 	r, w, _ := os.Pipe()
 	old := os.Stdout
 	os.Stdout = w
-	code := run(false)
+	code := run(false, "ClaudeCode")
 	w.Close()
 	os.Stdout = old
 
@@ -252,7 +252,7 @@ func TestRun_NoToken_NoBearerInOutput(t *testing.T) {
 	r, w, _ := os.Pipe()
 	old := os.Stdout
 	os.Stdout = w
-	run(false)
+	run(false, "ClaudeCode")
 	w.Close()
 	os.Stdout = old
 
@@ -285,7 +285,7 @@ func TestRun_BearerTokenNotInCacheFile(t *testing.T) {
 	_, w, _ := os.Pipe()
 	old := os.Stdout
 	os.Stdout = w
-	run(false)
+	run(false, "ClaudeCode")
 	w.Close()
 	os.Stdout = old
 
@@ -335,7 +335,7 @@ func TestRun_CacheHit_ResolvesTokenFromEnv(t *testing.T) {
 	r, w, _ := os.Pipe()
 	old := os.Stdout
 	os.Stdout = w
-	code := run(false)
+	code := run(false, "ClaudeCode")
 	w.Close()
 	os.Stdout = old
 
@@ -389,7 +389,7 @@ func TestRun_Layer1_CacheHit_NoToken_OmitsBearerGracefully(t *testing.T) {
 	r, w, _ := os.Pipe()
 	old := os.Stdout
 	os.Stdout = w
-	code := run(false)
+	code := run(false, "ClaudeCode")
 	w.Close()
 	os.Stdout = old
 
@@ -471,7 +471,7 @@ func TestRun_TestMode_ServesCachedHeaders(t *testing.T) {
 	r, w, _ := os.Pipe()
 	old := os.Stdout
 	os.Stdout = w
-	code := run(true)
+	code := run(true, "idc-test")
 	w.Close()
 	os.Stdout = old
 
@@ -484,5 +484,38 @@ func TestRun_TestMode_ServesCachedHeaders(t *testing.T) {
 	out := string(buf[:n])
 	if !strings.Contains(out, "qnamzn+developer@amazon.com") {
 		t.Errorf("test-mode output must surface the cached email; got:\n%s", out)
+	}
+}
+
+// TestResolveProfile_Precedence locks in the resolution order:
+// --profile flag > CCWB_PROFILE env > AWS_PROFILE env > "ClaudeCode" default.
+func TestResolveProfile_Precedence(t *testing.T) {
+	t.Setenv("CCWB_PROFILE", "CcwbProfile")
+	t.Setenv("AWS_PROFILE", "EnvProfile")
+
+	// CCWB_PROFILE (ccwb-specific override, same convention as
+	// credential-process) beats the ambient AWS_PROFILE.
+	if got := resolveProfile(""); got != "CcwbProfile" {
+		t.Errorf("resolveProfile(\"\") = %q, want CCWB_PROFILE value \"CcwbProfile\"", got)
+	}
+
+	if got := resolveProfile("FlagProfile"); got != "FlagProfile" {
+		t.Errorf("resolveProfile(flag) = %q, want \"FlagProfile\"", got)
+	}
+	// The flag must be exported so child processes (credential-process) and
+	// the AWS SDK in proxy mode resolve the same profile.
+	if got := os.Getenv("AWS_PROFILE"); got != "FlagProfile" {
+		t.Errorf("AWS_PROFILE after flag resolution = %q, want \"FlagProfile\"", got)
+	}
+
+	t.Setenv("CCWB_PROFILE", "")
+	t.Setenv("AWS_PROFILE", "EnvProfile")
+	if got := resolveProfile(""); got != "EnvProfile" {
+		t.Errorf("resolveProfile(\"\") = %q, want AWS_PROFILE value \"EnvProfile\"", got)
+	}
+
+	t.Setenv("AWS_PROFILE", "")
+	if got := resolveProfile(""); got != "ClaudeCode" {
+		t.Errorf("resolveProfile with no flag/env = %q, want \"ClaudeCode\"", got)
 	}
 }

--- a/source/go/cmd/otel-helper/status.go
+++ b/source/go/cmd/otel-helper/status.go
@@ -39,12 +39,10 @@ type CacheStatus struct {
 }
 
 // runStatus prints otel-helper status as JSON and returns exit code.
-func runStatus(proxyPort int) int {
-	profile := os.Getenv("AWS_PROFILE")
-	if profile == "" {
-		profile = "ClaudeCode"
-	}
-
+// The profile is resolved by the caller via resolveProfile (--profile flag >
+// CCWB_PROFILE > AWS_PROFILE > default) so --status reports the same profile
+// the header-serving path would use.
+func runStatus(proxyPort int, profile string) int {
 	output := StatusOutput{
 		Version:  version.Version,
 		Platform: runtime.GOOS + "/" + runtime.GOARCH,

--- a/source/otel_helper/__main__.py
+++ b/source/otel_helper/__main__.py
@@ -67,6 +67,11 @@ def parse_args():
     parser.add_argument("--test", action="store_true", help="Run in test mode with verbose output")
     parser.add_argument("--verbose", action="store_true", help="Show verbose output")
     parser.add_argument(
+        "--profile",
+        metavar="NAME",
+        help="AWS profile name (overrides the AWS_PROFILE environment variable)",
+    )
+    parser.add_argument(
         "--anonymous",
         action="store_true",
         help="Force anonymous mode using AWS caller identity instead of JWT auth",
@@ -84,6 +89,17 @@ def parse_args():
         help="Port for the local OTLP proxy (default: 4318)",
     )
     args = parser.parse_args()
+
+    # Single source of truth for profile resolution: --profile flag >
+    # CCWB_PROFILE env (the ccwb-specific override, same convention as
+    # credential-process) > AWS_PROFILE env > "ClaudeCode" default at the
+    # read sites. The winner is exported to AWS_PROFILE so every downstream
+    # consumer — the cache path, the credential-process subprocess, and the
+    # collector sidecar — resolves the SAME profile from the environment.
+    if args.profile:
+        os.environ["AWS_PROFILE"] = args.profile
+    elif os.environ.get("CCWB_PROFILE"):
+        os.environ["AWS_PROFILE"] = os.environ["CCWB_PROFILE"]
 
     global TEST_MODE, ANONYMOUS_MODE
     TEST_MODE = args.test

--- a/source/otel_helper/otel-helper.ps1
+++ b/source/otel_helper/otel-helper.ps1
@@ -15,16 +15,30 @@
 # which is flagged by some AV solutions as an unsigned/unknown binary.
 
 param(
-    [string]$Profile = $env:AWS_PROFILE
+    [Parameter(ValueFromRemainingArguments = $true)][string[]]$HelperArgs
 )
 
-if (-not $Profile) { $Profile = "ClaudeCode" }
+# Resolve profile: explicit --profile argument wins, then CCWB_PROFILE (the
+# ccwb-specific override, same convention as credential-process), then
+# AWS_PROFILE, then the "ClaudeCode" default. The argument is parsed by hand
+# because this script is invoked with Go-style flags (otel-helper.cmd passes
+# the same args it gives otel-helper.exe), which PowerShell parameter binding
+# can't map. Keep in sync with the Go binary's resolveProfile and otel-helper.sh.
+$ProfileName = $env:CCWB_PROFILE
+if (-not $ProfileName) { $ProfileName = $env:AWS_PROFILE }
+for ($i = 0; $i -lt $HelperArgs.Count - 1; $i++) {
+    if ($HelperArgs[$i] -in @('--profile', '-profile', '-Profile')) {
+        $ProfileName = $HelperArgs[$i + 1]
+    }
+}
+if (-not $ProfileName) { $ProfileName = "ClaudeCode" }
+$env:AWS_PROFILE = $ProfileName
 
 $installDir = Join-Path $env:USERPROFILE "claude-code-with-bedrock"
 $cacheDir = Join-Path $env:USERPROFILE ".claude-code-session"
-$cacheFile = Join-Path $cacheDir "$Profile-otel-headers.json"
-$rawFile = Join-Path $cacheDir "$Profile-otel-headers.raw"
-$monitoringFile = Join-Path $cacheDir "$Profile-monitoring.json"
+$cacheFile = Join-Path $cacheDir "$ProfileName-otel-headers.json"
+$rawFile = Join-Path $cacheDir "$ProfileName-otel-headers.raw"
+$monitoringFile = Join-Path $cacheDir "$ProfileName-monitoring.json"
 $pidFile = Join-Path $installDir "collector.pid"
 
 # Anti-hammering TTL: how long an empty-headers cache entry is valid (seconds).
@@ -56,16 +70,17 @@ if ((Test-Path $otelcol) -and (Test-Path $collectorConfig)) {
     if (-not $collectorRunning) {
         try {
             $logFile = Join-Path $cacheDir "collector.log"
-            $env:AWS_PROFILE = "$Profile-collector"
+            $env:AWS_PROFILE = "$ProfileName-collector"
             $proc = Start-Process -FilePath $otelcol -ArgumentList "--config", $collectorConfig `
                 -RedirectStandardOutput $logFile -RedirectStandardError $logFile `
                 -WindowStyle Hidden -PassThru -ErrorAction SilentlyContinue
             if ($proc) {
                 Set-Content -Path $pidFile -Value $proc.Id
             }
-            $env:AWS_PROFILE = $Profile
+            $env:AWS_PROFILE = $ProfileName
         } catch {
             # Collector start failed - non-fatal, continue without sidecar
+            $env:AWS_PROFILE = $ProfileName
         }
     }
 }
@@ -153,7 +168,7 @@ if ($shouldWriteEmpty) {
 $credProcess = Join-Path $installDir "credential-process.exe"
 if (Test-Path $credProcess) {
     try {
-        Start-Process -FilePath $credProcess -ArgumentList "--get-monitoring-token", "--profile", $Profile -WindowStyle Hidden -ErrorAction SilentlyContinue
+        Start-Process -FilePath $credProcess -ArgumentList "--get-monitoring-token", "--profile", $ProfileName -WindowStyle Hidden -ErrorAction SilentlyContinue
     } catch {
         # credential-process unavailable - nothing we can do
     }

--- a/source/otel_helper/otel-helper.sh
+++ b/source/otel_helper/otel-helper.sh
@@ -1,7 +1,19 @@
 #!/bin/bash
 # ABOUTME: Lightweight shell wrapper for otel-helper that ensures the local OTEL collector
 # ABOUTME: sidecar is running (when present), then checks file cache for headers (avoids PyInstaller startup)
-PROFILE="${AWS_PROFILE:-ClaudeCode}"
+# Resolve profile: explicit --profile argument wins, then CCWB_PROFILE (the
+# ccwb-specific override, same convention as credential-process), then
+# AWS_PROFILE, then the "ClaudeCode" default. Keep in sync with the Go
+# binary's resolveProfile and otel-helper.ps1.
+PROFILE="${CCWB_PROFILE:-${AWS_PROFILE:-ClaudeCode}}"
+prev=""
+for arg in "$@"; do
+    if [ "$prev" = "--profile" ] && [ -n "$arg" ]; then
+        PROFILE="$arg"
+    fi
+    prev="$arg"
+done
+export AWS_PROFILE="$PROFILE"
 INSTALL_DIR="$HOME/claude-code-with-bedrock"
 PID_FILE="$INSTALL_DIR/collector.pid"
 CACHE_DIR="$HOME/.claude-code-session"

--- a/source/tests/cli/commands/test_package_idc_otel_helper.py
+++ b/source/tests/cli/commands/test_package_idc_otel_helper.py
@@ -93,13 +93,13 @@ def _generate(profile: Profile) -> dict:
 class TestOtelHeadersHelperWiring:
     def test_oidc_wires_helper(self):
         settings = _generate(_oidc_profile())
-        assert settings.get("otelHeadersHelper") == "__OTEL_HELPER_PATH__"
+        assert settings.get("otelHeadersHelper") == "__OTEL_HELPER_PATH__ --profile test"
 
     def test_idc_with_binary_wires_helper(self):
         """The bug: IDC + binary previously skipped the helper, so dashboards
         attributed every IDC user to one static identity."""
         settings = _generate(_idc_with_binary_profile())
-        assert settings.get("otelHeadersHelper") == "__OTEL_HELPER_PATH__", (
+        assert settings.get("otelHeadersHelper") == "__OTEL_HELPER_PATH__ --profile test", (
             "IDC with credential-process binary must wire otelHeadersHelper for per-user attribution"
         )
 

--- a/source/tests/integration/test_package_structure.py
+++ b/source/tests/integration/test_package_structure.py
@@ -234,7 +234,7 @@ class TestClaudeSettingsGeneration:
                 settings = json.load(f)
 
             assert "otelHeadersHelper" in settings, "otelHeadersHelper must be configured when monitoring is enabled"
-            assert settings["otelHeadersHelper"] == "__OTEL_HELPER_PATH__"
+            assert settings["otelHeadersHelper"] == "__OTEL_HELPER_PATH__ --profile ClaudeCode"
             assert settings["env"]["CLAUDE_CODE_ENABLE_TELEMETRY"] == "1"
             assert settings["env"]["OTEL_EXPORTER_OTLP_ENDPOINT"] == "https://collector.example.com:4318"
 

--- a/source/tests/test_otel_helper_profile.py
+++ b/source/tests/test_otel_helper_profile.py
@@ -1,0 +1,67 @@
+# ABOUTME: Tests for otel-helper profile resolution (--profile flag) across
+# ABOUTME: the cache path, credential-process subprocess, and collector sidecar.
+
+"""Profile resolution regression tests.
+
+The otel-helper previously resolved its profile ONLY from AWS_PROFILE, so a
+Claude Code config pointing the helper at a non-default profile was ignored.
+Resolution order (kept in sync with the Go binary's resolveProfile and the
+.sh/.ps1 wrappers):
+
+    --profile flag > CCWB_PROFILE env > AWS_PROFILE env > "ClaudeCode"
+
+The winner is exported to AWS_PROFILE so every downstream consumer (cache
+path, credential-process subprocess, collector sidecar) resolves the same
+profile.
+"""
+
+import os
+import sys
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clean_profile_env(monkeypatch):
+    """Isolate each test from ambient profile overrides."""
+    monkeypatch.delenv("CCWB_PROFILE", raising=False)
+    monkeypatch.delenv("AWS_PROFILE", raising=False)
+
+
+def _parse(monkeypatch, argv):
+    from otel_helper.__main__ import parse_args
+
+    monkeypatch.setattr(sys, "argv", ["otel-helper"] + argv)
+    return parse_args()
+
+
+class TestProfileResolution:
+    def test_profile_flag_overrides_env(self, monkeypatch):
+        monkeypatch.setenv("CCWB_PROFILE", "CcwbProfile")
+        monkeypatch.setenv("AWS_PROFILE", "EnvProfile")
+        _parse(monkeypatch, ["--profile", "FlagProfile"])
+        # The flag must be exported so cache path, credential-process, and the
+        # collector sidecar all resolve the SAME profile.
+        assert os.environ["AWS_PROFILE"] == "FlagProfile"
+
+    def test_ccwb_profile_beats_aws_profile(self, monkeypatch):
+        # CCWB_PROFILE is the ccwb-specific override (same convention as
+        # credential-process) and must win over the ambient AWS_PROFILE.
+        monkeypatch.setenv("CCWB_PROFILE", "CcwbProfile")
+        monkeypatch.setenv("AWS_PROFILE", "EnvProfile")
+        _parse(monkeypatch, [])
+        assert os.environ["AWS_PROFILE"] == "CcwbProfile"
+
+    def test_no_flag_leaves_env_untouched(self, monkeypatch):
+        monkeypatch.setenv("AWS_PROFILE", "EnvProfile")
+        _parse(monkeypatch, [])
+        assert os.environ["AWS_PROFILE"] == "EnvProfile"
+
+    def test_cache_path_follows_profile_flag(self, monkeypatch, tmp_path):
+        from otel_helper.__main__ import get_cache_path
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
+        monkeypatch.setenv("AWS_PROFILE", "EnvProfile")
+        _parse(monkeypatch, ["--profile", "FlagProfile"])
+        assert get_cache_path().name == "FlagProfile-otel-headers.json"


### PR DESCRIPTION
## Why
The otel-helper resolves its profile only from the `AWS_PROFILE` env var, and the packaged Claude Code settings give `otelHeadersHelper` no profile argument at all — unlike `AWS_CREDENTIAL_PROCESS` and `awsAuthRefresh`, which already pass `--profile`. Users on a non-default profile get attribution headers from the wrong cache and a collector sidecar running under the wrong AWS profile, with no way to pin the helper to the right one.

## What
One resolution rule across all four helper variants, aligned with credential-process's existing `CCWB_PROFILE` convention:

`--profile` flag > `CCWB_PROFILE` env > `AWS_PROFILE` env > `"ClaudeCode"`

An explicit override is exported to `AWS_PROFILE` so the header cache path, credential-process subprocess, `<profile>-collector` sidecar profile, and the AWS SDK in proxy mode all resolve the same profile.

- `package.py` / `package_cb.py` write `otelHeadersHelper` as `__OTEL_HELPER_PATH__ --profile <name>`
- Go: new `--profile` flag + `resolveProfile()`; `--status` reports the resolved profile instead of re-reading `AWS_PROFILE` inline
- Python: new `--profile` argparse option; `otel-helper.sh` parses `--profile`; `otel-helper.ps1` hand-parses it from `$args` (PowerShell `-File` can't bind Go-style `--profile`, so the old `param([string]$Profile)` errored when `otel-helper.cmd` forwarded args — and shadowed the automatic `$PROFILE` variable)

## Testing
- Go `TestResolveProfile_Precedence` pins the four-tier order and the `AWS_PROFILE` export; Python `tests/test_otel_helper_profile.py` mirrors it and asserts the cache path follows the flag; packaging tests updated to expect the `--profile` suffix
- Full Python suite (1688) and `go test ./...` pass; cross-compiles for windows/darwin verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)