### PR TITLE
fix(credential-process): quota-blocked users recover automatically — remove ~/.aws/credentials stanza instead of writing EXPIRED placeholder

### DIFF
--- a/source/go/cmd/credential-process/main.go
+++ b/source/go/cmd/credential-process/main.go
@@ -274,12 +274,13 @@ func (a *credentialApp) clearCache() {
 	if a.cfg.CredentialStorage == "keyring" {
 		_ = storage.ClearKeyring(a.profile)
 	}
-	// Also clear session file
-	expired := &federation.AWSCredentials{
-		Version: 1, AccessKeyID: "EXPIRED", SecretAccessKey: "EXPIRED",
-		SessionToken: "EXPIRED", Expiration: "2000-01-01T00:00:00Z",
-	}
-	_ = storage.SaveToCredentialsFile(expired, a.profile)
+	// Remove the profile section from ~/.aws/credentials rather than writing an
+	// EXPIRED placeholder. That file outranks credential_process in the AWS SDK
+	// resolution chain, so a placeholder entry would permanently wedge SDK
+	// consumers (Claude Code): they'd keep reading the static EXPIRED keys and
+	// never invoke this binary again. With the section removed, the SDK falls
+	// through to credential_process and recovery is automatic.
+	_ = storage.RemoveFromCredentialsFile(a.profile)
 	// Clear refresh token
 	storage.ClearRefreshToken(a.profile)
 	fmt.Fprintf(os.Stderr, "Cleared cached credentials for profile '%s'\n", a.profile)

--- a/source/go/internal/storage/session.go
+++ b/source/go/internal/storage/session.go
@@ -105,6 +105,46 @@ func credentialsFilePath() string {
 	return filepath.Join(home, ".aws", "credentials")
 }
 
+// RemoveFromCredentialsFile deletes a profile's section from ~/.aws/credentials.
+// Leaving a stale or placeholder section behind is harmful: ~/.aws/credentials
+// outranks credential_process in the AWS SDK resolution chain, so any static
+// entry for the profile prevents the SDK from ever invoking this binary again.
+// Removing the section lets the SDK fall through to credential_process and
+// recover automatically. Other profiles in the file are preserved.
+func RemoveFromCredentialsFile(profile string) error {
+	credPath := credentialsFilePath()
+	if _, err := os.Stat(credPath); os.IsNotExist(err) {
+		return nil
+	}
+
+	cfg, err := ini.LoadSources(ini.LoadOptions{
+		IgnoreInlineComment: true,
+	}, credPath)
+	if err != nil {
+		return fmt.Errorf("reading credentials file: %w", err)
+	}
+
+	if _, err := cfg.GetSection(profile); err != nil {
+		return nil // Section doesn't exist — nothing to remove
+	}
+	cfg.DeleteSection(profile)
+
+	// Atomic write, same pattern as SaveToCredentialsFile
+	tmpPath := credPath + ".tmp"
+	if err := cfg.SaveTo(tmpPath); err != nil {
+		return fmt.Errorf("writing credentials: %w", err)
+	}
+	if err := os.Chmod(tmpPath, 0600); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Rename(tmpPath, credPath); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return nil
+}
+
 // IsExpiredDummy checks if credentials are the "EXPIRED" placeholder.
 func IsExpiredDummy(creds *federation.AWSCredentials) bool {
 	return creds != nil && creds.AccessKeyID == "EXPIRED"


### PR DESCRIPTION
## Why

Fixes #767.

When quota enforcement blocks a user, `clearCache()` writes an `EXPIRED` placeholder credential stanza into `~/.aws/credentials`. That file outranks `credential_process` in the AWS SDK resolution chain, so SDK consumers (Claude Code / Claude Desktop) keep reading the dead static keys and **never invoke credential-process again**. When the quota resets or an admin runs `ccwb quota unblock`, the user does not recover — they stay on "credentials expired / refresh failed" until the stanza is deleted by hand. In keyring mode the stanza is written *only* at block time, so every blocked-then-unblocked keyring user hits this.

Confirmed in a production enterprise deployment (Entra ID OIDC, Direct STS, keyring storage): a user blocked overnight remained hard-down after the daily reset; the same binary run manually minted credentials fine (it bypasses the SDK chain), and deleting the `[profile]` stanza restored service instantly.

## What

- **storage**: add `RemoveFromCredentialsFile(profile)` — deletes just that profile's section from `~/.aws/credentials` via the same atomic tmp-write/chmod/rename pattern as `SaveToCredentialsFile`; preserves other profiles; no-op when the file or section is absent.
- **clearCache()**: call it instead of writing the `EXPIRED` placeholder.

Deleting the section achieves the same invalidation the placeholder was for: `getCachedCredentials()` already treats "no entry" and "expired dummy" identically, while the SDK treats them very differently — "no entry" falls through to `credential_process` (automatic recovery); a static entry is terminal.

`IsExpiredDummy()` and its callers are intentionally kept so binaries remain tolerant of credentials files poisoned by older builds.

## Testing

- `go build ./...`, `go vet`, and the full `internal/storage` + `cmd/credential-process` suites pass.
- End-to-end: built the binary, seeded a sandbox `$HOME/.aws/credentials` with the incident state (EXPIRED stanza for the CCWB profile + an unrelated static profile), ran `--clear-cache`: the CCWB profile section is removed entirely, the unrelated profile survives byte-for-byte.

## Behavior change

Before: after a quota block, `~/.aws/credentials` contains a poisoned stanza that requires manual deletion once the block is lifted.
After: after a quota block, the profile has no entry in `~/.aws/credentials`; the SDK falls through to `credential_process` on the next invocation, the quota re-check runs, and recovery is automatic.
