### PR TITLE
release: v2.5.2 — quota enforcement fixes, credential recovery, auth/cowork fixes, offline packaging

### DIFF
--- a/.claude/rules/credential-flow.md
+++ b/.claude/rules/credential-flow.md
@@ -11,8 +11,8 @@ AWS SDK → credential-process [Go or Python]
   2. If valid + not expired → return immediately (fast path, ~5ms)
   3. If expired → try silent refresh (refresh_token exchange, no browser)
   4. If no refresh_token → OIDC browser flow (or IDC passthrough)
-  5. Exchange token → STS AssumeRoleWithWebIdentity → temporary credentials
-  6. Check quota (if configured) → blocked? exit non-zero
+  5. Check quota with the id_token (if configured) → blocked? exit non-zero
+  6. Exchange token → STS AssumeRoleWithWebIdentity → temporary credentials
   7. Save credentials to cache
   8. Emit OTEL attribution headers to cache file
   9. Print JSON to stdout → AWS SDK uses credentials
@@ -39,10 +39,14 @@ print(json.dumps(credentials))  # only JSON on stdout
 
 ## Quota Integration
 
-Quota check happens AFTER auth but BEFORE outputting credentials:
+Quota check happens AFTER auth (id_token in hand) but BEFORE the STS
+exchange — an over-quota user must never mint or cache fresh AWS
+credentials (#761):
 - If quota blocks → exit non-zero (credential-process contract: no JSON = failure)
 - If quota warns → print warning to stderr, still output credentials
 - Quota check uses the same token (OIDC: Bearer, IDC: SigV4)
+- Check with the in-scope id_token; never re-read it from storage and
+  silently skip when the read comes back empty (fail per quota_fail_mode)
 
 ## OTEL Attribution
 

--- a/.claude/rules/token-endpoint-single-builder.md
+++ b/.claude/rules/token-endpoint-single-builder.md
@@ -31,8 +31,9 @@ tokenURL = provider.TokenEndpointURL(providerType, oktaAuthServerID, providerDom
 
 ## Callers (must all use the shared builder)
 - `oidc/flow.go` — browser authorization-code exchange
-- `tryRefreshToken()` in main.go — silent refresh
-- `refreshIDTokenOnly()` — monitoring token refresh (when added)
+- `tryRefreshToken()` in main.go — the single silent refresh_token exchange
+  (serves credential refresh, monitoring token refresh, and the MCP auth
+  header path; the former `refreshIDTokenOnly()` twin was merged into it)
 - Any future token endpoint caller
 
 ## Related

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "beta"
     schedule:
       interval: "weekly"
     commit-message:
@@ -12,6 +13,7 @@ updates:
 
   - package-ecosystem: "pip"
     directory: "/source"
+    target-branch: "beta"
     schedule:
       interval: "weekly"
     commit-message:

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           ref: ${{ github.event_name == 'schedule' && 'beta' || github.ref }}
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
           go-version-file: source/go/go.mod
 

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version: '1.24'
           cache-dependency-path: source/go/go.sum

--- a/.github/workflows/release-main.yml
+++ b/.github/workflows/release-main.yml
@@ -101,7 +101,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Set up Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         with:
           go-version-file: source/go/go.mod
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,8 +46,8 @@ AWS SDK calls credential-process
   → read cache → [valid?] → return cached credentials
   → [expired?] → try silent refresh (refresh_token)
   → [no token?] → OIDC browser flow or IDC passthrough
+  → check quota with id_token → [blocked?] → exit non-zero
   → STS AssumeRoleWithWebIdentity → credentials
-  → check quota → [blocked?] → exit non-zero
   → emit OTEL attribution headers → cache → stdout JSON
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Guidance for Claude Code and Cowork on Amazon Bedrock
 
-[![Stable Release](https://img.shields.io/github/v/release/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock?style=for-the-badge&label=stable)](https://github.com/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock/releases/latest)
+[![Stable Release](https://img.shields.io/github/v/release/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock?style=for-the-badge&label=stable&filter=v*.*.*)](https://github.com/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock/releases/latest)
 [![Beta Release](https://img.shields.io/github/v/release/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock?style=for-the-badge&include_prereleases&label=beta)](https://github.com/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock/tree/beta)
 
 This guidance enables enterprise deployment of Claude Code and Claude Cowork on Amazon Bedrock across command-line (CLI) and desktop surfaces — with secure single sign-on (SSO), usage monitoring, and cost controls.

--- a/assets/docs/CLI_REFERENCE.md
+++ b/assets/docs/CLI_REFERENCE.md
@@ -257,34 +257,7 @@ poetry run ccwb package [options]
 2. Creates `config.json` with federation config read from the admin profile
 3. Creates `claude-settings/settings.json` with Bedrock model and OTel endpoint (or `managed-settings.json` if `--managed` was used during init)
 4. Creates installer scripts (`install.sh`, `install.bat`, `ccwb-install.ps1`)
-5. Copies any admin-defined **extra files** into the build folder (see below)
-6. Outputs to `dist/{profile}/{timestamp}/`
-
-**Extra Files:**
-
-You can ship additional files or folders on top of the generated package —
-preinstall/postinstall scripts, an OIDC signing certificate, a CA bundle, and
-so on. Configure them during `ccwb init` (the "Extra files" step); they are
-stored in your admin deployment profile, never in the runtime `config.json` and
-never delivered to end users' Claude Code config.
-
-Each entry has three fields:
-
-| Field | Meaning |
-|---|---|
-| `name` | path inside the package (relative — no `..` or absolute paths) |
-| `targets` | which machines receive it (see tokens below) |
-| `from` | source path on your machine (a file or a whole folder) |
-
-`targets` accepts `all`, a family (`macos`, `linux`, `windows`), an
-architecture (`macos-arm64`, `macos-intel`, `linux-x64`, `linux-arm64`), or a
-list such as `["macos", "linux"]`.
-
-`ccwb package` copies **all** extras into the build folder. `ccwb distribute`
-then filters them per platform — a `macos` extra lands in the macOS package but
-not the Windows one; an `all` extra lands in every package. `package` fails
-fast (non-zero exit) if a `from` source is missing or a `name` collides with a
-generated artifact, so a listed file is never silently dropped.
+5. Outputs to `dist/{profile}/{timestamp}/`
 
 **Build Modes:**
 
@@ -304,6 +277,22 @@ With `--go`, all 5 platforms are always available regardless of the admin's OS. 
 - **Windows x64**: Native PE with embedded version info (~14 MB, unstripped for Defender compatibility)
 
 **Offline Packaging:**
+
+`ccwb package` normally needs internet on the admin machine for three things: Go module downloads for `source/go`, the OCB (OpenTelemetry Collector Builder) binary from GitHub, and Go module downloads for the OCB-generated collector module (sidecar mode only). A `vendor/` directory cannot cover the collector build — OCB generates a fresh Go module in a temp directory on every run.
+
+For air-gapped environments, use `--prepare-offline` to pre-seed everything:
+
+```bash
+# On an internet-connected machine (same OS/arch and Go version as the offline box):
+poetry run ccwb package --prepare-offline
+# Transfer ccwb-offline-go-bundle.tar.gz to the offline machine, extract, then:
+tar xzf ccwb-offline-go-bundle.tar.gz
+./scripts/prepare-offline-go-bundle.sh install
+source ccwb-offline-go-bundle/offline-env.sh
+poetry run ccwb package
+```
+
+The bundle contains the pinned OCB binary (installed to `~/.cache/ocb/`, where `package.py` looks before downloading) and a pre-populated Go module cache covering both `source/go` and the collector. Because every `go`/`ocb` subprocess inherits the environment, `GOPROXY=off` plus the seeded `GOMODCACHE` satisfies all module resolution — including the `go mod tidy` OCB runs internally. The `prepare` step rehearses a fully offline collector build before archiving, so a bundle that ships is a bundle that works.
 
 **Legacy mode platform details (PyInstaller / Nuitka / Docker):**
 

--- a/assets/docs/CLI_REFERENCE.md
+++ b/assets/docs/CLI_REFERENCE.md
@@ -257,7 +257,34 @@ poetry run ccwb package [options]
 2. Creates `config.json` with federation config read from the admin profile
 3. Creates `claude-settings/settings.json` with Bedrock model and OTel endpoint (or `managed-settings.json` if `--managed` was used during init)
 4. Creates installer scripts (`install.sh`, `install.bat`, `ccwb-install.ps1`)
-5. Outputs to `dist/{profile}/{timestamp}/`
+5. Copies any admin-defined **extra files** into the build folder (see below)
+6. Outputs to `dist/{profile}/{timestamp}/`
+
+**Extra Files:**
+
+You can ship additional files or folders on top of the generated package —
+preinstall/postinstall scripts, an OIDC signing certificate, a CA bundle, and
+so on. Configure them during `ccwb init` (the "Extra files" step); they are
+stored in your admin deployment profile, never in the runtime `config.json` and
+never delivered to end users' Claude Code config.
+
+Each entry has three fields:
+
+| Field | Meaning |
+|---|---|
+| `name` | path inside the package (relative — no `..` or absolute paths) |
+| `targets` | which machines receive it (see tokens below) |
+| `from` | source path on your machine (a file or a whole folder) |
+
+`targets` accepts `all`, a family (`macos`, `linux`, `windows`), an
+architecture (`macos-arm64`, `macos-intel`, `linux-x64`, `linux-arm64`), or a
+list such as `["macos", "linux"]`.
+
+`ccwb package` copies **all** extras into the build folder. `ccwb distribute`
+then filters them per platform — a `macos` extra lands in the macOS package but
+not the Windows one; an `all` extra lands in every package. `package` fails
+fast (non-zero exit) if a `from` source is missing or a `name` collides with a
+generated artifact, so a listed file is never silently dropped.
 
 **Build Modes:**
 

--- a/assets/docs/COWORK_3P.md
+++ b/assets/docs/COWORK_3P.md
@@ -177,6 +177,7 @@ When Claude Cowork starts a session:
 3. The output is cached for `inferenceCredentialHelperTtlSec` seconds (default: 3500, just under the 1h STS token lifetime)
 4. When the cache expires, Claude Desktop automatically re-runs the helper — **no restart required**
 5. If credentials are rejected mid-session, Claude Desktop re-runs with `CLAUDE_HELPER_CONTEXT=mid-session-refresh` for seamless recovery (20s timeout)
+6. Because this mode also sets `inferenceBedrockProfile` (as an AWS SDK region/metadata fallback, not the active auth path), this solution additionally sets `inferenceCredentialKind` to `helper-script` so Claude Desktop doesn't have to pick between the two — without it, Desktop may prefer the profile instead and authentication fails
 
 The credential-process binary handles the `CLAUDE_HELPER_CONTEXT` environment variable:
 - `interactive` → Full browser-based OIDC authentication

--- a/assets/docs/MONITORING.md
+++ b/assets/docs/MONITORING.md
@@ -130,6 +130,31 @@ are only populated for OIDC. IDC attributes `user.email` only. See
 [Cost Attribution](COST_ATTRIBUTION.md#idc-limitation) for the CUR/ABAC path to
 per-user team/department breakdowns under IDC.
 
+### Tracking deployed package versions (`settings_version`)
+
+`ccwb package` stamps the dist-folder timestamp (e.g. `2026-07-08-120000`) into
+the generated `settings.json` as a `settings_version` entry in
+`OTEL_RESOURCE_ATTRIBUTES`. Every user's telemetry then carries the version of
+the distribution package they installed, so you can see who is running an
+outdated package. Installs from packages built before this attribute existed
+simply report no `settings_version` — itself a signal that the user is on an
+old package.
+
+When the analytics pipeline is enabled, the `awsemf` exporter converts resource
+attributes to fields on every metric event in `/aws/claude-code/metrics`, so
+adoption is queryable in CloudWatch Logs Insights without any collector change:
+
+```
+fields @timestamp
+| stats count_distinct(`user.email`) as users by settings_version
+```
+
+To surface `settings_version` as a first-class CloudWatch metric dimension for
+dashboards or alarms, add a `metric_declarations` entry for it in
+`otel-collector.yaml` — scope it to a single metric (e.g.
+`claude_code.token.usage`) rather than `.*`, since every package release adds a
+new dimension value and broad declarations multiply custom-metric cost.
+
 ## Usage Quota Monitoring
 
 Quota monitoring uses the CloudWatch Prometheus-compatible API (`monitoring.<region>.amazonaws.com/api/v1/query`) to query per-user token usage via PromQL. The quota monitor Lambda runs every 15 minutes, fetches usage data via PromQL, writes results to a DynamoDB table (`UserQuotaMetrics`), and checks against quota policies.

--- a/assets/docs/WEB_SEARCH.md
+++ b/assets/docs/WEB_SEARCH.md
@@ -1,103 +1,78 @@
-commit abdbe3753b5025b204d69606a3fc229d88cd5571
-Author: Chiara Relandini <chiara.relandini@gmail.com>
-Date:   Mon Jun 22 10:37:10 2026 +0200
+# Web Search for Claude Cowork (Amazon Bedrock AgentCore)
 
-    feat(websearch): decouple JWT validation mode, add data residency note and WEB_SEARCH.md
-    
-    Address PR #607 review:
-    - Replace ProviderType (cognito/azure) with JwtValidationMode (client_id/
-      audience), decoupling the CUSTOM_JWT authorizer from provider name so the
-      template also serves Okta, Auth0 and generic OIDC. The CLI maps provider_type
-      to the mode and remains the gate for which providers are offered/tested.
-    - Add a data residency warning to the template Description and a
-      Metadata.DataResidency block: web search queries are processed in
-      WebSearchRegion (us-east-1), which may differ from the customer's region.
-    - Add assets/docs/WEB_SEARCH.md: standalone deployment guide, parameters, data
-      residency note, manual Cowork wiring (managedMcpServers), and cost.
-    
-    Re-validated with cfn-lint and a real create-stack in us-east-1 (client_id mode).
+This guide covers the optional web search capability for **Claude Cowork** (Claude Desktop in third‑party platform mode) on Amazon Bedrock. It deploys an **Amazon Bedrock AgentCore Gateway** with the fully managed **Web Search connector** and exposes it to Cowork as a managed MCP server.
 
-diff --git a/assets/docs/WEB_SEARCH.md b/assets/docs/WEB_SEARCH.md
-new file mode 100644
-index 0000000..9ff2d28
---- /dev/null
-+++ b/assets/docs/WEB_SEARCH.md
-@@ -0,0 +1,78 @@
-+# Web Search for Claude Cowork (Amazon Bedrock AgentCore)
-+
-+This guide covers the optional web search capability for **Claude Cowork** (Claude Desktop in third‑party platform mode) on Amazon Bedrock. It deploys an **Amazon Bedrock AgentCore Gateway** with the fully managed **Web Search connector** and exposes it to Cowork as a managed MCP server.
-+
-+> **Status:** This page documents the standalone CloudFormation template (`deployment/infrastructure/bedrock-agentcore-gateway.yaml`). `ccwb` CLI integration (init wizard + automatic MDM wiring) ships in follow‑up PRs; until then, wire the gateway to Cowork manually as described below.
-+
-+## What it does
-+
-+The [Web Search tool on Amazon Bedrock AgentCore](https://aws.amazon.com/blogs/aws/announcing-web-search-on-amazon-bedrock-agentcore-ground-your-ai-agents-in-current-accurate-web-knowledge/) is a managed, MCP‑compliant connector backed by Amazon's own web index. It returns titles, URLs, snippets, and publication dates so the model can ground answers in current information. There is no third‑party search API to provision and no outbound credentials to manage — queries stay within AWS.
-+
-+The template provisions:
-+
-+- An **AgentCore Gateway** (MCP protocol) whose inbound authorization (`CUSTOM_JWT`) reuses your existing OIDC identity provider — the same one the rest of this solution already uses.
-+- A **Gateway target** configured with the managed `web-search` connector (optional domain denylist).
-+- A least‑privilege **gateway execution IAM role** (`GetGateway`, `GetConfigurationBundleVersion`, `InvokeWebSearch`).
-+
-+## Prerequisites
-+
-+- This solution already deployed with an OIDC identity provider (the Web Search gateway reuses it for inbound auth).
-+- Deployment into a region where the Web Search connector is available — **`us-east-1` only** at time of writing.
-+
-+## Deployment
-+
-+```bash
-+aws cloudformation deploy \
-+  --region us-east-1 \
-+  --stack-name <your-stack-name> \
-+  --template-file deployment/infrastructure/bedrock-agentcore-gateway.yaml \
-+  --capabilities CAPABILITY_IAM \
-+  --parameter-overrides \
-+      WebSearchRegion=us-east-1 \
-+      JwtValidationMode=client_id \
-+      JwtDiscoveryUrl=https://cognito-idp.<idp-region>.amazonaws.com/<user-pool-id>/.well-known/openid-configuration \
-+      JwtAllowedClients=<your-app-client-id>
-+```
-+
-+### Parameters
-+
-+| Parameter | Description |
-+|-----------|-------------|
-+| `WebSearchRegion` | Region to deploy into. Constrained to where the connector is GA (`us-east-1`). |
-+| `JwtValidationMode` | `client_id` (Cognito — validates against `AllowedClients`) or `audience` (Entra ID / Okta / Auth0 / generic OIDC — validates against the token `aud` via `AllowedAudience`). |
-+| `JwtDiscoveryUrl` | Your IdP OIDC discovery URL (ends with `/.well-known/openid-configuration`). |
-+| `JwtAllowedClients` | Allowed client IDs (use with `JwtValidationMode=client_id`). |
-+| `JwtAllowedAudience` | Allowed `aud` values (use with `JwtValidationMode=audience`). For Entra ID this is the API Application ID URI, e.g. `api://<app-id>`. |
-+| `WebSearchDomainDenylist` | Optional. Comma‑separated domains to exclude from results. |
-+
-+The stack output **`GatewayMcpEndpoint`** is the MCP endpoint URL to give to Claude Cowork.
-+
-+## Data residency
-+
-+> ⚠️ Web search queries (and fragments of user prompts) are processed by the managed connector in **`WebSearchRegion`** (`us-east-1` today), regardless of where the user's IDE session runs or where Bedrock inference happens. Organizations with data residency or sovereignty obligations (e.g. GDPR) should evaluate whether this is acceptable before enabling web search.
-+
-+## Wire it to Claude Cowork (manual, until CLI support lands)
-+
-+Add a `managedMcpServers` entry to your Cowork MDM configuration pointing at the gateway endpoint. Cowork authenticates with an OAuth authorization‑code flow against the **same IdP**, reusing your existing client ID and the `localhost` callback port (default `8400`) — no secret is stored in the config:
-+
-+```json
-+{
-+  "managedMcpServers": "[{\"name\": \"agentcore-websearch\", \"transport\": \"http\", \"url\": \"<GatewayMcpEndpoint>\", \"oauth\": {\"clientId\": \"<your-app-client-id>\", \"authorizationServer\": [\"<oidc-issuer>\"], \"scope\": \"openid email profile\", \"callbackHost\": \"localhost\", \"callbackPort\": 8400}}]"
-+}
-+```
-+
-+- `<GatewayMcpEndpoint>` — the stack output (already includes the `/mcp` path).
-+- `<oidc-issuer>` — for Cognito `https://cognito-idp.<region>.amazonaws.com/<user-pool-id>`; for Entra ID your Entra issuer.
-+- The IdP app client must already allow the `http://localhost:8400/...` redirect URI (this solution already requires it for Claude Code).
-+
-+See [COWORK_3P.md](COWORK_3P.md) for the full MDM configuration reference and the custom‑MDM‑key mechanism.
-+
-+## Cost
-+
-+Web Search on Amazon Bedrock AgentCore is usage‑based: **$7 per 1,000 search queries** at time of writing (the gateway itself has no fixed hourly charge). See the [Amazon Bedrock AgentCore pricing](https://aws.amazon.com/bedrock/agentcore/pricing/) page for current pricing. New AWS customers may receive Free Tier credits.
-+
-+## References
-+
-+- [Announcing Web Search on Amazon Bedrock AgentCore](https://aws.amazon.com/blogs/aws/announcing-web-search-on-amazon-bedrock-agentcore-ground-your-ai-agents-in-current-accurate-web-knowledge/)
-+- [AgentCore Gateway documentation](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway.html)
-+- [CoWork 3P Guide](COWORK_3P.md)
+> **Status:** This page documents the standalone CloudFormation template (`deployment/infrastructure/bedrock-agentcore-gateway.yaml`). `ccwb` CLI integration (init wizard + automatic MDM wiring) ships in follow‑up PRs; until then, wire the gateway to Cowork manually as described below.
+
+## What it does
+
+The [Web Search tool on Amazon Bedrock AgentCore](https://aws.amazon.com/blogs/aws/announcing-web-search-on-amazon-bedrock-agentcore-ground-your-ai-agents-in-current-accurate-web-knowledge/) is a managed, MCP‑compliant connector backed by Amazon's own web index. It returns titles, URLs, snippets, and publication dates so the model can ground answers in current information. There is no third‑party search API to provision and no outbound credentials to manage — queries stay within AWS.
+
+The template provisions:
+
+- An **AgentCore Gateway** (MCP protocol) whose inbound authorization (`CUSTOM_JWT`) reuses your existing OIDC identity provider — the same one the rest of this solution already uses.
+- A **Gateway target** configured with the managed `web-search` connector (optional domain denylist).
+- A least‑privilege **gateway execution IAM role** (`GetGateway`, `GetConfigurationBundleVersion`, `InvokeWebSearch`).
+
+## Prerequisites
+
+- This solution already deployed with an OIDC identity provider (the Web Search gateway reuses it for inbound auth).
+- Deployment into a region where the Web Search connector is available — **`us-east-1` only** at time of writing.
+
+## Deployment
+
+```bash
+aws cloudformation deploy \
+  --region us-east-1 \
+  --stack-name <your-stack-name> \
+  --template-file deployment/infrastructure/bedrock-agentcore-gateway.yaml \
+  --capabilities CAPABILITY_IAM \
+  --parameter-overrides \
+      WebSearchRegion=us-east-1 \
+      JwtValidationMode=client_id \
+      JwtDiscoveryUrl=https://cognito-idp.<idp-region>.amazonaws.com/<user-pool-id>/.well-known/openid-configuration \
+      JwtAllowedClients=<your-app-client-id>
+```
+
+### Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `WebSearchRegion` | Region to deploy into. Constrained to where the connector is GA (`us-east-1`). |
+| `JwtValidationMode` | `client_id` (Cognito — validates against `AllowedClients`) or `audience` (Entra ID / Okta / Auth0 / generic OIDC — validates against the token `aud` via `AllowedAudience`). |
+| `JwtDiscoveryUrl` | Your IdP OIDC discovery URL (ends with `/.well-known/openid-configuration`). |
+| `JwtAllowedClients` | Allowed client IDs (use with `JwtValidationMode=client_id`). |
+| `JwtAllowedAudience` | Allowed `aud` values (use with `JwtValidationMode=audience`). For Entra ID this is the API Application ID URI, e.g. `api://<app-id>`. |
+| `WebSearchDomainDenylist` | Optional. Comma‑separated domains to exclude from results. |
+
+The stack output **`GatewayMcpEndpoint`** is the MCP endpoint URL to give to Claude Cowork.
+
+## Data residency
+
+> ⚠️ Web search queries (and fragments of user prompts) are processed by the managed connector in **`WebSearchRegion`** (`us-east-1` today), regardless of where the user's IDE session runs or where Bedrock inference happens. Organizations with data residency or sovereignty obligations (e.g. GDPR) should evaluate whether this is acceptable before enabling web search.
+
+## Wire it to Claude Cowork (manual, until CLI support lands)
+
+Add a `managedMcpServers` entry to your Cowork MDM configuration pointing at the gateway endpoint. Cowork authenticates with an OAuth authorization‑code flow against the **same IdP**, reusing your existing client ID and the `localhost` callback port (default `8400`) — no secret is stored in the config:
+
+```json
+{
+  "managedMcpServers": "[{\"name\": \"agentcore-websearch\", \"transport\": \"http\", \"url\": \"<GatewayMcpEndpoint>\", \"oauth\": {\"clientId\": \"<your-app-client-id>\", \"authorizationServer\": [\"<oidc-issuer>\"], \"scope\": \"openid email profile\", \"callbackHost\": \"localhost\", \"callbackPort\": 8400}}]"
+}
+```
+
+- `<GatewayMcpEndpoint>` — the stack output (already includes the `/mcp` path).
+- `<oidc-issuer>` — for Cognito `https://cognito-idp.<region>.amazonaws.com/<user-pool-id>`; for Entra ID your Entra issuer.
+- The IdP app client must already allow the `http://localhost:8400/...` redirect URI (this solution already requires it for Claude Code).
+
+See [COWORK_3P.md](COWORK_3P.md) for the full MDM configuration reference and the custom‑MDM‑key mechanism.
+
+## Cost
+
+Web Search on Amazon Bedrock AgentCore is usage‑based: **$7 per 1,000 search queries** at time of writing (the gateway itself has no fixed hourly charge). See the [Amazon Bedrock AgentCore pricing](https://aws.amazon.com/bedrock/agentcore/pricing/) page for current pricing. New AWS customers may receive Free Tier credits.
+
+## References
+
+- [Announcing Web Search on Amazon Bedrock AgentCore](https://aws.amazon.com/blogs/aws/announcing-web-search-on-amazon-bedrock-agentcore-ground-your-ai-agents-in-current-accurate-web-knowledge/)
+- [AgentCore Gateway documentation](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/gateway.html)
+- [CoWork 3P Guide](COWORK_3P.md)

--- a/deployment/infrastructure/bedrock-auth-google.yaml
+++ b/deployment/infrastructure/bedrock-auth-google.yaml
@@ -100,6 +100,7 @@ Resources:
             Action:
               - 'bedrock:InvokeModel'
               - 'bedrock:InvokeModelWithResponseStream'
+              - 'bedrock:CallWithBearerToken'
             Resource:
               - !Sub 'arn:${AWS::Partition}:bedrock:*::foundation-model/*'
               - !Sub 'arn:${AWS::Partition}:bedrock:*:*:inference-profile/*'
@@ -111,6 +112,7 @@ Resources:
             Action:
               - 'bedrock:InvokeModel'
               - 'bedrock:InvokeModelWithResponseStream'
+              - 'bedrock:CallWithBearerToken'
             Resource:
               - !Sub 'arn:${AWS::Partition}:bedrock:::foundation-model/*'
           - Sid: AllowBedrockListRegional

--- a/deployment/infrastructure/cowork-dashboard.yaml
+++ b/deployment/infrastructure/cowork-dashboard.yaml
@@ -324,13 +324,14 @@ Resources:
               }
             },
             {
-              "type": "metric",
+              "type": "chart",
               "x": 12, "y": 12, "width": 12, "height": 6,
               "properties": {
                 "title": "Avg Cost Per Turn (USD)",
-                "view": "timeSeries",
+                "view": "line",
                 "region": "${MetricsRegion}",
-                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"ClaudeCoWork\", MetricName=\"cost.usage\"}) / sum({\"ClaudeCoWork\", MetricName=\"session.turns\"})", "step": 60, "label": "$/turn" }] }
+                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "sum({\"ClaudeCoWork\", MetricName=\"cost.usage\"}) / sum({\"ClaudeCoWork\", MetricName=\"session.turns\"})", "step": 60, "label": "$/turn" }] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
@@ -339,57 +340,58 @@ Resources:
               "properties": { "markdown": "## Per-User Breakdown\n*Desktop mode only — LAM events do not emit user_email*" }
             },
             {
-              "type": "metric",
+              "type": "chart",
               "x": 0, "y": 19, "width": 12, "height": 6,
               "properties": {
                 "title": "Top Users by Token Usage",
-                "view": "timeSeries",
-                "stacked": true,
+                "view": "line",
                 "region": "${MetricsRegion}",
-                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(10, sum by (\"user_email\")({\"ClaudeCoWork\", MetricName=\"token.usage.input\"}))", "step": 60 }] }
+                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(10, sum by (\"user_email\")({\"ClaudeCoWork\", MetricName=\"token.usage.input\"}))", "step": 60 }] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": true, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
-              "type": "metric",
+              "type": "chart",
               "x": 12, "y": 19, "width": 12, "height": 6,
               "properties": {
                 "title": "Estimated Cost by User (USD)",
-                "view": "timeSeries",
-                "stacked": true,
+                "view": "line",
                 "region": "${MetricsRegion}",
-                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(10, sum by (\"user_email\")({\"ClaudeCoWork\", MetricName=\"cost.usage\"}))", "step": 60 }] }
+                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(10, sum by (\"user_email\")({\"ClaudeCoWork\", MetricName=\"cost.usage\"}))", "step": 60 }] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": true, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
-              "type": "metric",
+              "type": "chart",
               "x": 0, "y": 25, "width": 12, "height": 6,
               "properties": {
                 "title": "Session Turns by User",
-                "view": "timeSeries",
-                "stacked": true,
+                "view": "line",
                 "region": "${MetricsRegion}",
-                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(10, sum by (\"user_email\")({\"ClaudeCoWork\", MetricName=\"session.turns\"}))", "step": 60 }] }
+                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(10, sum by (\"user_email\")({\"ClaudeCoWork\", MetricName=\"session.turns\"}))", "step": 60 }] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": true, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
-              "type": "metric",
+              "type": "chart",
               "x": 12, "y": 25, "width": 12, "height": 6,
               "properties": {
                 "title": "Cost by Model",
-                "view": "timeSeries",
-                "stacked": true,
+                "view": "line",
                 "region": "${MetricsRegion}",
-                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(10, sum by (\"model\")({\"ClaudeCoWork\", MetricName=\"cost.usage\"}))", "step": 60 }] }
+                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "topk(10, sum by (\"model\")({\"ClaudeCoWork\", MetricName=\"cost.usage\"}))", "step": 60 }] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": true, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {
-              "type": "metric",
+              "type": "chart",
               "x": 0, "y": 31, "width": 6, "height": 4,
               "properties": {
                 "title": "Active Users",
-                "view": "singleValue",
+                "view": "number",
                 "region": "${MetricsRegion}",
-                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "count(group by (\"user_email\")({\"ClaudeCoWork\", MetricName=\"session.turns\"}))", "step": 60, "label": "Active Users" }] }
+                "data": { "queries": [{ "id": "a", "type": "cloudwatch-metrics", "language": "PromQL", "query": "count(group by (\"user_email\")({\"ClaudeCoWork\", MetricName=\"session.turns\"}))", "step": 60, "label": "Active Users" }] },
+                "plotOptions": { "legend": { "position": "bottom", "show": true }, "xAxis": { "type": "datetime" }, "yAxis": [{ "type": "linear" }], "style": { "lineOptions": { "filled": false, "stacked": false, "width": 2, "pattern": "solid", "spline": false }, "numberOptions": { "sparkline": true }, "pieOptions": { "innerSize": "50%" }, "barOptions": {}, "gaugeOptions": {} } }
               }
             },
             {

--- a/deployment/infrastructure/lambda-functions/quota_check/index.py
+++ b/deployment/infrastructure/lambda-functions/quota_check/index.py
@@ -24,6 +24,11 @@ ERROR_HANDLING_MODE = os.environ.get("ERROR_HANDLING_MODE", "fail_closed")
 ENABLE_FINEGRAINED_QUOTAS = os.environ.get("ENABLE_FINEGRAINED_QUOTAS", "false").lower() == "true"
 MONTHLY_TOKEN_LIMIT = int(os.environ.get("MONTHLY_TOKEN_LIMIT", "0"))
 DAILY_TOKEN_LIMIT = int(os.environ.get("DAILY_TOKEN_LIMIT", "0"))
+# Cost-based limits ($/user). 0 disables. When configured, the cost checks in
+# the enforcement section take precedence over token checks; the wizard's cost
+# mode also sets the token limits to 0 so cost is the sole control.
+MONTHLY_COST_LIMIT_USD = float(os.environ.get("MONTHLY_COST_LIMIT_USD", "0") or 0)
+DAILY_COST_LIMIT_USD = float(os.environ.get("DAILY_COST_LIMIT_USD", "0") or 0)
 MONTHLY_ENFORCEMENT_MODE = os.environ.get("MONTHLY_ENFORCEMENT_MODE", "block")
 DAILY_ENFORCEMENT_MODE = os.environ.get("DAILY_ENFORCEMENT_MODE", "alert")
 WARNING_THRESHOLD_80 = int(os.environ.get("WARNING_THRESHOLD_80", "240000000"))
@@ -332,13 +337,18 @@ def resolve_quota_for_user(email: str, groups: list) -> dict | None:
     Returns:
         Policy dict or None if no policy applies (unlimited).
     """
-    if not ENABLE_FINEGRAINED_QUOTAS and MONTHLY_TOKEN_LIMIT > 0:
+    # Cost mode sets token limits to 0, so the default policy must also
+    # activate when only a cost limit is configured — otherwise cost-based
+    # deployments resolved no policy at all and every user was unlimited.
+    if not ENABLE_FINEGRAINED_QUOTAS and (MONTHLY_TOKEN_LIMIT > 0 or MONTHLY_COST_LIMIT_USD > 0):
         # Return default limits from environment
         return {
             "policy_type": "default",
             "identifier": "environment",
             "monthly_token_limit": MONTHLY_TOKEN_LIMIT,
             "daily_token_limit": DAILY_TOKEN_LIMIT if DAILY_TOKEN_LIMIT > 0 else None,
+            "monthly_cost_limit": MONTHLY_COST_LIMIT_USD,
+            "daily_cost_limit": DAILY_COST_LIMIT_USD,
             "warning_threshold_80": WARNING_THRESHOLD_80,
             "warning_threshold_90": WARNING_THRESHOLD_90,
             "enforcement_mode": MONTHLY_ENFORCEMENT_MODE,

--- a/deployment/infrastructure/lambda-functions/quota_check/index.py
+++ b/deployment/infrastructure/lambda-functions/quota_check/index.py
@@ -36,6 +36,7 @@ policies_table = dynamodb.Table(POLICIES_TABLE)
 
 class DecimalEncoder(json.JSONEncoder):
     """JSON encoder that handles Decimal types."""
+
     def default(self, obj):
         if isinstance(obj, Decimal):
             return float(obj)
@@ -88,43 +89,50 @@ def lambda_handler(event, context):
             # Neither JWT nor IAM identity resolved
             print(f"No user identity found. JWT claims: {list(jwt_claims.keys())}")
             allow_missing_email = MISSING_EMAIL_ENFORCEMENT != "block"
-            return build_response(200, {
-                "error": "No user identity found (no JWT email claim or IAM session name)",
-                "allowed": allow_missing_email,
-                "reason": "missing_identity",
-                "message": "Could not resolve user identity" + (" - quota check skipped" if allow_missing_email else " - access denied for security")
-            })
+            return build_response(
+                200,
+                {
+                    "error": "No user identity found (no JWT email claim or IAM session name)",
+                    "allowed": allow_missing_email,
+                    "reason": "missing_identity",
+                    "message": "Could not resolve user identity"
+                    + (" - quota check skipped" if allow_missing_email else " - access denied for security"),
+                },
+            )
 
         # 1. Resolve the effective quota policy for this user
         policy = resolve_quota_for_user(email, groups)
 
         if policy is None:
             # No policy = unlimited (quota monitoring disabled)
-            return build_response(200, {
-                "allowed": True,
-                "reason": "no_policy",
-                "enforcement_mode": None,
-                "usage": None,
-                "policy": None,
-                "unblock_status": None,
-                "message": "No quota policy configured - unlimited access"
-            })
+            return build_response(
+                200,
+                {
+                    "allowed": True,
+                    "reason": "no_policy",
+                    "enforcement_mode": None,
+                    "usage": None,
+                    "policy": None,
+                    "unblock_status": None,
+                    "message": "No quota policy configured - unlimited access",
+                },
+            )
 
         # 2. Check for active unblock override
         unblock_status = get_unblock_status(email)
         if unblock_status and unblock_status.get("is_unblocked"):
-            return build_response(200, {
-                "allowed": True,
-                "reason": "unblocked",
-                "enforcement_mode": policy.get("enforcement_mode", "alert"),
-                "usage": get_user_usage_summary(email, policy),
-                "policy": {
-                    "type": policy.get("policy_type"),
-                    "identifier": policy.get("identifier")
+            return build_response(
+                200,
+                {
+                    "allowed": True,
+                    "reason": "unblocked",
+                    "enforcement_mode": policy.get("enforcement_mode", "alert"),
+                    "usage": get_user_usage_summary(email, policy),
+                    "policy": {"type": policy.get("policy_type"), "identifier": policy.get("identifier")},
+                    "unblock_status": unblock_status,
+                    "message": f"Access granted - temporarily unblocked until {unblock_status.get('expires_at')}",
                 },
-                "unblock_status": unblock_status,
-                "message": f"Access granted - temporarily unblocked until {unblock_status.get('expires_at')}"
-            })
+            )
 
         # 3. Get current usage
         usage = get_user_usage(email)
@@ -135,23 +143,23 @@ def lambda_handler(event, context):
 
         if enforcement_mode != "block":
             # Alert-only mode - always allow
-            return build_response(200, {
-                "allowed": True,
-                "reason": "within_quota",
-                "enforcement_mode": enforcement_mode,
-                "usage": usage_summary,
-                "policy": {
-                    "type": policy.get("policy_type"),
-                    "identifier": policy.get("identifier")
+            return build_response(
+                200,
+                {
+                    "allowed": True,
+                    "reason": "within_quota",
+                    "enforcement_mode": enforcement_mode,
+                    "usage": usage_summary,
+                    "policy": {"type": policy.get("policy_type"), "identifier": policy.get("identifier")},
+                    "unblock_status": {"is_unblocked": False},
+                    "message": "Access granted - enforcement mode is alert-only",
                 },
-                "unblock_status": {"is_unblocked": False},
-                "message": "Access granted - enforcement mode is alert-only"
-            })
+            )
 
         # 5. Check limits (monthly, daily) — supports both token and cost modes
         monthly_tokens = usage.get("total_tokens", 0)
         daily_tokens = usage.get("daily_tokens", 0)
-        monthly_cost = float(usage.get("cost_usd", 0))
+        monthly_cost = float(usage.get("estimated_cost", 0))
         daily_cost = float(usage.get("daily_cost_usd", 0))
 
         monthly_limit = policy.get("monthly_token_limit", 0)
@@ -161,98 +169,102 @@ def lambda_handler(event, context):
 
         # Cost-based enforcement (takes precedence when configured)
         if monthly_cost_limit > 0 and monthly_cost >= monthly_cost_limit:
-            return build_response(200, {
-                "allowed": False,
-                "reason": "monthly_cost_exceeded",
-                "enforcement_mode": enforcement_mode,
-                "usage": usage_summary,
-                "policy": {
-                    "type": policy.get("policy_type"),
-                    "identifier": policy.get("identifier")
+            return build_response(
+                200,
+                {
+                    "allowed": False,
+                    "reason": "monthly_cost_exceeded",
+                    "enforcement_mode": enforcement_mode,
+                    "usage": usage_summary,
+                    "policy": {"type": policy.get("policy_type"), "identifier": policy.get("identifier")},
+                    "unblock_status": {"is_unblocked": False},
+                    "message": f"Monthly spend limit exceeded: ${monthly_cost:.2f} / ${monthly_cost_limit:.2f} ({monthly_cost / monthly_cost_limit * 100:.1f}%). Contact your administrator.",
                 },
-                "unblock_status": {"is_unblocked": False},
-                "message": f"Monthly spend limit exceeded: ${monthly_cost:.2f} / ${monthly_cost_limit:.2f} ({monthly_cost/monthly_cost_limit*100:.1f}%). Contact your administrator."
-            })
+            )
 
         if daily_cost_limit > 0 and daily_cost >= daily_cost_limit:
             daily_mode = policy.get("daily_enforcement_mode", "alert")
             if daily_mode == "block":
-                return build_response(200, {
-                    "allowed": False,
-                    "reason": "daily_cost_exceeded",
-                    "enforcement_mode": enforcement_mode,
-                    "usage": usage_summary,
-                    "policy": {
-                        "type": policy.get("policy_type"),
-                        "identifier": policy.get("identifier")
+                return build_response(
+                    200,
+                    {
+                        "allowed": False,
+                        "reason": "daily_cost_exceeded",
+                        "enforcement_mode": enforcement_mode,
+                        "usage": usage_summary,
+                        "policy": {"type": policy.get("policy_type"), "identifier": policy.get("identifier")},
+                        "unblock_status": {"is_unblocked": False},
+                        "message": f"Daily spend limit exceeded: ${daily_cost:.2f} / ${daily_cost_limit:.2f}. Resets at UTC midnight.",
                     },
-                    "unblock_status": {"is_unblocked": False},
-                    "message": f"Daily spend limit exceeded: ${daily_cost:.2f} / ${daily_cost_limit:.2f}. Resets at UTC midnight."
-                })
+                )
 
         # Token-based enforcement (existing behavior)
         # Check monthly token limit
         if monthly_limit > 0 and monthly_tokens >= monthly_limit:
-            return build_response(200, {
-                "allowed": False,
-                "reason": "monthly_exceeded",
-                "enforcement_mode": enforcement_mode,
-                "usage": usage_summary,
-                "policy": {
-                    "type": policy.get("policy_type"),
-                    "identifier": policy.get("identifier")
+            return build_response(
+                200,
+                {
+                    "allowed": False,
+                    "reason": "monthly_exceeded",
+                    "enforcement_mode": enforcement_mode,
+                    "usage": usage_summary,
+                    "policy": {"type": policy.get("policy_type"), "identifier": policy.get("identifier")},
+                    "unblock_status": {"is_unblocked": False},
+                    "message": f"Monthly quota exceeded: {int(monthly_tokens):,} / {int(monthly_limit):,} tokens ({monthly_tokens / monthly_limit * 100:.1f}%). Contact your administrator for assistance.",
                 },
-                "unblock_status": {"is_unblocked": False},
-                "message": f"Monthly quota exceeded: {int(monthly_tokens):,} / {int(monthly_limit):,} tokens ({monthly_tokens/monthly_limit*100:.1f}%). Contact your administrator for assistance."
-            })
+            )
 
         # Check daily token limit (if configured)
         if daily_limit and daily_limit > 0 and daily_tokens >= daily_limit:
             daily_mode = policy.get("daily_enforcement_mode", "alert")
             if daily_mode == "block":
-                return build_response(200, {
-                    "allowed": False,
-                    "reason": "daily_exceeded",
-                    "enforcement_mode": enforcement_mode,
-                    "usage": usage_summary,
-                    "policy": {
-                        "type": policy.get("policy_type"),
-                        "identifier": policy.get("identifier")
+                return build_response(
+                    200,
+                    {
+                        "allowed": False,
+                        "reason": "daily_exceeded",
+                        "enforcement_mode": enforcement_mode,
+                        "usage": usage_summary,
+                        "policy": {"type": policy.get("policy_type"), "identifier": policy.get("identifier")},
+                        "unblock_status": {"is_unblocked": False},
+                        "message": f"Daily quota exceeded: {int(daily_tokens):,} / {int(daily_limit):,} tokens ({daily_tokens / daily_limit * 100:.1f}%). Quota resets at UTC midnight.",
                     },
-                    "unblock_status": {"is_unblocked": False},
-                    "message": f"Daily quota exceeded: {int(daily_tokens):,} / {int(daily_limit):,} tokens ({daily_tokens/daily_limit*100:.1f}%). Quota resets at UTC midnight."
-                })
+                )
 
         # All checks passed - access allowed
-        return build_response(200, {
-            "allowed": True,
-            "reason": "within_quota",
-            "enforcement_mode": enforcement_mode,
-            "usage": usage_summary,
-            "policy": {
-                "type": policy.get("policy_type"),
-                "identifier": policy.get("identifier")
+        return build_response(
+            200,
+            {
+                "allowed": True,
+                "reason": "within_quota",
+                "enforcement_mode": enforcement_mode,
+                "usage": usage_summary,
+                "policy": {"type": policy.get("policy_type"), "identifier": policy.get("identifier")},
+                "unblock_status": {"is_unblocked": False},
+                "message": "Access granted - within quota limits",
             },
-            "unblock_status": {"is_unblocked": False},
-            "message": "Access granted - within quota limits"
-        })
+        )
 
     except Exception as e:
         print(f"Error during quota check: {str(e)}")
         import traceback
+
         traceback.print_exc()
 
         # Security: Honor error handling mode - default to fail-closed for security
         allow_on_error = ERROR_HANDLING_MODE != "fail_closed"
-        return build_response(200, {
-            "allowed": allow_on_error,
-            "reason": "check_failed",
-            "enforcement_mode": None,
-            "usage": None,
-            "policy": None,
-            "unblock_status": None,
-            "message": f"Quota check failed ({ERROR_HANDLING_MODE}): {str(e)}"
-        })
+        return build_response(
+            200,
+            {
+                "allowed": allow_on_error,
+                "reason": "check_failed",
+                "enforcement_mode": None,
+                "usage": None,
+                "policy": None,
+                "unblock_status": None,
+                "message": f"Quota check failed ({ERROR_HANDLING_MODE}): {str(e)}",
+            },
+        )
 
 
 def build_response(status_code: int, body: dict) -> dict:
@@ -263,9 +275,9 @@ def build_response(status_code: int, body: dict) -> dict:
             "Content-Type": "application/json",
             "Access-Control-Allow-Origin": "*",
             "Access-Control-Allow-Methods": "GET, OPTIONS",
-            "Access-Control-Allow-Headers": "Content-Type, Authorization"
+            "Access-Control-Allow-Headers": "Content-Type, Authorization",
         },
-        "body": json.dumps(body, cls=DecimalEncoder)
+        "body": json.dumps(body, cls=DecimalEncoder),
     }
 
 
@@ -376,6 +388,8 @@ def get_policy(policy_type: str, identifier: str) -> dict | None:
             "identifier": item.get("identifier"),
             "monthly_token_limit": int(item.get("monthly_token_limit", 0)),
             "daily_token_limit": int(item.get("daily_token_limit", 0)) if item.get("daily_token_limit") else None,
+            "monthly_cost_limit": float(item.get("monthly_cost_limit", 0)),
+            "daily_cost_limit": float(item.get("daily_cost_limit", 0)),
             "warning_threshold_80": int(item.get("warning_threshold_80", 0)),
             "warning_threshold_90": int(item.get("warning_threshold_90", 0)),
             "enforcement_mode": item.get("enforcement_mode", "alert"),
@@ -412,7 +426,7 @@ def get_unblock_status(email: str) -> dict:
             "unblocked_by": item.get("unblocked_by"),
             "unblocked_at": item.get("unblocked_at"),
             "reason": item.get("reason"),
-            "duration_type": item.get("duration_type")
+            "duration_type": item.get("duration_type"),
         }
     except Exception as e:
         print(f"Error checking unblock status for {email}: {e}")
@@ -439,7 +453,9 @@ def get_user_usage(email: str) -> dict:
                 "daily_date": current_date,
                 "input_tokens": 0,
                 "output_tokens": 0,
-                "cache_tokens": 0
+                "cache_tokens": 0,
+                "estimated_cost": 0,
+                "daily_cost_usd": 0,
             }
 
         # Check if daily tokens need to be reset (different day)
@@ -456,7 +472,9 @@ def get_user_usage(email: str) -> dict:
             "daily_date": daily_date,
             "input_tokens": float(item.get("input_tokens", 0)),
             "output_tokens": float(item.get("output_tokens", 0)),
-            "cache_tokens": float(item.get("cache_tokens", 0))
+            "cache_tokens": float(item.get("cache_tokens", 0)),
+            "estimated_cost": float(item.get("estimated_cost", 0)),
+            "daily_cost_usd": float(item.get("daily_cost_usd", 0)) if daily_date == current_date else 0,
         }
     except Exception as e:
         print(f"Error getting usage for {email}: {e}")
@@ -466,7 +484,9 @@ def get_user_usage(email: str) -> dict:
             "daily_date": current_date,
             "input_tokens": 0,
             "output_tokens": 0,
-            "cache_tokens": 0
+            "cache_tokens": 0,
+            "estimated_cost": 0,
+            "daily_cost_usd": 0,
         }
 
 
@@ -482,7 +502,7 @@ def build_usage_summary(usage: dict, policy: dict) -> dict:
         "monthly_tokens": int(monthly_tokens),
         "monthly_limit": monthly_limit,
         "monthly_percent": round(monthly_tokens / monthly_limit * 100, 1) if monthly_limit > 0 else 0,
-        "daily_tokens": int(daily_tokens)
+        "daily_tokens": int(daily_tokens),
     }
 
     if daily_limit:

--- a/deployment/infrastructure/lambda-functions/quota_monitor/index.py
+++ b/deployment/infrastructure/lambda-functions/quota_monitor/index.py
@@ -81,22 +81,38 @@ TOKEN_TYPE_TO_RATE_KEY = {
 
 
 def fetch_usage_from_promql():
-    """Query PromQL for per-user token usage in the last aggregation window only."""
+    """Query PromQL for per-user token usage in the last aggregation window only.
+
+    Aggregation MUST use sum_over_time(), NOT increase(). Claude Code exports
+    ``claude_code.token.usage`` as an OpenTelemetry Counter with DELTA temporality
+    by default (OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta): each
+    datapoint is the tokens emitted since the last export, so the series steps up
+    AND down (a sawtooth). increase() assumes CUMULATIVE temporality (a monotonic
+    running total) and reads every down-step as a counter reset — it returns empty
+    or wildly understated results, which froze DynamoDB and surfaced as
+    "Daily Tokens: 0" in `ccwb quota usage`. sum_over_time() sums the per-interval
+    deltas in the window = tokens used in the last 15 minutes, matching how the
+    Athena/CloudWatch consumers compute usage.
+
+    Coupling: this is correct only while the metric is exported with delta
+    temporality. If a deployment sets the temporality preference to `cumulative`,
+    increase() would become the correct function instead.
+    """
     window = AGGREGATION_WINDOW
 
     # Delta tokens per user in the last window
     results = _promql_query(
-        f'sum by ("user.email")(increase({{"claude_code.token.usage"}}[{window}s]))'
+        f'sum by ("user.email")(sum_over_time({{"claude_code.token.usage"}}[{window}s]))'
     )
 
     # Delta token type AND model breakdown per user (for cost calculation)
     type_model_results = _promql_query(
-        f'sum by ("user.email", type, model)(increase({{"claude_code.token.usage"}}[{window}s]))'
+        f'sum by ("user.email", type, model)(sum_over_time({{"claude_code.token.usage"}}[{window}s]))'
     )
 
     # Delta token type breakdown per user (without model, for backward compat)
     type_results = _promql_query(
-        f'sum by ("user.email", type)(increase({{"claude_code.token.usage"}}[{window}s]))'
+        f'sum by ("user.email", type)(sum_over_time({{"claude_code.token.usage"}}[{window}s]))'
     )
 
     users = {}
@@ -149,11 +165,13 @@ def fetch_usage_from_promql():
     # per-user metrics into the ClaudeCoWork namespace with user_email dimension.
     # This ensures CoWork token consumption counts toward the same quota as Claude Code.
     try:
+        # CoWork metrics are MetricFilter-derived per-event token counts (delta,
+        # not cumulative) — use sum_over_time() for the same reason as above.
         cowork_input = _promql_query(
-            f'sum by ("user_email", "model")(increase({{"ClaudeCoWork","token.usage.input"}}[{window}s]))'
+            f'sum by ("user_email", "model")(sum_over_time({{"ClaudeCoWork","token.usage.input"}}[{window}s]))'
         )
         cowork_output = _promql_query(
-            f'sum by ("user_email", "model")(increase({{"ClaudeCoWork","token.usage.output"}}[{window}s]))'
+            f'sum by ("user_email", "model")(sum_over_time({{"ClaudeCoWork","token.usage.output"}}[{window}s]))'
         )
         cowork_count = 0
         for r in cowork_input + cowork_output:

--- a/deployment/infrastructure/lambda-functions/quota_monitor/index.py
+++ b/deployment/infrastructure/lambda-functions/quota_monitor/index.py
@@ -67,6 +67,18 @@ def _promql_query(query, time_param=None):
 
 AGGREGATION_WINDOW = 900  # 15 minutes in seconds (matches EventBridge schedule)
 
+# Map the metric's `type` dimension values to pricing.py rate keys.
+# The CloudWatch `type` dimension is camelCase (input/output/cacheRead/
+# cacheCreation); the rate tables in shared/pricing.py are snake_case
+# (input/output/cache_read/cache_write). cacheCreation (cache-write) is usually
+# the majority of tokens, so a missing mapping silently drops most of the cost.
+TOKEN_TYPE_TO_RATE_KEY = {
+    "input": "input",
+    "output": "output",
+    "cacheRead": "cache_read",
+    "cacheCreation": "cache_write",
+}
+
 
 def fetch_usage_from_promql():
     """Query PromQL for per-user token usage in the last aggregation window only."""
@@ -123,7 +135,7 @@ def fetch_usage_from_promql():
                 u = users.setdefault(email, {})
                 family = resolve_model_family(model)
                 family_rates = rates.get(family, rates.get("sonnet", {}))
-                rate = family_rates.get(token_type.replace("cacheRead", "cache_read"), 0)
+                rate = family_rates.get(TOKEN_TYPE_TO_RATE_KEY.get(token_type, token_type), 0)
                 cost_delta = (val / 1_000_000) * rate
                 u["cost_usd"] = u.get("cost_usd", 0) + cost_delta
     except Exception as e:

--- a/deployment/infrastructure/lambda-functions/quota_monitor/index.py
+++ b/deployment/infrastructure/lambda-functions/quota_monitor/index.py
@@ -27,6 +27,10 @@ METRICS_REGION = os.environ.get("METRICS_REGION", os.environ.get("AWS_REGION", "
 MONTHLY_TOKEN_LIMIT = int(os.environ.get("MONTHLY_TOKEN_LIMIT", "300000000"))
 WARNING_THRESHOLD_80 = int(os.environ.get("WARNING_THRESHOLD_80", "240000000"))
 WARNING_THRESHOLD_90 = int(os.environ.get("WARNING_THRESHOLD_90", "270000000"))
+# Cost-based limits ($/user). 0 disables. Cost mode sets the token limits to 0
+# (token alerts are skipped at 0 — see check_limits_and_generate_alerts).
+MONTHLY_COST_LIMIT_USD = float(os.environ.get("MONTHLY_COST_LIMIT_USD", "0") or 0)
+DAILY_COST_LIMIT_USD = float(os.environ.get("DAILY_COST_LIMIT_USD", "0") or 0)
 
 # DynamoDB tables
 quota_table = dynamodb.Table(QUOTA_TABLE)
@@ -259,15 +263,20 @@ def _build_usage_entry(item, current_date):
     (UTC), the daily counter belongs to a prior day and must be treated as 0.
     Otherwise an idle user whose daily_tokens froze above the limit gets a fresh
     "daily exceeded" alert every new UTC day even though they had no activity.
-    Monthly (total_tokens) is unaffected — it accumulates across the whole month.
+    Monthly (total_tokens / estimated_cost) is unaffected — it accumulates
+    across the whole month. The same guard applies to the daily cost counter.
     """
     daily_tokens = float(item.get("daily_tokens", 0))
+    daily_cost = float(item.get("daily_cost_usd", 0))
     daily_date = item.get("daily_date")
     if daily_date != current_date:
         daily_tokens = 0
+        daily_cost = 0
     return {
         "total_tokens": float(item.get("total_tokens", 0)),
         "daily_tokens": daily_tokens,
+        "monthly_cost": float(item.get("estimated_cost", 0)),
+        "daily_cost": daily_cost,
     }
 
 
@@ -295,7 +304,7 @@ def lambda_handler(event, context):
         # guard that quota_check uses (quota_check/index.py). Without it, an idle
         # user's frozen daily_tokens is read verbatim and re-alerted every new UTC
         # day even though they had no activity.
-        projection = "email, total_tokens, daily_tokens, daily_date"
+        projection = "email, total_tokens, daily_tokens, daily_date, estimated_cost, daily_cost_usd"
         response = quota_table.scan(
             FilterExpression=Attr("sk").eq(f"MONTH#{current_month}") & Attr("pk").begins_with("USER#"),
             ProjectionExpression=projection,
@@ -344,6 +353,7 @@ def lambda_handler(event, context):
                 email=email, total_tokens=total_tokens, daily_tokens=daily_tokens,
                 policy=policy, month_name=month_name, current_date=current_date,
                 days_remaining=days_remaining, days_in_month=days_in_month, sent_alerts=sent_alerts,
+                monthly_cost=usage.get("monthly_cost", 0), daily_cost=usage.get("daily_cost", 0),
             )
 
             monthly_pct = (total_tokens / policy["monthly_token_limit"]) * 100 if policy["monthly_token_limit"] > 0 else 0
@@ -390,6 +400,8 @@ def load_all_policies():
                     "policy_type": pt, "identifier": ident,
                     "monthly_token_limit": int(item.get("monthly_token_limit", 0)),
                     "daily_token_limit": int(item.get("daily_token_limit", 0)) if item.get("daily_token_limit") else None,
+                    "monthly_cost_limit": float(item.get("monthly_cost_limit", 0) or 0),
+                    "daily_cost_limit": float(item.get("daily_cost_limit", 0) or 0),
                     "warning_threshold_80": int(item.get("warning_threshold_80", 0)),
                     "warning_threshold_90": int(item.get("warning_threshold_90", 0)),
                     "enforcement_mode": item.get("enforcement_mode", "alert"),
@@ -420,6 +432,7 @@ def resolve_user_quota(email, groups, policies_cache):
         return {
             "policy_type": "default", "identifier": "environment",
             "monthly_token_limit": MONTHLY_TOKEN_LIMIT, "daily_token_limit": None,
+            "monthly_cost_limit": MONTHLY_COST_LIMIT_USD, "daily_cost_limit": DAILY_COST_LIMIT_USD,
             "warning_threshold_80": WARNING_THRESHOLD_80, "warning_threshold_90": WARNING_THRESHOLD_90,
             "enforcement_mode": "alert", "enabled": True,
         }
@@ -437,8 +450,9 @@ def resolve_user_quota(email, groups, policies_cache):
 
 
 def check_limits_and_generate_alerts(email, total_tokens, daily_tokens, policy,
-                                     month_name, current_date, days_remaining, days_in_month, sent_alerts):
-    """Check limits and generate alert dicts."""
+                                     month_name, current_date, days_remaining, days_in_month, sent_alerts,
+                                     monthly_cost=0.0, daily_cost=0.0):
+    """Check limits and generate alert dicts (token- and cost-denominated)."""
     alerts = []
     policy_info = f"{policy['policy_type']}:{policy['identifier']}"
     enforcement_mode = policy.get("enforcement_mode", "alert")
@@ -447,13 +461,17 @@ def check_limits_and_generate_alerts(email, total_tokens, daily_tokens, policy,
     daily_average = total_tokens / max(1, int(current_date.split("-")[2]))
     projected_total = daily_average * days_in_month
 
+    # Token limits. A limit of 0 means token limits are DISABLED (cost mode
+    # zeroes them) — without this guard every user with any usage generated a
+    # bogus "monthly exceeded" alert on each 15-minute scan.
     level = None
-    if total_tokens > monthly_limit:
-        level = "exceeded"
-    elif total_tokens > policy["warning_threshold_90"]:
-        level = "critical"
-    elif total_tokens > policy["warning_threshold_80"]:
-        level = "warning"
+    if monthly_limit > 0:
+        if total_tokens > monthly_limit:
+            level = "exceeded"
+        elif total_tokens > policy["warning_threshold_90"]:
+            level = "critical"
+        elif total_tokens > policy["warning_threshold_80"]:
+            level = "warning"
 
     if level and f"{email}#monthly#{level}" not in sent_alerts:
         alerts.append({
@@ -482,6 +500,45 @@ def check_limits_and_generate_alerts(email, total_tokens, daily_tokens, policy,
                 "percentage": round(daily_pct, 1), "date": current_date,
                 "policy_info": policy_info, "enforcement_mode": enforcement_mode,
             })
+
+    # Cost limits ($ budgets, cost mode). Same 80/90/100 ladder as tokens;
+    # quota_check does the blocking, these alerts are the early warning.
+    monthly_cost_limit = float(policy.get("monthly_cost_limit", 0) or 0)
+    if monthly_cost_limit > 0:
+        cost_pct = (monthly_cost / monthly_cost_limit) * 100
+        clevel = None
+        if monthly_cost > monthly_cost_limit:
+            clevel = "exceeded"
+        elif monthly_cost > monthly_cost_limit * 0.9:
+            clevel = "critical"
+        elif monthly_cost > monthly_cost_limit * 0.8:
+            clevel = "warning"
+        if clevel and f"{email}#monthly_cost#{clevel}" not in sent_alerts:
+            alerts.append({
+                "user": email, "alert_type": "monthly_cost", "alert_level": clevel,
+                "current_usage": round(monthly_cost, 2), "limit": monthly_cost_limit,
+                "percentage": round(cost_pct, 1), "month": month_name,
+                "days_remaining": days_remaining, "policy_info": policy_info,
+                "enforcement_mode": enforcement_mode,
+            })
+
+    daily_cost_limit = float(policy.get("daily_cost_limit", 0) or 0)
+    if daily_cost_limit > 0:
+        dcost_pct = (daily_cost / daily_cost_limit) * 100
+        dclevel = None
+        if daily_cost > daily_cost_limit:
+            dclevel = "exceeded"
+        elif daily_cost > daily_cost_limit * 0.9:
+            dclevel = "critical"
+        elif daily_cost > daily_cost_limit * 0.8:
+            dclevel = "warning"
+        if dclevel and f"{email}#daily_cost#{current_date}#{dclevel}" not in sent_alerts:
+            alerts.append({
+                "user": email, "alert_type": "daily_cost", "alert_level": dclevel,
+                "current_usage": round(daily_cost, 2), "limit": daily_cost_limit,
+                "percentage": round(dcost_pct, 1), "date": current_date,
+                "policy_info": policy_info, "enforcement_mode": enforcement_mode,
+            })
     return alerts
 
 
@@ -497,7 +554,7 @@ def get_sent_alerts(month_name):
             parts = item["sk"].split("#")
             if len(parts) >= 5:
                 email, atype, alevel = parts[2], parts[3], parts[4]
-                if atype == "daily" and len(parts) >= 6:
+                if atype.startswith("daily") and len(parts) >= 6:
                     sent.add(f"{email}#{atype}#{parts[5]}#{alevel}")
                 else:
                     sent.add(f"{email}#{atype}#{alevel}")
@@ -523,7 +580,7 @@ def record_sent_alert(month_name, email, alert_type, alert_level, alert_data):
     """Record sent alert to prevent duplicates."""
     try:
         month_prefix = datetime.now(timezone.utc).strftime("%Y-%m")
-        if alert_type == "daily":
+        if alert_type.startswith("daily"):
             date = alert_data.get("date", datetime.now(timezone.utc).strftime("%Y-%m-%d"))
             sk = f"{month_prefix}#ALERT#{email}#{alert_type}#{alert_level}#{date}"
         else:
@@ -547,10 +604,19 @@ def send_alerts(alerts):
     for alert in alerts:
         try:
             level_prefix = {"warning": "WARNING", "critical": "CRITICAL", "exceeded": "EXCEEDED"}.get(alert["alert_level"], "ALERT")
-            type_label = {"monthly": "Monthly Token Quota", "daily": "Daily Token Quota"}.get(alert["alert_type"], "Quota")
+            type_label = {
+                "monthly": "Monthly Token Quota",
+                "daily": "Daily Token Quota",
+                "monthly_cost": "Monthly Spend Budget",
+                "daily_cost": "Daily Spend Budget",
+            }.get(alert["alert_type"], "Quota")
+            if "cost" in alert["alert_type"]:
+                usage_str = f"${alert['current_usage']:.2f} / ${alert['limit']:.2f}"
+            else:
+                usage_str = f"{alert['current_usage']:,} / {alert['limit']:,}"
             subject = f"Claude Code {level_prefix} - {type_label} - {alert['percentage']:.0f}%"
             message = (f"USER: {alert['user']}\nALERT: {type_label} - {alert['alert_level'].upper()}\n"
-                       f"Usage: {alert['current_usage']:,} / {alert['limit']:,} ({alert['percentage']:.1f}%)\n"
+                       f"Usage: {usage_str} ({alert['percentage']:.1f}%)\n"
                        f"Policy: {alert.get('policy_info', 'default')}\n"
                        f"Enforcement: {alert.get('enforcement_mode', 'alert')}")
             sns_client.publish(TopicArn=SNS_TOPIC_ARN, Subject=subject, Message=message)

--- a/deployment/infrastructure/quota-monitoring.yaml
+++ b/deployment/infrastructure/quota-monitoring.yaml
@@ -5,8 +5,10 @@ Parameters:
   MonthlyTokenLimit:
     Type: Number
     Default: 10000000
-    Description: Default monthly token limit per user (10M tokens) - used when no policy is defined
-    MinValue: 1000000
+    Description: >-
+      Default monthly token limit per user (10M tokens) - used when no policy
+      is defined. 0 disables token-denominated limits (cost-based quota mode).
+    MinValue: 0
     MaxValue: 1000000000
 
   WarningThreshold80:
@@ -265,6 +267,8 @@ Resources:
           DAILY_ENFORCEMENT_MODE: !Ref DailyEnforcementMode
           MONTHLY_ENFORCEMENT_MODE: !Ref MonthlyEnforcementMode
           ENABLE_FINEGRAINED_QUOTAS: !Ref EnableFinegrainedQuotas
+          MONTHLY_COST_LIMIT_USD: !Ref MonthlyCostLimitUsd
+          DAILY_COST_LIMIT_USD: !Ref DailyCostLimitUsd
           METRICS_REGION: !Ref 'AWS::Region'
       Code: ./lambda-functions/quota_monitor/
 
@@ -435,6 +439,8 @@ Resources:
           POLICIES_TABLE: !Ref QuotaPolicies
           MONTHLY_TOKEN_LIMIT: !Ref MonthlyTokenLimit
           DAILY_TOKEN_LIMIT: !Ref DailyTokenLimit
+          MONTHLY_COST_LIMIT_USD: !Ref MonthlyCostLimitUsd
+          DAILY_COST_LIMIT_USD: !Ref DailyCostLimitUsd
           DAILY_ENFORCEMENT_MODE: !Ref DailyEnforcementMode
           MONTHLY_ENFORCEMENT_MODE: !Ref MonthlyEnforcementMode
           ENABLE_FINEGRAINED_QUOTAS: !Ref EnableFinegrainedQuotas

--- a/scripts/prepare-offline-go-bundle.sh
+++ b/scripts/prepare-offline-go-bundle.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# ABOUTME: Prepares (on an internet-connected machine) and installs (on an offline
+# ABOUTME: machine) everything `ccwb package` needs to build Go binaries and the
+# ABOUTME: OTEL Collector sidecar without network access.
+#
+# The sidecar collector build (`_build_otelcol` in package.py) cannot use a
+# vendor/ directory: OCB generates a fresh Go module in a temp dir on every
+# run, then resolves its dependencies from the network. Instead, this script
+# pre-seeds the two artifacts that build consults before touching the network:
+#
+#   1. The OCB binary at ~/.cache/ocb/ocb_<ver>_<os>_<arch> — package.py only
+#      downloads it when that exact file is missing.
+#   2. A Go module cache (GOMODCACHE) containing every module needed by both
+#      source/go (credential-process, otel-helper) and the OCB-generated
+#      collector. With GOPROXY=off, all `go` invocations — including the
+#      `go mod tidy` OCB runs internally — resolve from this cache.
+#
+# Because every go/ocb subprocess in package.py inherits the parent
+# environment, no changes to ccwb itself are required.
+#
+# Usage:
+#   On a machine WITH internet (same OS/arch and Go version as the offline box):
+#       ./scripts/prepare-offline-go-bundle.sh prepare [bundle-dir]
+#   Transfer the resulting ccwb-offline-go-bundle.tar.gz, then on the OFFLINE box:
+#       tar xzf ccwb-offline-go-bundle.tar.gz
+#       ./scripts/prepare-offline-go-bundle.sh install [bundle-dir]
+#       source <bundle-dir>/offline-env.sh
+#       poetry run ccwb package --go
+#
+# Requirements on both machines: bash, Go >= 1.23 (ideally the same minor version).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PACKAGE_PY="$REPO_ROOT/source/claude_code_with_bedrock/cli/commands/package.py"
+MANIFEST="$REPO_ROOT/source/otel_helper/ocb-manifest.yaml"
+
+MODE="${1:-prepare}"
+BUNDLE_DIR="$(cd "$(dirname "${2:-$REPO_ROOT/ccwb-offline-go-bundle}")" 2>/dev/null && pwd)/$(basename "${2:-ccwb-offline-go-bundle}")"
+
+# OCB version is pinned in package.py — parse it so the bundle can never drift.
+OCB_VERSION="$(sed -n 's/.*OCB_VERSION = "\([0-9.]*\)".*/\1/p' "$PACKAGE_PY")"
+if [ -z "$OCB_VERSION" ]; then
+    echo "ERROR: could not parse OCB_VERSION from $PACKAGE_PY" >&2
+    exit 1
+fi
+
+case "$(uname -s)" in
+    Darwin) OCB_OS=darwin ;;
+    MINGW*|MSYS*|CYGWIN*) OCB_OS=windows ;;
+    *) OCB_OS=linux ;;
+esac
+case "$(uname -m)" in
+    arm64|aarch64) OCB_ARCH=arm64 ;;
+    *) OCB_ARCH=amd64 ;;
+esac
+OCB_SUFFIX=""
+[ "$OCB_OS" = "windows" ] && OCB_SUFFIX=".exe"
+OCB_NAME="ocb_${OCB_VERSION}_${OCB_OS}_${OCB_ARCH}${OCB_SUFFIX}"
+
+write_env_file() {
+    cat > "$BUNDLE_DIR/offline-env.sh" <<EOF
+# Source this before running 'ccwb package' on the offline machine.
+export GOMODCACHE="$BUNDLE_DIR/gomodcache"
+export GOPROXY=off
+export GOSUMDB=off
+export GOTOOLCHAIN=local
+EOF
+}
+
+prepare() {
+    command -v go >/dev/null || { echo "ERROR: Go is required" >&2; exit 1; }
+    mkdir -p "$BUNDLE_DIR/ocb" "$BUNDLE_DIR/gomodcache"
+    go version | awk '{print $3}' > "$BUNDLE_DIR/GO_VERSION"
+
+    echo "==> Downloading OCB v$OCB_VERSION ($OCB_OS/$OCB_ARCH)"
+    if [ ! -f "$BUNDLE_DIR/ocb/$OCB_NAME" ]; then
+        curl -fsSL -o "$BUNDLE_DIR/ocb/$OCB_NAME" \
+            "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/cmd%2Fbuilder%2Fv${OCB_VERSION}/${OCB_NAME}"
+        [ "$OCB_OS" != "windows" ] && chmod +x "$BUNDLE_DIR/ocb/$OCB_NAME"
+    fi
+
+    export GOMODCACHE="$BUNDLE_DIR/gomodcache" GOTOOLCHAIN=local
+
+    echo "==> Seeding module cache: source/go (credential-process, otel-helper)"
+    # Copy go.mod/go.sum to a temp module so 'download all' can't mutate the repo's go.sum.
+    tmp_mod="$(mktemp -d)"
+    cp "$REPO_ROOT/source/go/go.mod" "$REPO_ROOT/source/go/go.sum" "$tmp_mod/"
+    (cd "$tmp_mod" && go mod download all)
+    rm -rf "$tmp_mod"
+
+    echo "==> Seeding module cache: OCB-generated collector module"
+    build_dir="$(mktemp -d)"
+    sed "s|output_path: ./build/otelcol|output_path: $build_dir|" "$MANIFEST" > "$build_dir/manifest.yaml"
+    "$BUNDLE_DIR/ocb/$OCB_NAME" --config "$build_dir/manifest.yaml" --skip-compilation
+    (cd "$build_dir" && go mod download)
+
+    echo "==> Verifying: rebuilding collector with GOPROXY=off (offline rehearsal)"
+    verify_dir="$(mktemp -d)"
+    sed "s|output_path: ./build/otelcol|output_path: $verify_dir|" "$MANIFEST" > "$verify_dir/manifest.yaml"
+    (
+        export GOPROXY=off GOSUMDB=off
+        "$BUNDLE_DIR/ocb/$OCB_NAME" --config "$verify_dir/manifest.yaml" --skip-compilation
+        cd "$verify_dir" && go mod download
+        GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -trimpath -o /dev/null .
+    )
+    rm -rf "$build_dir" "$verify_dir"
+
+    write_env_file
+
+    echo "==> Creating archive"
+    tar -C "$(dirname "$BUNDLE_DIR")" -czf "$BUNDLE_DIR.tar.gz" "$(basename "$BUNDLE_DIR")"
+    echo ""
+    echo "Bundle ready: $BUNDLE_DIR.tar.gz ($(du -sh "$BUNDLE_DIR.tar.gz" | cut -f1))"
+    echo "Transfer it to the offline machine, extract, then run:"
+    echo "    ./scripts/prepare-offline-go-bundle.sh install <bundle-dir>"
+}
+
+install_bundle() {
+    [ -d "$BUNDLE_DIR" ] || { echo "ERROR: bundle dir not found: $BUNDLE_DIR" >&2; exit 1; }
+
+    if command -v go >/dev/null; then
+        local_go="$(go version | awk '{print $3}')"
+        bundled_go="$(cat "$BUNDLE_DIR/GO_VERSION" 2>/dev/null || echo unknown)"
+        if [ "$local_go" != "$bundled_go" ]; then
+            echo "WARNING: bundle was prepared with $bundled_go but this machine has $local_go." >&2
+            echo "         Module resolution is usually compatible, but prefer matching versions." >&2
+        fi
+    fi
+
+    echo "==> Installing OCB binary to ~/.cache/ocb/ (package.py skips its download when present)"
+    mkdir -p "$HOME/.cache/ocb"
+    cp "$BUNDLE_DIR/ocb/$OCB_NAME" "$HOME/.cache/ocb/$OCB_NAME"
+    [ "$OCB_OS" != "windows" ] && chmod +x "$HOME/.cache/ocb/$OCB_NAME"
+
+    write_env_file
+    echo ""
+    echo "Done. Before running 'ccwb package', activate the offline Go environment:"
+    echo "    source $BUNDLE_DIR/offline-env.sh"
+    echo "    poetry run ccwb package --go"
+}
+
+case "$MODE" in
+    prepare) prepare ;;
+    install) install_bundle ;;
+    *) echo "Usage: $0 {prepare|install} [bundle-dir]" >&2; exit 1 ;;
+esac

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -1323,11 +1323,19 @@ class DeployCommand(Command):
                 # Sidecar bypass detection: opt-in detective control (default off).
                 enable_bypass_detection = getattr(profile, "enable_bypass_detection", False)
 
+                # Cost-based limits ($/user, 0 disables). In cost mode the token
+                # limits above are 0 and the Lambdas skip token checks; cost
+                # enforcement in quota_check takes precedence when configured.
+                monthly_cost_limit = getattr(profile, "monthly_cost_limit_usd", 0) or 0
+                daily_cost_limit = getattr(profile, "daily_cost_limit_usd", 0) or 0
+
                 params = [
                     f"MonthlyTokenLimit={monthly_limit}",
                     f"WarningThreshold80={warning_80}",
                     f"WarningThreshold90={warning_90}",
                     f"DailyTokenLimit={daily_limit or 0}",
+                    f"MonthlyCostLimitUsd={monthly_cost_limit}",
+                    f"DailyCostLimitUsd={daily_cost_limit}",
                     f"DailyEnforcementMode={daily_enforcement}",
                     f"MonthlyEnforcementMode={monthly_enforcement}",
                     f"OidcIssuerUrl={oidc_issuer_url}",
@@ -1743,6 +1751,8 @@ class DeployCommand(Command):
                 f"WarningThreshold80={getattr(profile, 'warning_threshold_80', int(monthly_limit * 0.8))}",
                 f"WarningThreshold90={getattr(profile, 'warning_threshold_90', int(monthly_limit * 0.9))}",
                 f"DailyTokenLimit={daily_limit or 0}",
+                f"MonthlyCostLimitUsd={getattr(profile, 'monthly_cost_limit_usd', 0) or 0}",
+                f"DailyCostLimitUsd={getattr(profile, 'daily_cost_limit_usd', 0) or 0}",
                 f"DailyEnforcementMode={getattr(profile, 'daily_enforcement_mode', 'alert')}",
                 f"MonthlyEnforcementMode={getattr(profile, 'monthly_enforcement_mode', 'block')}",
                 f"OidcIssuerUrl={profile.provider_domain}",

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -1954,6 +1954,10 @@ class DeployCommand(Command):
         deploying_types = {stack_type for stack_type, _ in stacks_to_deploy}
 
         # Check for orphaned stacks
+        from claude_code_with_bedrock.utils.partition import aws_partition_for_region
+
+        profile_partition = aws_partition_for_region(profile.aws_region)
+
         orphaned = []
         for stack_type in all_stack_types:
             if stack_type not in deploying_types:
@@ -1961,16 +1965,36 @@ class DeployCommand(Command):
                 # CodeBuild and websearch may live in a different region, so
                 # check them there or a cross-region orphan is never detected.
                 stack_name = profile.stack_names.get(stack_type, f"{profile.identity_pool_name}-{stack_type}")
-                mgr = cf_manager
+                check_region = profile.aws_region
                 if stack_type == "codebuild":
-                    cb_region = get_codebuild_region(profile)
-                    if cb_region != profile.aws_region:
-                        mgr = CloudFormationManager(region=cb_region)
+                    check_region = get_codebuild_region(profile)
                 elif stack_type == "websearch":
-                    ws_region = get_websearch_region(profile)
-                    if ws_region != profile.aws_region:
-                        mgr = CloudFormationManager(region=ws_region)
-                status = mgr.get_stack_status(stack_name)
+                    check_region = get_websearch_region(profile)
+
+                # Never probe across partitions: websearch defaults to
+                # us-east-1 (commercial-only service), so a GovCloud deploy
+                # would call a commercial CloudFormation endpoint — typically
+                # unreachable there (SSL/connect errors), and the stack cannot
+                # exist in another partition anyway.
+                if aws_partition_for_region(check_region) != profile_partition:
+                    continue
+
+                mgr = cf_manager
+                if check_region != profile.aws_region:
+                    mgr = CloudFormationManager(region=check_region)
+
+                # Best-effort advisory check: a network/endpoint failure
+                # (air-gapped or proxied environments) must not abort the
+                # deploy — get_stack_status only handles ClientError, so
+                # connection/SSL errors would otherwise propagate.
+                try:
+                    status = mgr.get_stack_status(stack_name)
+                except Exception as e:
+                    console.print(
+                        f"[dim]Skipping orphaned-stack check for {stack_type} "
+                        f"({check_region}): {type(e).__name__}[/dim]"
+                    )
+                    continue
 
                 if status and status not in ["DELETE_COMPLETE", "DELETE_IN_PROGRESS"]:
                     orphaned.append((stack_type, stack_name, status))

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -833,11 +833,14 @@ class DeployCommand(Command):
                     template = project_root / "deployment" / "infrastructure" / "bedrock-auth-idc.yaml"
                     stack_name = profile.stack_names.get("auth", f"{profile.identity_pool_name}-stack")
 
-                    from claude_code_with_bedrock.models import get_all_bedrock_regions
+                    from claude_code_with_bedrock.models import expand_bedrock_regions, get_all_bedrock_regions
 
                     bedrock_regions = profile.allowed_bedrock_regions
                     if not bedrock_regions:
                         bedrock_regions = [r for r in get_all_bedrock_regions() if "gov" not in r]
+                    # Expand sentinels (e.g. "all-commercial") into real regions so they
+                    # never land in the role's aws:RequestedRegion IAM condition.
+                    bedrock_regions = expand_bedrock_regions(bedrock_regions)
 
                     idc_role_name = getattr(profile, "idc_permission_set_name", None) or "BedrockIDCFederatedRole"
                     params = [
@@ -947,6 +950,11 @@ class DeployCommand(Command):
                     from claude_code_with_bedrock.models import get_all_bedrock_regions
 
                     bedrock_regions = [r for r in get_all_bedrock_regions() if "gov" not in r]
+                # Expand sentinels (e.g. "all-commercial") into real regions so they
+                # never land in the role's aws:RequestedRegion IAM condition.
+                from claude_code_with_bedrock.models import expand_bedrock_regions
+
+                bedrock_regions = expand_bedrock_regions(bedrock_regions)
 
                 params.extend(
                     [
@@ -1602,11 +1610,14 @@ class DeployCommand(Command):
             console.print("\n[cyan]" + "\n".join(lines) + "[/cyan]")
 
         if stack_type == "auth":
+            from claude_code_with_bedrock.models import expand_bedrock_regions, get_all_bedrock_regions
+
             bedrock_regions = profile.allowed_bedrock_regions
             if not bedrock_regions:
-                from claude_code_with_bedrock.models import get_all_bedrock_regions
-
                 bedrock_regions = [r for r in get_all_bedrock_regions() if "gov" not in r]
+            # Expand sentinels (e.g. "all-commercial") into real regions so they
+            # never land in the role's aws:RequestedRegion IAM condition.
+            bedrock_regions = expand_bedrock_regions(bedrock_regions)
 
             stack_name = profile.stack_names.get("auth", f"{profile.identity_pool_name}-stack")
             auth_type = profile.effective_auth_type

--- a/source/claude_code_with_bedrock/cli/commands/distribute.py
+++ b/source/claude_code_with_bedrock/cli/commands/distribute.py
@@ -596,6 +596,7 @@ class DistributeCommand(Command):
                 ("README.md", "README.md"),
                 ("cowork-3p.reg", "cowork-3p.reg"),
                 ("cowork-3p-config.json", "cowork-3p-config.json"),
+                ("cowork-credential-helper.cmd", "cowork-credential-helper.cmd"),
             ],
             "linux": [
                 ("credential-process-linux-x64", "credential-process-linux-x64"),
@@ -613,6 +614,7 @@ class DistributeCommand(Command):
                 ("config.json", "config.json"),
                 ("README.md", "README.md"),
                 ("cowork-3p-config.json", "cowork-3p-config.json"),
+                ("cowork-credential-helper.sh", "cowork-credential-helper.sh"),
             ],
             "mac": [
                 ("credential-process-macos-arm64", "credential-process-macos-arm64"),
@@ -628,6 +630,7 @@ class DistributeCommand(Command):
                 ("README.md", "README.md"),
                 ("cowork-3p.mobileconfig", "cowork-3p.mobileconfig"),
                 ("cowork-3p-config.json", "cowork-3p-config.json"),
+                ("cowork-credential-helper.sh", "cowork-credential-helper.sh"),
             ],
         }
 
@@ -1514,6 +1517,8 @@ class DistributeCommand(Command):
             "cowork-3p.reg",
             "cowork-3p.mobileconfig",
             "cowork-3p-config.json",
+            "cowork-credential-helper.sh",
+            "cowork-credential-helper.cmd",
         ]
 
         with zipfile.ZipFile(archive_path, "w", zipfile.ZIP_DEFLATED) as zf:

--- a/source/claude_code_with_bedrock/cli/commands/distribute.py
+++ b/source/claude_code_with_bedrock/cli/commands/distribute.py
@@ -726,6 +726,12 @@ class DistributeCommand(Command):
                                     f"claude-code-package/{rel_path.as_posix()}", self._read_file_with_retry(file)
                                 )
 
+                    # Add matching extras. "all-platforms" takes everything
+                    # (token=None); each family zip filters by its landing token
+                    # (mac/linux/windows).
+                    extra_token = None if platform == "all-platforms" else platform
+                    self._add_extra_files_to_zip(zipf, package_path, getattr(profile, "extra_files", None), extra_token)
+
                 # Upload to S3 at packages/{platform}/latest.zip
                 s3_key = f"packages/{platform}/latest.zip"
                 try:
@@ -996,7 +1002,7 @@ class DistributeCommand(Command):
         ) as progress:
             # Create archive
             task = progress.add_task("Creating distribution archive...", total=None)
-            archive_path = self._create_archive(package_path)
+            archive_path = self._create_archive(package_path, getattr(profile, "extra_files", None))
 
             # Calculate checksum
             progress.update(task, description="Calculating checksum...")
@@ -1241,7 +1247,7 @@ class DistributeCommand(Command):
         """Create and distribute separate packages per OS platform."""
         console.print("\n[cyan]Creating per-OS distribution packages...[/cyan]\n")
 
-        archives = self._create_per_os_archives(package_path)
+        archives = self._create_per_os_archives(package_path, getattr(profile, "extra_files", None))
         if not archives:
             console.print("[red]No platform binaries found to package.[/red]")
             return 1
@@ -1425,12 +1431,48 @@ class DistributeCommand(Command):
                         continue
                 raise
 
-    def _create_archive(self, package_path: Path) -> Path:
+    def _add_extra_files_to_zip(self, zf, package_path: Path, entries, platform_token) -> None:
+        """Add admin-defined extra files to an open zip, filtered by platform.
+
+        Extras were already copied into ``package_path`` by ``package`` (distribute
+        never re-reads the ``from`` source), so this reads plain files/dirs from the
+        build folder and writes them under the ``claude-code-package/`` prefix using
+        ``writestr()`` + ``_read_file_with_retry()`` (no temp files — SSL/AV invariant).
+
+        ``platform_token=None`` includes every extra (the all-OS archive). Otherwise
+        an entry is included only when its ``targets`` match ``platform_token`` via
+        ``extra_applies_to`` (per-OS zips and landing-family zips).
+        """
+        from claude_code_with_bedrock.extra_files import extra_applies_to, validate_extra_files
+
+        if not entries or validate_extra_files(entries):
+            # No extras, or an invalid config — package already fails fast on
+            # invalid entries, so skip silently rather than shipping garbage.
+            return
+
+        for entry in entries:
+            if platform_token is not None and not extra_applies_to(entry["targets"], platform_token):
+                continue
+            name = entry["name"]
+            src = package_path / name
+            if not src.exists():
+                continue
+            if src.is_dir():
+                for f in src.rglob("*"):
+                    if f.is_file():
+                        rel = f.relative_to(package_path)
+                        zf.writestr(f"claude-code-package/{rel.as_posix()}", self._read_file_with_retry(f))
+            else:
+                zf.writestr(f"claude-code-package/{name}", self._read_file_with_retry(src))
+
+    def _create_archive(self, package_path: Path, extra_files=None) -> Path:
         """Create a zip archive of the package directory.
 
         Builds the ZIP directly from source files using writestr() to avoid
         temp directory operations that fail on Windows with spaces in paths
         or when antivirus locks newly-written files.
+
+        ``extra_files`` (admin-defined) are added unconditionally (all-OS archive).
         """
         import zipfile
 
@@ -1489,6 +1531,9 @@ class DistributeCommand(Command):
                         rel_path = f.relative_to(package_path)
                         zf.writestr(f"claude-code-package/{rel_path.as_posix()}", self._read_file_with_retry(f))
 
+            # All-OS archive gets every extra file (platform_token=None).
+            self._add_extra_files_to_zip(zf, package_path, extra_files, None)
+
         return archive_path
 
     # Platform-to-files mapping for per-OS packages
@@ -1520,11 +1565,14 @@ class DistributeCommand(Command):
         },
     }
 
-    def _create_per_os_archives(self, package_path: Path) -> list[tuple[str, Path]]:
+    def _create_per_os_archives(self, package_path: Path, extra_files=None) -> list[tuple[str, Path]]:
         """Create separate zip archives per OS platform. Returns list of (platform_label, archive_path).
 
         Builds ZIPs directly from source files using writestr() to avoid
         temp directory operations that fail on Windows with spaces in paths.
+
+        ``extra_files`` are filtered per platform via the per-OS token (``macos-arm64``,
+        ``windows``, ``linux-x64``, …) so a ``macos`` extra never lands in the Windows zip.
         """
         import zipfile
 
@@ -1566,6 +1614,9 @@ class DistributeCommand(Command):
                         if f.is_file():
                             rel_path = f.relative_to(package_path)
                             zf.writestr(f"claude-code-package/{rel_path.as_posix()}", self._read_file_with_retry(f))
+
+                # Add matching extras for this per-OS token (e.g. macos-arm64).
+                self._add_extra_files_to_zip(zf, package_path, extra_files, platform)
 
             archives.append((platform, pconfig["label"], archive_path))
 

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -2286,7 +2286,138 @@ class InitCommand(Command):
         else:
             config["tags"] = config.get("tags", {})
 
+        # Extra files (optional) — admin-defined files/folders shipped on top of
+        # the generated package. Preserves the existing list on cancel.
+        config["extra_files"] = self._configure_extra_files(config.get("extra_files", []))
+
         return config
+
+    def _configure_extra_files(self, existing: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Interactively add/edit/remove admin-defined extra files.
+
+        Extra files are copied on top of the generated package by `package` and
+        filtered per-OS by `distribute`. Returns the (possibly unchanged) list.
+
+        Non-interactive / cancel safety: any prompt returning None (Ctrl+C or no
+        TTY) leaves the existing list untouched — the wizard never crashes and
+        never silently drops configured entries.
+        """
+        from claude_code_with_bedrock.extra_files import VALID_TARGET_TOKENS, validate_extra_files
+
+        console = Console()
+        # Work on a copy so a mid-loop cancel can fall back to the original.
+        entries: list[dict[str, Any]] = [dict(e) for e in (existing or [])]
+
+        console.print("\n[bold]Extra Files (Optional)[/bold]")
+        console.print("[dim]Ship extra files/folders on top of the package (preinstall scripts, certs, etc.).[/dim]")
+
+        want = questionary.confirm(
+            "Add or edit extra files to include in the package?",
+            default=bool(entries),
+        ).ask()
+        if want is None:
+            return existing or []
+        if not want:
+            return entries
+
+        # Sorted for a stable checkbox order in the Add prompt.
+        token_choices = sorted(VALID_TARGET_TOKENS)
+
+        while True:
+            if entries:
+                console.print("\n[dim]Current extra files:[/dim]")
+                for i, e in enumerate(entries, 1):
+                    targets = e.get("targets")
+                    targets_str = ", ".join(targets) if isinstance(targets, list) else str(targets)
+                    console.print(f"  {i}. {e.get('name')}  → {targets_str}  ← {e.get('from')}")
+            else:
+                console.print("\n[dim]No extra files configured yet.[/dim]")
+
+            action = questionary.select(
+                "Extra files:",
+                choices=["Add", "Edit", "Remove", "Done"] if entries else ["Add", "Done"],
+            ).ask()
+            if action is None or action == "Done":
+                break
+
+            if action == "Remove":
+                idx = self._pick_extra_file_index(entries, "Remove which entry?")
+                if idx is not None:
+                    removed = entries.pop(idx)
+                    console.print(f"[yellow]✗[/yellow] Removed: {removed.get('name')}")
+                continue
+
+            # Add or Edit both gather the same three fields.
+            current = None
+            if action == "Edit":
+                idx = self._pick_extra_file_index(entries, "Edit which entry?")
+                if idx is None:
+                    continue
+                current = entries[idx]
+
+            src = questionary.text(
+                "Source path (file or folder) on this machine:",
+                default=(current.get("from") if current else "") or "",
+            ).ask()
+            if src is None or not src.strip():
+                console.print("[dim]Cancelled.[/dim]")
+                continue
+            src = src.strip()
+
+            default_name = (current.get("name") if current else "") or Path(src).expanduser().name
+            name = questionary.text(
+                "Name inside the package:",
+                default=default_name,
+            ).ask()
+            if name is None or not name.strip():
+                console.print("[dim]Cancelled.[/dim]")
+                continue
+            name = name.strip()
+
+            # Pre-check the entry's current targets when editing; nothing on Add.
+            # Save exactly what the admin checks — "all" is just another token and
+            # can be combined with specific platforms (the matcher treats "all" as
+            # matching everything, so extra picks alongside it are harmless).
+            current_targets = current.get("targets", []) if current else []
+            if isinstance(current_targets, str):
+                current_targets = [current_targets]
+            targets = questionary.checkbox(
+                "Which machines get this? (space to select, enter to confirm)",
+                choices=[questionary.Choice(t, value=t, checked=(t in current_targets)) for t in token_choices],
+            ).ask()
+            if targets is None or not targets:
+                console.print("[yellow]![/yellow] No targets selected — entry not saved.")
+                continue
+
+            entry = {"name": name, "targets": targets, "from": src}
+            errors = validate_extra_files([entry])
+            if errors:
+                for err in errors:
+                    console.print(f"[red]✗ {err}[/red]")
+                console.print("[dim]Entry not saved — fix the issue and try again.[/dim]")
+                continue
+
+            # Warn (don't block) if the source doesn't exist yet — the admin may
+            # create it before running `package`. Build time enforces presence.
+            if not Path(src).expanduser().exists():
+                console.print(f"[yellow]![/yellow] Source not found yet: {src} (must exist at package time)")
+
+            if current is not None:
+                entries[idx] = entry
+                console.print(f"[green]✓[/green] Updated: {name}")
+            else:
+                entries.append(entry)
+                console.print(f"[green]✓[/green] Added: {name}")
+
+        return entries
+
+    @staticmethod
+    def _pick_extra_file_index(entries: list[dict[str, Any]], prompt: str) -> int | None:
+        """Prompt for an entry by name; return its index or None if cancelled."""
+        if not entries:
+            return None
+        choices = [questionary.Choice(f"{e.get('name')} ← {e.get('from')}", value=i) for i, e in enumerate(entries)]
+        return questionary.select(prompt, choices=choices).ask()
 
     @staticmethod
     def _store_idp_secret(secrets_client, secret_name: str, secret_value: str, description: str = "") -> str:
@@ -2432,6 +2563,11 @@ class InitCommand(Command):
         extra_keys = config.get("cowork_3p", {}).get("extra_keys", {})
         if extra_keys:
             table.add_row("Custom MDM Keys", ", ".join(f"{k}={v}" for k, v in extra_keys.items()))
+
+        # Show admin-defined extra files
+        extra_files = config.get("extra_files", [])
+        if extra_files:
+            table.add_row("Extra Files", ", ".join(str(e.get("name", "?")) for e in extra_files))
 
         console.print(table)
 
@@ -2707,6 +2843,7 @@ class InitCommand(Command):
             "lock_default_model": config_data.get("lock_default_model", False),
             "tags": config_data.get("tags", {}),
             "redirect_port": config_data.get("redirect_port"),
+            "extra_files": config_data.get("extra_files", []),
         }
 
         if existing_profile:
@@ -3140,6 +3277,9 @@ class InitCommand(Command):
             # Add resource tags if present
             if hasattr(profile, "tags") and profile.tags:
                 existing_config["tags"] = profile.tags
+
+            # Restore admin-defined extra files so re-running init shows them.
+            existing_config["extra_files"] = getattr(profile, "extra_files", [])
 
             return existing_config
 

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -3049,11 +3049,15 @@ class InitCommand(Command):
         sso_enabled = config.get("sso_enabled", True)
         okta_domain = config.get("okta", {}).get("domain", "none") if sso_enabled else "none"
         okta_client_id = config.get("okta", {}).get("client_id", "none") if sso_enabled else "none"
+        # Expand region sentinels (e.g. "all-commercial") before they reach the
+        # AllowedBedrockRegions CFN param → aws:RequestedRegion IAM condition.
+        from claude_code_with_bedrock.models import expand_bedrock_regions
+
         param_map = {
             "OktaDomain": okta_domain,
             "OktaClientId": okta_client_id,
             "IdentityPoolName": config["aws"]["identity_pool_name"],
-            "AllowedBedrockRegions": ",".join(config["aws"]["allowed_bedrock_regions"]),
+            "AllowedBedrockRegions": ",".join(expand_bedrock_regions(config["aws"]["allowed_bedrock_regions"])),
             "EnableMonitoring": "true" if config["monitoring"]["enabled"] else "false",
             "MaxSessionDuration": "28800",  # 8 hours
         }

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -793,6 +793,27 @@ class InitCommand(Command):
                 config["client_certificate_path"] = client_certificate_path
                 config["client_certificate_key_path"] = client_certificate_key_path
 
+            elif provider_type == "google":
+                # Google's installed-app OAuth flow requires a client_secret for the
+                # token exchange (PKCE alone is insufficient). Google documents this
+                # secret as NON-confidential for installed apps, so — unlike Azure —
+                # it is stored in config.json and shipped to end users by `ccwb
+                # package`, not held in the OS keyring. See config-sync.md.
+                console.print("\n[bold]Google OAuth Client Secret[/bold]")
+                console.print(
+                    "Google's installed-app flow requires the OAuth client secret\n"
+                    "(the GOCSPX-… value from your Google Cloud OAuth client).\n"
+                )
+                client_secret = questionary.password(
+                    "Enter your Google OAuth client secret:",
+                    validate=lambda x: bool(x) or "Client secret cannot be empty",
+                    default=config.get("client_secret", "") or "",
+                ).ask()
+                if not client_secret:
+                    return None
+                config["client_secret"] = client_secret
+                console.print("[dim]  ✓ Client secret saved to profile (shipped to users by 'ccwb package')[/dim]")
+
             # Credential Storage Method
             from claude_code_with_bedrock.cli.utils.helpers import is_keyring_available, is_wsl
 
@@ -2856,6 +2877,9 @@ class InitCommand(Command):
             "idc_permission_set_name": config_data.get("idc_permission_set_name"),
             "sso_region": config_data.get("sso_region"),
             "azure_auth_mode": config_data.get("azure_auth_mode"),
+            # Google's client_secret is non-confidential and persisted in config.json
+            # (Azure's confidential secret lives in the OS keyring and stays None here).
+            "client_secret": config_data.get("client_secret"),
             "client_certificate_path": config_data.get("client_certificate_path"),
             "client_certificate_key_path": config_data.get("client_certificate_key_path"),
             "enable_codebuild": config_data.get("codebuild", {}).get("enabled", False),
@@ -3330,9 +3354,13 @@ class InitCommand(Command):
                 existing_config["analytics"] = {"enabled": profile.analytics_enabled}
 
             # Preserve confidential client configuration if present
-            # client_secret is never written to config — it lives in the OS keyring
+            # Azure's client_secret lives in the OS keyring (never in config); Google's
+            # client_secret is non-confidential and persisted in the profile — restore
+            # it so re-running init pre-fills the value instead of losing it.
             if getattr(profile, "azure_auth_mode", None):
                 existing_config["azure_auth_mode"] = profile.azure_auth_mode
+            if getattr(profile, "client_secret", None):
+                existing_config["client_secret"] = profile.client_secret
             if getattr(profile, "client_certificate_path", None):
                 existing_config["client_certificate_path"] = profile.client_certificate_path
                 existing_config["client_certificate_key_path"] = profile.client_certificate_key_path

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1256,75 +1256,80 @@ class InitCommand(Command):
                             "[dim]  \u26a0 Estimates use published on-demand Bedrock rates. Use AWS Cost Explorer for billing truth.[/dim]"
                         )
 
-                        # Set token limits to 0 (disabled) when using cost mode
+                        # Cost mode: token-denominated limits are DISABLED (0).
+                        # The Lambdas skip token checks at 0, so the budgets
+                        # above are the sole control — do NOT prompt for token
+                        # counts (previously the token block below ran anyway
+                        # and overwrote these zeros with a token answer).
                         config["quota"]["monthly_limit"] = 0
                         config["quota"]["daily_limit"] = 0
+                        config["quota"]["warning_threshold_80"] = 0
+                        config["quota"]["warning_threshold_90"] = 0
                         monthly_limit = 0
+                        daily_limit = 0
 
                     else:
                         # Token-based limits (existing behavior)
                         config["quota"]["monthly_cost_limit"] = 0
                         config["quota"]["daily_cost_limit"] = 0
 
-                    # Monthly token limit (only prompted for token mode)
-                    if limit_type == "token":
                         console.print("\n[bold]Monthly Limit[/bold]")
-                    monthly_limit_millions = questionary.text(
-                        "Monthly token limit per user (in millions):",
-                        default=str(config.get("quota", {}).get("monthly_limit_millions", 225)),
-                        validate=lambda x: x.isdigit() and int(x) > 0,
-                    ).ask()
+                        monthly_limit_millions = questionary.text(
+                            "Monthly token limit per user (in millions):",
+                            default=str(config.get("quota", {}).get("monthly_limit_millions", 225)),
+                            validate=lambda x: x.isdigit() and int(x) > 0,
+                        ).ask()
 
-                    monthly_limit = int(monthly_limit_millions) * 1000000
-                    warning_80 = int(monthly_limit * 0.8)
-                    warning_90 = int(monthly_limit * 0.9)
+                        monthly_limit = int(monthly_limit_millions) * 1000000
+                        warning_80 = int(monthly_limit * 0.8)
+                        warning_90 = int(monthly_limit * 0.9)
 
-                    config["quota"]["monthly_limit"] = monthly_limit
-                    config["quota"]["warning_threshold_80"] = warning_80
-                    config["quota"]["warning_threshold_90"] = warning_90
+                        config["quota"]["monthly_limit"] = monthly_limit
+                        config["quota"]["warning_threshold_80"] = warning_80
+                        config["quota"]["warning_threshold_90"] = warning_90
 
-                    console.print(f"  → Monthly limit: {monthly_limit:,} tokens")
-                    console.print(f"  → Warning at 80%: {warning_80:,} tokens")
-                    console.print(f"  → Critical at 90%: {warning_90:,} tokens")
+                        console.print(f"  → Monthly limit: {monthly_limit:,} tokens")
+                        console.print(f"  → Warning at 80%: {warning_80:,} tokens")
+                        console.print(f"  → Critical at 90%: {warning_90:,} tokens")
 
-                    # Daily limit configuration (Bill Shock Protection)
-                    console.print("\n[bold]Daily Limit (Bill Shock Protection)[/bold]")
-                    console.print("Prevent runaway usage by setting a daily limit with a burst buffer.")
+                        # Daily limit configuration (Bill Shock Protection)
+                        console.print("\n[bold]Daily Limit (Bill Shock Protection)[/bold]")
+                        console.print("Prevent runaway usage by setting a daily limit with a burst buffer.")
 
-                    base_daily = monthly_limit / 30
+                        base_daily = monthly_limit / 30
 
-                    # Show burst buffer options
-                    console.print(f"\nBase daily limit (monthly ÷ 30): {int(base_daily):,} tokens")
-                    console.print("\nBurst buffer allows daily variation above the average:")
-                    console.print(f"  • [dim]5%  (strict)[/dim]   → {int(base_daily * 1.05):,}/day")
-                    console.print(f"  • [cyan]10% (default)[/cyan]  → {int(base_daily * 1.10):,}/day")
-                    console.print(f"  • [dim]25% (flexible)[/dim] → {int(base_daily * 1.25):,}/day")
+                        # Show burst buffer options
+                        console.print(f"\nBase daily limit (monthly ÷ 30): {int(base_daily):,} tokens")
+                        console.print("\nBurst buffer allows daily variation above the average:")
+                        console.print(f"  • [dim]5%  (strict)[/dim]   → {int(base_daily * 1.05):,}/day")
+                        console.print(f"  • [cyan]10% (default)[/cyan]  → {int(base_daily * 1.10):,}/day")
+                        console.print(f"  • [dim]25% (flexible)[/dim] → {int(base_daily * 1.25):,}/day")
 
-                    burst_buffer = questionary.text(
-                        "Burst buffer percentage (5-25%):",
-                        default=str(config.get("quota", {}).get("burst_buffer_percent", 10)),
-                        validate=lambda x: x.isdigit() and 5 <= int(x) <= 25,
-                    ).ask()
+                        burst_buffer = questionary.text(
+                            "Burst buffer percentage (5-25%):",
+                            default=str(config.get("quota", {}).get("burst_buffer_percent", 10)),
+                            validate=lambda x: x.isdigit() and 5 <= int(x) <= 25,
+                        ).ask()
 
-                    burst_percent = int(burst_buffer)
-                    calculated_daily = int(base_daily * (1 + burst_percent / 100))
+                        burst_percent = int(burst_buffer)
+                        calculated_daily = int(base_daily * (1 + burst_percent / 100))
 
-                    console.print(f"  → Calculated daily limit: {calculated_daily:,} tokens")
+                        console.print(f"  → Calculated daily limit: {calculated_daily:,} tokens")
 
-                    # Allow custom override
-                    custom_daily = questionary.text(
-                        f"Custom daily limit (Enter to accept {calculated_daily:,}):",
-                        default="",
-                        validate=lambda x: x == "" or (x.isdigit() and int(x) > 0),
-                    ).ask()
+                        # Allow custom override
+                        custom_daily = questionary.text(
+                            f"Custom daily limit (Enter to accept {calculated_daily:,}):",
+                            default="",
+                            validate=lambda x: x == "" or (x.isdigit() and int(x) > 0),
+                        ).ask()
 
-                    daily_limit = int(custom_daily) if custom_daily else calculated_daily
+                        daily_limit = int(custom_daily) if custom_daily else calculated_daily
 
-                    config["quota"]["daily_limit"] = daily_limit
-                    config["quota"]["burst_buffer_percent"] = burst_percent
+                        config["quota"]["daily_limit"] = daily_limit
+                        config["quota"]["burst_buffer_percent"] = burst_percent
 
-                    if custom_daily:
-                        console.print(f"  → Using custom daily limit: {daily_limit:,} tokens")
+                        if custom_daily:
+                            console.print(f"  → Using custom daily limit: {daily_limit:,} tokens")
 
                     # Enforcement mode configuration
                     console.print("\n[bold]Enforcement Modes[/bold]")
@@ -1351,6 +1356,9 @@ class InitCommand(Command):
                     ).ask()
 
                     config["quota"]["daily_enforcement_mode"] = daily_enforcement
+                    # (Previously never saved — the wizard's monthly enforcement
+                    # answer was silently dropped and the default always won.)
+                    config["quota"]["monthly_enforcement_mode"] = monthly_enforcement
 
                     # Quota re-check interval
                     console.print("\n[bold]Quota Re-Check Interval[/bold]")
@@ -1388,9 +1396,18 @@ class InitCommand(Command):
                         config["quota"]["enable_bypass_detection"] = False
 
                     console.print("\n[green]✓[/green] Quota monitoring configured:")
-                    console.print(f"  • Monthly: {monthly_limit:,} tokens ({monthly_enforcement})")
-                    console.print(f"  • Daily:   {daily_limit:,} tokens ({daily_enforcement})")
-                    console.print(f"  • Burst buffer: {burst_percent}%")
+                    if limit_type == "cost":
+                        console.print(
+                            f"  • Monthly budget: ${config['quota']['monthly_cost_limit']:.2f}/user ({monthly_enforcement})"
+                        )
+                        if config["quota"]["daily_cost_limit"] > 0:
+                            console.print(
+                                f"  • Daily cap: ${config['quota']['daily_cost_limit']:.2f}/user ({daily_enforcement})"
+                            )
+                    else:
+                        console.print(f"  • Monthly: {monthly_limit:,} tokens ({monthly_enforcement})")
+                        console.print(f"  • Daily:   {daily_limit:,} tokens ({daily_enforcement})")
+                        console.print(f"  • Burst buffer: {burst_percent}%")
                     console.print(f"  • Re-check interval: {check_interval} minutes")
                     if config["quota"].get("enable_bypass_detection"):
                         console.print("  • Sidecar bypass detection: enabled")
@@ -2839,6 +2856,9 @@ class InitCommand(Command):
             "daily_token_limit": config_data.get("quota", {}).get("daily_limit"),
             "burst_buffer_percent": config_data.get("quota", {}).get("burst_buffer_percent", 10),
             "daily_enforcement_mode": config_data.get("quota", {}).get("daily_enforcement_mode", "alert"),
+            "quota_limit_type": config_data.get("quota", {}).get("limit_type", "token"),
+            "monthly_cost_limit_usd": config_data.get("quota", {}).get("monthly_cost_limit", 0),
+            "daily_cost_limit_usd": config_data.get("quota", {}).get("daily_cost_limit", 0),
             "monthly_enforcement_mode": config_data.get("quota", {}).get("monthly_enforcement_mode", "block"),
             "quota_check_interval": config_data.get("quota", {}).get("check_interval", 30),
             "enable_bypass_detection": config_data.get("quota", {}).get("enable_bypass_detection", False),
@@ -3268,6 +3288,9 @@ class InitCommand(Command):
                     "burst_buffer_percent": getattr(profile, "burst_buffer_percent", 10),
                     "daily_enforcement_mode": getattr(profile, "daily_enforcement_mode", "alert"),
                     "monthly_enforcement_mode": getattr(profile, "monthly_enforcement_mode", "block"),
+                    "limit_type": getattr(profile, "quota_limit_type", "token"),
+                    "monthly_cost_limit": getattr(profile, "monthly_cost_limit_usd", 0),
+                    "daily_cost_limit": getattr(profile, "daily_cost_limit_usd", 0),
                     "check_interval": getattr(profile, "quota_check_interval", 30),
                     "enable_bypass_detection": getattr(profile, "enable_bypass_detection", False),
                 }

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -40,6 +40,26 @@ from claude_code_with_bedrock.config import WEBSEARCH_SUPPORTED_REGIONS, Config,
 _CHOICE_NONE = "__none__"
 
 
+def _model_keys_for_region(region: str | None) -> list[str]:
+    """Model registry keys the wizard should offer for a target AWS region.
+
+    GovCloud is a separate partition: only models with a "us-gov" CRIS profile
+    are invokable there, and those profiles are not invokable from commercial
+    regions. Filtering keeps the wizard from offering models the selected
+    region can never serve (previously a GovCloud admin saw every commercial
+    model, and picking one produced a deployment that 400s on invoke).
+    """
+    from claude_code_with_bedrock.models import CLAUDE_MODELS, get_available_profiles_for_model
+    from claude_code_with_bedrock.utils.partition import aws_partition_for_region
+
+    in_govcloud = aws_partition_for_region(region or "") == "aws-us-gov"
+    return [
+        model_key
+        for model_key in CLAUDE_MODELS
+        if ("us-gov" in get_available_profiles_for_model(model_key)) == in_govcloud
+    ]
+
+
 def validate_identity_pool_name(value: str) -> bool | str:
     """Validate identity pool name format.
 
@@ -2065,10 +2085,18 @@ class InitCommand(Command):
                     if saved_model_key:
                         break
 
-            # Step 1: Select Claude model
+            # Step 1: Select Claude model. Offer only models the selected
+            # region's partition can invoke (GovCloud ↔ commercial).
+            offered_model_keys = _model_keys_for_region(config.get("aws", {}).get("region"))
+
             model_choices = []
-            default_model_key = saved_model_key or "sonnet-4-5"
-            for model_key, model_info in CLAUDE_MODELS.items():
+            default_model_key = saved_model_key if saved_model_key in offered_model_keys else None
+            if default_model_key is None:
+                default_model_key = (
+                    "sonnet-4-5-govcloud" if "sonnet-4-5-govcloud" in offered_model_keys else "sonnet-4-5"
+                )
+            for model_key in offered_model_keys:
+                model_info = CLAUDE_MODELS[model_key]
                 # Build region list from available profiles
                 available_profiles = get_available_profiles_for_model(model_key)
                 regions = []
@@ -2076,10 +2104,12 @@ class InitCommand(Command):
                     regions.append("Global")
                 if "us" in available_profiles:
                     regions.append("US")
-                if "europe" in available_profiles:
+                if "eu" in available_profiles or "europe" in available_profiles:
                     regions.append("Europe")
                 if "apac" in available_profiles:
                     regions.append("APAC")
+                if "us-gov" in available_profiles:
+                    regions.append("GovCloud")
                 regions_text = ", ".join(regions)
 
                 choice_text = f"{model_info['name']} ({regions_text})"

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -31,6 +31,14 @@ from claude_code_with_bedrock.cli.utils.validators import (
 )
 from claude_code_with_bedrock.config import WEBSEARCH_SUPPORTED_REGIONS, Config, Profile
 
+# questionary.Choice treats value=None as "no value given" and FALLS BACK TO
+# THE TITLE STRING — so a "Disabled"/"Skip" choice built with value=None
+# returns its title (e.g. "Disabled") from .ask(), which is truthy and leaks
+# into the profile (enable_distribution flipped on, title strings stored as
+# codebuild region / hosted zone ID). Use this sentinel for "none" choices and
+# map it back to None right after .ask().
+_CHOICE_NONE = "__none__"
+
 
 def validate_identity_pool_name(value: str) -> bool | str:
     """Validate identity pool name format.
@@ -1445,9 +1453,11 @@ class InitCommand(Command):
                     choices=[
                         questionary.Choice(nearest_label, value=nearest),
                         *[questionary.Choice(r, value=r) for r in CODEBUILD_WINDOWS_REGIONS if r != nearest],
-                        questionary.Choice("Skip CodeBuild (build Windows binaries manually)", value=None),
+                        questionary.Choice("Skip CodeBuild (build Windows binaries manually)", value=_CHOICE_NONE),
                     ],
                 ).ask()
+                if cb_choice == _CHOICE_NONE:
+                    cb_choice = None
 
                 prior_region = config["codebuild"].get("region")
                 config["codebuild"]["region"] = cb_choice
@@ -1655,7 +1665,7 @@ class InitCommand(Command):
         distribution_choices = [
             questionary.Choice("Presigned S3 URLs (simple, no authentication)", value="presigned-s3"),
             questionary.Choice("Authenticated Landing Page (IdP + ALB)", value="landing-page"),
-            questionary.Choice("Disabled", value=None),
+            questionary.Choice("Disabled", value=_CHOICE_NONE),
         ]
 
         # Get saved value or default to None
@@ -1667,6 +1677,8 @@ class InitCommand(Command):
             choices=distribution_choices,
             default=default_choice,
         ).ask()
+        if distribution_type == _CHOICE_NONE:
+            distribution_type = None
 
         # Preserve existing distribution settings, only update enabled/type
         if "distribution" not in config:
@@ -1954,7 +1966,7 @@ class InitCommand(Command):
                         )
                         for zone in hosted_zones
                     ]
-                    zone_choices.append(questionary.Choice("Skip (no Route53 managed domain)", value=None))
+                    zone_choices.append(questionary.Choice("Skip (no Route53 managed domain)", value=_CHOICE_NONE))
 
                     # Find the default choice based on existing zone
                     default_choice = None
@@ -1969,6 +1981,8 @@ class InitCommand(Command):
                         choices=zone_choices,
                         default=default_choice if default_choice else zone_choices[0],
                     ).ask()
+                    if hosted_zone_id == _CHOICE_NONE:
+                        hosted_zone_id = None
                 else:
                     console.print("[yellow]No Route53 hosted zones found in this account[/yellow]")
                     console.print("You can still use custom domain if it's managed externally")

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -873,7 +873,27 @@ class InitCommand(Command):
                 return None
 
             config["federation_type"] = federation_type
-            config["max_session_duration"] = 43200 if federation_type == "direct" else 28800
+
+            # Session duration — how long issued AWS credentials remain valid before
+            # re-authentication. Retain any previously configured value across re-runs;
+            # otherwise fall back to the federation-type recommended default.
+            _recommended_duration = 43200 if federation_type == "direct" else 28800
+            _existing_duration = config.get("max_session_duration")
+            _default_duration = _existing_duration if _existing_duration else _recommended_duration
+
+            console.print("\n[cyan]Session Duration[/cyan]")
+            console.print(
+                "How long issued AWS credentials stay valid before re-authentication "
+                f"(3600–43200 seconds; recommended {_recommended_duration})."
+            )
+            duration_str = questionary.text(
+                "Max session duration (seconds):",
+                validate=lambda x: (
+                    (x.isdigit() and 3600 <= int(x) <= 43200) or "Must be a number between 3600 and 43200"
+                ),
+                default=str(_default_duration),
+            ).ask()
+            config["max_session_duration"] = int(duration_str) if duration_str else _default_duration
 
             # Save progress
             progress.save_step("oidc_complete", config)

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -3189,6 +3189,16 @@ for _ccwb_mdm in "cowork-3p.mobileconfig" "cowork-3p-config.json"; do
     fi
 done
 
+# Install the CoWork credential-helper wrapper (helper-script mode). Claude
+# Desktop runs inferenceCredentialHelper with no arguments, so the --desktop
+# --profile flags live inside this wrapper, which execs the co-located binary.
+if [ -f "cowork-credential-helper.sh" ]; then
+    cp "cowork-credential-helper.sh" "$ACTUAL_HOME/claude-code-with-bedrock/cowork-credential-helper.sh"
+    chmod +x "$ACTUAL_HOME/claude-code-with-bedrock/cowork-credential-helper.sh"
+    if [ -n "$SUDO_USER" ]; then chown "$ACTUAL_USER" "$ACTUAL_HOME/claude-code-with-bedrock/cowork-credential-helper.sh"; fi
+    echo "OK Installed cowork-credential-helper.sh"
+fi
+
 # macOS Gatekeeper + Keychain notices
 if [[ "$OSTYPE" == "darwin"* ]]; then
     # Remove quarantine flag added by macOS when downloading unsigned binaries.
@@ -3728,6 +3738,14 @@ if exist "cowork-3p.reg" (
     echo Resolving home directory in cowork-3p.reg...
     powershell -NoProfile -Command "$h = $env:USERPROFILE.Replace('\\','\\\\'); (Get-Content 'cowork-3p.reg' -Raw).Replace('__CCWB_HOME__', $h) | Set-Content 'cowork-3p.reg'"
     echo OK Resolved home directory in cowork-3p.reg ^(import it with: reg import cowork-3p.reg, then fully restart Claude^)
+)
+
+REM Install the CoWork credential-helper wrapper (helper-script mode). Claude
+REM Desktop runs inferenceCredentialHelper with no arguments, so the --desktop
+REM --profile flags live inside this wrapper, which calls the co-located binary.
+if exist "cowork-credential-helper.cmd" (
+    copy /Y "cowork-credential-helper.cmd" "%USERPROFILE%\\claude-code-with-bedrock\\cowork-credential-helper.cmd" >nul
+    echo OK Installed cowork-credential-helper.cmd
 )
 
 REM Copy Claude Code settings if they exist

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -811,11 +811,11 @@ class PackageCommand(Command):
             console.print("\n[cyan]Generating CoWork 3P MDM configuration...[/cyan]")
             self._generate_cowork_3p_mdm_config(output_dir, profile, profile_name)
 
-        # Copy admin-defined extra files into the build folder (superset; per-OS
-        # filtering happens in distribute at zip time). Fail fast on a missing
-        # source or a validation error — a listed cert the admin expects shipped
-        # must not be silently skipped.
-        copied_extra_files = self._copy_extra_files(profile, output_dir, console)
+        # Copy admin-defined extra files into the build folder, filtered to the
+        # platforms actually being built (distribute filters again per-OS at zip
+        # time). Fail fast on a missing source or a validation error — a listed
+        # cert the admin expects shipped must not be silently skipped.
+        copied_extra_files = self._copy_extra_files(profile, output_dir, console, platforms_to_build)
         if copied_extra_files is None:
             return 1
 
@@ -878,17 +878,21 @@ class PackageCommand(Command):
 
         return 0
 
-    def _copy_extra_files(self, profile, output_dir: Path, console: Console) -> list[tuple[str, str]] | None:
+    def _copy_extra_files(
+        self, profile, output_dir: Path, console: Console, platforms_to_build: list[str] | None = None
+    ) -> list[tuple[str, str]] | None:
         """Copy admin-defined extra files into the build folder.
 
-        Copies the full superset of entries (per-OS filtering happens later at
-        zip time in distribute). Returns a list of ``(name, targets)`` tuples for
-        the package summary, or ``None`` to signal a fatal error (missing source
-        or validation failure) — the caller must return a non-zero exit code.
+        Copies only the entries whose ``targets`` apply to at least one platform
+        in ``platforms_to_build`` (``None`` disables filtering and copies every
+        entry). Distribute filters again per-OS at zip time. Returns a list of
+        ``(name, targets)`` tuples for the package summary, or ``None`` to signal
+        a fatal error (missing source or validation failure) — the caller must
+        return a non-zero exit code.
         """
         import shutil
 
-        from claude_code_with_bedrock.extra_files import validate_extra_files
+        from claude_code_with_bedrock.extra_files import extra_applies_to_any, validate_extra_files
 
         entries = getattr(profile, "extra_files", []) or []
         if not entries:
@@ -905,6 +909,9 @@ class PackageCommand(Command):
         copied: list[tuple[str, str]] = []
         for entry in entries:
             name = entry["name"]
+            if platforms_to_build is not None and not extra_applies_to_any(entry["targets"], platforms_to_build):
+                console.print(f"  [dim]– {name} skipped (not targeted for this build)[/dim]")
+                continue
             src = Path(entry["from"]).expanduser()
             if not src.exists():
                 console.print(f"[red]Extra file source not found for '{name}': {src}[/red]")

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -250,6 +250,11 @@ class PackageCommand(Command):
             description="Skip configuration validation checks",
             flag=True,
         ),
+        option(
+            "prepare-offline",
+            description="Prepare an offline bundle (OCB binary + Go module cache) for air-gapped builds",
+            flag=True,
+        ),
     ]
 
     def handle(self) -> int:
@@ -268,6 +273,10 @@ class PackageCommand(Command):
             console.print("  • [cyan]poetry run ccwb builds --status latest[/cyan]    (check latest build)")
             console.print("\nRedirecting to builds command...\n")
             return self._check_build_status(self.option("status"), console)
+
+        # Prepare offline bundle for air-gapped environments
+        if self.option("prepare-offline"):
+            return self._prepare_offline_bundle(console)
 
         # Load configuration first (needed to check CodeBuild status)
         config = Config.load()
@@ -1161,7 +1170,15 @@ class PackageCommand(Command):
                 f"cmd%2Fbuilder%2Fv{OCB_VERSION}/ocb_{OCB_VERSION}_{ocb_os}_{ocb_arch}{ocb_suffix}"
             )
             console.print(f"[dim]Downloading OCB v{OCB_VERSION}...[/dim]")
-            urllib.request.urlretrieve(url, ocb_path)  # noqa: S310 (trusted GitHub release URL)
+            try:
+                urllib.request.urlretrieve(url, ocb_path)  # noqa: S310 (trusted GitHub release URL)
+            except (urllib.error.URLError, OSError) as e:
+                console.print(f"[red]Failed to download OCB: {e}[/red]")
+                console.print(
+                    "[yellow]For air-gapped environments, run "
+                    "'ccwb package --prepare-offline' on a connected machine first.[/yellow]"
+                )
+                raise
             if ocb_os != "windows":
                 ocb_path.chmod(0o755)
 
@@ -2456,6 +2473,41 @@ RUN pyinstaller \
             raise RuntimeError(f"Nuitka build failed for OTEL helper: {result.stderr}")
 
         return output_dir / binary_name
+
+    def _prepare_offline_bundle(self, console: Console) -> int:
+        """Prepare an offline bundle for air-gapped Go and OTEL collector builds.
+
+        Downloads the OCB binary and pre-seeds the Go module cache so that
+        `ccwb package` can run without network access. The bundle is saved
+        to `ccwb-offline-go-bundle/` in the repo root.
+        """
+        import subprocess
+
+        script_path = Path(__file__).resolve().parents[4] / "scripts" / "prepare-offline-go-bundle.sh"
+        if not script_path.exists():
+            console.print(f"[red]Offline bundle script not found at {script_path}[/red]")
+            return 1
+
+        console.print("[bold]Preparing offline bundle...[/bold]")
+        console.print("[dim]This downloads OCB + Go modules and verifies the bundle with a test build.[/dim]\n")
+
+        try:
+            result = subprocess.run(
+                ["bash", str(script_path), "prepare"],
+                cwd=script_path.parent.parent,
+            )
+            if result.returncode == 0:
+                console.print("\n[green]✓ Offline bundle ready.[/green]")
+                console.print("\n[bold]Next steps:[/bold]")
+                console.print("  1. Transfer [cyan]ccwb-offline-go-bundle.tar.gz[/cyan] to the air-gapped machine")
+                console.print("  2. Extract: [cyan]tar xzf ccwb-offline-go-bundle.tar.gz[/cyan]")
+                console.print("  3. Install: [cyan]./scripts/prepare-offline-go-bundle.sh install[/cyan]")
+                console.print("  4. Source env: [cyan]source ccwb-offline-go-bundle/offline-env.sh[/cyan]")
+                console.print("  5. Build: [cyan]poetry run ccwb package[/cyan]")
+            return result.returncode
+        except FileNotFoundError:
+            console.print("[red]bash not found. This command requires a Unix-like environment.[/red]")
+            return 1
 
     def _regenerate_installers(self, profile, profile_name: str, console: Console) -> int:
         """Regenerate installer scripts using existing binaries from the latest dist folder."""
@@ -4281,9 +4333,7 @@ Available metrics include:
                     # already resolved to http://localhost:4318 above; in central
                     # mode it is the ALB address from the profile/CloudFormation.
                     resource_attrs = otel_resource_attributes or (
-                        "department=default,team.id=default,"
-                        "cost_center=default,organization=default,"
-                        "project=default"
+                        "department=default,team.id=default,cost_center=default,organization=default,project=default"
                     )
 
                     settings["env"].update(

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -804,6 +804,7 @@ class PackageCommand(Command):
             profile_name,
             otel_resource_attributes,
             is_idc_zero_binary=is_idc_zero_binary,
+            settings_version=timestamp,
         )
 
         # Generate CoWork 3P MDM configuration if enabled
@@ -2642,7 +2643,14 @@ RUN pyinstaller \
 
         # Regenerate Claude Code settings
         console.print("[cyan]Generating Claude Code settings...[/cyan]")
-        self._create_claude_settings(output_dir, profile, include_coauthored_by, profile_name, otel_resource_attributes)
+        self._create_claude_settings(
+            output_dir,
+            profile,
+            include_coauthored_by,
+            profile_name,
+            otel_resource_attributes,
+            settings_version=timestamp,
+        )
 
         # Summary
         console.print("\n[green]✓ Installers regenerated successfully![/green]")
@@ -4104,6 +4112,7 @@ Available metrics include:
         profile_name: str = "ClaudeCode",
         otel_resource_attributes: str | None = None,
         is_idc_zero_binary: bool = False,
+        settings_version: str | None = None,
     ) -> None:
         """Create Claude Code settings.json with Bedrock and optional monitoring configuration."""
         console = Console()
@@ -4342,6 +4351,13 @@ Available metrics include:
                     resource_attrs = otel_resource_attributes or (
                         "department=default,team.id=default,cost_center=default,organization=default,project=default"
                     )
+                    # Stamp the dist-folder timestamp so telemetry records which
+                    # packaged distribution each user runs. The collector's
+                    # resource_to_telemetry_conversion surfaces it as a field on
+                    # every EMF event in /aws/claude-code/metrics, so adoption is
+                    # queryable without any collector change.
+                    if settings_version:
+                        resource_attrs += f",settings_version={settings_version}"
 
                     settings["env"].update(
                         {

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -4224,7 +4224,7 @@ Available metrics include:
                     # already resolved to http://localhost:4318 above; in central
                     # mode it is the ALB address from the profile/CloudFormation.
                     resource_attrs = otel_resource_attributes or (
-                        "department=engineering,team.id=default,"
+                        "department=default,team.id=default,"
                         "cost_center=default,organization=default,"
                         "project=default"
                     )

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -3658,7 +3658,7 @@ REM external command" and silently drops all metrics, so we fail the install
 REM loudly rather than leave a broken telemetry config.
 if exist "otel-helper.cmd" (
     copy /Y "otel-helper.cmd" "%USERPROFILE%\\claude-code-with-bedrock\\otel-helper.cmd" >nul
-    if %errorlevel% neq 0 (
+    if !errorlevel! neq 0 (
         echo ERROR: Failed to copy otel-helper.cmd
         pause
         exit /b 1
@@ -3676,7 +3676,7 @@ if exist "otel-helper.cmd" (
 )
 if exist "otel-helper.ps1" (
     copy /Y "otel-helper.ps1" "%USERPROFILE%\\claude-code-with-bedrock\\otel-helper.ps1" >nul
-    if %errorlevel% neq 0 (
+    if !errorlevel! neq 0 (
         echo ERROR: Failed to copy otel-helper.ps1
         pause
         exit /b 1
@@ -3741,7 +3741,7 @@ if exist "claude-settings" (
 
         REM Check for Administrator privileges
         net session >nul 2>&1
-        if %errorlevel% neq 0 (
+        if !errorlevel! neq 0 (
             echo ERROR: Managed settings require Administrator privileges.
             echo        Right-click install.bat and select "Run as administrator"
             echo        [Target: C:\\Program Files\\ClaudeCode\\managed-settings.json]
@@ -3760,25 +3760,31 @@ if exist "claude-settings" (
 
     REM Copy user-scope settings.json if present (with merge support)
     if exist "claude-settings\\settings.json" (
-        set SKIP_SETTINGS=false
+        set WRITE_SETTINGS=false
         if exist "%USERPROFILE%\\.claude\\settings.json" (
             echo Existing Claude Code settings found - merging...
 
-            REM Merge new settings into existing (preserves user customizations)
-            powershell -NoProfile -Command "$otelPath = ($env:USERPROFILE + '\\claude-code-with-bedrock\\otel-helper.cmd').Replace('\\','\\\\'); $credPath = $env:USERPROFILE + '\\claude-code-with-bedrock\\credential-process.exe' -replace '\\\\', '/'; $existing = Get-Content (Join-Path $env:USERPROFILE '.claude\\settings.json') | ConvertFrom-Json; $incoming = (Get-Content 'claude-settings\\settings.json') -replace '__OTEL_HELPER_PATH__', $otelPath -replace '__CREDENTIAL_PROCESS_PATH__', $credPath | ConvertFrom-Json; foreach ($prop in $incoming.PSObject.Properties) {{{{ $existing | Add-Member -MemberType NoteProperty -Name $prop.Name -Value $prop.Value -Force }}}}; $existing | ConvertTo-Json -Depth 10 | Set-Content (Join-Path $env:USERPROFILE '.claude\\settings.json')"
-            if %errorlevel% equ 0 (
+            REM Merge new settings into existing. Top-level keys from the new
+            REM settings win, but the 'env' object is DEEP-merged so custom env
+            REM vars the user added survive. $ErrorActionPreference=Stop plus
+            REM the catch/exit 1 makes any failure visible via !errorlevel!.
+            powershell -NoProfile -Command "$ErrorActionPreference = 'Stop'; try {{ $otelPath = ($env:USERPROFILE + '\\claude-code-with-bedrock\\otel-helper.cmd').Replace('\\','\\\\'); $credPath = $env:USERPROFILE + '\\claude-code-with-bedrock\\credential-process.exe' -replace '\\\\', '/'; $settingsPath = Join-Path $env:USERPROFILE '.claude\\settings.json'; $existing = Get-Content $settingsPath -Raw | ConvertFrom-Json; $incoming = (Get-Content 'claude-settings\\settings.json' -Raw) -replace '__OTEL_HELPER_PATH__', $otelPath -replace '__CREDENTIAL_PROCESS_PATH__', $credPath | ConvertFrom-Json; foreach ($prop in $incoming.PSObject.Properties) {{ if ($prop.Name -eq 'env' -and $existing.PSObject.Properties['env']) {{ foreach ($envProp in $prop.Value.PSObject.Properties) {{ $existing.env | Add-Member -MemberType NoteProperty -Name $envProp.Name -Value $envProp.Value -Force }} }} else {{ $existing | Add-Member -MemberType NoteProperty -Name $prop.Name -Value $prop.Value -Force }} }}; $existing | ConvertTo-Json -Depth 10 | Set-Content $settingsPath }} catch {{ Write-Error $_; exit 1 }}"
+            if !errorlevel! equ 0 (
                 echo OK Claude Code settings merged [user settings preserved]
             ) else (
                 set /p OVERWRITE="Merge failed. Overwrite with new settings? (y/n): "
-                if /i not "%OVERWRITE%"=="y" (
+                if /i "!OVERWRITE!"=="y" (
+                    set WRITE_SETTINGS=true
+                ) else (
                     echo Skipping Claude Code settings...
-                    set SKIP_SETTINGS=true
                 )
             )
+        ) else (
+            set WRITE_SETTINGS=true
         )
 
-        if not "%SKIP_SETTINGS%"=="true" if not exist "%USERPROFILE%\\.claude\\settings.json" (
-            REM No existing settings - write directly
+        if "!WRITE_SETTINGS!"=="true" (
+            REM No existing settings [or user chose overwrite] - write directly
             powershell -Command "$otelPath = ($env:USERPROFILE + '\\claude-code-with-bedrock\\otel-helper.cmd').Replace('\\','\\\\'); $credPath = $env:USERPROFILE + '\\claude-code-with-bedrock\\credential-process.exe' -replace '\\\\', '/'; (Get-Content 'claude-settings\\settings.json') -replace '__OTEL_HELPER_PATH__', $otelPath -replace '__CREDENTIAL_PROCESS_PATH__', $credPath | Set-Content (Join-Path $env:USERPROFILE '.claude\\settings.json')"
             echo OK Claude Code settings configured
         )

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -4396,7 +4396,10 @@ Available metrics include:
                     _is_idc = getattr(profile, "effective_auth_type", profile.auth_type) == "idc"
                     _idc_zero_binary = _is_idc and not bool(getattr(profile, "quota_api_endpoint", None))
                     if not _idc_zero_binary:
-                        settings["otelHeadersHelper"] = "__OTEL_HELPER_PATH__"
+                        # Pass the profile explicitly (same as AWS_CREDENTIAL_PROCESS /
+                        # awsAuthRefresh above) so the helper serves THIS profile even
+                        # when AWS_PROFILE in the helper's environment points elsewhere.
+                        settings["otelHeadersHelper"] = f"__OTEL_HELPER_PATH__ --profile {profile_name}"
 
                     is_https = endpoint.startswith("https://")
                     console.print(f"[dim]Added monitoring with {'HTTPS' if is_https else 'HTTP'} endpoint[/dim]")

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -802,6 +802,14 @@ class PackageCommand(Command):
             console.print("\n[cyan]Generating CoWork 3P MDM configuration...[/cyan]")
             self._generate_cowork_3p_mdm_config(output_dir, profile, profile_name)
 
+        # Copy admin-defined extra files into the build folder (superset; per-OS
+        # filtering happens in distribute at zip time). Fail fast on a missing
+        # source or a validation error — a listed cert the admin expects shipped
+        # must not be silently skipped.
+        copied_extra_files = self._copy_extra_files(profile, output_dir, console)
+        if copied_extra_files is None:
+            return 1
+
         # Summary
         console.print("\n[green]✓ Package created successfully![/green]")
         console.print(f"\nOutput directory: [cyan]{output_dir}[/cyan]")
@@ -832,6 +840,8 @@ class PackageCommand(Command):
                 console.print("  • cowork-3p.mobileconfig - CoWork 3P MDM profile (macOS)")
             if (output_dir / "cowork-3p.reg").exists():
                 console.print("  • cowork-3p.reg - CoWork 3P registry file (Windows)")
+        for name, targets in copied_extra_files:
+            console.print(f"  • {name} - Extra file (targets: {targets})")
 
         # Next steps
         console.print("\n[bold]Distribution steps:[/bold]")
@@ -858,6 +868,53 @@ class PackageCommand(Command):
             return 1
 
         return 0
+
+    def _copy_extra_files(self, profile, output_dir: Path, console: Console) -> list[tuple[str, str]] | None:
+        """Copy admin-defined extra files into the build folder.
+
+        Copies the full superset of entries (per-OS filtering happens later at
+        zip time in distribute). Returns a list of ``(name, targets)`` tuples for
+        the package summary, or ``None`` to signal a fatal error (missing source
+        or validation failure) — the caller must return a non-zero exit code.
+        """
+        import shutil
+
+        from claude_code_with_bedrock.extra_files import validate_extra_files
+
+        entries = getattr(profile, "extra_files", []) or []
+        if not entries:
+            return []
+
+        errors = validate_extra_files(entries)
+        if errors:
+            console.print("[red]Invalid extra_files configuration:[/red]")
+            for err in errors:
+                console.print(f"  [red]• {err}[/red]")
+            return None
+
+        console.print("\n[cyan]Copying extra files...[/cyan]")
+        copied: list[tuple[str, str]] = []
+        for entry in entries:
+            name = entry["name"]
+            src = Path(entry["from"]).expanduser()
+            if not src.exists():
+                console.print(f"[red]Extra file source not found for '{name}': {src}[/red]")
+                console.print("[red]Fix the 'from' path or remove the entry, then re-run.[/red]")
+                return None
+
+            dst = output_dir / name
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            if src.is_dir():
+                shutil.copytree(src, dst, dirs_exist_ok=True)
+            else:
+                shutil.copy2(src, dst)
+
+            targets = entry["targets"]
+            targets_label = ", ".join(targets) if isinstance(targets, list) else str(targets)
+            copied.append((name, targets_label))
+            console.print(f"  [green]✓[/green] {name} ← {src} (targets: {targets_label})")
+
+        return copied
 
     def _check_build_status(self, build_id: str, console: Console) -> int:
         """Check the status of a CodeBuild build."""

--- a/source/claude_code_with_bedrock/cli/commands/package_cb.py
+++ b/source/claude_code_with_bedrock/cli/commands/package_cb.py
@@ -457,7 +457,7 @@ class PackageCbCommand(Command):
 
                     if endpoint:
                         resource_attrs = otel_resource_attributes or (
-                            "department=engineering,team.id=default,"
+                            "department=default,team.id=default,"
                             "cost_center=default,organization=default,"
                             "project=default"
                         )

--- a/source/claude_code_with_bedrock/cli/commands/package_cb.py
+++ b/source/claude_code_with_bedrock/cli/commands/package_cb.py
@@ -487,7 +487,10 @@ class PackageCbCommand(Command):
                                 "OTEL_RESOURCE_ATTRIBUTES": resource_attrs,
                             }
                         )
-                        settings["otelHeadersHelper"] = "__OTEL_HELPER_PATH__"
+                        # Pass the profile explicitly (same as the credential-process
+                        # settings) so the helper serves THIS profile even when
+                        # AWS_PROFILE in the helper's environment points elsewhere.
+                        settings["otelHeadersHelper"] = f"__OTEL_HELPER_PATH__ --profile {profile_name}"
 
                         is_https = endpoint.startswith("https://")
                         console.print(f"[dim]Added monitoring with {'HTTPS' if is_https else 'HTTP'} endpoint[/dim]")

--- a/source/claude_code_with_bedrock/cli/commands/package_cb.py
+++ b/source/claude_code_with_bedrock/cli/commands/package_cb.py
@@ -276,7 +276,14 @@ class PackageCbCommand(Command):
                 pkg._create_documentation(output_dir, profile, timestamp)
 
         console.print("[cyan]Creating Claude Code settings...[/cyan]")
-        self._create_claude_settings(output_dir, profile, include_coauthored_by, profile_name, otel_resource_attributes)
+        self._create_claude_settings(
+            output_dir,
+            profile,
+            include_coauthored_by,
+            profile_name,
+            otel_resource_attributes,
+            settings_version=timestamp,
+        )
 
         # Show configuration
         console.print()
@@ -400,6 +407,7 @@ class PackageCbCommand(Command):
         include_coauthored_by: bool,
         profile_name: str,
         otel_resource_attributes: str | None = None,
+        settings_version: str | None = None,
     ) -> None:
         """Create Claude Code settings.json with Bedrock and optional monitoring configuration."""
         console = Console()
@@ -461,6 +469,11 @@ class PackageCbCommand(Command):
                             "cost_center=default,organization=default,"
                             "project=default"
                         )
+                        # Stamp the dist-folder timestamp so telemetry records
+                        # which packaged distribution each user runs (mirrors
+                        # package.py — keep both in sync).
+                        if settings_version:
+                            resource_attrs += f",settings_version={settings_version}"
                         settings["env"].update(
                             {
                                 "CLAUDE_CODE_ENABLE_TELEMETRY": "1",

--- a/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
+++ b/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
@@ -210,8 +210,21 @@ def build_mdm_config(
         config["inferenceCredentialHelperSilentRefreshEnabled"] = "true"
         # Keep the AWS profile as fallback for SDK-level operations (region, etc.)
         config["inferenceBedrockProfile"] = profile_name
+        # Disambiguate for Claude Desktop: shipping both inferenceCredentialHelper
+        # and inferenceBedrockProfile together is intentional (the profile is a
+        # region/metadata fallback, not the active auth path), but Desktop logs
+        # "Multiple credential methods configured (vendor-profile, helper-script);
+        # using vendor-profile" and silently prefers the WRONG one without this key
+        # — causing repeated "Authentication Failed" since the SDK profile path was
+        # never the supported one. Setting it explicitly removes the ambiguity.
+        config["inferenceCredentialKind"] = "helper-script"
     else:
-        # Legacy profile mode — rely on AWS SDK credential_process chain.
+        # Legacy profile mode — rely on AWS SDK credential_process chain. Only
+        # inferenceBedrockProfile is set here, so there is no ambiguity for
+        # Claude Desktop to resolve — do not add inferenceCredentialKind, whose
+        # name/values are inferred from a Desktop log string and unverified
+        # against any published schema. Confine that unverified key to the one
+        # mode (helper) that has the reported ambiguity bug.
         config["inferenceBedrockProfile"] = profile_name
 
     if extra_keys:

--- a/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
+++ b/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
@@ -117,22 +117,34 @@ def _infer_tier_from_model_id(model_id: str) -> str | None:
     return None
 
 
+# Wrapper scripts that Claude Desktop invokes as inferenceCredentialHelper.
+# Per Anthropic's contract, Claude Desktop "runs the executable at the configured
+# path with no arguments" — it does NOT parse a command line. So the helper value
+# must be a bare path to a script, and the --desktop/--profile arguments are
+# baked INSIDE the wrapper (which calls the co-located credential-process binary).
+# Pointing inferenceCredentialHelper directly at "credential-process --desktop
+# --profile X" makes Claude Desktop treat the whole string as one filename and
+# fail to spawn it (ENOENT).
+COWORK_HELPER_SCRIPT_UNIX = "cowork-credential-helper.sh"
+COWORK_HELPER_SCRIPT_WINDOWS = "cowork-credential-helper.cmd"
+
+
 def _credential_process_path(profile_name: str) -> dict[str, str]:
-    """Return platform-specific credential-process paths for inferenceCredentialHelper.
+    """Return platform-specific, argument-free wrapper-script paths for
+    inferenceCredentialHelper.
 
-    The installer places the binary at a predictable location per-platform:
-    - macOS/Linux: <home>/claude-code-with-bedrock/credential-process
-    - Windows: <home>\\claude-code-with-bedrock\\credential-process.exe
+    The installer places the wrapper alongside the binary per-platform:
+    - macOS/Linux: <home>/claude-code-with-bedrock/cowork-credential-helper.sh
+    - Windows: <home>\\claude-code-with-bedrock\\cowork-credential-helper.cmd
 
-    Claude Desktop does NOT expand "~"/env vars in MDM values on EITHER platform,
-    so both paths embed CCWB_HOME_PLACEHOLDER. `install.sh` (macOS/Linux) and
-    `install.bat` (Windows) substitute it with the real home at install time —
-    Windows escapes it for the .reg (see generate_reg_file). Using %USERPROFILE%
-    here would NOT work: Claude reads the literal string from the registry.
+    The wrapper hardcodes `--desktop --profile <name>` and execs the co-located
+    credential-process binary. Claude Desktop does NOT expand "~"/env vars in MDM
+    values, so both paths embed CCWB_HOME_PLACEHOLDER; `install.sh`/`install.bat`
+    substitute it with the real home at install time.
     """
     return {
-        "unix": f"{CCWB_HOME_PLACEHOLDER}/claude-code-with-bedrock/credential-process --desktop --profile {profile_name}",
-        "windows": f"{CCWB_HOME_PLACEHOLDER}\\claude-code-with-bedrock\\credential-process.exe --desktop --profile {profile_name}",
+        "unix": f"{CCWB_HOME_PLACEHOLDER}/claude-code-with-bedrock/{COWORK_HELPER_SCRIPT_UNIX}",
+        "windows": f"{CCWB_HOME_PLACEHOLDER}\\claude-code-with-bedrock\\{COWORK_HELPER_SCRIPT_WINDOWS}",
     }
 
 
@@ -537,21 +549,21 @@ def generate_mobileconfig(output_dir: Path, mdm_config: dict) -> Path:
 
 
 def _to_windows_credential_helper(value: str) -> str:
-    """Convert the unix inferenceCredentialHelper path to the Windows form.
+    """Convert the unix inferenceCredentialHelper wrapper path to the Windows form.
 
-    ``__CCWB_HOME__/claude-code-with-bedrock/credential-process --profile X``
-    becomes ``__CCWB_HOME__\\claude-code-with-bedrock\\credential-process.exe --profile X``.
+    ``__CCWB_HOME__/claude-code-with-bedrock/cowork-credential-helper.sh``
+    becomes ``__CCWB_HOME__\\claude-code-with-bedrock\\cowork-credential-helper.cmd``.
     Keeps the ``__CCWB_HOME__`` placeholder (resolved at install/deploy time by
-    install.bat / the Intune .ps1); only rewrites slashes and adds the ``.exe``
-    suffix. No-op when the value is not a placeholder path.
+    install.bat / the Intune .ps1); rewrites slashes and swaps the .sh wrapper
+    for its .cmd counterpart. The value is a bare, argument-free path (Claude
+    Desktop runs it with no arguments). No-op when not a placeholder path.
     """
     if not (isinstance(value, str) and value.startswith(f"{CCWB_HOME_PLACEHOLDER}/")):
         return value
-    parts = value.split(" ", 1)
-    binary_part = parts[0].replace("/", "\\")
-    if not binary_part.endswith(".exe"):
-        binary_part += ".exe"
-    return f"{binary_part} {parts[1]}" if len(parts) > 1 else binary_part
+    windows = value.replace("/", "\\")
+    if windows.endswith(COWORK_HELPER_SCRIPT_UNIX):
+        windows = windows[: -len(COWORK_HELPER_SCRIPT_UNIX)] + COWORK_HELPER_SCRIPT_WINDOWS
+    return windows
 
 
 def generate_reg_file(output_dir: Path, mdm_config: dict) -> Path:
@@ -598,8 +610,48 @@ def generate_reg_file(output_dir: Path, mdm_config: dict) -> Path:
     return reg_path
 
 
+def generate_helper_wrappers(output_dir: Path, profile_name: str) -> list[str]:
+    """Write the argument-free credential-helper wrapper scripts.
+
+    Claude Desktop runs inferenceCredentialHelper "at the configured path with no
+    arguments", so the --desktop/--profile flags live inside these wrappers, which
+    exec the co-located credential-process binary. The installer places them next
+    to the binary; %~dp0 / $(dirname) resolves the binary relative to the wrapper.
+
+    Returns the generated filenames.
+    """
+    sh = (
+        "#!/bin/bash\n"
+        "# ABOUTME: CoWork 3P credential helper — emits a Bedrock bearer token.\n"
+        "# Invoked by Claude Desktop as inferenceCredentialHelper (no arguments).\n"
+        "set -euo pipefail\n"
+        'SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"\n'
+        f'exec "$SCRIPT_DIR/credential-process" --desktop --profile {profile_name}\n'
+    )
+    sh_path = output_dir / COWORK_HELPER_SCRIPT_UNIX
+    with open(sh_path, "w", encoding="utf-8", newline="\n") as f:
+        f.write(sh)
+    try:
+        sh_path.chmod(0o755)
+    except OSError:
+        pass  # no-op on Windows
+
+    cmd = (
+        "@echo off\r\n"
+        "REM CoWork 3P credential helper - emits a Bedrock bearer token.\r\n"
+        "REM Invoked by Claude Desktop as inferenceCredentialHelper (no arguments).\r\n"
+        f'"%~dp0credential-process.exe" --desktop --profile {profile_name}\r\n'
+        "exit /b %errorlevel%\r\n"
+    )
+    cmd_path = output_dir / COWORK_HELPER_SCRIPT_WINDOWS
+    with open(cmd_path, "w", encoding="utf-8", newline="") as f:
+        f.write(cmd)
+
+    return [COWORK_HELPER_SCRIPT_UNIX, COWORK_HELPER_SCRIPT_WINDOWS]
+
+
 def generate_all(output_dir: Path, mdm_config: dict, console: Console) -> list[str]:
-    """Generate all three CoWork 3P MDM configuration files.
+    """Generate all CoWork 3P MDM configuration files (+ helper wrappers).
 
     Args:
         output_dir: Directory to write files to.
@@ -622,6 +674,12 @@ def generate_all(output_dir: Path, mdm_config: dict, console: Console) -> list[s
     generate_reg_file(output_dir, mdm_config)
     generated.append("cowork-3p.reg")
     console.print("[green]✓[/green] Generated cowork-3p.reg (Windows)")
+
+    # helper-script mode: ship the wrapper scripts Claude Desktop invokes.
+    if "inferenceCredentialHelper" in mdm_config:
+        profile_name = mdm_config.get("inferenceBedrockProfile", "ClaudeCode")
+        generated += generate_helper_wrappers(output_dir, profile_name)
+        console.print("[green]✓[/green] Generated cowork-credential-helper.sh / .cmd")
 
     return generated
 

--- a/source/claude_code_with_bedrock/cli/validators.py
+++ b/source/claude_code_with_bedrock/cli/validators.py
@@ -41,7 +41,13 @@ def validate_profile_for_packaging(profile) -> list[ValidationError]:
 
     allowed_regions = getattr(profile, "allowed_bedrock_regions", None)
     if allowed_regions and getattr(profile, "aws_region", None):
-        if profile.aws_region not in allowed_regions:
+        # Expand model region sentinels (e.g. "all-commercial") before comparing —
+        # a global-model profile legitimately stores the sentinel, which expands to
+        # include aws_region. Comparing against the raw list warned spuriously.
+        from claude_code_with_bedrock.models import expand_bedrock_regions
+
+        effective_regions = expand_bedrock_regions(allowed_regions)
+        if profile.aws_region not in effective_regions:
             errors.append(
                 ValidationError(
                     "aws_region",

--- a/source/claude_code_with_bedrock/cli/validators.py
+++ b/source/claude_code_with_bedrock/cli/validators.py
@@ -50,8 +50,12 @@ def validate_profile_for_packaging(profile) -> list[ValidationError]:
                 )
             )
 
-    # Monitoring consistency
-    if getattr(profile, "monitoring_enabled", False):
+    # Monitoring consistency — CENTRAL mode only. Sidecar packages hardcode
+    # the local collector endpoint (http://localhost:4318) at package time and
+    # never have an ALB endpoint in the profile, so this warning was spurious
+    # for every sidecar deployment — and its advice (deploy the central
+    # monitoring stack) is exactly what sidecar mode must NOT do.
+    if getattr(profile, "monitoring_enabled", False) and getattr(profile, "monitoring_mode", "central") == "central":
         endpoint = getattr(profile, "otel_collector_endpoint", None)
         config_mode = getattr(profile, "cowork_config_mode", "static")
         if not endpoint and config_mode != "dynamic":

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -101,6 +101,12 @@ class Profile:
     quota_fail_mode: str = "open"  # "open" (allow on error) or "closed" (deny on error)
     quota_check_interval: int = 30  # Minutes between quota re-checks (0 = every request)
     enable_bypass_detection: bool = False  # Detect Bedrock use without a running OTEL sidecar (opt-in)
+    # Cost-based quota (limit_type "cost"): dollar budgets per user, enforced
+    # server-side from per-model Bedrock pricing. In cost mode the token limits
+    # above are set to 0 (disabled) and these become the sole control.
+    quota_limit_type: str = "token"  # "token" (raw counts) or "cost" ($ budgets)
+    monthly_cost_limit_usd: float = 0.0  # Monthly $ budget per user (0 = no cost limit)
+    daily_cost_limit_usd: float = 0.0  # Daily $ cap per user (0 = no daily cap)
 
     # Monitoring endpoint (saved from deploy, avoids re-reading CloudFormation outputs)
     otel_collector_endpoint: str | None = None  # OTel collector ALB endpoint URL

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -591,10 +591,15 @@ class Config:
         if not profile:
             raise ValueError(f"Profile not found: {profile_name}")
 
+        # Expand sentinels (e.g. "all-commercial") into concrete regions — the
+        # value feeds the role's aws:RequestedRegion IAM condition, which would
+        # deny every invoke if handed a sentinel that matches no real region.
+        from claude_code_with_bedrock.models import expand_bedrock_regions
+
         return {
             "OktaDomain": profile.okta_domain,
             "OktaClientId": profile.okta_client_id,
             "IdentityPoolName": profile.identity_pool_name,
-            "AllowedBedrockRegions": ",".join(profile.allowed_bedrock_regions),
+            "AllowedBedrockRegions": ",".join(expand_bedrock_regions(profile.allowed_bedrock_regions)),
             "EnableMonitoring": "true" if profile.monitoring_enabled else "false",
         }

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -179,6 +179,12 @@ class Profile:
     websearch_domain_denylist: list[str] = field(default_factory=list)  # Optional domains to exclude from results
     websearch_headers_helper_path: str = ""  # Absolute path override for the Cowork headersHelper (default: ~/claude-code-with-bedrock/websearch-headers)
 
+    # Admin-only extra files copied into the package on top of generated artifacts.
+    # Consumed ONLY by `package`/`distribute` — deliberately NOT mirrored in the Go
+    # ProfileConfig (config-sync.md) and NOT written to the runtime config.json.
+    # Each entry: {"name": str, "targets": str | list[str], "from": str}
+    extra_files: list[dict[str, Any]] = field(default_factory=list)
+
     # Legacy field support
     @property
     def okta_domain(self) -> str:

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -136,7 +136,11 @@ class Profile:
     # If azure_auth_mode == "certificate", certificate paths are stored in config.json
     #   and used to build a signed JWT assertion.
     azure_auth_mode: str | None = None  # "public", "secret", or "certificate"
-    client_secret: str | None = None  # In-memory only — loaded from OS keyring at runtime
+    # Azure (azure_auth_mode == "secret"): confidential — loaded from OS keyring at runtime,
+    #   never written to config.json.
+    # Google: non-confidential per Google's installed-app OAuth docs — persisted in
+    #   config.json and shipped to end users by `ccwb package`. See config-sync.md.
+    client_secret: str | None = None
     client_certificate_path: str | None = None  # Path to PEM certificate file
     client_certificate_key_path: str | None = None  # Path to PEM private key file
 

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -282,6 +282,22 @@ class Profile:
                 except Exception:
                     pass  # Leave provider_type unset if parsing fails
 
+        # Heal profiles corrupted by questionary's value=None fallback: Choice
+        # values of None fall back to the choice TITLE, so the wizard's
+        # "Disabled" option saved enable_distribution=True with
+        # distribution_type="Disabled" — making sidecar deploys schedule the
+        # networking + distribution stacks. The same fallback could store
+        # choice titles as the CodeBuild region or Route53 hosted zone ID
+        # (titles contain spaces; valid values never do). Must run BEFORE the
+        # legacy migration below, which would otherwise legitimize the value.
+        if data.get("distribution_type") not in (None, "presigned-s3", "landing-page"):
+            data["distribution_type"] = None
+            data["enable_distribution"] = False
+        if data.get("codebuild_region") and " " in str(data["codebuild_region"]):
+            data["codebuild_region"] = None
+        if data.get("distribution_hosted_zone_id") and " " in str(data["distribution_hosted_zone_id"]):
+            data["distribution_hosted_zone_id"] = None
+
         # Migrate legacy distribution configuration
         if "enable_distribution" in data and data.get("enable_distribution"):
             # If distribution was enabled but no type specified, default to presigned-s3

--- a/source/claude_code_with_bedrock/extra_files.py
+++ b/source/claude_code_with_bedrock/extra_files.py
@@ -1,0 +1,210 @@
+# ABOUTME: Declarative extra-files list shared by the package and distribute commands
+# ABOUTME: Provides OS-token matching and validation for admin-defined extra files
+
+"""Admin-defined extra files for packaging and distribution.
+
+Admins can list extra files/folders (preinstall scripts, certificates, CA
+bundles, etc.) to ship *on top of* the generated package. The list lives in the
+admin-side deployment profile (never in the runtime ``config.json`` and never
+synced to the Go credential-process) and is consumed by two commands:
+
+- ``package`` copies the full superset of extras into the build folder.
+- ``distribute`` filters extras per-OS across its three archive builders.
+
+Each entry is a plain dict with three keys::
+
+    {"name": "certs", "targets": "all", "from": "~/secure/azure-oidc-certs"}
+
+- ``name``    — path inside the package (relative, no traversal).
+- ``targets`` — which machines get it: a single token or a list of tokens.
+- ``from``    — source path on the admin's machine (a file or a whole folder).
+
+The ``targets`` tokens form a hierarchy ``all`` > family > arch so that a single
+list can be resolved against three different platform vocabularies (see
+``extra_applies_to``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Arch-specific tokens mapped to their OS family.
+_FAMILY_OF: dict[str, str] = {
+    "macos-arm64": "macos",
+    "macos-intel": "macos",
+    "linux-x64": "linux",
+    "linux-arm64": "linux",
+    "windows": "windows",
+}
+
+# All family tokens.
+_FAMILIES: frozenset[str] = frozenset(_FAMILY_OF.values())
+
+# Every token an admin may put in ``targets``.
+VALID_TARGET_TOKENS: frozenset[str] = frozenset({"all"}) | _FAMILIES | frozenset(_FAMILY_OF)
+
+# Landing-page family tokens -> internal family. The landing page groups by
+# family only (no arch split), so ``mac`` maps to the ``macos`` family.
+_LANDING_FAMILY: dict[str, str] = {"mac": "macos", "linux": "linux", "windows": "windows"}
+
+# Generated artifacts and reserved directories that an extra file's ``name``
+# must never collide with — clobbering these would silently break the package.
+RESERVED_NAMES: frozenset[str] = frozenset(
+    {
+        "config.json",
+        "install.sh",
+        "install.bat",
+        "ccwb-install.ps1",
+        "readme.md",
+        "collector-config.yaml",
+        "otel-helper.sh",
+        "otel-helper.ps1",
+        "otel-helper.cmd",
+        "cowork-3p.reg",
+        "cowork-3p.mobileconfig",
+        "cowork-3p-config.json",
+    }
+)
+
+# Reserved top-level directory names (an extra must not shadow these).
+RESERVED_DIRS: frozenset[str] = frozenset({"claude-settings"})
+
+# Prefixes of generated binaries an extra's top-level name must not collide with.
+_RESERVED_PREFIXES: tuple[str, ...] = (
+    "credential-process-",
+    "otel-helper-",
+    "otelcol-",
+)
+
+
+def normalize_targets(targets: Any) -> list[str]:
+    """Return ``targets`` as a lowercased list of tokens.
+
+    Accepts a single string or a list of strings. Non-string members are
+    coerced defensively but validation (``validate_extra_files``) is what
+    rejects unknown tokens.
+    """
+    if isinstance(targets, str):
+        raw = [targets]
+    elif isinstance(targets, (list, tuple)):
+        raw = list(targets)
+    else:
+        return []
+    return [str(t).strip().lower() for t in raw]
+
+
+def extra_applies_to(targets: Any, platform_token: str) -> bool:
+    """True if an entry with ``targets`` should be included for ``platform_token``.
+
+    ``platform_token`` is one of:
+
+    - a per-OS token: ``windows``, ``linux-x64``, ``linux-arm64``,
+      ``macos-arm64``, ``macos-intel`` (used by ``_create_per_os_archives``);
+    - a landing family: ``mac``, ``linux``, ``windows`` (used by
+      ``_upload_landing_page_packages``).
+
+    The all-OS archive (``_create_archive``) does not call this — it includes
+    every extra unconditionally.
+
+    Matching rules (hierarchy ``all`` > family > arch):
+
+    - ``all`` matches everything.
+    - An exact token match always applies.
+    - A family target (``macos``) matches any arch in that family and the
+      family/landing token.
+    - An arch target (``macos-arm64``) matches its own per-OS token and its
+      landing family (``mac``) — the landing family has no arch split, so any
+      arch-specific extra for that family must appear in it.
+    """
+    plat = platform_token.strip().lower()
+    # Resolve the platform to its family, whether it's a per-OS token,
+    # an arch token, or a landing-family token.
+    plat_family = _LANDING_FAMILY.get(plat) or _FAMILY_OF.get(plat) or (plat if plat in _FAMILIES else None)
+
+    for token in normalize_targets(targets):
+        if token == "all":
+            return True
+        if token == plat:
+            return True
+        # Family target matches any platform in that family.
+        if token in _FAMILIES and token == plat_family:
+            return True
+        # Arch target matches its landing family (family has no arch split).
+        token_family = _FAMILY_OF.get(token)
+        if token_family and plat in _LANDING_FAMILY and _LANDING_FAMILY[plat] == token_family:
+            return True
+    return False
+
+
+def _name_errors(name: Any) -> list[str]:
+    """Validate the ``name`` field for path safety and reserved collisions."""
+    errors: list[str] = []
+    if not isinstance(name, str) or not name.strip():
+        return ["extra_files: 'name' must be a non-empty string"]
+
+    # Reject absolute paths and Windows drive letters (e.g. "C:\\x").
+    if name.startswith(("/", "\\")) or (len(name) >= 2 and name[1] == ":"):
+        errors.append(f"extra_files: 'name' must be a relative path, got '{name}'")
+
+    # Reject traversal in either separator style. Splitting on both catches
+    # "a/../b" and "a\\..\\b" regardless of the host OS.
+    segments = name.replace("\\", "/").split("/")
+    if ".." in segments:
+        errors.append(f"extra_files: 'name' must not contain '..' path segments, got '{name}'")
+
+    # Reserved-name / reserved-dir collision on the FIRST path segment
+    # (case-insensitive). The first segment is what lands at the package root.
+    top = segments[0].lower() if segments else ""
+    if top in RESERVED_NAMES or top in RESERVED_DIRS:
+        errors.append(f"extra_files: 'name' collides with a generated artifact: '{name}'")
+    elif top.startswith(_RESERVED_PREFIXES):
+        errors.append(f"extra_files: 'name' collides with a generated binary: '{name}'")
+
+    return errors
+
+
+def validate_extra_files(entries: Any) -> list[str]:
+    """Validate an ``extra_files`` list; return human-readable error strings.
+
+    An empty list (or non-error input) returns ``[]``. Presence of the ``from``
+    source path is intentionally NOT checked here — that is a build-time concern
+    handled by ``package`` (fail-fast). This validates shape, ``name`` safety,
+    ``targets`` tokens, and that ``from`` is a non-empty string.
+    """
+    if entries in (None, []):
+        return []
+    if not isinstance(entries, list):
+        return ["extra_files: must be a list of entries"]
+
+    errors: list[str] = []
+    for i, entry in enumerate(entries):
+        prefix = f"extra_files[{i}]"
+        if not isinstance(entry, dict):
+            errors.append(f"{prefix}: must be an object with 'name', 'targets', 'from'")
+            continue
+
+        expected = {"name", "targets", "from"}
+        keys = set(entry)
+        missing = expected - keys
+        extra = keys - expected
+        if missing:
+            errors.append(f"{prefix}: missing key(s): {', '.join(sorted(missing))}")
+        if extra:
+            errors.append(f"{prefix}: unexpected key(s): {', '.join(sorted(extra))}")
+
+        for err in _name_errors(entry.get("name")):
+            errors.append(f"{prefix}: {err.split(': ', 1)[-1]}")
+
+        tokens = normalize_targets(entry.get("targets"))
+        if not tokens:
+            errors.append(f"{prefix}: 'targets' must be a token or list of tokens")
+        else:
+            unknown = [t for t in tokens if t not in VALID_TARGET_TOKENS]
+            if unknown:
+                errors.append(f"{prefix}: unknown target(s) {unknown}; valid: {', '.join(sorted(VALID_TARGET_TOKENS))}")
+
+        src = entry.get("from")
+        if not isinstance(src, str) or not src.strip():
+            errors.append(f"{prefix}: 'from' must be a non-empty source path")
+
+    return errors

--- a/source/claude_code_with_bedrock/extra_files.py
+++ b/source/claude_code_with_bedrock/extra_files.py
@@ -8,7 +8,8 @@ bundles, etc.) to ship *on top of* the generated package. The list lives in the
 admin-side deployment profile (never in the runtime ``config.json`` and never
 synced to the Go credential-process) and is consumed by two commands:
 
-- ``package`` copies the full superset of extras into the build folder.
+- ``package`` copies the extras that apply to at least one platform being
+  built (``--target-platform``) into the build folder.
 - ``distribute`` filters extras per-OS across its three archive builders.
 
 Each entry is a plain dict with three keys::
@@ -134,6 +135,25 @@ def extra_applies_to(targets: Any, platform_token: str) -> bool:
         if token_family and plat in _LANDING_FAMILY and _LANDING_FAMILY[plat] == token_family:
             return True
     return False
+
+
+def extra_applies_to_any(targets: Any, platform_tokens: Any) -> bool:
+    """True if an entry with ``targets`` applies to at least one platform in
+    ``platform_tokens``.
+
+    ``platform_tokens`` uses the ``platforms_to_build`` vocabulary from the
+    ``package`` command: per-OS arch tokens (``macos-arm64``, ``windows``, …)
+    plus the generic family tokens ``macos`` / ``linux`` that the non-Go build
+    path can produce. A family token is expanded to its arches so an
+    arch-targeted extra (e.g. ``macos-arm64``) still ships in a generic
+    ``macos`` build.
+    """
+    expanded: set[str] = set()
+    for p in platform_tokens or []:
+        tok = str(p).strip().lower()
+        expanded.add(tok)
+        expanded.update(arch for arch, family in _FAMILY_OF.items() if family == tok)
+    return any(extra_applies_to(targets, tok) for tok in expanded)
 
 
 def _name_errors(name: Any) -> list[str]:

--- a/source/claude_code_with_bedrock/models.py
+++ b/source/claude_code_with_bedrock/models.py
@@ -318,6 +318,20 @@ _CLAUDE_MODELS_RAW = {
             },
         },
     },
+    "opus-4-8-govcloud": {
+        "name": "Claude Opus 4.8 (GovCloud)",
+        "base_model_id": "anthropic.claude-opus-4-8",
+        "profiles": {
+            "us-gov": {
+                "model_id": "us-gov.anthropic.claude-opus-4-8",
+                "description": "US GovCloud regions",
+                # Geo CRIS entry points: in-region in us-gov-west-1, geo-routed
+                # from us-gov-east-1 (model hosted in the West region).
+                "source_regions": ["us-gov-west-1", "us-gov-east-1"],
+                "destination_regions": ["us-gov-west-1", "us-gov-east-1"],
+            },
+        },
+    },
     "opus-4-7": {
         "name": "Claude Opus 4.7",
         "base_model_id": "anthropic.claude-opus-4-7",
@@ -1633,9 +1647,21 @@ def get_throttle_metrics() -> list[dict]:
 # Note: Haiku 3.5 is deprecated and not in CLAUDE_MODELS.
 # The "haiku" tier uses Haiku 4.5 first, then falls back to the latest Sonnet.
 MODEL_TIER_PREFERENCES = {
-    "haiku": ["haiku-4-5", "sonnet-4-6", "sonnet-4-5", "sonnet-4", "sonnet-3-7"],
-    "sonnet": ["sonnet-5", "sonnet-4-6", "sonnet-4-5", "sonnet-4", "sonnet-3-7"],
-    "opus": ["opus-4-8", "opus-4-7", "opus-4-6", "opus-4-5", "opus-4-1", "opus-4"],
+    # GovCloud keys are safe to include everywhere: commercial CRIS prefixes
+    # never match their us-gov-only profiles, and the us-gov prefix never
+    # matches commercial models — each partition resolves only its own entries.
+    # GovCloud has no Haiku, so its haiku tier falls through to Sonnet.
+    "haiku": ["haiku-4-5", "sonnet-4-6", "sonnet-4-5", "sonnet-4-5-govcloud", "sonnet-4", "sonnet-3-7"],
+    "sonnet": [
+        "sonnet-5",
+        "sonnet-4-6",
+        "sonnet-4-5",
+        "sonnet-4-5-govcloud",
+        "sonnet-4",
+        "sonnet-3-7",
+        "sonnet-3-7-govcloud",
+    ],
+    "opus": ["opus-4-8", "opus-4-8-govcloud", "opus-4-7", "opus-4-6", "opus-4-5", "opus-4-1", "opus-4"],
     "fable": ["fable-5"],
 }
 
@@ -1650,8 +1676,10 @@ PROFILE_KEY_ALIASES = {
 }
 
 # Data-residency prefixes: must NOT fall back to global/us.
-# These geographies have strict data residency requirements.
-DATA_RESIDENCY_PREFIXES = {"au", "jp", "eu"}
+# These geographies have strict data residency requirements. us-gov is also
+# a separate PARTITION — commercial CRIS profiles aren't invokable from
+# GovCloud at all, so falling back would produce a model ID that can't work.
+DATA_RESIDENCY_PREFIXES = {"au", "jp", "eu", "us-gov"}
 
 # Auto-derived from MODEL_TIER_PREFERENCES: model_key → tier
 MODEL_KEY_TO_TIER: dict[str, str] = {
@@ -1720,15 +1748,18 @@ def resolve_model_for_tier(tier: str, cris_prefix: str) -> str | None:
         all_model_keys = [
             "sonnet-5",
             "opus-4-8",
+            "opus-4-8-govcloud",
             "opus-4-7",
             "sonnet-4-6",
             "sonnet-4-5",
+            "sonnet-4-5-govcloud",
             "sonnet-4",
             "opus-4-6",
             "opus-4-5",
             "haiku-4-5",
             "fable-5",
             "sonnet-3-7",
+            "sonnet-3-7-govcloud",
             "opus-4-1",
             "opus-4",
         ]

--- a/source/claude_code_with_bedrock/models.py
+++ b/source/claude_code_with_bedrock/models.py
@@ -1590,6 +1590,43 @@ def get_all_bedrock_regions() -> list[str]:
     return sorted(regions)
 
 
+def expand_bedrock_regions(regions: list[str]) -> list[str]:
+    """Expand model destination-region sentinels into concrete AWS regions.
+
+    Global inference profiles carry the sentinel ``"all-commercial"`` in their
+    ``destination_regions`` (see CLAUDE_MODELS). That sentinel is fine as model
+    metadata, but it is NOT a real region — it must never reach an IAM policy's
+    ``aws:RequestedRegion`` condition, where it would match nothing and silently
+    deny every Bedrock invoke (a global model routes to real regions like
+    us-east-1, so the condition value must be those regions, not the sentinel).
+
+    This normalizes a region list for use as the ``AllowedBedrockRegions``
+    CloudFormation parameter:
+    - ``"all-commercial"`` expands to every non-GovCloud Bedrock region.
+    - Any other ``"all-*"`` sentinel is dropped (defensive; only all-commercial
+      exists today) so it can never leak into a policy condition.
+    - Concrete regions pass through unchanged.
+
+    Order is preserved for concrete regions; expanded regions are appended
+    sorted and de-duplicated. Returns a list with no sentinel values.
+    """
+    expanded: list[str] = []
+    seen: set[str] = set()
+    for r in regions:
+        if r == "all-commercial":
+            for cr in get_all_bedrock_regions():  # already excludes all-* sentinels
+                if "gov" not in cr and cr not in seen:
+                    expanded.append(cr)
+                    seen.add(cr)
+        elif r.startswith("all-"):
+            # Unknown sentinel — never emit it into an IAM condition.
+            continue
+        elif r not in seen:
+            expanded.append(r)
+            seen.add(r)
+    return expanded
+
+
 # Default rate limits by model family (TPM = tokens per minute, RPM = requests per minute).
 # These are approximate on-demand defaults; actual limits depend on account quotas.
 MODEL_RATE_LIMITS = {

--- a/source/credential_provider/__main__.py
+++ b/source/credential_provider/__main__.py
@@ -1679,14 +1679,12 @@ class MultiProviderAuth:
                 except Exception:
                     pass  # nosec B110
 
-            # Get AWS credentials (we need them but won't output them)
-            self._debug_print("Exchanging token for AWS credentials...")
-            credentials = self.get_aws_credentials(id_token, token_claims)
-
-            # Cache credentials for future use
-            self.save_credentials(credentials)
-
-            # Save monitoring token
+            # Persist the monitoring token only. Deliberately NO AWS credential
+            # exchange here: this entrypoint serves OTEL attribution, and
+            # minting credentials on it would bypass quota enforcement (#761) —
+            # every credential-minting path must enforce quota first. A blocked
+            # user still gets a monitoring token so their telemetry stays
+            # attributed.
             self.save_monitoring_token(id_token, token_claims)
 
             # Return just the monitoring token
@@ -2268,29 +2266,43 @@ class MultiProviderAuth:
     # End Quota Check Methods
     # ===========================================
 
-    def _try_silent_refresh(self):
-        """Attempt to refresh AWS credentials using a cached, still-valid OIDC id_token.
+    def _get_cached_token_for_silent_refresh(self):
+        """Return (id_token, token_claims) from the cached monitoring token, or (None, None).
 
-        Returns:
-            Tuple of (credentials, id_token, token_claims) if successful, (None, None, None) otherwise.
+        Read-only: no STS exchange happens here so the caller can enforce
+        quota with the token BEFORE any credentials are minted.
         """
         try:
             id_token = self.get_monitoring_token()
             if not id_token:
                 self._debug_print("No valid cached id_token for silent refresh")
-                return None, None, None
-
-            self._debug_print("Found valid cached id_token, attempting silent credential refresh...")
+                return None, None
             token_claims = jwt.decode(id_token, options={"verify_signature": False})
+            return id_token, token_claims
+        except Exception as e:
+            self._debug_print(f"Could not load cached id_token for silent refresh: {e}")
+            return None, None
 
+    def _try_silent_refresh(self, id_token, token_claims):
+        """Exchange a quota-cleared cached id_token for AWS credentials and persist them.
+
+        Callers MUST run the quota check first — this method mints and caches
+        credentials, so calling it before quota clearance would hand an
+        over-quota user a full STS session.
+
+        Returns:
+            Credentials dict if successful, None otherwise (caller falls back to browser auth).
+        """
+        try:
+            self._debug_print("Found valid cached id_token, attempting silent credential refresh...")
             credentials = self.get_aws_credentials(id_token, token_claims)
             self.save_credentials(credentials)
             self.save_monitoring_token(id_token, token_claims)
             self._debug_print("Silent credential refresh succeeded")
-            return credentials, id_token, token_claims
+            return credentials
         except Exception as e:
             self._debug_print(f"Silent refresh failed, will require browser auth: {e}")
-            return None, None, None
+            return None
 
     def _run_passthrough(self):
         """Emit credentials from the ambient AWS credential chain (Identity Center, env vars, instance profile).
@@ -2417,21 +2429,23 @@ class MultiProviderAuth:
                     print(json.dumps(cached))  # noqa: S105
                     return 0
 
-                # Try silent refresh using cached id_token before opening browser
-                silent_creds, id_token, token_claims = self._try_silent_refresh()
-                if silent_creds:
-                    # Check quota if configured (reuse token/claims already fetched above)
+                # Try silent refresh using cached id_token before opening browser.
+                # Quota is enforced BEFORE the STS exchange, using the id_token
+                # already in hand, so an over-quota user never mints or caches
+                # fresh credentials on this path (#761).
+                id_token, token_claims = self._get_cached_token_for_silent_refresh()
+                if id_token:
                     if self._should_check_quota():
-                        if id_token and token_claims:
-                            quota_result = self._check_quota(token_claims, id_token)
-                            self._save_quota_check_timestamp()
-                            if not quota_result.get("allowed", True):
-                                return self._handle_quota_blocked(quota_result)
-                            else:
-                                self._handle_quota_warning(quota_result)
+                        quota_result = self._check_quota(token_claims, id_token)
+                        self._save_quota_check_timestamp()
+                        if not quota_result.get("allowed", True):
+                            return self._handle_quota_blocked(quota_result)
+                        self._handle_quota_warning(quota_result)
 
-                    print(json.dumps(silent_creds))
-                    return 0
+                    silent_creds = self._try_silent_refresh(id_token, token_claims)
+                    if silent_creds:
+                        print(json.dumps(silent_creds))
+                        return 0
 
                 # Authenticate with OIDC provider (browser popup - only when id_token is also expired).
                 # Hand the still-bound lock socket to the OAuth callback server so

--- a/source/go/cmd/credential-process/desktop_helper.go
+++ b/source/go/cmd/credential-process/desktop_helper.go
@@ -37,8 +37,15 @@ func (a *credentialApp) runDesktopHelper() int {
 	if creds == nil {
 		// No cached creds — try silent refresh
 		if a.cfg.IsSsoEnabled() && !a.cfg.IsIDC() {
-			// OIDC: try refresh token
-			creds = a.tryRefreshToken()
+			// OIDC: try refresh token. Quota is enforced on the fresh id_token
+			// BEFORE the STS exchange (#761) — previously this path minted
+			// credentials with no quota check at all.
+			if auth := a.tryRefreshToken(); auth != nil {
+				if !a.enforceQuota(auth.IDToken) {
+					return 1
+				}
+				creds = a.exchangeAndSaveCredentials(auth)
+			}
 		}
 
 		if creds == nil && allowInteractive {
@@ -69,9 +76,15 @@ func (a *credentialApp) runDesktopHelper() int {
 	// Check if credentials are expired
 	remaining := storage.ParseExpirationSeconds(creds.Expiration)
 	if remaining <= 30 {
-		// Expired — try refresh
+		// Expired — try refresh (same quota-before-STS ordering as above)
 		if a.cfg.IsSsoEnabled() && !a.cfg.IsIDC() {
-			creds = a.tryRefreshToken()
+			creds = nil
+			if auth := a.tryRefreshToken(); auth != nil {
+				if !a.enforceQuota(auth.IDToken) {
+					return 1
+				}
+				creds = a.exchangeAndSaveCredentials(auth)
+			}
 		}
 		if creds == nil || storage.ParseExpirationSeconds(creds.Expiration) <= 30 {
 			if allowInteractive {

--- a/source/go/cmd/credential-process/main.go
+++ b/source/go/cmd/credential-process/main.go
@@ -274,12 +274,13 @@ func (a *credentialApp) clearCache() {
 	if a.cfg.CredentialStorage == "keyring" {
 		_ = storage.ClearKeyring(a.profile)
 	}
-	// Also clear session file
-	expired := &federation.AWSCredentials{
-		Version: 1, AccessKeyID: "EXPIRED", SecretAccessKey: "EXPIRED",
-		SessionToken: "EXPIRED", Expiration: "2000-01-01T00:00:00Z",
-	}
-	_ = storage.SaveToCredentialsFile(expired, a.profile)
+	// Remove the profile section from ~/.aws/credentials rather than writing an
+	// EXPIRED placeholder. That file outranks credential_process in the AWS SDK
+	// resolution chain, so a placeholder entry would permanently wedge SDK
+	// consumers (Claude Code): they'd keep reading the static EXPIRED keys and
+	// never invoke this binary again. With the section removed, the SDK falls
+	// through to credential_process and recovery is automatic.
+	_ = storage.RemoveFromCredentialsFile(a.profile)
 	// Clear refresh token
 	storage.ClearRefreshToken(a.profile)
 	fmt.Fprintf(os.Stderr, "Cleared cached credentials for profile '%s'\n", a.profile)

--- a/source/go/cmd/credential-process/main.go
+++ b/source/go/cmd/credential-process/main.go
@@ -98,6 +98,25 @@ func main() {
 		runExplain(profile, cfg)
 	}
 
+	// Resolve OIDC provider type + redirect port BEFORE the flag dispatch below.
+	// The --get-monitoring-token and --get-mcp-auth-header handlers perform a
+	// silent refresh_token exchange that depends on app.providerType (to build the
+	// token endpoint URL and pick the Azure confidential-auth path) and, on
+	// fall-through to browser auth, on app.redirectPort. Historically both fields
+	// were set only after the dispatch block (in the OIDC run() path), so those
+	// handlers ran with providerType=="" (empty token URL + no client assertion →
+	// failed exchange that wiped the refresh_token) and redirectPort==0 (browser
+	// fallback opened http://localhost:0 → ERR_UNSAFE_PORT).
+	//
+	// Gated to real OIDC profiles only: resolveProviderType calls provider.Detect,
+	// which returns "oidc" (→ os.Exit(1)) for the empty provider_domain typical of
+	// IDC/none profiles. IDC/none never use this OIDC refresh path, so skip them
+	// here and let their own dispatch branches (IsIDC / !IsSsoEnabled) handle them.
+	if cfg.IsSsoEnabled() && !cfg.IsIDC() {
+		app.providerType = resolveProviderType(cfg)
+		app.redirectPort = resolveRedirectPort(cfg)
+	}
+
 	// Flag dispatch — must run before auth-type branching so IDC users
 	// can use --get-monitoring-token, --show-tags, etc.
 	if *clearCache {
@@ -148,18 +167,15 @@ func main() {
 		exitAfterNotifications(app.runPassthrough())
 	}
 
-	// OIDC path — resolve provider type and redirect port
-	providerType := resolveProviderType(cfg)
-	redirectPort := 8400
-	if envPort := os.Getenv("REDIRECT_PORT"); envPort != "" {
-		if p, err := strconv.Atoi(envPort); err == nil && p > 0 {
-			redirectPort = p
-		}
-	} else if cfg.RedirectPort > 0 {
-		redirectPort = cfg.RedirectPort
+	// OIDC path — provider type + redirect port were already resolved above
+	// (before the flag dispatch) for this OIDC profile; resolve defensively if
+	// somehow unset.
+	if app.providerType == "" {
+		app.providerType = resolveProviderType(cfg)
 	}
-	app.providerType = providerType
-	app.redirectPort = redirectPort
+	if app.redirectPort == 0 {
+		app.redirectPort = resolveRedirectPort(cfg)
+	}
 
 	if *refreshIfNeeded {
 		if cfg.CredentialStorage != "session" {
@@ -196,6 +212,21 @@ type credentialApp struct {
 	cfg          *config.ProfileConfig
 	providerType string
 	redirectPort int
+}
+
+// resolveRedirectPort returns the OAuth callback port for the browser flow:
+// REDIRECT_PORT env override → profile RedirectPort → default 8400. Never returns
+// 0 (which would open http://localhost:0 → ERR_UNSAFE_PORT).
+func resolveRedirectPort(cfg *config.ProfileConfig) int {
+	if envPort := os.Getenv("REDIRECT_PORT"); envPort != "" {
+		if p, err := strconv.Atoi(envPort); err == nil && p > 0 {
+			return p
+		}
+	}
+	if cfg.RedirectPort > 0 {
+		return cfg.RedirectPort
+	}
+	return 8400
 }
 
 func resolveProviderType(cfg *config.ProfileConfig) string {
@@ -752,8 +783,17 @@ func (a *credentialApp) tryRefreshToken() *federation.AWSCredentials {
 	tokenResp, err := oidc.RefreshTokenExchange(tokenURL, refreshToken, a.cfg.ClientID, confidential)
 	if err != nil {
 		debugPrint("Refresh token exchange failed: %v", err)
-		// Token may be revoked/expired — clear it so we don't retry next time
-		storage.ClearRefreshToken(a.profile)
+		// Only discard the refresh_token when the IdP definitively rejected it
+		// (invalid_grant / invalid_token). Transient failures — network/5xx/
+		// timeout, or a misconfiguration such as an unresolved provider type —
+		// must retain the token so a later cycle can retry; clearing on those was
+		// what permanently disabled silent renewal until the next browser login.
+		if oidc.IsDefinitiveRefreshFailure(err) {
+			debugPrint("Refresh_token rejected by IdP (invalid_grant); clearing stored token")
+			storage.ClearRefreshToken(a.profile)
+		} else {
+			debugPrint("Transient refresh failure; retaining refresh_token for next attempt")
+		}
 		return nil
 	}
 
@@ -835,8 +875,15 @@ func (a *credentialApp) refreshIDTokenOnly() string {
 	tokenResp, err := oidc.RefreshTokenExchange(tokenURL, refreshToken, a.cfg.ClientID, confidential)
 	if err != nil {
 		debugPrint("Refresh token exchange failed: %v", err)
-		// Token may be revoked/expired — clear it so we don't retry next time.
-		storage.ClearRefreshToken(a.profile)
+		// Clear only on a definitive rejection (invalid_grant / invalid_token);
+		// retain on transient failures so a later cycle can retry. See the twin
+		// guard in tryRefreshToken.
+		if oidc.IsDefinitiveRefreshFailure(err) {
+			debugPrint("Refresh_token rejected by IdP (invalid_grant); clearing stored token")
+			storage.ClearRefreshToken(a.profile)
+		} else {
+			debugPrint("Transient refresh failure; retaining refresh_token for next attempt")
+		}
 		return ""
 	}
 	if tokenResp.IDToken == "" {

--- a/source/go/cmd/credential-process/main.go
+++ b/source/go/cmd/credential-process/main.go
@@ -50,6 +50,7 @@ func main() {
 	checkExpiration := flag.Bool("check-expiration", false, "Check if credentials are expired")
 	refreshIfNeeded := flag.Bool("refresh-if-needed", false, "Refresh credentials if expired")
 	showTags := flag.Bool("show-tags", false, "Print the https://aws.amazon.com/tags claim from the cached ID token (debug)")
+	showClaims := flag.Bool("show-claims", false, "Print ALL claims from the ID token as JSON (diagnostic: shows exactly what the IdP is sending — groups, department, custom claims). Uses the cached token; signs in only when none is cached.")
 	getTag := flag.String("get-tag", "", "Print the value of a single principal tag from the cached ID token (e.g. --get-tag Zone). Exit codes: 0 hit, 2 absent, 4 expired.")
 	login := flag.Bool("login", false, "Interactively sign in (IDC: run device authorization and cache the SSO token), then exit. Use this once on headless/SSH hosts before Claude Code runs.")
 	setClientSecret := flag.Bool("set-client-secret", false, "Store Azure AD client secret in OS secure storage. Set CCWB_CLIENT_SECRET env var for non-interactive use, or enter it at the prompt.")
@@ -125,6 +126,9 @@ func main() {
 	}
 	if *showTags {
 		os.Exit(app.showTags())
+	}
+	if *showClaims {
+		os.Exit(app.showClaims())
 	}
 	if *getTag != "" {
 		os.Exit(app.getTag(*getTag))
@@ -455,6 +459,50 @@ func (a *credentialApp) showTags() int {
 	pretty, err := json.MarshalIndent(summary, "", "  ")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Could not format tags claim: %v\n", err)
+		return 1
+	}
+	fmt.Println(string(pretty))
+	return 0
+}
+
+// showClaims prints ALL claims from the ID token as JSON. It is the
+// full-token sibling of showTags: it answers "what is my IdP actually
+// sending?" when wiring group-based quota policies or attribution
+// (groups, department, custom claims) without hand-decoding JWTs. Same
+// token acquisition as showTags: cached monitoring token first, fresh
+// OIDC flow only when nothing is cached.
+//
+// The Python provider's equivalent is the COGNITO_AUTH_DEBUG=1 claim dump
+// during auth (credential-helper-parity: both variants expose the claims).
+// Note: prints the token's real claims (email, sub, groups) — it is a local
+// diagnostic of the caller's own identity, same exposure as --show-tags.
+func (a *credentialApp) showClaims() int {
+	token, _ := storage.GetMonitoringToken(a.profile, a.cfg.CredentialStorage)
+	var claims jwt.Claims
+	if token != "" {
+		if c, err := jwt.DecodePayload(token); err == nil {
+			claims = c
+		}
+	}
+	if claims == nil {
+		debugPrint("No cached monitoring token; running OIDC flow to read claims")
+		authResult, err := a.authenticate()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			return 1
+		}
+		claims = authResult.TokenClaims
+		a.saveMonitoringTokenAndHeaders(authResult.IDToken, map[string]interface{}(claims))
+	}
+	if len(claims) == 0 {
+		fmt.Fprintln(os.Stderr, "No ID token claims available for this profile.")
+		fmt.Fprintln(os.Stderr, "(IDC auth has no JWT — identity comes from the IAM ARN, not IdP claims.)")
+		return 1
+	}
+
+	pretty, err := json.MarshalIndent(map[string]interface{}(claims), "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not format claims: %v\n", err)
 		return 1
 	}
 	fmt.Println(string(pretty))

--- a/source/go/cmd/credential-process/main.go
+++ b/source/go/cmd/credential-process/main.go
@@ -299,16 +299,13 @@ func (a *credentialApp) getMonitoringToken() int {
 	// token has aged past the 10-min buffer in storage.GetMonitoringToken
 	// while their refresh_token is still valid (typically 7-30 days).
 	//
-	// Note: trySilentRefresh() is intentionally not attempted here — its
-	// first step is storage.GetMonitoringToken(), which we just observed
-	// returns empty. Only refresh_token (separately stored) is meaningful.
-	if creds := a.tryRefreshToken(); creds != nil {
-		_ = creds // tryRefreshToken already saved AWS creds and the fresh monitoring token
-		if t, terr := storage.GetMonitoringToken(a.profile, a.cfg.CredentialStorage); terr == nil && t != "" {
-			fmt.Println(t)
-			return 0
-		}
-		debugPrint("refresh_token exchange succeeded but monitoring token unreadable; falling through to browser auth")
+	// Note: the cached-token path is intentionally not attempted here — we
+	// just observed storage.GetMonitoringToken() returns empty. Only
+	// refresh_token (separately stored) is meaningful. tryRefreshToken mints
+	// no AWS credentials, so this path cannot bypass quota enforcement.
+	if auth := a.tryRefreshToken(); auth != nil {
+		fmt.Println(auth.IDToken)
+		return 0
 	}
 
 	// No refresh_token available, refresh failed, or refresh produced no
@@ -330,15 +327,11 @@ func (a *credentialApp) getMonitoringToken() int {
 		return 1
 	}
 
-	// Get AWS creds (needed to complete the flow)
-	awsCreds, err := a.getAWSCredentials(authResult)
-	if err != nil {
-		debugPrint("Failed to get AWS credentials: %v", err)
-		return 1
-	}
-	_ = a.saveCredentials(awsCreds)
-
-	// Save monitoring token
+	// Persist the monitoring token only. Deliberately NO AWS credential
+	// exchange here: this entrypoint serves OTEL attribution, and minting
+	// credentials on it would bypass quota enforcement (#761) — every
+	// credential-minting path must enforce quota first. A blocked user
+	// still gets a monitoring token so their telemetry stays attributed.
 	a.saveMonitoringTokenAndHeaders(authResult.IDToken, map[string]interface{}(authResult.TokenClaims))
 
 	fmt.Println(authResult.IDToken)
@@ -361,13 +354,12 @@ func (a *credentialApp) getMCPAuthHeader() int {
 		// headersHelper can never drive an interactive login. Only attempt for
 		// OIDC; idc/none have no id_token.
 		//
-		// Use refreshIDTokenOnly (NOT tryRefreshToken): the gateway's CUSTOM_JWT
-		// authorizer only needs the id_token, so a successful refresh must NOT be
-		// thrown away just because the unrelated AWS STS/IAM credential exchange
-		// fails or times out. tryRefreshToken couples the two and would discard a
-		// perfectly valid refreshed id_token on a Cognito/STS hiccup.
-		if fresh := a.refreshIDTokenOnly(); fresh != "" {
-			token, err = fresh, nil
+		// tryRefreshToken performs only the token exchange (no AWS credential
+		// exchange), so a successful refresh is never thrown away because the
+		// unrelated AWS STS/IAM credential exchange fails or times out — the
+		// gateway's CUSTOM_JWT authorizer only needs the id_token.
+		if auth := a.tryRefreshToken(); auth != nil {
+			token, err = auth.IDToken, nil
 		}
 	}
 	if err != nil || token == "" {
@@ -540,42 +532,37 @@ func (a *credentialApp) run() int {
 		return 0
 	}
 
-	// Try silent refresh using cached id_token before opening browser
-	if creds := a.trySilentRefresh(); creds != nil {
-		if a.cfg.QuotaAPIEndpoint != "" {
-			token, _ := storage.GetMonitoringToken(a.profile, a.cfg.CredentialStorage)
-			if token != "" {
-				qr := quota.Check(a.cfg.QuotaAPIEndpoint, token, a.cfg.QuotaCheckTimeout, a.cfg.QuotaFailMode)
-				if !qr.Allowed {
-					printQuotaBlocked(qr)
-					return 1
-				}
-				printQuotaWarning(qr)
-				_ = storage.SaveQuotaState(a.profile)
-			}
+	// Try silent refresh using cached id_token before opening browser.
+	// Quota is enforced BEFORE the STS exchange, using the id_token already in
+	// hand, so an over-quota user never mints or caches fresh credentials and
+	// the check can never be skipped because a separate storage read came back
+	// empty (#761).
+	if auth := a.cachedTokenAuthResult(); auth != nil {
+		if !a.enforceQuota(auth.IDToken) {
+			return 1
 		}
-		outputJSON(creds)
-		return 0
+		if creds := a.exchangeAndSaveCredentials(auth); creds != nil {
+			debugPrint("Silent credential refresh succeeded")
+			outputJSON(creds)
+			return 0
+		}
+		debugPrint("Silent refresh failed, trying refresh_token exchange...")
 	}
 
 	// Try refresh_token exchange before falling back to browser auth.
 	// This enables Cowork 3P (Claude Desktop) to refresh silently even after
 	// the id_token expires, since Claude Desktop cannot open a browser popup.
-	if creds := a.tryRefreshToken(); creds != nil {
-		if a.cfg.QuotaAPIEndpoint != "" {
-			token, _ := storage.GetMonitoringToken(a.profile, a.cfg.CredentialStorage)
-			if token != "" {
-				qr := quota.Check(a.cfg.QuotaAPIEndpoint, token, a.cfg.QuotaCheckTimeout, a.cfg.QuotaFailMode)
-				if !qr.Allowed {
-					printQuotaBlocked(qr)
-					return 1
-				}
-				printQuotaWarning(qr)
-				_ = storage.SaveQuotaState(a.profile)
-			}
+	// Same ordering contract as above: quota first, credentials second.
+	if auth := a.tryRefreshToken(); auth != nil {
+		if !a.enforceQuota(auth.IDToken) {
+			return 1
 		}
-		outputJSON(creds)
-		return 0
+		if creds := a.exchangeAndSaveCredentials(auth); creds != nil {
+			debugPrint("Refresh token exchange succeeded — credentials renewed without browser")
+			outputJSON(creds)
+			return 0
+		}
+		debugPrint("AWS credential exchange after refresh failed, falling back to browser auth")
 	}
 
 	// Authenticate with OIDC provider (browser popup)
@@ -587,14 +574,8 @@ func (a *credentialApp) run() int {
 	}
 
 	// Quota check before issuing credentials
-	if a.cfg.QuotaAPIEndpoint != "" {
-		qr := quota.Check(a.cfg.QuotaAPIEndpoint, authResult.IDToken, a.cfg.QuotaCheckTimeout, a.cfg.QuotaFailMode)
-		if !qr.Allowed {
-			printQuotaBlocked(qr)
-			return 1
-		}
-		printQuotaWarning(qr)
-		_ = storage.SaveQuotaState(a.profile)
+	if !a.enforceQuota(authResult.IDToken) {
+		return 1
 	}
 
 	// Get AWS credentials
@@ -715,13 +696,45 @@ func (a *credentialApp) getAWSCredentials(auth *oidc.AuthResult) (*federation.AW
 	)
 }
 
-func (a *credentialApp) trySilentRefresh() *federation.AWSCredentials {
+// enforceQuota performs the pre-issuance quota check with the given id_token.
+// Returns false when credentials must NOT be issued. When a quota endpoint is
+// configured but no usable token is available, the outcome is decided by
+// quota_fail_mode — never silently skipped (#761).
+func (a *credentialApp) enforceQuota(idToken string) bool {
+	if a.cfg.QuotaAPIEndpoint == "" {
+		return true
+	}
+	if idToken == "" {
+		// The OIDC quota API expects a JWT. Never fall through to the SigV4
+		// path here — inside credential-process the default credential chain
+		// would recurse into ourselves.
+		if a.cfg.QuotaFailMode == "closed" {
+			fmt.Fprintln(os.Stderr, "Error: quota enforcement is configured but no identity token is available for the check (quota fail mode: closed).")
+			return false
+		}
+		debugPrint("Quota check has no identity token; allowing per fail mode 'open'")
+		return true
+	}
+	qr := quota.Check(a.cfg.QuotaAPIEndpoint, idToken, a.cfg.QuotaCheckTimeout, a.cfg.QuotaFailMode)
+	if !qr.Allowed {
+		printQuotaBlocked(qr)
+		return false
+	}
+	printQuotaWarning(qr)
+	_ = storage.SaveQuotaState(a.profile)
+	return true
+}
+
+// cachedTokenAuthResult builds an AuthResult from the cached monitoring
+// id_token, or returns nil when no valid unexpired token is cached. It makes
+// no network calls — the caller decides what to do with the token (quota
+// check first, then STS exchange).
+func (a *credentialApp) cachedTokenAuthResult() *oidc.AuthResult {
 	token, err := storage.GetMonitoringToken(a.profile, a.cfg.CredentialStorage)
 	if err != nil || token == "" {
 		debugPrint("No valid cached id_token for silent refresh")
 		return nil
 	}
-	debugPrint("Found valid cached id_token, attempting silent credential refresh...")
 	claims, err := jwt.DecodePayload(token)
 	if err != nil {
 		debugPrint("Failed to decode cached id_token: %v", err)
@@ -732,18 +745,26 @@ func (a *credentialApp) trySilentRefresh() *federation.AWSCredentials {
 		debugPrint("Cached id_token is expired, silent refresh not possible")
 		return nil
 	}
-	authResult := &oidc.AuthResult{IDToken: token, TokenClaims: claims}
-	creds, err := a.getAWSCredentials(authResult)
+	debugPrint("Found valid cached id_token, attempting silent credential refresh...")
+	return &oidc.AuthResult{IDToken: token, TokenClaims: claims}
+}
+
+// exchangeAndSaveCredentials exchanges a quota-cleared id_token for AWS
+// credentials and persists them plus the monitoring token. Callers MUST run
+// enforceQuota first — this is the only place the silent-refresh paths mint
+// credentials, which keeps the "quota before STS" ordering in one spot.
+// Returns nil on failure so callers can fall through to the next auth path.
+func (a *credentialApp) exchangeAndSaveCredentials(auth *oidc.AuthResult) *federation.AWSCredentials {
+	creds, err := a.getAWSCredentials(auth)
 	if err != nil {
-		debugPrint("Silent refresh failed, will require browser auth: %v", err)
+		debugPrint("AWS credential exchange failed: %v", err)
 		return nil
 	}
 	if saveErr := a.saveCredentials(creds); saveErr != nil {
-		debugPrint("Failed to save silently-refreshed credentials: %v", saveErr)
+		debugPrint("Failed to save credentials: %v", saveErr)
 	}
 	// Re-save monitoring token to refresh its expiry tracking
-	a.saveMonitoringTokenAndHeaders(token, map[string]interface{}(claims))
-	debugPrint("Silent credential refresh succeeded")
+	a.saveMonitoringTokenAndHeaders(auth.IDToken, map[string]interface{}(auth.TokenClaims))
 	return creds
 }
 
@@ -752,7 +773,12 @@ func (a *credentialApp) trySilentRefresh() *federation.AWSCredentials {
 // Cowork 3P (Claude Desktop): after the id_token expires, credential-process
 // can still silently refresh credentials as long as the refresh_token is valid
 // (typically 7-30 days depending on IdP configuration).
-func (a *credentialApp) tryRefreshToken() *federation.AWSCredentials {
+//
+// It persists the refreshed monitoring token and rotated refresh_token, but
+// deliberately does NOT exchange for AWS credentials: quota must be enforced
+// on the fresh id_token before any STS call (#761), and callers like
+// --get-mcp-auth-header and --get-monitoring-token only need the id_token.
+func (a *credentialApp) tryRefreshToken() *oidc.AuthResult {
 	refreshToken := storage.LoadRefreshToken(a.profile, a.cfg.CredentialStorage)
 	if refreshToken == "" {
 		debugPrint("No cached refresh_token, cannot refresh silently")
@@ -809,23 +835,6 @@ func (a *credentialApp) tryRefreshToken() *federation.AWSCredentials {
 		return nil
 	}
 
-	// Exchange for AWS credentials
-	authResult := &oidc.AuthResult{
-		IDToken:      tokenResp.IDToken,
-		RefreshToken: tokenResp.RefreshToken,
-		TokenClaims:  claims,
-	}
-	creds, err := a.getAWSCredentials(authResult)
-	if err != nil {
-		debugPrint("AWS credential exchange after refresh failed: %v", err)
-		return nil
-	}
-
-	// Save refreshed credentials
-	if saveErr := a.saveCredentials(creds); saveErr != nil {
-		debugPrint("Failed to save refresh-derived credentials: %v", saveErr)
-	}
-
 	// Update monitoring token with fresh id_token
 	a.saveMonitoringTokenAndHeaders(tokenResp.IDToken, map[string]interface{}(claims))
 
@@ -834,79 +843,12 @@ func (a *credentialApp) tryRefreshToken() *federation.AWSCredentials {
 		_ = storage.SaveRefreshToken(a.profile, a.cfg.CredentialStorage, tokenResp.RefreshToken)
 	}
 
-	debugPrint("Refresh token exchange succeeded — credentials renewed without browser")
-	return creds
-}
-
-// refreshIDTokenOnly performs the browserless refresh_token exchange and returns
-// a fresh id_token WITHOUT exchanging it for AWS credentials. It exists for the
-// MCP headersHelper path (--get-mcp-auth-header): the AgentCore CUSTOM_JWT gateway
-// authorizer validates only the id_token, so the header must still be emitted even
-// when the AWS STS/IAM credential exchange would fail or time out — a failure mode
-// unrelated to gateway auth. (tryRefreshToken couples the two and returns nil if
-// cred exchange fails, which would discard a valid refreshed id_token.)
-//
-// It mirrors tryRefreshToken's endpoint/confidential-auth resolution and persists
-// the refreshed monitoring token + rotated refresh_token so the next cache read
-// hits, but never opens a browser. Returns "" on any failure so the caller fails
-// cleanly. Only meaningful for OIDC (idc/none have no id_token).
-func (a *credentialApp) refreshIDTokenOnly() string {
-	refreshToken := storage.LoadRefreshToken(a.profile, a.cfg.CredentialStorage)
-	if refreshToken == "" {
-		debugPrint("No cached refresh_token, cannot refresh id_token silently")
-		return ""
+	debugPrint("id_token refreshed without browser")
+	return &oidc.AuthResult{
+		IDToken:      tokenResp.IDToken,
+		RefreshToken: tokenResp.RefreshToken,
+		TokenClaims:  claims,
 	}
-
-	// Resolve token endpoint URL — use shared builder from #666 to avoid
-	// Azure /v2.0 doubling and keep parity with tryRefreshToken.
-	var tokenURL string
-	if a.providerType == "generic" {
-		tokenURL = a.cfg.OIDCTokenEndpoint
-	} else {
-		tokenURL = provider.TokenEndpointURL(a.providerType, a.cfg.OktaAuthServerID, a.cfg.ProviderDomain)
-	}
-
-	confidential, err := a.resolveConfidentialAuth()
-	if err != nil {
-		debugPrint("Failed to resolve confidential auth for id_token refresh: %v", err)
-		return ""
-	}
-
-	tokenResp, err := oidc.RefreshTokenExchange(tokenURL, refreshToken, a.cfg.ClientID, confidential)
-	if err != nil {
-		debugPrint("Refresh token exchange failed: %v", err)
-		// Clear only on a definitive rejection (invalid_grant / invalid_token);
-		// retain on transient failures so a later cycle can retry. See the twin
-		// guard in tryRefreshToken.
-		if oidc.IsDefinitiveRefreshFailure(err) {
-			debugPrint("Refresh_token rejected by IdP (invalid_grant); clearing stored token")
-			storage.ClearRefreshToken(a.profile)
-		} else {
-			debugPrint("Transient refresh failure; retaining refresh_token for next attempt")
-		}
-		return ""
-	}
-	if tokenResp.IDToken == "" {
-		debugPrint("Refresh response did not contain an id_token")
-		return ""
-	}
-
-	claims, err := jwt.DecodePayload(tokenResp.IDToken)
-	if err != nil {
-		debugPrint("Failed to decode refreshed id_token: %v", err)
-		return ""
-	}
-
-	// Persist the refreshed monitoring token so the next cache read hits, and
-	// rotate the refresh_token (some IdPs rotate on every use). Deliberately no
-	// AWS credential exchange here — see the doc comment above.
-	a.saveMonitoringTokenAndHeaders(tokenResp.IDToken, map[string]interface{}(claims))
-	if tokenResp.RefreshToken != "" {
-		_ = storage.SaveRefreshToken(a.profile, a.cfg.CredentialStorage, tokenResp.RefreshToken)
-	}
-
-	debugPrint("id_token refreshed without browser (no AWS credential exchange)")
-	return tokenResp.IDToken
 }
 
 // saveMonitoringTokenAndHeaders persists the monitoring token and also writes
@@ -959,8 +901,8 @@ func (a *credentialApp) performQuotaRecheck() bool {
 		// getMonitoringToken() handler: try a silent refresh_token exchange to
 		// mint a fresh id_token before giving up, so an over-quota user is still
 		// warned/blocked on the cache-hit fast path instead of silently passing.
-		if creds := a.tryRefreshToken(); creds != nil {
-			token, _ = storage.GetMonitoringToken(a.profile, a.cfg.CredentialStorage)
+		if auth := a.tryRefreshToken(); auth != nil {
+			token = auth.IDToken
 		}
 	}
 	if token == "" {

--- a/source/go/cmd/credential-process/monitoring_refresh_test.go
+++ b/source/go/cmd/credential-process/monitoring_refresh_test.go
@@ -59,11 +59,14 @@ func TestGetMonitoringToken_RefreshTokenWiring(t *testing.T) {
 
 // TestGetMonitoringToken_RefreshTokenStoredCallsExchange exercises the path
 // that runs when a refresh_token IS stored. Without mocking the OIDC token
-// endpoint, the exchange itself will fail (test.example.com is unreachable).
-// What we verify is that the exchange is *attempted*: the failure path in
-// tryRefreshToken clears the refresh_token (because the IdP may have revoked
-// it). After calling tryRefreshToken with an unreachable token URL, the
-// stored refresh_token must be cleared.
+// endpoint, the exchange itself will fail (test.invalid.example.com is
+// unreachable). This is a *transient* failure (DNS/network), so tryRefreshToken
+// must RETAIN the refresh_token — clearing on a transient failure is exactly the
+// bug that permanently disabled silent renewal. We assert the token survives and
+// that the exchange was attempted (tryRefreshToken returns nil).
+//
+// The clear-on-failure path is covered separately by the invalid_grant test in
+// refresh_clear_test.go, which serves a real 400 {"error":"invalid_grant"}.
 func TestGetMonitoringToken_RefreshTokenStoredCallsExchange(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
@@ -88,15 +91,16 @@ func TestGetMonitoringToken_RefreshTokenStoredCallsExchange(t *testing.T) {
 	}
 	app := &credentialApp{profile: profile, cfg: cfg, providerType: "okta"}
 
-	// Exchange will fail (network or DNS); tryRefreshToken returns nil and
-	// clears the (presumed-revoked) refresh_token.
+	// Exchange will fail (network or DNS) — a transient failure. tryRefreshToken
+	// returns nil but must NOT clear the refresh_token.
 	if creds := app.tryRefreshToken(); creds != nil {
 		t.Fatalf("tryRefreshToken returned non-nil for unreachable IdP: %+v", creds)
 	}
 
-	// Clearing on failure is the contract — proves the exchange was attempted.
-	if got := storage.LoadRefreshToken(profile, "session"); got != "" {
-		t.Errorf("refresh_token not cleared after failed exchange (got %q); "+
-			"this means tryRefreshToken did NOT attempt the exchange — the wiring is broken", got)
+	// Retaining on a transient failure is the contract — a network blip must not
+	// permanently disable silent renewal.
+	if got := storage.LoadRefreshToken(profile, "session"); got != "rt_test_value" {
+		t.Errorf("refresh_token not retained after transient failure (got %q, want %q); "+
+			"a transient network failure must NOT clear the token", got, "rt_test_value")
 	}
 }

--- a/source/go/cmd/credential-process/quota_enforcement_order_test.go
+++ b/source/go/cmd/credential-process/quota_enforcement_order_test.go
@@ -1,0 +1,466 @@
+package main
+
+// ABOUTME: Regression tests for #761 — quota must be enforced BEFORE the STS
+// ABOUTME: exchange on the silent-refresh and refresh-token paths, and the
+// ABOUTME: check must never be silently skipped when a quota endpoint is set.
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"ccwb-go/internal/config"
+	"ccwb-go/internal/federation"
+	"ccwb-go/internal/storage"
+)
+
+// stsRecorder is an httptest server that counts AssumeRoleWithWebIdentity
+// calls and returns a syntactically valid credentials response. run() reaches
+// it via AWS_ENDPOINT_URL_STS, which the SDK's config loader honors.
+func stsRecorder(t *testing.T) (*httptest.Server, *int32) {
+	t.Helper()
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "text/xml")
+		fmt.Fprint(w, `<AssumeRoleWithWebIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRoleWithWebIdentityResult>
+    <Credentials>
+      <AccessKeyId>ASIAMOCKSTS12345</AccessKeyId>
+      <SecretAccessKey>mock-secret</SecretAccessKey>
+      <SessionToken>mock-session-token</SessionToken>
+      <Expiration>2099-01-01T00:00:00Z</Expiration>
+    </Credentials>
+    <SubjectFromWebIdentityToken>user-123</SubjectFromWebIdentityToken>
+  </AssumeRoleWithWebIdentityResult>
+  <ResponseMetadata><RequestId>mock-request</RequestId></ResponseMetadata>
+</AssumeRoleWithWebIdentityResponse>`)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &hits
+}
+
+// quotaRecorder returns a quota API stub that counts /check calls and answers
+// with the given allowed value.
+func quotaRecorder(t *testing.T, allowed bool) (*httptest.Server, *int32) {
+	t.Helper()
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		if allowed {
+			fmt.Fprint(w, `{"allowed": true, "reason": "within_limits", "message": "ok"}`)
+			return
+		}
+		fmt.Fprint(w, `{"allowed": false, "reason": "quota_exceeded", "message": "Usage quota exceeded."}`)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &hits
+}
+
+// freeLocalPort grabs an ephemeral port for run()'s port-lock acquisition so
+// parallel test runs never collide on the default 8400.
+func freeLocalPort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+	return port
+}
+
+// newQuotaOrderEnv isolates HOME/session storage and points the AWS SDK at the
+// mock STS server. Returns the temp home dir.
+func newQuotaOrderEnv(t *testing.T, stsURL string) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir) // Windows
+	t.Setenv("CLAUDE_CODE_MONITORING_TOKEN", "")
+	t.Setenv("AWS_ENDPOINT_URL_STS", stsURL)
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".claude-code-session"), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	return tmpDir
+}
+
+func directSTSConfig(quotaURL string, port int) *config.ProfileConfig {
+	return &config.ProfileConfig{
+		ClientID:           "test-client",
+		ProviderDomain:     "test.example.com",
+		CredentialStorage:  "session",
+		SsoEnabled:         boolPtr(true),
+		FederationType:     "direct",
+		FederatedRoleARN:   "arn:aws:iam::123456789012:role/TestRole",
+		AWSRegion:          "us-east-1",
+		MaxSessionDuration: 3600,
+		QuotaAPIEndpoint:   quotaURL,
+		QuotaFailMode:      "open",
+		QuotaCheckTimeout:  2,
+		RedirectPort:       port,
+	}
+}
+
+// assertNoSavedCredentials fails the test when real (non-dummy) credentials
+// were persisted for the profile.
+func assertNoSavedCredentials(t *testing.T, profile string) {
+	t.Helper()
+	creds, err := storage.ReadFromCredentialsFile(profile)
+	if err != nil || creds == nil || storage.IsExpiredDummy(creds) {
+		return
+	}
+	t.Errorf("credentials were saved for profile %q despite quota block: AccessKeyId=%s",
+		profile, creds.AccessKeyID)
+}
+
+// TestRun_SilentRefreshPath_QuotaBlockedBeforeSTS is the core regression test
+// for #761: with a valid cached id_token and a quota API that answers
+// allowed=false, run() must exit non-zero WITHOUT calling STS and WITHOUT
+// persisting credentials. Before the fix, trySilentRefresh() exchanged and
+// saved AWS credentials first and only then consulted the quota API.
+func TestRun_SilentRefreshPath_QuotaBlockedBeforeSTS(t *testing.T) {
+	setupNotificationTest(t)
+	stsSrv, stsHits := stsRecorder(t)
+	quotaSrv, quotaHits := quotaRecorder(t, false)
+	tmpDir := newQuotaOrderEnv(t, stsSrv.URL)
+
+	profile := "test-quota-order-silent-blocked"
+	idToken := fakeJWT(t, map[string]interface{}{
+		"sub": "user-123", "email": "test@example.com",
+		"exp": float64(time.Now().Unix() + 3600),
+	})
+	writeMonitoringToken(t, tmpDir, profile, idToken, time.Now().Unix()+3600)
+
+	app := &credentialApp{
+		profile:      profile,
+		cfg:          directSTSConfig(quotaSrv.URL, freeLocalPort(t)),
+		providerType: "okta",
+		redirectPort: 0,
+	}
+	app.redirectPort = app.cfg.RedirectPort
+
+	res := captureMCPStdout(t, app.run)
+	if res.code != 1 {
+		t.Fatalf("run() = %d, want 1 (quota blocked)", res.code)
+	}
+	if res.stdout != "" {
+		t.Errorf("run() printed to stdout despite quota block: %q", res.stdout)
+	}
+	if got := atomic.LoadInt32(quotaHits); got != 1 {
+		t.Errorf("quota API hits = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(stsHits); got != 0 {
+		t.Errorf("STS hits = %d, want 0 — credentials were exchanged before/despite the quota block", got)
+	}
+	assertNoSavedCredentials(t, profile)
+}
+
+// TestRun_RefreshTokenPath_QuotaBlockedBeforeSTS covers the refresh_token
+// (Cowork 3P) path: quota must be checked with the freshly-exchanged id_token
+// BEFORE any STS call, and a block must leave no credentials behind.
+func TestRun_RefreshTokenPath_QuotaBlockedBeforeSTS(t *testing.T) {
+	setupNotificationTest(t)
+	stsSrv, stsHits := stsRecorder(t)
+	quotaSrv, quotaHits := quotaRecorder(t, false)
+	newQuotaOrderEnv(t, stsSrv.URL)
+
+	profile := "test-quota-order-refresh-blocked"
+	t.Cleanup(func() { storage.ClearRefreshToken(profile) })
+
+	freshIDToken := fakeJWT(t, map[string]interface{}{
+		"sub": "user-123", "email": "test@example.com",
+		"exp": float64(time.Now().Unix() + 3600),
+	})
+	idpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"id_token": %q, "refresh_token": "rt_rotated", "token_type": "Bearer"}`, freshIDToken)
+	}))
+	defer idpSrv.Close()
+
+	if err := storage.SaveRefreshToken(profile, "session", "rt_original"); err != nil {
+		t.Fatalf("SaveRefreshToken: %v", err)
+	}
+
+	cfg := directSTSConfig(quotaSrv.URL, freeLocalPort(t))
+	cfg.OIDCTokenEndpoint = idpSrv.URL
+	app := &credentialApp{profile: profile, cfg: cfg, providerType: "generic", redirectPort: cfg.RedirectPort}
+
+	res := captureMCPStdout(t, app.run)
+	if res.code != 1 {
+		t.Fatalf("run() = %d, want 1 (quota blocked)", res.code)
+	}
+	if res.stdout != "" {
+		t.Errorf("run() printed to stdout despite quota block: %q", res.stdout)
+	}
+	if got := atomic.LoadInt32(quotaHits); got != 1 {
+		t.Errorf("quota API hits = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(stsHits); got != 0 {
+		t.Errorf("STS hits = %d, want 0 — credentials were exchanged before/despite the quota block", got)
+	}
+	assertNoSavedCredentials(t, profile)
+}
+
+// TestRun_RefreshTokenPath_ShortLivedTokenStillChecked pins the fix for the
+// silent-skip variant of #761: the pre-fix code re-read the monitoring token
+// from storage and skipped the quota check entirely when that read came back
+// empty. An IdP issuing id_tokens with a lifetime inside the 10-minute
+// storage buffer (exp - now <= 600s) made that skip systematic: credentials
+// were issued with the quota API never called. The fix checks quota with the
+// in-scope token, so the block must now fire.
+func TestRun_RefreshTokenPath_ShortLivedTokenStillChecked(t *testing.T) {
+	setupNotificationTest(t)
+	stsSrv, stsHits := stsRecorder(t)
+	quotaSrv, quotaHits := quotaRecorder(t, false)
+	newQuotaOrderEnv(t, stsSrv.URL)
+
+	profile := "test-quota-order-shortlived"
+	t.Cleanup(func() { storage.ClearRefreshToken(profile) })
+
+	// exp within the 600s buffer → storage.GetMonitoringToken returns ""
+	shortLivedToken := fakeJWT(t, map[string]interface{}{
+		"sub": "user-123", "email": "test@example.com",
+		"exp": float64(time.Now().Unix() + 300),
+	})
+	idpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"id_token": %q, "token_type": "Bearer"}`, shortLivedToken)
+	}))
+	defer idpSrv.Close()
+
+	if err := storage.SaveRefreshToken(profile, "session", "rt_original"); err != nil {
+		t.Fatalf("SaveRefreshToken: %v", err)
+	}
+
+	cfg := directSTSConfig(quotaSrv.URL, freeLocalPort(t))
+	cfg.OIDCTokenEndpoint = idpSrv.URL
+	app := &credentialApp{profile: profile, cfg: cfg, providerType: "generic", redirectPort: cfg.RedirectPort}
+
+	res := captureMCPStdout(t, app.run)
+	if res.code != 1 {
+		t.Fatalf("run() = %d, want 1 (quota blocked) — short-lived id_token must not skip the quota check", res.code)
+	}
+	if got := atomic.LoadInt32(quotaHits); got != 1 {
+		t.Errorf("quota API hits = %d, want 1 — the check was silently skipped", got)
+	}
+	if got := atomic.LoadInt32(stsHits); got != 0 {
+		t.Errorf("STS hits = %d, want 0", got)
+	}
+	assertNoSavedCredentials(t, profile)
+}
+
+// TestRun_SilentRefreshPath_QuotaAllowedIssuesCredentials proves the happy
+// path still works after the reordering: quota allows → STS is called →
+// credentials are printed and cached.
+func TestRun_SilentRefreshPath_QuotaAllowedIssuesCredentials(t *testing.T) {
+	setupNotificationTest(t)
+	stsSrv, stsHits := stsRecorder(t)
+	quotaSrv, quotaHits := quotaRecorder(t, true)
+	tmpDir := newQuotaOrderEnv(t, stsSrv.URL)
+
+	profile := "test-quota-order-allowed"
+	idToken := fakeJWT(t, map[string]interface{}{
+		"sub": "user-123", "email": "test@example.com",
+		"exp": float64(time.Now().Unix() + 3600),
+	})
+	writeMonitoringToken(t, tmpDir, profile, idToken, time.Now().Unix()+3600)
+
+	cfg := directSTSConfig(quotaSrv.URL, freeLocalPort(t))
+	app := &credentialApp{profile: profile, cfg: cfg, providerType: "okta", redirectPort: cfg.RedirectPort}
+
+	res := captureMCPStdout(t, app.run)
+	if res.code != 0 {
+		t.Fatalf("run() = %d, want 0 (quota allowed)", res.code)
+	}
+	if got := atomic.LoadInt32(quotaHits); got != 1 {
+		t.Errorf("quota API hits = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(stsHits); got != 1 {
+		t.Errorf("STS hits = %d, want 1", got)
+	}
+	creds, err := storage.ReadFromCredentialsFile(profile)
+	if err != nil || creds == nil {
+		t.Fatalf("expected saved credentials after allowed refresh, got err=%v", err)
+	}
+	if creds.AccessKeyID != "ASIAMOCKSTS12345" {
+		t.Errorf("saved AccessKeyId = %q, want mock STS value", creds.AccessKeyID)
+	}
+}
+
+// TestEnforceQuota_NoTokenHonorsFailMode pins the "never silently skip"
+// contract: with a quota endpoint configured but no token available, the
+// outcome is decided by quota_fail_mode instead of bypassing the check.
+func TestEnforceQuota_NoTokenHonorsFailMode(t *testing.T) {
+	cfgClosed := &config.ProfileConfig{QuotaAPIEndpoint: "https://quota.invalid.example.com", QuotaFailMode: "closed"}
+	appClosed := &credentialApp{profile: "test-enforce-closed", cfg: cfgClosed}
+	if appClosed.enforceQuota("") {
+		t.Errorf("enforceQuota(\"\") = true with fail mode 'closed', want false (fail closed)")
+	}
+
+	cfgOpen := &config.ProfileConfig{QuotaAPIEndpoint: "https://quota.invalid.example.com", QuotaFailMode: "open"}
+	appOpen := &credentialApp{profile: "test-enforce-open", cfg: cfgOpen}
+	if !appOpen.enforceQuota("") {
+		t.Errorf("enforceQuota(\"\") = false with fail mode 'open', want true")
+	}
+
+	cfgNone := &config.ProfileConfig{}
+	appNone := &credentialApp{profile: "test-enforce-none", cfg: cfgNone}
+	if !appNone.enforceQuota("") {
+		t.Errorf("enforceQuota(\"\") = false with no quota endpoint, want true")
+	}
+}
+
+// TestRunDesktopHelper_QuotaBlockedOnRefresh pins the desktop-helper (#761
+// follow-on): the --desktop silent refresh previously minted a Bedrock bearer
+// token with NO quota check at all. With CLAUDE_HELPER_CONTEXT=silent (no
+// interactive fallback), a quota block must exit 1 without touching STS and
+// without emitting a token.
+func TestRunDesktopHelper_QuotaBlockedOnRefresh(t *testing.T) {
+	setupNotificationTest(t)
+	stsSrv, stsHits := stsRecorder(t)
+	quotaSrv, quotaHits := quotaRecorder(t, false)
+	newQuotaOrderEnv(t, stsSrv.URL)
+	t.Setenv("CLAUDE_HELPER_CONTEXT", "silent")
+
+	profile := "test-desktop-quota-blocked"
+	t.Cleanup(func() { storage.ClearRefreshToken(profile) })
+
+	freshIDToken := fakeJWT(t, map[string]interface{}{
+		"sub": "user-123", "email": "test@example.com",
+		"exp": float64(time.Now().Unix() + 3600),
+	})
+	idpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"id_token": %q, "token_type": "Bearer"}`, freshIDToken)
+	}))
+	defer idpSrv.Close()
+
+	if err := storage.SaveRefreshToken(profile, "session", "rt_original"); err != nil {
+		t.Fatalf("SaveRefreshToken: %v", err)
+	}
+
+	cfg := directSTSConfig(quotaSrv.URL, freeLocalPort(t))
+	cfg.OIDCTokenEndpoint = idpSrv.URL
+	app := &credentialApp{profile: profile, cfg: cfg, providerType: "generic", redirectPort: cfg.RedirectPort}
+
+	res := captureMCPStdout(t, app.runDesktopHelper)
+	if res.code != 1 {
+		t.Fatalf("runDesktopHelper() = %d, want 1 (quota blocked)", res.code)
+	}
+	if res.stdout != "" {
+		t.Errorf("runDesktopHelper() emitted output despite quota block: %q", res.stdout)
+	}
+	if got := atomic.LoadInt32(quotaHits); got != 1 {
+		t.Errorf("quota API hits = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(stsHits); got != 0 {
+		t.Errorf("STS hits = %d, want 0 — desktop helper exchanged credentials despite quota block", got)
+	}
+	assertNoSavedCredentials(t, profile)
+}
+
+// TestRunDesktopHelper_QuotaAllowedEmitsToken proves the desktop happy path
+// still works with quota enforcement in place: allowed → STS exchange → a
+// Bedrock bearer token is emitted.
+func TestRunDesktopHelper_QuotaAllowedEmitsToken(t *testing.T) {
+	setupNotificationTest(t)
+	stsSrv, stsHits := stsRecorder(t)
+	quotaSrv, _ := quotaRecorder(t, true)
+	newQuotaOrderEnv(t, stsSrv.URL)
+	t.Setenv("CLAUDE_HELPER_CONTEXT", "silent")
+
+	profile := "test-desktop-quota-allowed"
+	t.Cleanup(func() { storage.ClearRefreshToken(profile) })
+
+	freshIDToken := fakeJWT(t, map[string]interface{}{
+		"sub": "user-123", "email": "test@example.com",
+		"exp": float64(time.Now().Unix() + 3600),
+	})
+	idpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"id_token": %q, "token_type": "Bearer"}`, freshIDToken)
+	}))
+	defer idpSrv.Close()
+
+	if err := storage.SaveRefreshToken(profile, "session", "rt_original"); err != nil {
+		t.Fatalf("SaveRefreshToken: %v", err)
+	}
+
+	cfg := directSTSConfig(quotaSrv.URL, freeLocalPort(t))
+	cfg.OIDCTokenEndpoint = idpSrv.URL
+	app := &credentialApp{profile: profile, cfg: cfg, providerType: "generic", redirectPort: cfg.RedirectPort}
+
+	res := captureMCPStdout(t, app.runDesktopHelper)
+	if res.code != 0 {
+		t.Fatalf("runDesktopHelper() = %d, want 0 (quota allowed)", res.code)
+	}
+	if got := atomic.LoadInt32(stsHits); got != 1 {
+		t.Errorf("STS hits = %d, want 1", got)
+	}
+	if !strings.Contains(res.stdout, `"token"`) {
+		t.Errorf("runDesktopHelper() stdout missing bearer token JSON: %q", res.stdout)
+	}
+}
+
+// TestPerformQuotaRecheck_ShortLivedTokenStillChecked pins the cache-hit
+// variant of the silent-skip fix: after a successful refresh_token exchange,
+// performQuotaRecheck must use the in-scope fresh id_token. The pre-fix code
+// re-read it from storage, where an id_token expiring inside the 10-minute
+// buffer reads back empty — so the recheck failed open and the blocked user
+// kept their cached credentials.
+func TestPerformQuotaRecheck_ShortLivedTokenStillChecked(t *testing.T) {
+	setupNotificationTest(t)
+	stsSrv, _ := stsRecorder(t)
+	quotaSrv, quotaHits := quotaRecorder(t, false)
+	newQuotaOrderEnv(t, stsSrv.URL)
+
+	profile := "test-recheck-shortlived"
+	t.Cleanup(func() { storage.ClearRefreshToken(profile) })
+
+	// exp within the 600s buffer → storage.GetMonitoringToken returns ""
+	shortLivedToken := fakeJWT(t, map[string]interface{}{
+		"sub": "user-123", "email": "test@example.com",
+		"exp": float64(time.Now().Unix() + 300),
+	})
+	idpSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"id_token": %q, "token_type": "Bearer"}`, shortLivedToken)
+	}))
+	defer idpSrv.Close()
+
+	if err := storage.SaveRefreshToken(profile, "session", "rt_original"); err != nil {
+		t.Fatalf("SaveRefreshToken: %v", err)
+	}
+	// Seed cached credentials that the block must wipe.
+	seeded := &federation.AWSCredentials{
+		Version: 1, AccessKeyID: "ASIASEEDED", SecretAccessKey: "seed",
+		SessionToken: "seed", Expiration: time.Now().Add(time.Hour).Format(time.RFC3339),
+	}
+	if err := storage.SaveToCredentialsFile(seeded, profile); err != nil {
+		t.Fatalf("SaveToCredentialsFile: %v", err)
+	}
+
+	cfg := directSTSConfig(quotaSrv.URL, freeLocalPort(t))
+	cfg.OIDCTokenEndpoint = idpSrv.URL
+	app := &credentialApp{profile: profile, cfg: cfg, providerType: "generic", redirectPort: cfg.RedirectPort}
+
+	if allowed := app.performQuotaRecheck(); allowed {
+		t.Fatalf("performQuotaRecheck = true with a blocking quota response — short-lived id_token silently skipped the check")
+	}
+	if got := atomic.LoadInt32(quotaHits); got != 1 {
+		t.Errorf("quota API hits = %d, want 1", got)
+	}
+	if creds, err := storage.ReadFromCredentialsFile(profile); err == nil && creds != nil && !storage.IsExpiredDummy(creds) {
+		t.Errorf("cached credentials survived a quota block: AccessKeyId=%s", creds.AccessKeyID)
+	}
+}

--- a/source/go/cmd/credential-process/quota_recheck_refresh_test.go
+++ b/source/go/cmd/credential-process/quota_recheck_refresh_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 
@@ -27,13 +29,24 @@ import (
 // is empty, attempt tryRefreshToken() to silently mint a fresh id_token
 // before giving up.
 //
-// This test proves the exchange is *attempted*: with a refresh_token stored
-// but an unreachable IdP, tryRefreshToken fails and clears the (presumed
-// revoked) refresh_token. Before the fix, performQuotaRecheck returned on the
-// empty-token check and NEVER touched the refresh_token, so it would remain
-// stored. The cleared-token assertion therefore fails without the fix and
-// passes with it.
+// This test proves the exchange is *attempted*: with a refresh_token stored and
+// an IdP that returns a definitive invalid_grant, tryRefreshToken fails and
+// clears the (revoked) refresh_token. Before the fix, performQuotaRecheck
+// returned on the empty-token check and NEVER touched the refresh_token, so it
+// would remain stored. The cleared-token assertion therefore fails without the
+// fix and passes with it.
+//
+// NOTE: the IdP must return invalid_grant (not merely be unreachable) — a
+// transient/unreachable failure now correctly RETAINS the token (that retention
+// is the OTEL-bearer undercount fix), so only a definitive rejection clears it.
 func TestPerformQuotaRecheck_AttemptsRefreshWhenTokenExpired(t *testing.T) {
+	// IdP that definitively rejects the refresh_token → tryRefreshToken clears it.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"revoked"}`))
+	}))
+	defer srv.Close()
+
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 	t.Setenv("USERPROFILE", tmpDir) // Windows
@@ -54,13 +67,13 @@ func TestPerformQuotaRecheck_AttemptsRefreshWhenTokenExpired(t *testing.T) {
 
 	cfg := &config.ProfileConfig{
 		ClientID:          "test-client",
-		ProviderDomain:    "test.invalid.example.com", // unreachable — exchange must fail
+		OIDCTokenEndpoint: srv.URL, // generic provider reads the endpoint directly
 		CredentialStorage: "session",
 		QuotaAPIEndpoint:  "https://quota.invalid.example.com",
 		QuotaFailMode:     "open",
 		QuotaCheckTimeout: 1,
 	}
-	app := &credentialApp{profile: profile, cfg: cfg, providerType: "okta"}
+	app := &credentialApp{profile: profile, cfg: cfg, providerType: "generic"}
 
 	// Exchange fails (unreachable IdP); with no usable token the recheck
 	// fails open and allows cached credentials through.
@@ -69,10 +82,10 @@ func TestPerformQuotaRecheck_AttemptsRefreshWhenTokenExpired(t *testing.T) {
 	}
 
 	// The core regression assertion: the refresh_token was consumed by a
-	// failed exchange. If it is still present, performQuotaRecheck never
-	// attempted the exchange — the fix is not wired in.
+	// definitive invalid_grant exchange. If it is still present, performQuotaRecheck
+	// never attempted the exchange — the fix is not wired in.
 	if got := storage.LoadRefreshToken(profile, "session"); got != "" {
-		t.Errorf("refresh_token not cleared after failed exchange (got %q); "+
+		t.Errorf("refresh_token not cleared after invalid_grant exchange (got %q); "+
 			"performQuotaRecheck did NOT attempt tryRefreshToken — quota recheck "+
 			"will silently fail open for over-quota users with expired id_tokens", got)
 	}

--- a/source/go/cmd/credential-process/refresh_clear_test.go
+++ b/source/go/cmd/credential-process/refresh_clear_test.go
@@ -80,43 +80,7 @@ func TestTryRefreshToken_ServerErrorRetainsToken(t *testing.T) {
 	}
 }
 
-// TestRefreshIDTokenOnly_ServerErrorRetainsToken guards the twin clear site on
-// the MCP-auth-header path (refreshIDTokenOnly), which had the identical
-// clear-on-any-failure bug.
-func TestRefreshIDTokenOnly_ServerErrorRetainsToken(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusBadGateway)
-		_, _ = w.Write([]byte(`bad gateway`))
-	}))
-	defer srv.Close()
-
-	profile := "test-idtoken-only-server-error"
-	app := newRefreshApp(t, profile, srv.URL)
-
-	if tok := app.refreshIDTokenOnly(); tok != "" {
-		t.Fatalf("refreshIDTokenOnly returned non-empty on 502: %q", tok)
-	}
-	if got := storage.LoadRefreshToken(profile, "session"); got != "rt_original" {
-		t.Errorf("refresh_token = %q after transient 502, want retained (%q)", got, "rt_original")
-	}
-}
-
-// TestRefreshIDTokenOnly_InvalidGrantClearsToken confirms the MCP path still
-// clears on a definitive rejection.
-func TestRefreshIDTokenOnly_InvalidGrantClearsToken(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
-	}))
-	defer srv.Close()
-
-	profile := "test-idtoken-only-invalid-grant"
-	app := newRefreshApp(t, profile, srv.URL)
-
-	if tok := app.refreshIDTokenOnly(); tok != "" {
-		t.Fatalf("refreshIDTokenOnly returned non-empty on invalid_grant: %q", tok)
-	}
-	if got := storage.LoadRefreshToken(profile, "session"); got != "" {
-		t.Errorf("refresh_token = %q after invalid_grant, want cleared", got)
-	}
-}
+// NOTE: the former refreshIDTokenOnly twin tests were removed when that
+// function was consolidated into tryRefreshToken (which no longer performs an
+// AWS credential exchange). The two tests above now cover the single
+// clear-vs-retain site for every caller, including the MCP-auth-header path.

--- a/source/go/cmd/credential-process/refresh_clear_test.go
+++ b/source/go/cmd/credential-process/refresh_clear_test.go
@@ -1,0 +1,122 @@
+package main
+
+// ABOUTME: Regression tests for the OTEL-bearer undercount bug —
+// ABOUTME: refresh_token must survive transient failures and only clear on invalid_grant.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"ccwb-go/internal/config"
+	"ccwb-go/internal/storage"
+)
+
+// newRefreshApp builds a credentialApp whose refresh_token exchange targets a
+// test server. It uses providerType "generic" so tryRefreshToken reads the
+// endpoint straight from cfg.OIDCTokenEndpoint (no domain concatenation), and a
+// session-storage temp HOME so the refresh_token round-trips through a real file.
+func newRefreshApp(t *testing.T, profile, tokenURL string) *credentialApp {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	if err := os.MkdirAll(tmp+"/.claude-code-session", 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	t.Cleanup(func() { storage.ClearRefreshToken(profile) })
+
+	if err := storage.SaveRefreshToken(profile, "session", "rt_original"); err != nil {
+		t.Fatalf("SaveRefreshToken: %v", err)
+	}
+	cfg := &config.ProfileConfig{
+		ClientID:          "test-client",
+		OIDCTokenEndpoint: tokenURL,
+		CredentialStorage: "session",
+	}
+	return &credentialApp{profile: profile, cfg: cfg, providerType: "generic"}
+}
+
+// TestTryRefreshToken_InvalidGrantClearsToken: a definitive invalid_grant
+// rejection means the refresh_token is dead — it must be cleared.
+func TestTryRefreshToken_InvalidGrantClearsToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"revoked"}`))
+	}))
+	defer srv.Close()
+
+	profile := "test-refresh-invalid-grant"
+	app := newRefreshApp(t, profile, srv.URL)
+
+	if creds := app.tryRefreshToken(); creds != nil {
+		t.Fatalf("tryRefreshToken returned non-nil on invalid_grant: %+v", creds)
+	}
+	if got := storage.LoadRefreshToken(profile, "session"); got != "" {
+		t.Errorf("refresh_token = %q after invalid_grant, want cleared", got)
+	}
+}
+
+// TestTryRefreshToken_ServerErrorRetainsToken: a 5xx is transient — the
+// refresh_token must survive so a later cycle can retry. This is the core of the
+// undercount fix: a single server blip must NOT permanently disable silent
+// renewal (which previously forced a full browser login to recover).
+func TestTryRefreshToken_ServerErrorRetainsToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"server_error"}`))
+	}))
+	defer srv.Close()
+
+	profile := "test-refresh-server-error"
+	app := newRefreshApp(t, profile, srv.URL)
+
+	if creds := app.tryRefreshToken(); creds != nil {
+		t.Fatalf("tryRefreshToken returned non-nil on 500: %+v", creds)
+	}
+	if got := storage.LoadRefreshToken(profile, "session"); got != "rt_original" {
+		t.Errorf("refresh_token = %q after transient 500, want retained (%q)", got, "rt_original")
+	}
+}
+
+// TestRefreshIDTokenOnly_ServerErrorRetainsToken guards the twin clear site on
+// the MCP-auth-header path (refreshIDTokenOnly), which had the identical
+// clear-on-any-failure bug.
+func TestRefreshIDTokenOnly_ServerErrorRetainsToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`bad gateway`))
+	}))
+	defer srv.Close()
+
+	profile := "test-idtoken-only-server-error"
+	app := newRefreshApp(t, profile, srv.URL)
+
+	if tok := app.refreshIDTokenOnly(); tok != "" {
+		t.Fatalf("refreshIDTokenOnly returned non-empty on 502: %q", tok)
+	}
+	if got := storage.LoadRefreshToken(profile, "session"); got != "rt_original" {
+		t.Errorf("refresh_token = %q after transient 502, want retained (%q)", got, "rt_original")
+	}
+}
+
+// TestRefreshIDTokenOnly_InvalidGrantClearsToken confirms the MCP path still
+// clears on a definitive rejection.
+func TestRefreshIDTokenOnly_InvalidGrantClearsToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
+	}))
+	defer srv.Close()
+
+	profile := "test-idtoken-only-invalid-grant"
+	app := newRefreshApp(t, profile, srv.URL)
+
+	if tok := app.refreshIDTokenOnly(); tok != "" {
+		t.Fatalf("refreshIDTokenOnly returned non-empty on invalid_grant: %q", tok)
+	}
+	if got := storage.LoadRefreshToken(profile, "session"); got != "" {
+		t.Errorf("refresh_token = %q after invalid_grant, want cleared", got)
+	}
+}

--- a/source/go/cmd/credential-process/resolve_port_test.go
+++ b/source/go/cmd/credential-process/resolve_port_test.go
@@ -1,0 +1,41 @@
+package main
+
+// ABOUTME: Regression tests for resolveRedirectPort — the browser callback port
+// ABOUTME: must never be 0 (http://localhost:0 → ERR_UNSAFE_PORT).
+
+import (
+	"testing"
+
+	"ccwb-go/internal/config"
+)
+
+// TestResolveRedirectPort guards the ERR_UNSAFE_PORT regression: once the
+// --get-monitoring-token path resolves the provider type early and can fall
+// through to browser auth, an unset redirect port would open http://localhost:0.
+// resolveRedirectPort must always yield a usable port.
+func TestResolveRedirectPort(t *testing.T) {
+	tests := []struct {
+		name    string
+		env     string
+		cfgPort int
+		want    int
+	}{
+		{name: "default when unset", env: "", cfgPort: 0, want: 8400},
+		{name: "profile port used", env: "", cfgPort: 9001, want: 9001},
+		{name: "env overrides profile", env: "9200", cfgPort: 9001, want: 9200},
+		{name: "invalid env falls back to profile", env: "not-a-port", cfgPort: 9001, want: 9001},
+		{name: "zero env falls back to default", env: "0", cfgPort: 0, want: 8400},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("REDIRECT_PORT", tc.env)
+			cfg := &config.ProfileConfig{RedirectPort: tc.cfgPort}
+			if got := resolveRedirectPort(cfg); got != tc.want {
+				t.Errorf("resolveRedirectPort = %d, want %d", got, tc.want)
+			}
+			if got := resolveRedirectPort(cfg); got == 0 {
+				t.Error("resolveRedirectPort returned 0 — would open http://localhost:0 (ERR_UNSAFE_PORT)")
+			}
+		})
+	}
+}

--- a/source/go/cmd/credential-process/show_claims_test.go
+++ b/source/go/cmd/credential-process/show_claims_test.go
@@ -1,0 +1,82 @@
+// ABOUTME: Tests for --show-claims — full ID-token claim dump for IdP diagnostics
+// ABOUTME: (what groups/department/custom claims is Okta actually sending?).
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"ccwb-go/internal/config"
+)
+
+// TestShowClaims_CachedToken verifies the full claim set of a cached token is
+// printed as JSON without any browser/network side effects.
+func TestShowClaims_CachedToken(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir) // Windows
+	t.Setenv("CLAUDE_CODE_MONITORING_TOKEN", "")
+
+	profile := "test-show-claims"
+	token := fakeJWT(t, map[string]interface{}{
+		"email":             "user@example.com",
+		"sub":               "00u1abcd",
+		"groups":            []string{"engineering", "platform-team"},
+		"custom:department": "R&D",
+		"exp":               time.Now().Unix() + 3600,
+	})
+	writeMonitoringToken(t, tmpDir, profile, token, time.Now().Unix()+3600)
+
+	cfg := &config.ProfileConfig{
+		ClientID:          "test-client",
+		ProviderDomain:    "test.example.com",
+		CredentialStorage: "session",
+		SsoEnabled:        boolPtr(true),
+	}
+	app := &credentialApp{profile: profile, cfg: cfg, providerType: "okta"}
+
+	r, w, _ := os.Pipe()
+	old := os.Stdout
+	os.Stdout = w
+	code := app.showClaims()
+	w.Close()
+	os.Stdout = old
+
+	if code != 0 {
+		t.Fatalf("showClaims exit = %d, want 0", code)
+	}
+
+	var buf [16384]byte
+	n, _ := r.Read(buf[:])
+	out := string(buf[:n])
+
+	var claims map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &claims); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
+	}
+	if claims["email"] != "user@example.com" {
+		t.Errorf("email claim = %v", claims["email"])
+	}
+	if claims["custom:department"] != "R&D" {
+		t.Errorf("custom claim missing: %v", claims["custom:department"])
+	}
+	groups, _ := claims["groups"].([]interface{})
+	if len(groups) != 2 {
+		t.Errorf("groups claim = %v, want 2 entries", claims["groups"])
+	}
+}
+
+// TestShowClaims_HelpTextAdvertisesDiagnostic pins the flag registration so
+// the diagnostic stays discoverable via --help.
+func TestShowClaims_HelpTextAdvertisesDiagnostic(t *testing.T) {
+	src, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(src), `flag.Bool("show-claims"`) {
+		t.Fatal("--show-claims flag registration missing from main.go")
+	}
+}

--- a/source/go/cmd/otel-helper/collector.go
+++ b/source/go/cmd/otel-helper/collector.go
@@ -1,0 +1,103 @@
+// ABOUTME: OTEL collector sidecar management — starts the local otelcol process
+// ABOUTME: when installed. Parity with otel-helper.sh / otel-helper.ps1 / Python helper.
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+// ensureCollectorRunning starts the local OTEL collector sidecar if this is a
+// sidecar-mode install (otelcol binary + collector-config.yaml present in the
+// install dir) and it isn't already running. It never fails the caller: any
+// error just means telemetry export will fail until the next invocation
+// retries.
+//
+// The collector runs under a dedicated "<profile>-collector" AWS profile so
+// its SDK resolves credentials via credential_process — the main profile's
+// static ~/.aws/credentials would shadow credential_process and can't
+// auto-refresh (same rationale as otel-helper.sh).
+//
+// stdout and stderr go to SEPARATE files (collector.log / collector.err):
+// Windows does not support redirecting both streams into the same file.
+func ensureCollectorRunning(profile string) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return
+	}
+	installDir := filepath.Join(home, "claude-code-with-bedrock")
+	binName := "otelcol"
+	if runtime.GOOS == "windows" {
+		binName = "otelcol.exe"
+	}
+	otelcol := filepath.Join(installDir, binName)
+	configPath := filepath.Join(installDir, "collector-config.yaml")
+	pidFile := filepath.Join(installDir, "collector.pid")
+
+	if _, err := os.Stat(otelcol); err != nil {
+		return // not a sidecar-mode install
+	}
+	if _, err := os.Stat(configPath); err != nil {
+		return
+	}
+
+	if pidData, err := os.ReadFile(pidFile); err == nil {
+		if pid, perr := strconv.Atoi(strings.TrimSpace(string(pidData))); perr == nil && pid > 0 && isProcessAlive(pid) {
+			return // already running
+		}
+	}
+
+	cacheDir := filepath.Join(home, ".claude-code-session")
+	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
+		return
+	}
+
+	outFile, err := os.OpenFile(filepath.Join(cacheDir, "collector.log"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return
+	}
+	defer outFile.Close()
+	errFile, err := os.OpenFile(filepath.Join(cacheDir, "collector.err"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return
+	}
+	defer errFile.Close()
+
+	cmd := exec.Command(otelcol, "--config", configPath) // nosemgrep: go.lang.security.audit.dangerous-exec-command.dangerous-exec-command
+	cmd.Stdout = outFile
+	cmd.Stderr = errFile
+	// AWS_SDK_LOAD_CONFIG: collector components built on aws-sdk-go v1 (the
+	// awsemf exporter's awsutil layer) do not read ~/.aws/config — where the
+	// "<profile>-collector" profile and its credential_process live — unless
+	// this is set. SDK v2 components (sigv4auth) read it regardless, which is
+	// why AMP export worked while EMF export failed without it.
+	env := envWithout(envWithout(os.Environ(), "AWS_PROFILE"), "AWS_SDK_LOAD_CONFIG")
+	cmd.Env = append(env, "AWS_PROFILE="+profile+"-collector", "AWS_SDK_LOAD_CONFIG=1")
+	cmd.SysProcAttr = detachedSysProcAttr()
+	if err := cmd.Start(); err != nil {
+		debugPrint("Failed to start collector sidecar: %v", err)
+		return
+	}
+	if err := os.WriteFile(pidFile, []byte(strconv.Itoa(cmd.Process.Pid)), 0o600); err != nil {
+		debugPrint("Failed to write collector PID file: %v", err)
+	}
+	debugPrint("Started collector sidecar (PID %d)", cmd.Process.Pid)
+	// Detach — the helper must not block on the long-running collector.
+	_ = cmd.Process.Release()
+}
+
+// envWithout returns env minus any entries for the given variable name.
+func envWithout(env []string, name string) []string {
+	prefix := name + "="
+	out := make([]string, 0, len(env))
+	for _, e := range env {
+		if !strings.HasPrefix(e, prefix) {
+			out = append(out, e)
+		}
+	}
+	return out
+}

--- a/source/go/cmd/otel-helper/collector_test.go
+++ b/source/go/cmd/otel-helper/collector_test.go
@@ -1,0 +1,119 @@
+// ABOUTME: Tests for collector sidecar management — separate stdout/stderr
+// ABOUTME: log files, PID reuse, and the central-mode no-op path.
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestEnvWithout(t *testing.T) {
+	in := []string{"A=1", "AWS_PROFILE=x", "B=2", "AWS_PROFILE=y"}
+	got := envWithout(in, "AWS_PROFILE")
+	if len(got) != 2 || got[0] != "A=1" || got[1] != "B=2" {
+		t.Errorf("envWithout = %v, want [A=1 B=2]", got)
+	}
+	// Must not match prefix-named variables like AWS_PROFILE_EXTRA.
+	got = envWithout([]string{"AWS_PROFILE_EXTRA=z"}, "AWS_PROFILE")
+	if len(got) != 1 {
+		t.Errorf("envWithout removed AWS_PROFILE_EXTRA, want it kept")
+	}
+}
+
+// TestEnsureCollectorRunning_NoSidecarInstall_NoOp: central-mode installs have
+// no otelcol binary; the helper must not create PID or log files.
+func TestEnsureCollectorRunning_NoSidecarInstall_NoOp(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+
+	ensureCollectorRunning("ClaudeCode")
+
+	if _, err := os.Stat(filepath.Join(tmp, "claude-code-with-bedrock", "collector.pid")); !os.IsNotExist(err) {
+		t.Errorf("pid file must not be created without a sidecar install (stat err = %v)", err)
+	}
+}
+
+// TestEnsureCollectorRunning_StartsWithSeparateLogFiles is the regression test
+// for the Windows sidecar bugs: (1) the Go helper previously never started the
+// collector at all (only the .sh/.ps1 wrappers did, and on Windows the .cmd
+// runs this binary first, so the collector never launched), and (2) stdout and
+// stderr must go to SEPARATE files — Windows cannot redirect both streams into
+// one file.
+func TestEnsureCollectorRunning_StartsWithSeparateLogFiles(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses a shell-script stand-in for otelcol")
+	}
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	installDir := filepath.Join(tmp, "claude-code-with-bedrock")
+	if err := os.MkdirAll(installDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Stand-in collector: proves which AWS profile and SDK config-loading
+	// env it was launched under, writes distinct stdout/stderr content,
+	// then stays alive briefly.
+	script := "#!/bin/sh\necho \"profile=$AWS_PROFILE sdkconfig=$AWS_SDK_LOAD_CONFIG\"\necho stderr-marker >&2\nsleep 10\n"
+	if err := os.WriteFile(filepath.Join(installDir, "otelcol"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(installDir, "collector-config.yaml"), []byte("receivers:\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ensureCollectorRunning("TestProfile")
+
+	pidData, err := os.ReadFile(filepath.Join(installDir, "collector.pid"))
+	if err != nil {
+		t.Fatalf("collector.pid not written: %v", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(pidData)))
+	if err != nil || pid <= 0 {
+		t.Fatalf("collector.pid content %q is not a PID", pidData)
+	}
+	defer func() {
+		if p, ferr := os.FindProcess(pid); ferr == nil {
+			_ = p.Kill()
+		}
+	}()
+
+	if !isProcessAlive(pid) {
+		t.Error("collector process should be alive after launch")
+	}
+
+	cacheDir := filepath.Join(tmp, ".claude-code-session")
+	// AWS_SDK_LOAD_CONFIG=1 is required for aws-sdk-go v1 components (the
+	// awsemf exporter) to read the -collector profile from ~/.aws/config.
+	waitForContent(t, filepath.Join(cacheDir, "collector.log"), "profile=TestProfile-collector sdkconfig=1")
+	waitForContent(t, filepath.Join(cacheDir, "collector.err"), "stderr-marker")
+
+	// A second invocation with a live PID must not respawn.
+	ensureCollectorRunning("TestProfile")
+	pidData2, err := os.ReadFile(filepath.Join(installDir, "collector.pid"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(pidData2) != string(pidData) {
+		t.Errorf("collector respawned despite live PID: %s -> %s", pidData, pidData2)
+	}
+}
+
+// waitForContent polls for a file to exist and contain the given substring.
+func waitForContent(t *testing.T, path, want string) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if data, err := os.ReadFile(path); err == nil && strings.Contains(string(data), want) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	data, err := os.ReadFile(path)
+	t.Fatalf("file %s never contained %q (content=%q, err=%v)", path, want, data, err)
+}

--- a/source/go/cmd/otel-helper/collector_unix.go
+++ b/source/go/cmd/otel-helper/collector_unix.go
@@ -1,0 +1,20 @@
+// ABOUTME: Unix process helpers for collector sidecar management —
+// ABOUTME: liveness check via signal 0 and session detach via Setsid.
+//go:build !windows
+
+package main
+
+import "syscall"
+
+// isProcessAlive reports whether a process with the given PID exists.
+// EPERM means the process exists but belongs to another user — still alive.
+func isProcessAlive(pid int) bool {
+	err := syscall.Kill(pid, 0)
+	return err == nil || err == syscall.EPERM
+}
+
+// detachedSysProcAttr detaches the collector into its own session so it
+// survives the short-lived otel-helper process exiting.
+func detachedSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setsid: true}
+}

--- a/source/go/cmd/otel-helper/collector_windows.go
+++ b/source/go/cmd/otel-helper/collector_windows.go
@@ -1,0 +1,36 @@
+// ABOUTME: Windows process helpers for collector sidecar management —
+// ABOUTME: liveness check via OpenProcess/GetExitCodeProcess, windowless detach.
+//go:build windows
+
+package main
+
+import "syscall"
+
+const (
+	processQueryLimitedInformation = 0x1000
+	stillActive                    = 259
+	createNoWindow                 = 0x08000000
+)
+
+// isProcessAlive reports whether a process with the given PID is running.
+// os.FindProcess always succeeds on Windows, so query the process directly.
+func isProcessAlive(pid int) bool {
+	h, err := syscall.OpenProcess(processQueryLimitedInformation, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	defer syscall.CloseHandle(h)
+	var code uint32
+	if err := syscall.GetExitCodeProcess(h, &code); err != nil {
+		return false
+	}
+	return code == stillActive
+}
+
+// detachedSysProcAttr starts the collector in its own process group with no
+// console window, so it outlives the helper and doesn't flash a window.
+func detachedSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP | createNoWindow,
+	}
+}

--- a/source/go/cmd/otel-helper/main.go
+++ b/source/go/cmd/otel-helper/main.go
@@ -114,6 +114,13 @@ func resolveProfile(flagValue string) string {
 }
 
 func run(testMode bool, profile string) int {
+	// Sidecar mode: make sure the local OTEL collector is running before
+	// Claude Code starts exporting to localhost (no-op unless otelcol is
+	// installed). The shell/PowerShell wrappers do the same; this binary is
+	// the primary entry point on Windows (otel-helper.cmd tries it first),
+	// so without this the collector never starts there.
+	ensureCollectorRunning(profile)
+
 	// Layer 1: Serve attribution from the file cache. The cache stores
 	// attribution headers only, never the token, so the Bearer is still
 	// resolved below (env var, then credential-process). credential-process

--- a/source/go/cmd/otel-helper/main.go
+++ b/source/go/cmd/otel-helper/main.go
@@ -60,6 +60,7 @@ func main() {
 	verboseFlag := flag.Bool("verbose", false, "Show verbose output")
 	versionFlag := flag.Bool("version", false, "Show version")
 	statusFlag := flag.Bool("status", false, "Print current otel-helper status as JSON and exit (proxy running? port? mode?)")
+	profileFlag := flag.String("profile", "", "Profile name (overrides CCWB_PROFILE/AWS_PROFILE environment variables)")
 	proxyMode := flag.Bool("proxy", false, "Run as SigV4 signing proxy for CoWork OTLP logs")
 	proxyPort := flag.Int("proxy-port", defaultProxyPort, "Port for the signing proxy (default 4318)")
 	proxyRegion := flag.String("proxy-region", "", "AWS region for CloudWatch OTLP (default: AWS_REGION env)")
@@ -70,18 +71,16 @@ func main() {
 		os.Exit(0)
 	}
 
-	if *statusFlag {
-		os.Exit(runStatus(*proxyPort))
-	}
-
 	verbose = *verboseFlag || *testMode
 	debug = os.Getenv("DEBUG_MODE") != "" || verbose
 
+	profile := resolveProfile(*profileFlag)
+
+	if *statusFlag {
+		os.Exit(runStatus(*proxyPort, profile))
+	}
+
 	if *proxyMode {
-		profile := os.Getenv("AWS_PROFILE")
-		if profile == "" {
-			profile = "ClaudeCode"
-		}
 		os.Exit(startProxy(proxyConfig{
 			port:    *proxyPort,
 			region:  *proxyRegion,
@@ -89,15 +88,32 @@ func main() {
 		}))
 	}
 
-	os.Exit(run(*testMode))
+	os.Exit(run(*testMode, profile))
 }
 
-func run(testMode bool) int {
-	profile := os.Getenv("AWS_PROFILE")
-	if profile == "" {
-		profile = "ClaudeCode"
+// resolveProfile determines which named profile this invocation serves.
+// Precedence: explicit --profile flag > CCWB_PROFILE env var (the ccwb-specific
+// override, same convention as credential-process) > AWS_PROFILE env var
+// (legacy behaviour — Claude Code settings export it) > "ClaudeCode".
+// When the flag is supplied it is also exported to AWS_PROFILE so everything
+// downstream — credential-process subprocesses and the AWS SDK credential
+// chain in proxy mode — resolves the SAME profile from one place.
+func resolveProfile(flagValue string) string {
+	if flagValue != "" {
+		os.Setenv("AWS_PROFILE", flagValue)
+		return flagValue
 	}
+	if p := os.Getenv("CCWB_PROFILE"); p != "" {
+		os.Setenv("AWS_PROFILE", p)
+		return p
+	}
+	if p := os.Getenv("AWS_PROFILE"); p != "" {
+		return p
+	}
+	return "ClaudeCode"
+}
 
+func run(testMode bool, profile string) int {
 	// Layer 1: Serve attribution from the file cache. The cache stores
 	// attribution headers only, never the token, so the Bearer is still
 	// resolved below (env var, then credential-process). credential-process

--- a/source/go/cmd/otel-helper/main_test.go
+++ b/source/go/cmd/otel-helper/main_test.go
@@ -57,7 +57,7 @@ func TestRun_NoToken_EmitsEmptyHeadersAndExitsZero(t *testing.T) {
 	// No credential-process binary exists under tmpDir/claude-code-with-bedrock,
 	// so getTokenViaCredentialProcess returns an error -> emitEmptyHeaders.
 
-	if code := run(false); code != 0 {
+	if code := run(false, "ClaudeCode"); code != 0 {
 		t.Fatalf("run() exit code = %d, want 0", code)
 	}
 
@@ -95,7 +95,7 @@ func TestRun_TestMode_NoToken_DoesNotWriteCache(t *testing.T) {
 	t.Setenv("AWS_PROFILE", "ClaudeCode")
 	t.Setenv("CLAUDE_CODE_MONITORING_TOKEN", "")
 
-	if code := run(true); code != 0 {
+	if code := run(true, "ClaudeCode"); code != 0 {
 		t.Fatalf("run(testMode) exit code = %d, want 0", code)
 	}
 
@@ -129,7 +129,7 @@ func TestRun_FreshEmptyCache_ServedViaLayer1(t *testing.T) {
 		t.Fatalf("seed cache: %v", err)
 	}
 
-	if code := run(false); code != 0 {
+	if code := run(false, "ClaudeCode"); code != 0 {
 		t.Fatalf("run() exit code = %d, want 0", code)
 	}
 
@@ -172,7 +172,7 @@ func TestRun_PopulatedExpiredEntry_ServedNotRewritten(t *testing.T) {
 		t.Fatalf("seed cache: %v", err)
 	}
 
-	if code := run(false); code != 0 {
+	if code := run(false, "ClaudeCode"); code != 0 {
 		t.Fatalf("run() exit code = %d, want 0", code)
 	}
 
@@ -212,7 +212,7 @@ func TestRun_WithToken_IncludesBearerHeader(t *testing.T) {
 	r, w, _ := os.Pipe()
 	old := os.Stdout
 	os.Stdout = w
-	code := run(false)
+	code := run(false, "ClaudeCode")
 	w.Close()
 	os.Stdout = old
 
@@ -252,7 +252,7 @@ func TestRun_NoToken_NoBearerInOutput(t *testing.T) {
 	r, w, _ := os.Pipe()
 	old := os.Stdout
 	os.Stdout = w
-	run(false)
+	run(false, "ClaudeCode")
 	w.Close()
 	os.Stdout = old
 
@@ -285,7 +285,7 @@ func TestRun_BearerTokenNotInCacheFile(t *testing.T) {
 	_, w, _ := os.Pipe()
 	old := os.Stdout
 	os.Stdout = w
-	run(false)
+	run(false, "ClaudeCode")
 	w.Close()
 	os.Stdout = old
 
@@ -335,7 +335,7 @@ func TestRun_CacheHit_ResolvesTokenFromEnv(t *testing.T) {
 	r, w, _ := os.Pipe()
 	old := os.Stdout
 	os.Stdout = w
-	code := run(false)
+	code := run(false, "ClaudeCode")
 	w.Close()
 	os.Stdout = old
 
@@ -389,7 +389,7 @@ func TestRun_Layer1_CacheHit_NoToken_OmitsBearerGracefully(t *testing.T) {
 	r, w, _ := os.Pipe()
 	old := os.Stdout
 	os.Stdout = w
-	code := run(false)
+	code := run(false, "ClaudeCode")
 	w.Close()
 	os.Stdout = old
 
@@ -471,7 +471,7 @@ func TestRun_TestMode_ServesCachedHeaders(t *testing.T) {
 	r, w, _ := os.Pipe()
 	old := os.Stdout
 	os.Stdout = w
-	code := run(true)
+	code := run(true, "idc-test")
 	w.Close()
 	os.Stdout = old
 
@@ -484,5 +484,38 @@ func TestRun_TestMode_ServesCachedHeaders(t *testing.T) {
 	out := string(buf[:n])
 	if !strings.Contains(out, "qnamzn+developer@amazon.com") {
 		t.Errorf("test-mode output must surface the cached email; got:\n%s", out)
+	}
+}
+
+// TestResolveProfile_Precedence locks in the resolution order:
+// --profile flag > CCWB_PROFILE env > AWS_PROFILE env > "ClaudeCode" default.
+func TestResolveProfile_Precedence(t *testing.T) {
+	t.Setenv("CCWB_PROFILE", "CcwbProfile")
+	t.Setenv("AWS_PROFILE", "EnvProfile")
+
+	// CCWB_PROFILE (ccwb-specific override, same convention as
+	// credential-process) beats the ambient AWS_PROFILE.
+	if got := resolveProfile(""); got != "CcwbProfile" {
+		t.Errorf("resolveProfile(\"\") = %q, want CCWB_PROFILE value \"CcwbProfile\"", got)
+	}
+
+	if got := resolveProfile("FlagProfile"); got != "FlagProfile" {
+		t.Errorf("resolveProfile(flag) = %q, want \"FlagProfile\"", got)
+	}
+	// The flag must be exported so child processes (credential-process) and
+	// the AWS SDK in proxy mode resolve the same profile.
+	if got := os.Getenv("AWS_PROFILE"); got != "FlagProfile" {
+		t.Errorf("AWS_PROFILE after flag resolution = %q, want \"FlagProfile\"", got)
+	}
+
+	t.Setenv("CCWB_PROFILE", "")
+	t.Setenv("AWS_PROFILE", "EnvProfile")
+	if got := resolveProfile(""); got != "EnvProfile" {
+		t.Errorf("resolveProfile(\"\") = %q, want AWS_PROFILE value \"EnvProfile\"", got)
+	}
+
+	t.Setenv("AWS_PROFILE", "")
+	if got := resolveProfile(""); got != "ClaudeCode" {
+		t.Errorf("resolveProfile with no flag/env = %q, want \"ClaudeCode\"", got)
 	}
 }

--- a/source/go/cmd/otel-helper/status.go
+++ b/source/go/cmd/otel-helper/status.go
@@ -39,12 +39,10 @@ type CacheStatus struct {
 }
 
 // runStatus prints otel-helper status as JSON and returns exit code.
-func runStatus(proxyPort int) int {
-	profile := os.Getenv("AWS_PROFILE")
-	if profile == "" {
-		profile = "ClaudeCode"
-	}
-
+// The profile is resolved by the caller via resolveProfile (--profile flag >
+// CCWB_PROFILE > AWS_PROFILE > default) so --status reports the same profile
+// the header-serving path would use.
+func runStatus(proxyPort int, profile string) int {
 	output := StatusOutput{
 		Version:  version.Version,
 		Platform: runtime.GOOS + "/" + runtime.GOARCH,

--- a/source/go/internal/oidc/refresh_error_test.go
+++ b/source/go/internal/oidc/refresh_error_test.go
@@ -1,0 +1,111 @@
+package oidc
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestRefreshTokenExchange_ErrorClassification verifies that RefreshTokenExchange
+// distinguishes a definitively-rejected refresh_token (invalid_grant /
+// invalid_token → discard) from transient failures (5xx, unexpected 4xx, bad
+// URL → retain). Clearing on a transient failure is the bug that permanently
+// disabled silent OTEL-bearer renewal until the next browser login.
+func TestRefreshTokenExchange_ErrorClassification(t *testing.T) {
+	tests := []struct {
+		name           string
+		status         int
+		body           string
+		wantDefinitive bool
+		wantOAuthCode  string
+	}{
+		{
+			name:           "invalid_grant is definitive",
+			status:         http.StatusBadRequest,
+			body:           `{"error":"invalid_grant","error_description":"Token expired or revoked"}`,
+			wantDefinitive: true,
+			wantOAuthCode:  "invalid_grant",
+		},
+		{
+			name:           "invalid_token is definitive",
+			status:         http.StatusUnauthorized,
+			body:           `{"error":"invalid_token"}`,
+			wantDefinitive: true,
+			wantOAuthCode:  "invalid_token",
+		},
+		{
+			name:           "500 server error is transient",
+			status:         http.StatusInternalServerError,
+			body:           `{"error":"server_error"}`,
+			wantDefinitive: false,
+			wantOAuthCode:  "server_error",
+		},
+		{
+			name:           "temporarily_unavailable is transient",
+			status:         http.StatusServiceUnavailable,
+			body:           `{"error":"temporarily_unavailable"}`,
+			wantDefinitive: false,
+			wantOAuthCode:  "temporarily_unavailable",
+		},
+		{
+			name:           "unexpected 400 without invalid_grant is transient",
+			status:         http.StatusBadRequest,
+			body:           `{"error":"invalid_request","error_description":"malformed"}`,
+			wantDefinitive: false,
+			wantOAuthCode:  "invalid_request",
+		},
+		{
+			name:           "non-JSON error body is transient",
+			status:         http.StatusBadGateway,
+			body:           `<html>502 Bad Gateway</html>`,
+			wantDefinitive: false,
+			wantOAuthCode:  "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			_, err := RefreshTokenExchange(srv.URL, "rt_value", "client", nil)
+			if err == nil {
+				t.Fatalf("expected an error for status %d, got nil", tc.status)
+			}
+			if got := IsDefinitiveRefreshFailure(err); got != tc.wantDefinitive {
+				t.Errorf("IsDefinitiveRefreshFailure = %v, want %v (err=%v)", got, tc.wantDefinitive, err)
+			}
+		})
+	}
+}
+
+// TestRefreshTokenExchange_EmptyURLIsTransient verifies the defense-in-depth
+// guard: an empty/relative token endpoint URL (the symptom of an unresolved
+// provider type) must fail as a transient error, never as a definitive rejection
+// that would discard the refresh_token.
+func TestRefreshTokenExchange_EmptyURLIsTransient(t *testing.T) {
+	for _, url := range []string{"", "login.microsoftonline.com/tenant/oauth2/v2.0/token"} {
+		_, err := RefreshTokenExchange(url, "rt_value", "client", nil)
+		if err == nil {
+			t.Fatalf("expected an error for URL %q, got nil", url)
+		}
+		if IsDefinitiveRefreshFailure(err) {
+			t.Errorf("empty/relative URL %q classified as definitive; must be transient", url)
+		}
+	}
+}
+
+// TestIsDefinitiveRefreshFailure_NilAndOther confirms the helper is safe for
+// a nil error and for unrelated error types (both → not definitive, so the
+// caller retains the token by default).
+func TestIsDefinitiveRefreshFailure_NilAndOther(t *testing.T) {
+	if IsDefinitiveRefreshFailure(nil) {
+		t.Error("nil error must not be definitive")
+	}
+	if IsDefinitiveRefreshFailure(http.ErrServerClosed) {
+		t.Error("unrelated error must not be definitive")
+	}
+}

--- a/source/go/internal/oidc/token.go
+++ b/source/go/internal/oidc/token.go
@@ -2,6 +2,7 @@ package oidc
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -9,6 +10,53 @@ import (
 	"strings"
 	"time"
 )
+
+// RefreshExchangeError describes a failed refresh_token exchange.
+//
+// Definitive is true ONLY when the IdP explicitly rejected the refresh_token
+// itself (OAuth 2.0 error "invalid_grant" / "invalid_token", RFC 6749 §5.2) —
+// i.e. the token is revoked/expired and a full re-authentication is required, so
+// the stored refresh_token should be discarded. For every other failure
+// (network error, 5xx, timeout, empty/misconfigured token URL, unparseable
+// body) Definitive is false and the caller MUST retain the refresh_token so a
+// later cycle can retry. Clearing on a transient failure is what permanently
+// disabled silent renewal until the next browser login (see the OTEL bearer
+// undercount bug).
+type RefreshExchangeError struct {
+	Definitive bool   // true only for invalid_grant / invalid_token
+	OAuthCode  string // parsed OAuth "error" field, if any
+	StatusCode int    // HTTP status, if the request completed
+	err        error  // underlying formatted error (preserves the old message)
+}
+
+func (e *RefreshExchangeError) Error() string { return e.err.Error() }
+
+func (e *RefreshExchangeError) Unwrap() error { return e.err }
+
+// IsDefinitiveRefreshFailure reports whether err from RefreshTokenExchange means
+// the refresh_token itself was rejected (invalid_grant / invalid_token) and must
+// be discarded. Any other error — including a nil error — is treated as transient
+// (retain the token). Callers use this to decide whether to ClearRefreshToken.
+func IsDefinitiveRefreshFailure(err error) bool {
+	var re *RefreshExchangeError
+	if errors.As(err, &re) {
+		return re.Definitive
+	}
+	return false
+}
+
+// parseOAuthErrorCode extracts the OAuth 2.0 "error" field from a token-endpoint
+// error body (e.g. {"error":"invalid_grant","error_description":"..."}). Returns
+// "" when the body is empty or not the expected JSON shape.
+func parseOAuthErrorCode(body []byte) string {
+	var e struct {
+		Error string `json:"error"`
+	}
+	if json.Unmarshal(body, &e) == nil {
+		return e.Error
+	}
+	return ""
+}
 
 // TokenResponse holds the OIDC token endpoint response.
 type TokenResponse struct {
@@ -67,13 +115,27 @@ func ExchangeCode(tokenURL, code, redirectURI, clientID, codeVerifier string, co
 // id_token (and possibly a rotated refresh_token). Falls back gracefully:
 // callers should treat any error as "refresh unavailable, try browser auth."
 func RefreshTokenExchange(tokenURL, refreshToken, clientID string, confidential *ConfidentialAuth) (*TokenResponse, error) {
+	// Guard against an empty/relative token URL. This should never happen once
+	// the provider type is resolved, but if it slips through (as it did on the
+	// --get-monitoring-token path before the provider type was resolved) the POST
+	// below would fail in a way that must NOT be mistaken for a revoked token —
+	// so surface it as an explicit, transient error (Definitive=false).
+	if !strings.HasPrefix(tokenURL, "https://") && !strings.HasPrefix(tokenURL, "http://") {
+		return nil, &RefreshExchangeError{
+			Definitive: false,
+			err:        fmt.Errorf("refresh token exchange: invalid token endpoint URL %q (provider type not resolved?)", tokenURL),
+		}
+	}
+
 	form := map[string]string{
 		"grant_type":    "refresh_token",
 		"refresh_token": refreshToken,
 		"client_id":     clientID,
 	}
 	if err := confidential.apply(form, tokenURL, clientID); err != nil {
-		return nil, err
+		// Failing to build the client assertion (missing cert, etc.) is a local
+		// misconfiguration, not a revoked token — retain the refresh_token.
+		return nil, &RefreshExchangeError{Definitive: false, err: err}
 	}
 	data := url.Values{}
 	for k, v := range form {
@@ -83,22 +145,33 @@ func RefreshTokenExchange(tokenURL, refreshToken, clientID string, confidential 
 	client := &http.Client{Timeout: 30 * time.Second}
 	resp, err := client.Post(tokenURL, "application/x-www-form-urlencoded", strings.NewReader(data.Encode()))
 	if err != nil {
-		return nil, fmt.Errorf("refresh token request failed: %w", err)
+		// Network/DNS/timeout — transient, retain the token.
+		return nil, &RefreshExchangeError{Definitive: false, err: fmt.Errorf("refresh token request failed: %w", err)}
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("reading refresh response: %w", err)
+		return nil, &RefreshExchangeError{Definitive: false, StatusCode: resp.StatusCode, err: fmt.Errorf("reading refresh response: %w", err)}
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("refresh token exchange failed (HTTP %d): %s", resp.StatusCode, string(body))
+		// Only invalid_grant / invalid_token mean the refresh_token is dead.
+		// Everything else (5xx, throttling, unexpected 4xx) is treated as
+		// transient so we don't discard a still-valid token on a server blip.
+		oauthCode := parseOAuthErrorCode(body)
+		definitive := oauthCode == "invalid_grant" || oauthCode == "invalid_token"
+		return nil, &RefreshExchangeError{
+			Definitive: definitive,
+			OAuthCode:  oauthCode,
+			StatusCode: resp.StatusCode,
+			err:        fmt.Errorf("refresh token exchange failed (HTTP %d): %s", resp.StatusCode, string(body)),
+		}
 	}
 
 	var tokenResp TokenResponse
 	if err := json.Unmarshal(body, &tokenResp); err != nil {
-		return nil, fmt.Errorf("parsing refresh response: %w", err)
+		return nil, &RefreshExchangeError{Definitive: false, StatusCode: resp.StatusCode, err: fmt.Errorf("parsing refresh response: %w", err)}
 	}
 
 	return &tokenResp, nil

--- a/source/go/internal/storage/session.go
+++ b/source/go/internal/storage/session.go
@@ -105,6 +105,46 @@ func credentialsFilePath() string {
 	return filepath.Join(home, ".aws", "credentials")
 }
 
+// RemoveFromCredentialsFile deletes a profile's section from ~/.aws/credentials.
+// Leaving a stale or placeholder section behind is harmful: ~/.aws/credentials
+// outranks credential_process in the AWS SDK resolution chain, so any static
+// entry for the profile prevents the SDK from ever invoking this binary again.
+// Removing the section lets the SDK fall through to credential_process and
+// recover automatically. Other profiles in the file are preserved.
+func RemoveFromCredentialsFile(profile string) error {
+	credPath := credentialsFilePath()
+	if _, err := os.Stat(credPath); os.IsNotExist(err) {
+		return nil
+	}
+
+	cfg, err := ini.LoadSources(ini.LoadOptions{
+		IgnoreInlineComment: true,
+	}, credPath)
+	if err != nil {
+		return fmt.Errorf("reading credentials file: %w", err)
+	}
+
+	if _, err := cfg.GetSection(profile); err != nil {
+		return nil // Section doesn't exist — nothing to remove
+	}
+	cfg.DeleteSection(profile)
+
+	// Atomic write, same pattern as SaveToCredentialsFile
+	tmpPath := credPath + ".tmp"
+	if err := cfg.SaveTo(tmpPath); err != nil {
+		return fmt.Errorf("writing credentials: %w", err)
+	}
+	if err := os.Chmod(tmpPath, 0600); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Rename(tmpPath, credPath); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return nil
+}
+
 // IsExpiredDummy checks if credentials are the "EXPIRED" placeholder.
 func IsExpiredDummy(creds *federation.AWSCredentials) bool {
 	return creds != nil && creds.AccessKeyID == "EXPIRED"

--- a/source/otel_helper/__main__.py
+++ b/source/otel_helper/__main__.py
@@ -903,17 +903,24 @@ def ensure_collector_running():
         except (ProcessLookupError, ValueError, OSError):
             pass  # stale PID file
 
-    # Launch collector with the -collector profile
+    # Launch collector with the -collector profile. AWS_SDK_LOAD_CONFIG:
+    # aws-sdk-go v1 components in the collector (the awsemf exporter) don't
+    # read ~/.aws/config — where the -collector profile's credential_process
+    # lives — without it; SDK v2 components (sigv4auth) always do.
     profile = os.environ.get("AWS_PROFILE", "ClaudeCode")
-    collector_env = {**os.environ, "AWS_PROFILE": f"{profile}-collector"}
+    collector_env = {**os.environ, "AWS_PROFILE": f"{profile}-collector", "AWS_SDK_LOAD_CONFIG": "1"}
 
     cache_dir = Path.home() / ".claude-code-session"
     cache_dir.mkdir(parents=True, exist_ok=True)
+    # stdout and stderr go to SEPARATE files — Windows does not support
+    # redirecting both streams into one file (parity with the Go binary and
+    # otel-helper.ps1, which enforce the same split).
     log_file = cache_dir / "collector.log"
+    err_file = cache_dir / "collector.err"
 
     try:
-        with open(log_file, "a") as lf:
-            kwargs = {"stdout": lf, "stderr": lf, "env": collector_env}
+        with open(log_file, "a", encoding="utf-8") as lf, open(err_file, "a", encoding="utf-8") as ef:
+            kwargs = {"stdout": lf, "stderr": ef, "env": collector_env}
             if platform_mod.system() == "Windows":
                 kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
             else:

--- a/source/otel_helper/__main__.py
+++ b/source/otel_helper/__main__.py
@@ -67,6 +67,11 @@ def parse_args():
     parser.add_argument("--test", action="store_true", help="Run in test mode with verbose output")
     parser.add_argument("--verbose", action="store_true", help="Show verbose output")
     parser.add_argument(
+        "--profile",
+        metavar="NAME",
+        help="AWS profile name (overrides the AWS_PROFILE environment variable)",
+    )
+    parser.add_argument(
         "--anonymous",
         action="store_true",
         help="Force anonymous mode using AWS caller identity instead of JWT auth",
@@ -84,6 +89,17 @@ def parse_args():
         help="Port for the local OTLP proxy (default: 4318)",
     )
     args = parser.parse_args()
+
+    # Single source of truth for profile resolution: --profile flag >
+    # CCWB_PROFILE env (the ccwb-specific override, same convention as
+    # credential-process) > AWS_PROFILE env > "ClaudeCode" default at the
+    # read sites. The winner is exported to AWS_PROFILE so every downstream
+    # consumer — the cache path, the credential-process subprocess, and the
+    # collector sidecar — resolves the SAME profile from the environment.
+    if args.profile:
+        os.environ["AWS_PROFILE"] = args.profile
+    elif os.environ.get("CCWB_PROFILE"):
+        os.environ["AWS_PROFILE"] = os.environ["CCWB_PROFILE"]
 
     global TEST_MODE, ANONYMOUS_MODE
     TEST_MODE = args.test

--- a/source/otel_helper/otel-helper.ps1
+++ b/source/otel_helper/otel-helper.ps1
@@ -15,16 +15,30 @@
 # which is flagged by some AV solutions as an unsigned/unknown binary.
 
 param(
-    [string]$Profile = $env:AWS_PROFILE
+    [Parameter(ValueFromRemainingArguments = $true)][string[]]$HelperArgs
 )
 
-if (-not $Profile) { $Profile = "ClaudeCode" }
+# Resolve profile: explicit --profile argument wins, then CCWB_PROFILE (the
+# ccwb-specific override, same convention as credential-process), then
+# AWS_PROFILE, then the "ClaudeCode" default. The argument is parsed by hand
+# because this script is invoked with Go-style flags (otel-helper.cmd passes
+# the same args it gives otel-helper.exe), which PowerShell parameter binding
+# can't map. Keep in sync with the Go binary's resolveProfile and otel-helper.sh.
+$ProfileName = $env:CCWB_PROFILE
+if (-not $ProfileName) { $ProfileName = $env:AWS_PROFILE }
+for ($i = 0; $i -lt $HelperArgs.Count - 1; $i++) {
+    if ($HelperArgs[$i] -in @('--profile', '-profile', '-Profile')) {
+        $ProfileName = $HelperArgs[$i + 1]
+    }
+}
+if (-not $ProfileName) { $ProfileName = "ClaudeCode" }
+$env:AWS_PROFILE = $ProfileName
 
 $installDir = Join-Path $env:USERPROFILE "claude-code-with-bedrock"
 $cacheDir = Join-Path $env:USERPROFILE ".claude-code-session"
-$cacheFile = Join-Path $cacheDir "$Profile-otel-headers.json"
-$rawFile = Join-Path $cacheDir "$Profile-otel-headers.raw"
-$monitoringFile = Join-Path $cacheDir "$Profile-monitoring.json"
+$cacheFile = Join-Path $cacheDir "$ProfileName-otel-headers.json"
+$rawFile = Join-Path $cacheDir "$ProfileName-otel-headers.raw"
+$monitoringFile = Join-Path $cacheDir "$ProfileName-monitoring.json"
 $pidFile = Join-Path $installDir "collector.pid"
 
 # Anti-hammering TTL: how long an empty-headers cache entry is valid (seconds).
@@ -56,16 +70,17 @@ if ((Test-Path $otelcol) -and (Test-Path $collectorConfig)) {
     if (-not $collectorRunning) {
         try {
             $logFile = Join-Path $cacheDir "collector.log"
-            $env:AWS_PROFILE = "$Profile-collector"
+            $env:AWS_PROFILE = "$ProfileName-collector"
             $proc = Start-Process -FilePath $otelcol -ArgumentList "--config", $collectorConfig `
                 -RedirectStandardOutput $logFile -RedirectStandardError $logFile `
                 -WindowStyle Hidden -PassThru -ErrorAction SilentlyContinue
             if ($proc) {
                 Set-Content -Path $pidFile -Value $proc.Id
             }
-            $env:AWS_PROFILE = $Profile
+            $env:AWS_PROFILE = $ProfileName
         } catch {
             # Collector start failed - non-fatal, continue without sidecar
+            $env:AWS_PROFILE = $ProfileName
         }
     }
 }
@@ -153,7 +168,7 @@ if ($shouldWriteEmpty) {
 $credProcess = Join-Path $installDir "credential-process.exe"
 if (Test-Path $credProcess) {
     try {
-        Start-Process -FilePath $credProcess -ArgumentList "--get-monitoring-token", "--profile", $Profile -WindowStyle Hidden -ErrorAction SilentlyContinue
+        Start-Process -FilePath $credProcess -ArgumentList "--get-monitoring-token", "--profile", $ProfileName -WindowStyle Hidden -ErrorAction SilentlyContinue
     } catch {
         # credential-process unavailable - nothing we can do
     }

--- a/source/otel_helper/otel-helper.ps1
+++ b/source/otel_helper/otel-helper.ps1
@@ -69,10 +69,19 @@ if ((Test-Path $otelcol) -and (Test-Path $collectorConfig)) {
     }
     if (-not $collectorRunning) {
         try {
+            # stdout and stderr must go to SEPARATE files: Start-Process throws
+            # "same file for redirecting both standard output and standard error
+            # is not supported" on Windows if they share one path, which used to
+            # silently prevent the collector from ever starting.
             $logFile = Join-Path $cacheDir "collector.log"
+            $errFile = Join-Path $cacheDir "collector.err"
             $env:AWS_PROFILE = "$ProfileName-collector"
+            # aws-sdk-go v1 components in the collector (awsemf exporter) don't
+            # read ~/.aws/config (credential_process profiles) without this;
+            # SDK v2 components (sigv4auth) always do.
+            $env:AWS_SDK_LOAD_CONFIG = "1"
             $proc = Start-Process -FilePath $otelcol -ArgumentList "--config", $collectorConfig `
-                -RedirectStandardOutput $logFile -RedirectStandardError $logFile `
+                -RedirectStandardOutput $logFile -RedirectStandardError $errFile `
                 -WindowStyle Hidden -PassThru -ErrorAction SilentlyContinue
             if ($proc) {
                 Set-Content -Path $pidFile -Value $proc.Id

--- a/source/otel_helper/otel-helper.sh
+++ b/source/otel_helper/otel-helper.sh
@@ -1,7 +1,19 @@
 #!/bin/bash
 # ABOUTME: Lightweight shell wrapper for otel-helper that ensures the local OTEL collector
 # ABOUTME: sidecar is running (when present), then checks file cache for headers (avoids PyInstaller startup)
-PROFILE="${AWS_PROFILE:-ClaudeCode}"
+# Resolve profile: explicit --profile argument wins, then CCWB_PROFILE (the
+# ccwb-specific override, same convention as credential-process), then
+# AWS_PROFILE, then the "ClaudeCode" default. Keep in sync with the Go
+# binary's resolveProfile and otel-helper.ps1.
+PROFILE="${CCWB_PROFILE:-${AWS_PROFILE:-ClaudeCode}}"
+prev=""
+for arg in "$@"; do
+    if [ "$prev" = "--profile" ] && [ -n "$arg" ]; then
+        PROFILE="$arg"
+    fi
+    prev="$arg"
+done
+export AWS_PROFILE="$PROFILE"
 INSTALL_DIR="$HOME/claude-code-with-bedrock"
 PID_FILE="$INSTALL_DIR/collector.pid"
 CACHE_DIR="$HOME/.claude-code-session"

--- a/source/otel_helper/otel-helper.sh
+++ b/source/otel_helper/otel-helper.sh
@@ -27,7 +27,10 @@ RAW_FILE="$CACHE_DIR/${PROFILE}-otel-headers.raw"
 if [ -x "$INSTALL_DIR/otelcol" ] && [ -f "$INSTALL_DIR/collector-config.yaml" ]; then
     if ! { [ -f "$PID_FILE" ] && kill -0 "$(cat "$PID_FILE" 2>/dev/null)" 2>/dev/null; }; then
         mkdir -p "$CACHE_DIR"
-        AWS_PROFILE="${PROFILE}-collector" \
+        # AWS_SDK_LOAD_CONFIG: aws-sdk-go v1 components in the collector (the
+        # awsemf exporter) don't read ~/.aws/config (credential_process
+        # profiles) without it; SDK v2 components (sigv4auth) always do.
+        AWS_PROFILE="${PROFILE}-collector" AWS_SDK_LOAD_CONFIG=1 \
         "$INSTALL_DIR/otelcol" --config "$INSTALL_DIR/collector-config.yaml" \
             >> "$CACHE_DIR/collector.log" 2>&1 &
         echo $! > "$PID_FILE"

--- a/source/poetry.lock
+++ b/source/poetry.lock
@@ -181,18 +181,18 @@ uvloop = ["uvloop (>=0.15.2) ; sys_platform != \"win32\"", "winloop (>=0.5.0) ; 
 
 [[package]]
 name = "boto3"
-version = "1.43.46"
+version = "1.43.51"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "boto3-1.43.46-py3-none-any.whl", hash = "sha256:69453e2c1bcb9fd9806527ab99950cacfc2826cb0dce9a3a0414d19270c06c3c"},
-    {file = "boto3-1.43.46.tar.gz", hash = "sha256:66c0d943b049a46a492ec4ec2ebe73c930b1842c7137bee83aad6d93e95d4d96"},
+    {file = "boto3-1.43.51-py3-none-any.whl", hash = "sha256:a97057bb609fd38c80448db6a93db770786775dabd651401debf09816d4553d7"},
+    {file = "boto3-1.43.51.tar.gz", hash = "sha256:b5a416cc703db73b69b22bef563c89c1fb14a4b10a93628d3c7abc4dd1aaf979"},
 ]
 
 [package.dependencies]
-botocore = ">=1.43.46,<1.44.0"
+botocore = ">=1.43.51,<1.44.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.19.0,<0.20.0"
 
@@ -201,14 +201,14 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.43.46"
+version = "1.43.51"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "botocore-1.43.46-py3-none-any.whl", hash = "sha256:cb673891e623ae6e6a1bf24d94ef169504f3eb02584adb5d5bee2f6aae819b60"},
-    {file = "botocore-1.43.46.tar.gz", hash = "sha256:59f2e1ac3cdc66d191cae91c0804bc41847ce817dc8147cf43eaada8f76a5533"},
+    {file = "botocore-1.43.51-py3-none-any.whl", hash = "sha256:7c2c538c932bddc95834e177ce6f91dcc388c6a7934b4f8d0db13caa30e3e543"},
+    {file = "botocore-1.43.51.tar.gz", hash = "sha256:e0e5e88585fdb01dcb6b533ac2dd3f18d5d45092a14ccbfd330e3576a4152128"},
 ]
 
 [package.dependencies]
@@ -217,7 +217,7 @@ python-dateutil = ">=2.1,<3.0.0"
 urllib3 = ">=1.25.4,<2.2.0 || >2.2.0,<3"
 
 [package.extras]
-crt = ["awscrt (==0.32.2)"]
+crt = ["awscrt (==0.36.0)"]
 
 [[package]]
 name = "certifi"
@@ -1214,62 +1214,62 @@ tests = ["pytest (>=4.6)"]
 
 [[package]]
 name = "mypy"
-version = "2.2.0"
+version = "2.3.0"
 description = "Optional static typing for Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "mypy-2.2.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:97d21f3a1582ef30d0b77f9ca3ad88b4263f3c5aea9e7380cb5d7175160aec7e"},
-    {file = "mypy-2.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2529017942b951cc43db2e2712b71cc3aa7e9d90567630c03ed63d430aeec61a"},
-    {file = "mypy-2.2.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0823d7f273f3b4a49df7573eac271ddbf77a0e5f53e24d294a4f0f77ad22e1d7"},
-    {file = "mypy-2.2.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d78a0fc90704894bc9948d78affad14b882b08183a7c30412d185748aaa9418b"},
-    {file = "mypy-2.2.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:6efab25fa3568569fda06928743382900860c48be9200c1758ef5ce94b532714"},
-    {file = "mypy-2.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:daeaf5287091d68f674c91416cabab0f80f36e347ed17fded38d7ebde682e9d1"},
-    {file = "mypy-2.2.0-cp310-cp310-win_arm64.whl", hash = "sha256:f8d97940a0259e09c219903579720b2df12170c0c3a3b3799837c1fb63deb44e"},
-    {file = "mypy-2.2.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ea6fe1a30f3e7dc574d641497ffead2428046b0f8bc5804d13b4e4392fdc317b"},
-    {file = "mypy-2.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6965829a6d847a0925f51149472bbeb7a39332fb4801972fdfd9cedd9f8d43a4"},
-    {file = "mypy-2.2.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5a906bfc9c4c5de3ece6dc4726f8076d56ce9be1720baf0c6f84e926c10262a4"},
-    {file = "mypy-2.2.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:91df92625cb3452758f27f4965b000fb05ad89b00c282cc3430a7bd6b0e5389e"},
-    {file = "mypy-2.2.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d42893d15894fd34f395090e2d78315ba7c637d5ee221683e02893f578c2f548"},
-    {file = "mypy-2.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:d3abaeec02cdc72e30a147d99eb81852b6b745a2c8d19607e25241d79b1abbce"},
-    {file = "mypy-2.2.0-cp311-cp311-win_arm64.whl", hash = "sha256:c39bdb7ceab252d15011e26d3a254b4aaa3bbf121b551febfa301df9b0c69abe"},
-    {file = "mypy-2.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:484a2be712b245ac6e89847141f1f50c612b0a924aa25917e63e6cfcf4da07cd"},
-    {file = "mypy-2.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fb0a020dc68480d40e484675558ed637140df1ccbf896a81ba68bca85f2b50a0"},
-    {file = "mypy-2.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc361340732ce7108fa0308812caf02bb6868f16112f1efd35bcad88badf3327"},
-    {file = "mypy-2.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b0179a3a0b833f724a65f22613607cf7ea941ab17ec34fa283f8d6dfe21d9fa9"},
-    {file = "mypy-2.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9e0899b13da1e4ba44b880550f247402ce90ffecc71c54b220bcbe7ecb34f394"},
-    {file = "mypy-2.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:511320b17467402e2906130e185abffffa3d7648aff1444fc2abb61f4c8a087d"},
-    {file = "mypy-2.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:7589f370b33dcdd95708f5340f13a67c2c49140957f934b42ef63064d343cca0"},
-    {file = "mypy-2.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6968f27347ef539c443ddfd6897e79db525ddb8c856aa8fbf14c34f310ca5193"},
-    {file = "mypy-2.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3df226d2a0ae2c3b03845af217800a68e2965d4b14914c99b78d3a2c8ae23299"},
-    {file = "mypy-2.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fc53553996aca2094216ad9306a6f06c5265d206c1bcb54dd367560bd3557825"},
-    {file = "mypy-2.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:996abf2f0bebf572556c60720e8dc0cf5292b64060fa68d7f2bc9caa48e01b6f"},
-    {file = "mypy-2.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ec287c2381898c652bf8ff79448627fe1a9ee76d22005181fac7315a485c7108"},
-    {file = "mypy-2.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:c2c967a7685fa93fcf1a778b3ebe76e756b28ba14655f539d7b61ff3da69352a"},
-    {file = "mypy-2.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:d59a4b80351ec92e5f7415fcdd008bd77fcbefc7adf9cbc7ffe4eb9f71617734"},
-    {file = "mypy-2.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1f6c3d76853071409ac58fc0aadfb276a22af5f190fdaa02152a858088a39ebd"},
-    {file = "mypy-2.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bdaa177e80cc3292824d4ef3670b5b58771ee8d57c290e0c9c89e7968212332c"},
-    {file = "mypy-2.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:80923e6d6e7878291f537ee11052f974954c20cb569798429a5dc265eb780b47"},
-    {file = "mypy-2.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f24bd465a09077c8d64be8f19a6646db467a55490fd315fe7871afe6bb9645"},
-    {file = "mypy-2.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:db34595464869f474708e769413d1d739fc33a69850f253757b9a4cc20bc1fec"},
-    {file = "mypy-2.2.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:b48092132c7b0ef4322773fecae62fc5b0bc339be348badeec8af502122a4a51"},
-    {file = "mypy-2.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:6fc0e98b95e31755ca06d89f75fafa7820fbb3ea2caace6d83cba17625cd0acb"},
-    {file = "mypy-2.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:bc73a5b4d40e8a3e6b12ef82eb0c90430964e34016a36c2aff4e3bfe37ba41f0"},
-    {file = "mypy-2.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:6257bd4b4c0ae2148548b869a1ff3758e38645b92c8fe65eca401866c3c551c1"},
-    {file = "mypy-2.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:dfa22b3ae862ac1ce76f5976ddd402651b5f090bcfd49c6d0484b8983a29eaf8"},
-    {file = "mypy-2.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30a430bf26fe8cf372f3933fbd83e633d6561868803645a20e4e6d4523f52a3b"},
-    {file = "mypy-2.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d58655a60e823b1a4c9ebcda072897fb0193c2f3e6f8e7c433e152aa4cb00233"},
-    {file = "mypy-2.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d4452c955caf14e28bb046cbd0c3671272e6381630a8b81b0da9713558148890"},
-    {file = "mypy-2.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:68f5b7f7f755200f68c7181e3dfb28be9858162257690e539759c9f57721e388"},
-    {file = "mypy-2.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:78d201accfafce3801d978f2b8dbbd473a9ce364cc0a0dfd9192fe47d977e129"},
-    {file = "mypy-2.2.0-py3-none-any.whl", hash = "sha256:ecc138da861e932d1344214da4bae866b21900a9c2778824b51fe2fb47f5180e"},
-    {file = "mypy-2.2.0.tar.gz", hash = "sha256:2cdd99d48590dce6f6b7f1961eda75386364398fcdaad86923bc0f0231bf9baf"},
+    {file = "mypy-2.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1fa8d916ac3b705af733c4c1e6c9ebe38fd0d52beb15b105c3e8355b55e6ecdc"},
+    {file = "mypy-2.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:28e1e2af8cd8fff551fd30f2fe4b03fb76764ac8b1ba6c6a1bd00ad32b412db3"},
+    {file = "mypy-2.3.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3e77244df3843048c3f927182916730e40c124cbaa43905c1fb86cb382aa0805"},
+    {file = "mypy-2.3.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9559ab18a9c9957dfa3004ab57cd4bac5f26a724329a9584e583367f0c2e1117"},
+    {file = "mypy-2.3.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:09abd66d8685e73f8f7d17b847c3e104d9a7b164a8706ea87d6c96a3d45816d5"},
+    {file = "mypy-2.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:5e91adad1ca81742ac7ef9893959911df867752206b37135185e88dfb3c89494"},
+    {file = "mypy-2.3.0-cp310-cp310-win_arm64.whl", hash = "sha256:6f99ec626e3c3a2f7c0b22c5b90ddb5dabb1c18729c971e9bdaca1f1766d2cee"},
+    {file = "mypy-2.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3419d00717afbc5265b50dd14b1278f29ea4884dd398ab67873489ac093fd329"},
+    {file = "mypy-2.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:cfca8ee88544090f86b6dcce05ec55d66eb48a762412ac2507810ba4bd793b6f"},
+    {file = "mypy-2.3.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:75cbb4b9ef04a0c84a957f07abc4504fbf64b8dcc145675101f2d3a78a4b1d6a"},
+    {file = "mypy-2.3.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:982e3d53dd23d0a4cef67dd66791fdbede0cf38f9eb617bf47663554c51e1e36"},
+    {file = "mypy-2.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:85c5385b93012ffa3b31479ab579aef5415f4f3a32c6cf1ae07a984d2a0ff461"},
+    {file = "mypy-2.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:13b1b16e2fa39f3b2e33fb1c468abc7a69369fa2e886b4b87b5afc81472325cd"},
+    {file = "mypy-2.3.0-cp311-cp311-win_arm64.whl", hash = "sha256:b5cd2f027a972a4a5f2278a11fac9747f5f81a53a30b714d74950b6807e55568"},
+    {file = "mypy-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d53fc67b9d28a43c6199077f49fea0f05839e36cf6158500331c9549225e5a5"},
+    {file = "mypy-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fbc00cee7bdbb9291979ddc9d08034a29dfcda4932628c9bbc28c1edd589df0c"},
+    {file = "mypy-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04e617030eca5221909c8b7d8d7fd1c637948199aa2100b2ad9813feb07e1491"},
+    {file = "mypy-2.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56c184d2c20ca6b6378d58d1960270a767f41f5e44acbbd27f05effef4f4e1d7"},
+    {file = "mypy-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3961a4a34b05f7c74b0f05aa51fbfe99a2d1e126038df40318d15c8f558b7ef3"},
+    {file = "mypy-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:b1942b9314d4c784b8ea1dbab4972603290e5dd5630f06675f13aec97526bc4c"},
+    {file = "mypy-2.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:be51653d7669d7d7955d613b8d0bb57d5b652eaf71a873ddf65ac87254dd2595"},
+    {file = "mypy-2.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:91ad22a52ae2c7e621c2f67c94d5a17f66b3209a4cff5cf8a573579835c69e97"},
+    {file = "mypy-2.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:99ac767cc5d3b64c8d0ae226ead10c96694f94e4e7da1668642225dcd4e75aac"},
+    {file = "mypy-2.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:de6d2c484742a4d7b0ed6d07b143375624d3b899c5749c7b3c947f56261f48a6"},
+    {file = "mypy-2.3.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7da939dd335cfd2ad788bdfd081c9f4e47634ab995e5a45eb15fd1e5bc052f8b"},
+    {file = "mypy-2.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7247eb2824f996722a949530183394921ca71deb9680052a338cf53cff7925c2"},
+    {file = "mypy-2.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:75b0984bb3cbd76bb5c9291a8671f7ae66ca3b51c7584c358fc2e923259f0757"},
+    {file = "mypy-2.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:d78fcf900b59cb7e82cb7e3a235e31b462d9333d92285bd1e4952d355b8ffba1"},
+    {file = "mypy-2.3.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ea317b060ce83e26050f8f9e4d7d6bf44ed7597c8ff9990bccffbb9d1d8522db"},
+    {file = "mypy-2.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:094af99f92638aa92852326188b85a89e50f4a472f44827c03362228482f0762"},
+    {file = "mypy-2.3.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:de121747278144fc9ae7caa2e978cf5df12aebc82933182f5b3b86081a30baef"},
+    {file = "mypy-2.3.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:37fa4de896a84e2dc9200d91e614c22563b43d1a266789d4bbac7b22ebe6192b"},
+    {file = "mypy-2.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f1b3a98dfd21058bc759bb3337d5d1f61d0fdf9f3cf9c00f4291790fb5427bff"},
+    {file = "mypy-2.3.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:944c665d984157cb96a679dfb7a4a81dd1d36b24b9c284b699514e6e626b82d4"},
+    {file = "mypy-2.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:4359424140d985192c778c1ce2c114a10c1ca58a381ed79cfa70d37df94b299f"},
+    {file = "mypy-2.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:3dd0bed92c4bdec57c42505b96416fb9e6a5aa7be84d2809bcd5f2ecec2860d7"},
+    {file = "mypy-2.3.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:691fdc37132b1ae628d834f672e74de83462d9fb4aff621835767fb43a8dd373"},
+    {file = "mypy-2.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:aec15d465d477558fd842757b487849007311cf3897849cdda0e3162ac0ac556"},
+    {file = "mypy-2.3.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b352b7e49f5e6576009e8df730e1ff4f915cb565b851b396d2ffe2f5a6f5da88"},
+    {file = "mypy-2.3.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c6c6bf687b17f90dbfcad95b960d32eaa0154c00da45f03ab50bf8952e047fe"},
+    {file = "mypy-2.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f4ed18f111bfe2d599bca7468e7f9251042c1c2118f762c8de2766a56d773c60"},
+    {file = "mypy-2.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0b025a93cffb9781d231f232be07a17912f35f10a313c24f301c81e842870654"},
+    {file = "mypy-2.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:adebc76aab4f3495a88b41d48aa4aff0c03f2822501da76625afcca5975f19e5"},
+    {file = "mypy-2.3.0-py3-none-any.whl", hash = "sha256:6b1cdb579446b60432432b2b2403a6201b4b475a004d7f488511c9ba177c9e88"},
+    {file = "mypy-2.3.0.tar.gz", hash = "sha256:465965d41cd9a2726694e983e8ce7113259327bec798115d1e1dfa2a52fb666e"},
 ]
 
 [package.dependencies]
 ast-serialize = ">=0.6.0,<1.0.0"
-librt = {version = ">=0.12.0", markers = "platform_python_implementation != \"PyPy\""}
+librt = {version = ">=0.13.0", markers = "platform_python_implementation != \"PyPy\""}
 mypy_extensions = ">=1.0.0"
 pathspec = ">=1.0.0"
 tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
@@ -2374,30 +2374,30 @@ files = [
 
 [[package]]
 name = "ruff"
-version = "0.15.21"
+version = "0.15.22"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
 files = [
-    {file = "ruff-0.15.21-py3-none-linux_armv6l.whl", hash = "sha256:63ea0e965e5d73c90e95b2434beeafc70820536717f561b32ab6e777cb9bdf5d"},
-    {file = "ruff-0.15.21-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0f212c5d7d54c01bbfe6dcab02b724a39300f3e34ed7acbe995ccb320a2c58bd"},
-    {file = "ruff-0.15.21-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e6312e41bc96791299614995ea3a977c5857c3b5662b1ecef6755b02b87cb646"},
-    {file = "ruff-0.15.21-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:01d65b4831c6b2a4ba8ee6faa84049d44d982b7a706e622c4094c509e51673be"},
-    {file = "ruff-0.15.21-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2c5a913a589120ce67933d5d05fd6ddbcc2481c6a054980ee767f7414c72b4fd"},
-    {file = "ruff-0.15.21-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5ef04b681d02ad4dc9620f00f83ac5c22f652d0e9a9cfe431d219b16ad5ccc41"},
-    {file = "ruff-0.15.21-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:16d090c0740916594157e75b80d666eab8e78083b39b3b0e1d698f4670a17b86"},
-    {file = "ruff-0.15.21-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3a10e74757dd65004d779b73e2f3c5210156d9980b41224d50d2ebcf1db51e67"},
-    {file = "ruff-0.15.21-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bab0905d2f29e0d9fbc3c373ed23db0095edaa3f71f1f4f519ec15134d9e85c8"},
-    {file = "ruff-0.15.21-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:00eca240af5789fec6fe7df74c088cc1f9644ed83027113468efba7c92b94075"},
-    {file = "ruff-0.15.21-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:262ab31557a75141325e32d3357f3597645a7f084e732b6b054dde428ecd9341"},
-    {file = "ruff-0.15.21-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:659c4e7a4212f83306045ec7c5e5a356d16d9a6ef4ae0c7a4d872914fc655d9d"},
-    {file = "ruff-0.15.21-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9e866eab611a5f959d36df2d10e446973a3610bc42b0c15b31dc27977d59c233"},
-    {file = "ruff-0.15.21-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e89bc93c0d3803ba870b55c29671bad9dc6d94bb1eb181b056b52eb05b52854f"},
-    {file = "ruff-0.15.21-py3-none-win32.whl", hash = "sha256:01f8d5be84823c172b389e123174f781f9daf86d6c58719d603f941932195cdd"},
-    {file = "ruff-0.15.21-py3-none-win_amd64.whl", hash = "sha256:d4b8d9a2f0f12b816b50447f6eccb9f4bb01a6b82c86b50fb3b5354b458dc6d3"},
-    {file = "ruff-0.15.21-py3-none-win_arm64.whl", hash = "sha256:6e83115d4b9377c1cbc13abf0e051f069fab0ef815ea0504a8a008cee24dd0a8"},
-    {file = "ruff-0.15.21.tar.gz", hash = "sha256:d0cfc841c572283c36548f82664a54ce6565567f1b0d5b4cf2caac693d8b7500"},
+    {file = "ruff-0.15.22-py3-none-linux_armv6l.whl", hash = "sha256:44423e73493737f5e7c5b41d475483898ff37afcdae38bc3da5085e29af1c2d8"},
+    {file = "ruff-0.15.22-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b82c6482946e9eda7ff2e091d25b8bad3f718684e1916d41bd56873cee05b697"},
+    {file = "ruff-0.15.22-py3-none-macosx_11_0_arm64.whl", hash = "sha256:11c1c715af53a09f714e011106bffc419751ec8232fcb5da42173284ea3fec6f"},
+    {file = "ruff-0.15.22-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:742a29cf29bddb7c8327895d6a10e0e6c5b38a96dd407af9b5d0857f809c0576"},
+    {file = "ruff-0.15.22-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72af58b951b0ae395935ae79763dc349bc0eb706319d28f7a33ad2cfb3cfc178"},
+    {file = "ruff-0.15.22-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:62d425005c1835eb24e2ee4161cb90e8db263415f4a71c8c72c33abaa6c0c224"},
+    {file = "ruff-0.15.22-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e8b9b3f8779a4f08c969defc3c8c35abffaa757e601ed5ae66d6d1db6519969a"},
+    {file = "ruff-0.15.22-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1e0dd1b2e4d3d585f897a0d137cbf4eaf6223bef4e8ce34d6bb12556c5f9249e"},
+    {file = "ruff-0.15.22-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:365523eb91d9224e1bcb03b022fbf0facb8f9e23792a2c53d9d4b3924bdbdebb"},
+    {file = "ruff-0.15.22-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:fabfd168afdf29fee5be98b831efa9683c94d7c5a3b58b9ce5a2e38444589a74"},
+    {file = "ruff-0.15.22-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:225dbf095a87f1d9f90f5fd7924d2613ee452a75a4308c63a8f50f761787aa7c"},
+    {file = "ruff-0.15.22-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:1877d63b9d24ed278744f1523fd11b85540566d54641f97c566d7d9dc5ca5296"},
+    {file = "ruff-0.15.22-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a1606c510bd7215680d32efab38965f7cdec3ef69f5170a3f4791404ffdd5262"},
+    {file = "ruff-0.15.22-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:630479b18625f5ffc373f77603a22a9f8ac0acd7ff0501178b5db28ec71e9c64"},
+    {file = "ruff-0.15.22-py3-none-win32.whl", hash = "sha256:e5ba0e4a13fd14abbed2a77b517a3911290c6c6c59ef67784328d1668fab76cf"},
+    {file = "ruff-0.15.22-py3-none-win_amd64.whl", hash = "sha256:9be63ba1eb936acd2d1342fb8337c356353706fce233b2a15a09a97037e6acde"},
+    {file = "ruff-0.15.22-py3-none-win_arm64.whl", hash = "sha256:e1168075b72158510839f250027659cdd78476f40507dd517892304c41318661"},
+    {file = "ruff-0.15.22.tar.gz", hash = "sha256:3f15175b1fb580126f58285a5dae6b2ea89000136d980c64499211f116b54809"},
 ]
 
 [[package]]
@@ -2531,14 +2531,14 @@ files = [
 
 [[package]]
 name = "types-requests"
-version = "2.33.0.20260518"
+version = "2.33.0.20260712"
 description = "Typing stubs for requests"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "types_requests-2.33.0.20260518-py3-none-any.whl", hash = "sha256:626d697d1adaaff76e2044dc8c5c051d8f21abc157bdfe204a75558076fe0bf0"},
-    {file = "types_requests-2.33.0.20260518.tar.gz", hash = "sha256:df7bd3bfe0ca8402dfb841e7d9be714bb5578203283d66d7dc4ef69343449a5e"},
+    {file = "types_requests-2.33.0.20260712-py3-none-any.whl", hash = "sha256:de027e28c171d3da529689cbfa023b0b4eab188c8dfa22fd834eebd2cee6e7bb"},
+    {file = "types_requests-2.33.0.20260712.tar.gz", hash = "sha256:2141b67ab534a5c5cd2dac5034f2a35f42e699c5bf185eee608c5246a069d7fb"},
 ]
 
 [package.dependencies]

--- a/source/poetry.lock
+++ b/source/poetry.lock
@@ -26,43 +26,46 @@ files = [
 
 [[package]]
 name = "ast-serialize"
-version = "0.3.0"
+version = "0.6.0"
 description = "Python bindings for mypy AST serialization"
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
 files = [
-    {file = "ast_serialize-0.3.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:3a867927df59f76a18dc1d874a0b2c079b42c58972dca637905576deb0912e14"},
-    {file = "ast_serialize-0.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a6fb063bf040abf8321e7b8113a0554eda445ffc508aa51287f8808886a5ae22"},
-    {file = "ast_serialize-0.3.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5075cd8482573d743586779e5f9b652a015e37d4e95132d7e5a9bc5c8f483d8f"},
-    {file = "ast_serialize-0.3.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:41560b27794f4553b0f77811e9fb325b77db4a2b39018d437e09932275306e66"},
-    {file = "ast_serialize-0.3.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b967c01ca74909c5d90e0fe4393401e2cc5da5ebd9a6262a19e45ffd3757dec8"},
-    {file = "ast_serialize-0.3.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:424ebb8f46cd993f7cec4009d119312d8433dd90e6b0df0499cd2c91bdcc5af9"},
-    {file = "ast_serialize-0.3.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d14b1d566b56e2ee70b11fec1de7e0b94ec7cd83717ec7d189967841a361190e"},
-    {file = "ast_serialize-0.3.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7ba30b18735f047ec11103d1ab92f4789cf1fea1e0dc89b04a2f5a0632fd79de"},
-    {file = "ast_serialize-0.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e6ea0754cb7b0f682ebb005ffb0d18f8d17993490d9c289863cd69cacc4ab8df"},
-    {file = "ast_serialize-0.3.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:a0c5aa1073a5ba7b2abaa4b54abe8b8d75c4d1e2d54a2ff70b0ca6222fea5728"},
-    {file = "ast_serialize-0.3.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:4e52650d834c1ea7791969a361de2c54c13b2fb4c519ec79445fa8b9021a147d"},
-    {file = "ast_serialize-0.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:15bd6af3f136c61dae27805eb6b8f3269e85a545c4c27ffe9e530ead78d2b36d"},
-    {file = "ast_serialize-0.3.0-cp314-cp314t-win32.whl", hash = "sha256:d188bfe37b674b49708497683051d4b571366a668799c9b8e8a94513694969d9"},
-    {file = "ast_serialize-0.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:5832c2fdf8f8a6cf682b4cfcf677f5eaf39b4ddbc490f5480cfccdd1e7ce8fa1"},
-    {file = "ast_serialize-0.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:670f177188d128fb7f9f15b5ad0e1b553d22c34e3f584dcb83eb8077600437f0"},
-    {file = "ast_serialize-0.3.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:2ec2fafa5e4313cc8feed96e436ebe19ac7bc6fa41fbc2827e826c48b9e4c3a9"},
-    {file = "ast_serialize-0.3.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ef6d3c08b7b4cd29b48410338e134764a00e76d25841eb02c1084e868c888ecc"},
-    {file = "ast_serialize-0.3.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3d841424f41b886e98044abc80769c14a956e6e5ccd5fb5b0d9f5ead72be18a4"},
-    {file = "ast_serialize-0.3.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d21453734ad39367ede5d37efe4f59f830ce1c09f432fc72a90e368f77a4a3e7"},
-    {file = "ast_serialize-0.3.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f5e110cdce2a347e1dd987529c88ef54d26f67848dce3eba1b3b2cc2cf085c94"},
-    {file = "ast_serialize-0.3.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3b6e23a98e57560a055f5c4b68700a0fd5ce483d2814c23140b3638c7f5d1e61"},
-    {file = "ast_serialize-0.3.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c1c9e763d70293d65ce1e1ea8c943140c68d0953f0268c7ee0998f2e07f77dd0"},
-    {file = "ast_serialize-0.3.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4388a1796c228f1ce5c391426f7d21a0003ad3b47f677dbeded9bd1a85c7209f"},
-    {file = "ast_serialize-0.3.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:5283cdcc0c64c3d8b9b688dc6aaa012d9c0cf1380a7f774a6bae6a1c01b3205a"},
-    {file = "ast_serialize-0.3.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:f5ef88cc5842a5d7a6ac09dc0d5fc2c98f5d276c1f076f866d55047ce886785b"},
-    {file = "ast_serialize-0.3.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:cc14bf402bdc0978594ecce783793de2c7470cd4f5cd7eb286ca97ed8ff7cba9"},
-    {file = "ast_serialize-0.3.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:11eae0cf1b7b3e0678133cc2daa974ea972caf02eb4b3aa062af6fa9acd52c57"},
-    {file = "ast_serialize-0.3.0-cp39-abi3-win32.whl", hash = "sha256:2db3dd99de5e6a5a11d7dda73de8750eb6e5baaf25245adf7bdcfe64b6108ae2"},
-    {file = "ast_serialize-0.3.0-cp39-abi3-win_amd64.whl", hash = "sha256:a2cd125adccf7969470621905d302750cd25951f22ea430d9a25b7be031e5549"},
-    {file = "ast_serialize-0.3.0-cp39-abi3-win_arm64.whl", hash = "sha256:0dd00da29985f15f50dc35728b7e1e7c84507bccfea1d9914738530f1c72238a"},
-    {file = "ast_serialize-0.3.0.tar.gz", hash = "sha256:1bc3ca09a63a021376527c4e938deedd11d11d675ce850e6f9c7487f5889992b"},
+    {file = "ast_serialize-0.6.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:a7520b672827885bafeae7501f684d14d47d17e5f45256f9df547686cca52264"},
+    {file = "ast_serialize-0.6.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a14191beec7e0c078d2fc1f6edc0aee88bcd4db9f18e1bc9f8052b559c22dddc"},
+    {file = "ast_serialize-0.6.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32ef62ec34cf6be20ad77d4799556638fbdf187f3ae10698dfb20ef9f2c89516"},
+    {file = "ast_serialize-0.6.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:13b7769970a39983b0adf2f38917b1cd3b8946f76df045756c3d741bc689f089"},
+    {file = "ast_serialize-0.6.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6f7a408601bb3edaefb3bc67a4c01f5235e3253653b6a5729a2ee2382b35341c"},
+    {file = "ast_serialize-0.6.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8670bfa51208a2c0c8d138928e40e998fab158f9200d53bb80c088b5b8eda7b8"},
+    {file = "ast_serialize-0.6.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a4826809eb8597a8cd59fd924b6d7c285b8969a1e0007e2cb652cab62376270f"},
+    {file = "ast_serialize-0.6.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:577a6c189068686869f5f1ddc38363f3ae1808a4753b577266f9202071a7bb66"},
+    {file = "ast_serialize-0.6.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:085de7f62dc9cc247eb01e965a362707d1d90b1d89a82c5bf78301a60a3c417b"},
+    {file = "ast_serialize-0.6.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9f8a8b78b13173de6a9ec22111d9be674874cd5bdccda04f14ae5ebc2bef403a"},
+    {file = "ast_serialize-0.6.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:f2ff3baffc3a29c1f15bc9098aa0c09763410262d5e6cef42116f7356c184554"},
+    {file = "ast_serialize-0.6.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:0067b25fce104eaae5b88383de9ab803faeb671831e14ca698b771b356e2600f"},
+    {file = "ast_serialize-0.6.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c617417f9cbb0cb144f6283c3cbe0d2e0f01beaf9f608f662b21191058a626ec"},
+    {file = "ast_serialize-0.6.0-cp314-cp314t-win32.whl", hash = "sha256:5337cb256dcea3df9288205213d1601581536526b8f4da44b6974f1180f3252a"},
+    {file = "ast_serialize-0.6.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2d947e45cafc4b09bd7528917fa84c517654a43de173c79785574b7b3068ac24"},
+    {file = "ast_serialize-0.6.0-cp314-cp314t-win_arm64.whl", hash = "sha256:6e15ec740436e1a0d62de848641abe5f3a2f89a7f94907d534795ac91bbacf14"},
+    {file = "ast_serialize-0.6.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:093cb8bb91b720d8523580498d031791bb1bbaa048599c3d21085d380e11a596"},
+    {file = "ast_serialize-0.6.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e61580a69faf47e3689795367ed211f2a10fd741478cc0f36a0f128793360aad"},
+    {file = "ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:305802f2ce2a7c4e87835078ea85c58b586ddda8095b92fe2ead9364ae19c80a"},
+    {file = "ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c7b8b8f0c42f752ea00b2b7d7c090b3f80d9c1c5c75cadf16423790a0cc74081"},
+    {file = "ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cd5b91b9e6f2356ace3a556963b0cd783b395fbbb0bb17b4defc283415466e77"},
+    {file = "ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4d6ef91590258ada18909b9caea344dac4de2013906b035473cd674a43f4b790"},
+    {file = "ast_serialize-0.6.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dcbed41e9386059fc0261d602445ede0976c2ecec2939688bcbcb9ed0b6f28b7"},
+    {file = "ast_serialize-0.6.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:cdc4e6f930b9090c2f92c9036ad12ffb8e6e44d4a5ba06f1458a05d60f203f7b"},
+    {file = "ast_serialize-0.6.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:897ac47b5637be41c0c07061c8a912fafa967ef1dc73fa115e4bfa70882a093b"},
+    {file = "ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c4af9a1386166e40ed01464991806f89038a2d89782576c7774876fa77034e32"},
+    {file = "ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c901adbd750029b9ac4ad3d6aa56853e0ad4875119fbf52b7b8298afc223828b"},
+    {file = "ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae22a366b752ab4496191525b78b097b5b72d531752e3c1dd7e383a8f2c8a1a"},
+    {file = "ast_serialize-0.6.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4ed29121da8b3fdc291002801a1de0f76248fa07dce89157a5f277842cf6126e"},
+    {file = "ast_serialize-0.6.0-cp39-abi3-pyemscripten_2026_0_wasm32.whl", hash = "sha256:b1dac4e09d341c1300ba69cdcbe62867b32a8c75d90db9bf4d083bec3b039f0b"},
+    {file = "ast_serialize-0.6.0-cp39-abi3-win32.whl", hash = "sha256:82c312a7844d2fdeb4d5c48bd3d215bf940dafd4704e1a9bcf252a99010a99b1"},
+    {file = "ast_serialize-0.6.0-cp39-abi3-win_amd64.whl", hash = "sha256:113b58346f9ceb664352032770caca817d4a3c86f611c6088e6ef65ddaa70f0e"},
+    {file = "ast_serialize-0.6.0-cp39-abi3-win_arm64.whl", hash = "sha256:ccd132fe8db56f61fe743b1f644d01b8d65b83248a8da506f3132bda86d6ed5e"},
+    {file = "ast_serialize-0.6.0.tar.gz", hash = "sha256:aadd3ffcf4858c9726bf3515f7b199c7eadbe504f96028e4a87172c0da65a8fe"},
 ]
 
 [[package]]
@@ -87,14 +90,14 @@ tests-mypy = ["mypy (>=1.11.1) ; platform_python_implementation == \"CPython\" a
 
 [[package]]
 name = "aws-sam-translator"
-version = "1.110.0"
+version = "1.111.0"
 description = "AWS SAM Translator is a library that transform SAM templates into AWS CloudFormation templates"
 optional = false
 python-versions = "!=4.0,<=4.0,>=3.10"
 groups = ["dev"]
 files = [
-    {file = "aws_sam_translator-1.110.0-py3-none-any.whl", hash = "sha256:69b09aacf2d305ac747037b7b913224cb8a9d653f47a0306509c1d20e420b670"},
-    {file = "aws_sam_translator-1.110.0.tar.gz", hash = "sha256:466ee0e8200992c51b7fd5ede5e56ca2e8dd5473cc551e8495c14f2f4d636127"},
+    {file = "aws_sam_translator-1.111.0-py3-none-any.whl", hash = "sha256:510d0ad8cd40b245a62004f2dc974ddbb6ff0d496bdec0bc7d9cd209b46d5fad"},
+    {file = "aws_sam_translator-1.111.0.tar.gz", hash = "sha256:6884d94e28dc20384e5e0396e9386a456fe59303d706924deb2646329b4d97d3"},
 ]
 
 [package.dependencies]
@@ -178,18 +181,18 @@ uvloop = ["uvloop (>=0.15.2) ; sys_platform != \"win32\"", "winloop (>=0.5.0) ; 
 
 [[package]]
 name = "boto3"
-version = "1.43.40"
+version = "1.43.46"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "boto3-1.43.40-py3-none-any.whl", hash = "sha256:5fa80de4b4b7bab383dd8c563e235d51fcc7df4502662af56f0a2472c3c15651"},
-    {file = "boto3-1.43.40.tar.gz", hash = "sha256:a7108b9ce25b8f92d1ce96b9e35090794d5c58b219ff2f6a7a65c8986a4ed6f4"},
+    {file = "boto3-1.43.46-py3-none-any.whl", hash = "sha256:69453e2c1bcb9fd9806527ab99950cacfc2826cb0dce9a3a0414d19270c06c3c"},
+    {file = "boto3-1.43.46.tar.gz", hash = "sha256:66c0d943b049a46a492ec4ec2ebe73c930b1842c7137bee83aad6d93e95d4d96"},
 ]
 
 [package.dependencies]
-botocore = ">=1.43.40,<1.44.0"
+botocore = ">=1.43.46,<1.44.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.19.0,<0.20.0"
 
@@ -198,14 +201,14 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.43.40"
+version = "1.43.46"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "botocore-1.43.40-py3-none-any.whl", hash = "sha256:0bc9d352267c9e48415c5d7bb61ff05c3f193eac2fc7e69cfd229a05fbab67d6"},
-    {file = "botocore-1.43.40.tar.gz", hash = "sha256:2085a4314cfd2c8bc1d08ab8039f76c92e99278db0d2a0e2437010526d5d5d70"},
+    {file = "botocore-1.43.46-py3-none-any.whl", hash = "sha256:cb673891e623ae6e6a1bf24d94ef169504f3eb02584adb5d5bee2f6aae819b60"},
+    {file = "botocore-1.43.46.tar.gz", hash = "sha256:59f2e1ac3cdc66d191cae91c0804bc41847ce817dc8147cf43eaada8f76a5533"},
 ]
 
 [package.dependencies]
@@ -357,18 +360,18 @@ six = "*"
 
 [[package]]
 name = "cfn-lint"
-version = "1.52.1"
+version = "1.53.0"
 description = "Checks CloudFormation templates for practices and behaviour that could potentially be improved"
 optional = false
 python-versions = "<3.15,>=3.10"
 groups = ["dev"]
 files = [
-    {file = "cfn_lint-1.52.1-py3-none-any.whl", hash = "sha256:26222d5891f7893c53a97020ed1b390063fec440da941e6eb9d12d3a741c2ac4"},
-    {file = "cfn_lint-1.52.1.tar.gz", hash = "sha256:696cf93fc3c20c257eb7c5ce4622621bc8f5b0823cb5e0ea2d042e1eb0c2cd0c"},
+    {file = "cfn_lint-1.53.0-py3-none-any.whl", hash = "sha256:8a91d1f0d8d18614410a0c1676213df8cd0ac55fa462f3f6369fb9fdaa7ae28d"},
+    {file = "cfn_lint-1.53.0.tar.gz", hash = "sha256:dcf285939dea3c15e06bcb23a817bbdecb6c3e0ab19d98147877f04e02b5b07c"},
 ]
 
 [package.dependencies]
-aws-sam-translator = ">=1.110.0"
+aws-sam-translator = ">=1.111.0"
 jsonpatch = "*"
 networkx = ">=2.4,<4"
 pyyaml = ">=6.0.3"
@@ -1025,103 +1028,105 @@ type = ["pygobject-stubs", "pytest-mypy (>=1.0.1)", "shtab", "types-pywin32"]
 
 [[package]]
 name = "librt"
-version = "0.11.0"
+version = "0.13.0"
 description = "Mypyc runtime library"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 markers = "platform_python_implementation != \"PyPy\""
 files = [
-    {file = "librt-0.11.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6e94ebfcfa2d5e9926d6c3b9aa4617ffc42a845b4321fb84021b872358c82a0f"},
-    {file = "librt-0.11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ae627397a2f351560440d872d6f7c8dbb4072e57868e7b2fc5b8b430fe489d45"},
-    {file = "librt-0.11.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc329359321b67d24efdf4bc69012b0597001649544db662c001db5a0184794c"},
-    {file = "librt-0.11.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:7e82e642ab0f7608ce2fe53d76ca2280a9ee33a1b06556142c7c6fe80a86fc33"},
-    {file = "librt-0.11.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:88145c15c67731d54283d135b03244028c750cc9edc334a96a4f5950ebdb2884"},
-    {file = "librt-0.11.0-cp310-cp310-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9d36a51b3d93320b686588e27123f4995804dbf1bce81df78c02fc3c6eea9280"},
-    {file = "librt-0.11.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d00f3ac06a2a8b246327f11e186a53a100a4d5c7ed52346367e5ec751d51586c"},
-    {file = "librt-0.11.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:461bbceede621f1ffb8839755f8663e886087ee7af16294cab7fb4d782c62eeb"},
-    {file = "librt-0.11.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:0cad8a4d6a8ff03c9b76f9414caccd78e7cfbc8a2e12fa334d8e1d9932753783"},
-    {file = "librt-0.11.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f37aa505b3cf60701562eddb32df74b12a9e380c207fd8b06dd157a943ac7ea0"},
-    {file = "librt-0.11.0-cp310-cp310-win32.whl", hash = "sha256:94663a21534637f0e787ec2a2a756022df6e5b7b2335a5cdd7d8e33d68a2af89"},
-    {file = "librt-0.11.0-cp310-cp310-win_amd64.whl", hash = "sha256:dec7db73758c2b54953fd8b7fe348c45188fe26b39ee18446196edd08453a5d4"},
-    {file = "librt-0.11.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:93d95bd45b7d58343d8b90d904450a545144eec19a002511163426f8ab1fae29"},
-    {file = "librt-0.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ee278c769a713638cdacd4c0436d72156e75df3ebc0166ab2b9dc43acc386c9"},
-    {file = "librt-0.11.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f230cb1cbc9faaa616f9a678f530ebcf186e414b6bcbd88b960e4ba1b92428d5"},
-    {file = "librt-0.11.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:5d63c855d86938d9de93e265c9bd8c705b51ec494de5738340ee93767a686e4b"},
-    {file = "librt-0.11.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:993f028be9e96a08d31df3479ac80d99be374d17f3b78e4796b3fd3c913d4e89"},
-    {file = "librt-0.11.0-cp311-cp311-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:258d73a0aa66a055e65b2e4d1b8cdb23b9d132c5bb915d9547d804fcaed116cc"},
-    {file = "librt-0.11.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0827efe7854718f04aaddf6496e96960a956e676fe1d0f04eb41511fd8ad06d5"},
-    {file = "librt-0.11.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:7753e57d6e12d019c0d8786f1c09c709f4c3fcc57c3887b24e36e6c06ec938b7"},
-    {file = "librt-0.11.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:11bd19822431cc21af9f27374e7ae2e58103c7d98bda823536a6c47f6bb2bb3d"},
-    {file = "librt-0.11.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:22bdf239b219d3993761a148ffa134b19e52e9989c84f845d5d7b71d70a17412"},
-    {file = "librt-0.11.0-cp311-cp311-win32.whl", hash = "sha256:46c60b61e308eb535fbd6fa622b1ee1bb2815691c1ad9c98bf7b84952ec3bc8d"},
-    {file = "librt-0.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:902e546ff044f579ff1c953ff5fce97b636fe9e3943996b2177710c6ef076f73"},
-    {file = "librt-0.11.0-cp311-cp311-win_arm64.whl", hash = "sha256:65ac3bc20f78aa0ee5ae84baa68917f89fef4af63e941084dd019a0d0e749f0c"},
-    {file = "librt-0.11.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b87504f1690a23b9a2cca841191a04f83895d4fc2dd04df91d82b1a04ca2ad46"},
-    {file = "librt-0.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40071fc5fe0ce8daa6de616702314a01e1250711682b0523d6ab8d4525910cb3"},
-    {file = "librt-0.11.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:137e79445c896a0ea7b265f52d23954e05b64222ee1af69e2cb34219067cbb67"},
-    {file = "librt-0.11.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:cca6644054e78746d8d4ef238681f9c34ff8b584fe6b988ecebb8db3b15e622a"},
-    {file = "librt-0.11.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d5b0eea49f5562861ee8d757a32ef7d559c1d35be2aaaa1ec28941d74c9ffc8a"},
-    {file = "librt-0.11.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0d1029d7e1ae1a7e647ed6fb5df8c4ce2dffefb7a9f5fd1376a4554d96dac09f"},
-    {file = "librt-0.11.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bc3ce6b33c5828d9e80592011a5c584cb2ce86edbc4088405f70da47dc1d1b3b"},
-    {file = "librt-0.11.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:936c5995f3514a42111f20099397d8177c79b4d7e70961e396c6f5a0a3566766"},
-    {file = "librt-0.11.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:9bc0ca6ad9381cbe8e4aa6e5726e4c80c78115a6e9723c599ed1d73e092bc49d"},
-    {file = "librt-0.11.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:070aa8c26c0a74774317a72df8851facc7f0f012a5b406557ac56992d92e1ec8"},
-    {file = "librt-0.11.0-cp312-cp312-win32.whl", hash = "sha256:6bf14feb84b05ae945277395451998c89c54d0def4070eb5c08de544930b245a"},
-    {file = "librt-0.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:75672f0bc524ede266287d532d7923dbce94c7514ad07627bac3d0c6d92cc4d9"},
-    {file = "librt-0.11.0-cp312-cp312-win_arm64.whl", hash = "sha256:2f10cf143e4a9bb0f4f5af568a00df94a2d69ef41c2579584454bb0fe5cc642c"},
-    {file = "librt-0.11.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:78dc31f7fdfe9c9d0eb0e8f42d139db230e826415bbcabd9f0e9faaaee909894"},
-    {file = "librt-0.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fa475675db22290c3158e1d42326d0f5a65f04f44a0e68c3630a25b53560fb9c"},
-    {file = "librt-0.11.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:621db29691044bdeda22e789e482e1b0f3a985d90e3426c9c6d17606416205ea"},
-    {file = "librt-0.11.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:a9010e2ed5b3a9e158c5fd966b3ab7e834bb3d3aacc8f66c91dd4b57a3799230"},
-    {file = "librt-0.11.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c39513d8b7477a2e1ed8c43fc21c524e8d5a0f8d4e8b7b074dbdbe7820a08e2"},
-    {file = "librt-0.11.0-cp313-cp313-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7aef3cf1d5af86e770ab04bfd993dfc4ae8b8c17f66fb77dd4a7d50de7bbb1a3"},
-    {file = "librt-0.11.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:557183ddc36babe46b27dd60facbd5adb4492181a5be887587d57cda6e092f21"},
-    {file = "librt-0.11.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:83d3e1f72bd42f6c5c0b7daec530c3f829bd02db42c70b8ddf0c2d90a2459930"},
-    {file = "librt-0.11.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:4ce1f21fbe589bc1afd7872dece84fb0e1144f794a288e58a10d2c54a55c43be"},
-    {file = "librt-0.11.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b09f7044ea2b64c9da42fd3d335666518cfd1c6e8a182c95da73d0214b41e"},
-    {file = "librt-0.11.0-cp313-cp313-win32.whl", hash = "sha256:78fddc31cd4d3caa897ad5d31f856b1faadc9474021ad6cb182b9018793e254e"},
-    {file = "librt-0.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:8ca8aa88751a775870b764e93bad5135385f563cb8dcee399abf034ea4d3cb47"},
-    {file = "librt-0.11.0-cp313-cp313-win_arm64.whl", hash = "sha256:96f044bb325fd9cf1a723015638c219e9143f0dfbc0ca54c565df2b7fc748b44"},
-    {file = "librt-0.11.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4a017a95e5837dc15a8c5661d60e05daa96b90908b1aa6b7acdf443cd25c8ebd"},
-    {file = "librt-0.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b1ecbd9819deccc39b7542bf4d2a740d8a620694d39989e58661d3763458f8d4"},
-    {file = "librt-0.11.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7da327dacd7be8f8ec36547373550744a3cc0e536d54665cd83f8bcd961200e8"},
-    {file = "librt-0.11.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0dc56b1f8d06e60db362cc3fdae206681817f86ce4725d34511473487f12a34b"},
-    {file = "librt-0.11.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05fb8fb2ab90e21c8d12ea240d744ad514da9baf381ebfa70d91d20d21713175"},
-    {file = "librt-0.11.0-cp314-cp314-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cae74872be221df4374d10fec61f93ed1513b9546ea84f2c0bf73ab3e9bd0b03"},
-    {file = "librt-0.11.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:32bcc918c0148eb7e3d57385125bac7e5f9e4359d05f07448b09f6f778c2f31c"},
-    {file = "librt-0.11.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:f9743fc99135d5f78d2454435615f6dec0473ca507c26ce9d92b10b562a280d3"},
-    {file = "librt-0.11.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:5ba067f4aadae8fda802d91d2124c90c42195ff32d9161d3549e6d05cfe26f96"},
-    {file = "librt-0.11.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:de3bf945454d032f9e390b85c4072e0a0570bf825421c8be0e71209fa65e1abe"},
-    {file = "librt-0.11.0-cp314-cp314-win32.whl", hash = "sha256:d2277a05f6dcb9fd13db9566aac4fabd68c3ea1ea46ee5567d4eef8efa495a2f"},
-    {file = "librt-0.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:ab73e8db5e3f564d812c1f5c3a175930a5f9bc96ccb5e3b22a34d7858b401cf7"},
-    {file = "librt-0.11.0-cp314-cp314-win_arm64.whl", hash = "sha256:aea3caa317752e3a466fa8af45d91ee0ea8c7fdd96e42b0a8dd9b76a7931eba1"},
-    {file = "librt-0.11.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:d1b36540d7aaf9b9101b3a6f376c8d8e9f7a9aec93ed05918f2c69d493ffef72"},
-    {file = "librt-0.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:efbb343ab2ce3540f4ecbe6315d677ed70f37cd9a72b1e58066c918ca83acbaa"},
-    {file = "librt-0.11.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0dd688aab3f7914d3e6e5e3554978e0383312fb8e771d84be008a35b9ee548"},
-    {file = "librt-0.11.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:f5fb36b8c6c63fdcbb1d526d94c0d1331610d43f4118cc1beb4efef4f3faacb2"},
-    {file = "librt-0.11.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4a9a237d13addb93715b6fee74023d5ee3469b53fce527626c0e088aa585805f"},
-    {file = "librt-0.11.0-cp314-cp314t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5ddd17bd87b2c56ddd60e546a7984a2e64c4e8eab92fb4cf3830a48ad5469d51"},
-    {file = "librt-0.11.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd43992b4473d42f12ff9e68326079f0696d9d4e6000e8f39a0238d482ba6ee2"},
-    {file = "librt-0.11.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:f8e3e8056dd674e279741485e2e512d6e9a751c7455809d0114e6ebf8d781085"},
-    {file = "librt-0.11.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c1f708d8ae9c56cf38a903c44297243d2ec83fd82b396b977e0144a3e76217e3"},
-    {file = "librt-0.11.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0add982e0e7b9fc14cf4b33789d5f13f66581889b88c2f58099f6ce8f92617bd"},
-    {file = "librt-0.11.0-cp314-cp314t-win32.whl", hash = "sha256:2b481d846ac894c4e8403c5fd0e87c5d11d6499e404b474602508a224ff531c8"},
-    {file = "librt-0.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:28edb433edde181112a908c78907af28f964eabc15f4dd16c9d66c834302677c"},
-    {file = "librt-0.11.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dee008f20b542e3cd162ba338a7f9ec0f6d23d395f66fe8aeeec3c9d067ea253"},
-    {file = "librt-0.11.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6bd72d903911d995ab666dbd1871f8b1e80925a699af8063fbf50053329fb05f"},
-    {file = "librt-0.11.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:0ef69ac715f3cd8e5cd252cb2aebfa72c015492aacc339d5d7bf8fef3c62c677"},
-    {file = "librt-0.11.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:624a40c4a4ad7773315c287276cd024509b2c66ff5904f504bfc08d2c70293ab"},
-    {file = "librt-0.11.0-cp39-cp39-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:41dc19fe150b69716c8ece4f76773a9e8813fe3e35e032a58b4d46423fb8d7c0"},
-    {file = "librt-0.11.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4e8bd98ea9c47ae90b319a087ab28dac493f1ffbc1ecd1f28fcdbf3b7e1108d1"},
-    {file = "librt-0.11.0-cp39-cp39-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:84308fc49423ce6475d1c5d1985cd69a8ca9f0325fc7d5f81bb690a3f3625d4e"},
-    {file = "librt-0.11.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:ff0fbaf5f44a21beeb0110f2ab64f45135a9536a834b79c0d1ef018f2786bbfa"},
-    {file = "librt-0.11.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:9c028a9442a18e266955d364ce42259136e79a7ba14d773e0d778d5f70cd56f1"},
-    {file = "librt-0.11.0-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:9f1692105a02bcf853f355032a5fdc5494358ef83d8fd22d16de375c85cec3f5"},
-    {file = "librt-0.11.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:7a80a71e1fda83cc752a9141e87aae7fef279538597564d670e9ce513f286192"},
-    {file = "librt-0.11.0-cp39-cp39-win32.whl", hash = "sha256:140695816ddf3c86eb972981a26f35efd871c44b0c3aed44c8cd01749386617f"},
-    {file = "librt-0.11.0-cp39-cp39-win_amd64.whl", hash = "sha256:92f7ff819c197fc30473190a12c2856f325ac90aabfccbeb2072d28cc2e234e3"},
-    {file = "librt-0.11.0.tar.gz", hash = "sha256:075dc3ef4458a278e0195cbf6ac9d38808d9b906c5a6c7f7f79c3888276a3fb1"},
+    {file = "librt-0.13.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:34e47058fcc69a313293d6dee94216a4f30c929ae6f2476e58c5ba635aa639d5"},
+    {file = "librt-0.13.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dbdd5b6509d0c2a8fe72cf494c299a61dbd58142a90a4190664ae159e4a7b547"},
+    {file = "librt-0.13.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e56ea4ee4df77585a6b5c138f6538680886024fa559f5b55bd14b12e98e67b2"},
+    {file = "librt-0.13.0-cp310-cp310-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:f1f9cc4d09a46d9cb3c2063ae100629d3f52a6517c3c08c2f4c9828261883929"},
+    {file = "librt-0.13.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f125f5d46b20f89dc5587a55cc416b4ba2a5b2ffda36d048ee120e17598a653a"},
+    {file = "librt-0.13.0-cp310-cp310-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2608d3b39f9e0b4a66a130d9150c615cba40a5090d25eeeaa225e0e46de8c0ac"},
+    {file = "librt-0.13.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:9fd35e95ab5e45c3901d37110263c7db85a961110f5460588fe37f8c131f88a7"},
+    {file = "librt-0.13.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:5f31b0aa13c9b04370d4da6be1ab7779776b3a075cceb6747a39a4be85fe1e40"},
+    {file = "librt-0.13.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:0b795f5fc70fbbb787ceaf79bb3a0d627bcc33c53de51741755263ec406b775a"},
+    {file = "librt-0.13.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:36b306a623aaad96fe4b378692b54f9c0789fccd833b9851753d5fbf6138cfde"},
+    {file = "librt-0.13.0-cp310-cp310-win32.whl", hash = "sha256:a3762e75fcac8c9e4dacaaf438bffd9003e2ca2c531b756f3c0035deefa674c8"},
+    {file = "librt-0.13.0-cp310-cp310-win_amd64.whl", hash = "sha256:d63bae12a8aeb51380be3438e4dc4bd27354d0f8e19166b2f44e3e94d6f552dc"},
+    {file = "librt-0.13.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1b5a7bbff495baedbd9b916c367d66854008f8f3b575908ded477c499dc60082"},
+    {file = "librt-0.13.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:34bc7938b9fdf14fe32a406c19c71faf894c5cee7e7474bd0be2f17200b82d14"},
+    {file = "librt-0.13.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f40e56b61b41be5f7dec938cfeffd660668cf4b5e72c78e7bd671d66b7bc2c79"},
+    {file = "librt-0.13.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:9c5d02b89de5acd0379a51ec44a89476fb03df6145442e1c8ecd6bee2f91b176"},
+    {file = "librt-0.13.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7db9a3ff32ef5f7d1703d93831a3316cdf0b537de6a1cc03cc8fdd09b9194e89"},
+    {file = "librt-0.13.0-cp311-cp311-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3dbb2a31882456cadc7053378e81ad7ed7693db4ac9f98ab5f81ef034aa8ec9f"},
+    {file = "librt-0.13.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c6014e3c80f9c1fe268ef8b0e0ef113bac672cc032f2f93866e7ddad4f3e663d"},
+    {file = "librt-0.13.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:091b60a4d2174fc1ec5c34cdc0b72efb6224753d76b7da61ebeab7a191aec8bd"},
+    {file = "librt-0.13.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:66cb1138f384a191a6d75f986064841fcfdc0cea98f7bd9c9ab9b38049917588"},
+    {file = "librt-0.13.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:17221a7569f8f292aa0014226e48aa25b8c2b08da18088cd230953d0ea0f9cd1"},
+    {file = "librt-0.13.0-cp311-cp311-win32.whl", hash = "sha256:fc67741da44c6eaa90e01eafb586bbba9b51eb5b6ed381ee6f5ae72eb3316d21"},
+    {file = "librt-0.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:cc99dfb62b23c9207c33d0be8a2e2af7a42e21e6ea388b380a0c948c7b88953b"},
+    {file = "librt-0.13.0-cp311-cp311-win_arm64.whl", hash = "sha256:40ccd13c252d3fe473ffc8a57be7565abc8b64cf1b108344c859d5164f7f3e0c"},
+    {file = "librt-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30536798f4504c0fad0885b1d371b0539abb081e4570c9d7c641cb51141b49f0"},
+    {file = "librt-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:93d24ebb82aa4420b1409c389e7857bc35bd0b668007ac8172427d5c73cc8cc5"},
+    {file = "librt-0.13.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cb8a1adce42d8b75485a5d56a9623a50bcab995b6079f1dac59fc44034dd93d9"},
+    {file = "librt-0.13.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0763ca2ab66058174f9dee426dc64f5e0a89c24a7df8d3fe3f1836c04e25de4b"},
+    {file = "librt-0.13.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b222493da6e7b6199db9bd79502436cf5a27da3c1f7fa83c7e285444fc93fd03"},
+    {file = "librt-0.13.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fadc63331f4388c3dc90090448f682a7e9feafc11481391c1e94f2f907a3976e"},
+    {file = "librt-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:70d9c62a4cffd9f23396cd5ef93fc5d11b31596b9b7d6306074abe3d5fcf09bd"},
+    {file = "librt-0.13.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:66c0e7e6b02a155576df2c77ec933a70b72da726e248c494abf690923e624348"},
+    {file = "librt-0.13.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ac04bcd3328eb91d99dfedf6a60d9c1f15d3434e6f6daf922f0420f7d90b85c7"},
+    {file = "librt-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:db327e7271e653c32040b85ae6188059c924b57d7e1e29f935523fa017cd4e82"},
+    {file = "librt-0.13.0-cp312-cp312-win32.whl", hash = "sha256:860bd1d8ba48456ce08feaf8d343a8aaeb2fa086f2bcaa2a923fa3f7a3ff9aa3"},
+    {file = "librt-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:e54a315caf843c8d77e388cadc56ea9ded569935ee2d2347d7ea94992e5aa6fa"},
+    {file = "librt-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:c718e99a0992127af84385378460db624103b559ab260435abcfe77a4e4ed1c1"},
+    {file = "librt-0.13.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a468951af16155824e88bdd8326ebe5bdb371f3ec0ac04642994b98201d914f3"},
+    {file = "librt-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ae01d8512cc17079e53425635327dbf3f7ff57a42c00dec348bf79791c56444c"},
+    {file = "librt-0.13.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:32c26893cd085c1efe83219e78d866da23fb20a066101b8f68210004361d224c"},
+    {file = "librt-0.13.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:5929da1981a46bcf4b28b1b9499905f0ff58e2419da402a048234e9783acbc4b"},
+    {file = "librt-0.13.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:94b85d664d777bab6c0d709416cb42938251fda9e221b79e3a2215d85df5f4f9"},
+    {file = "librt-0.13.0-cp313-cp313-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:531b2df3e9fe96b1fcf73a6d165921e4656be5f58d631d384ebce344298368db"},
+    {file = "librt-0.13.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:109b84a9edf69ad89dc1f66358659e14a031baca95e3e5b0060bd903ede8efd6"},
+    {file = "librt-0.13.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1304368a3e7ffc3e9db986796cc5326fdb5943a3567ecc137cff318e4240c0e7"},
+    {file = "librt-0.13.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:e4f9b472e7d308d94b62c801982065661158c6ed02790d6c7ddb4337cea0f9c1"},
+    {file = "librt-0.13.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9f836c37478f167a81200d8c8b2c920a22224564bed2c23d7aeec760965c367a"},
+    {file = "librt-0.13.0-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:4000d961ff9598ac6ea603c6c836a5ed49bc205ade5fc378b998dfe1e2c36628"},
+    {file = "librt-0.13.0-cp313-cp313-win32.whl", hash = "sha256:79e44cff71750d299d61a678e49995b0d5935a9cda238c2574daeca3ba536927"},
+    {file = "librt-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:54dab44a847d5ad1acd05c8a83fe518ae685516ecf4d3f7cc6e3df2a66767650"},
+    {file = "librt-0.13.0-cp313-cp313-win_arm64.whl", hash = "sha256:d4cb6fbfdf874340ab5e51450753c0f817b6958a3621125ee695bbc3de866566"},
+    {file = "librt-0.13.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:25218d94b1d2cbc0ba1d8a3f9dc9af578d9646e5ed16443a70cde1dfdcce6d71"},
+    {file = "librt-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f26629539d4893c2957a16c41bb058e1e135c1f150f6a2e25ed047f64cf3f5c6"},
+    {file = "librt-0.13.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a4517d47b2b8af26975a406fba7d314de9696d864252e0257c6ea90238cfe27f"},
+    {file = "librt-0.13.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:f19e181de5b3a1148bb3420b8c4b0b0ea0fce6950099724ad151d6cea5acc180"},
+    {file = "librt-0.13.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22034924f5b42d5a56371cf271771bfeaabf235a7a8b6264bef2d20013f786c6"},
+    {file = "librt-0.13.0-cp314-cp314-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c7897db4e95e22468bdda33d8e012ceacd0182abf001e6389d763f0def6286b9"},
+    {file = "librt-0.13.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1ce61b3746545029d4f5c17d6bd74b676254ad98433086c846ffb5e8fa73f007"},
+    {file = "librt-0.13.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:46c330e82565962c761dbce7941be2cff7db674ee807455a8d0cadc5f9b759b0"},
+    {file = "librt-0.13.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:375f5af8f99cbaa99dd293af986e3d57caabc9ba81a5d3f021603764854197a1"},
+    {file = "librt-0.13.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:9320d34c3376ae204b2cd176e8d4883a013934e0aef822f1aed9c536490c275d"},
+    {file = "librt-0.13.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:9af313c66157a69dc69ea0059a66961692250e0dc95af9c385a48ffb770a0d16"},
+    {file = "librt-0.13.0-cp314-cp314-win32.whl", hash = "sha256:f2a7253458e34f33543551394ae4fe104b497ec2a65ac266074de64c1df82e37"},
+    {file = "librt-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:a3dfe4edf10e8ed7e55b026a8bfc2c2a8704218b659cd4bffdf604fab966dc39"},
+    {file = "librt-0.13.0-cp314-cp314-win_arm64.whl", hash = "sha256:68a5faee4bba381cb93b5961f684a514cf0053cb92308ff9c792c2fea0b174c6"},
+    {file = "librt-0.13.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:a38fb81d8376dfa2f8963b265fec07637802b0d01e2a127c19c66cb070fb24f5"},
+    {file = "librt-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d4c8d9bd5abce34b2e75edb3bf37ab0f34e49b1f915a40ae8468eb7c85bc5b46"},
+    {file = "librt-0.13.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:387e2f1d27e89bffe0d3f520f0da0662c973fd607ca16c1808f8a5085419485e"},
+    {file = "librt-0.13.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:4f6db193d2e5e0ed60359b9a5a682cd67205d0d3b1e459a867dd4b5c4e7eaa7a"},
+    {file = "librt-0.13.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d38604854e8d22faadf683ec6c02bb0f886e2ba56ef981a1c36ee275f21ea22"},
+    {file = "librt-0.13.0-cp314-cp314t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:371f7ce73026815dafd51c50ce38416e91428b28c4b2ec97cd39271164b0045c"},
+    {file = "librt-0.13.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3aaedf52171bee90860704c560bc798fe83b76247df47568e0197e9b13c735a0"},
+    {file = "librt-0.13.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:96bad8725a4f196a798366c25ce075d1f7543a4ec045ffc13e6a7ec095cdab04"},
+    {file = "librt-0.13.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6bf6a559ffe4a93bbea6cf31ddf01a7fd9ba342ef51f27beb178e318b74acd61"},
+    {file = "librt-0.13.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:301067672387902c55f94b51d5022304b36c966ea9fe1f21caab99a9bef487c9"},
+    {file = "librt-0.13.0-cp314-cp314t-win32.whl", hash = "sha256:5fdcf34f86de8fb66d7dc7589f96ba91c4aa46671200d400e6fd6f109a483f18"},
+    {file = "librt-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:260c33e92263fa629b4f6d3c51967a1c2158fe6c33237aaa3ebeac586b085259"},
+    {file = "librt-0.13.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2f281549a4c52ac7bb97997f14353f8bd0e53a34ca0dad1c905cfd0b4a58ae99"},
+    {file = "librt-0.13.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f442e3954b1addc759faae22a7c9a3f1e16d7d1db3f484279dc27d62e06968fa"},
+    {file = "librt-0.13.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9e786428f291dd2d2f1cbfc0e0caa45a2e395fab0ad3e2c9314daa8873414390"},
+    {file = "librt-0.13.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21b7ac084f701a9cdff6139745a6620579d65a9379ac2d9d50a86368b109e63c"},
+    {file = "librt-0.13.0-cp39-cp39-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:a6e556d6aba31c93dd97ce661d66614d2429c0a3923f9dc8f0af7e8df10223a4"},
+    {file = "librt-0.13.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3657346f867469e962549435aa05fd15330b1d6a92829f8e27988e194382d005"},
+    {file = "librt-0.13.0-cp39-cp39-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:791aa18a373b90da8ac3c44fc77544f33fdf53ae403acdce9b39f1c26b4a3b94"},
+    {file = "librt-0.13.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:d6fb0eaa108814581c4d3bfbd068c3fb6757812a81415008d1bae08267cca360"},
+    {file = "librt-0.13.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:a001519c315d5db40710f2665d32c4791f1d4779fc96a9423fd18d92c8b9ac7b"},
+    {file = "librt-0.13.0-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:d9188caac26e47671b52836a5e2a49873a7fc11c673b0c122d22515f98bc14e1"},
+    {file = "librt-0.13.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:05d96b80b95d3a2721b619f8982b8558848b04875bb4772fd54842b59f61dd97"},
+    {file = "librt-0.13.0-cp39-cp39-win32.whl", hash = "sha256:c3cd253cf32fe4f4662960d6bf7d55cb8be0c31a5d644a4d48aeafebaff3409a"},
+    {file = "librt-0.13.0-cp39-cp39-win_amd64.whl", hash = "sha256:b15e26cc0fe622d0c67e98bee6ef6bc8f792e20ee3006aa12627a00463d9399f"},
+    {file = "librt-0.13.0.tar.gz", hash = "sha256:1d2a610c14ac0d0750ee0a3ab8548e83155258387891caaca04def4bf7289781"},
 ]
 
 [[package]]
@@ -1209,61 +1214,62 @@ tests = ["pytest (>=4.6)"]
 
 [[package]]
 name = "mypy"
-version = "2.1.0"
+version = "2.2.0"
 description = "Optional static typing for Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "mypy-2.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:11a6beb180257a805961aea9ec591bbd0bd17f1e18d35b8456d57aee5bedfedc"},
-    {file = "mypy-2.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8ef78c1d306bbf9a8a12f526c44902c9c28dffd6c52c52bf6a72641ce18d3849"},
-    {file = "mypy-2.1.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c209a90853081ff01d01ee895cafe10f7db1474e0d95beaeef0f6c1db9119bbd"},
-    {file = "mypy-2.1.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47cebf61abde7c088a4e27718a8b13a81655686b2e9c251f5c0915a802248166"},
-    {file = "mypy-2.1.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:d57a90ae5e872138a425ec328edbc9b235d1934c4377881a33ec05b341acc9a8"},
-    {file = "mypy-2.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:aea7f7a8a55b459c34275fc468ada6ca7c173a5e43a68f5dbe588a563d8a06b8"},
-    {file = "mypy-2.1.0-cp310-cp310-win_arm64.whl", hash = "sha256:c989640253f0d76843e9c6c1bbf4bd48c5e85ada61bde4beb37cb3eca035685e"},
-    {file = "mypy-2.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a683016b16fe2f572dc04c72be7ee0504ac1605a265d0200f5cea695fb788f41"},
-    {file = "mypy-2.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1a293c534adb55271fef24a26da04b855540a8c13cc07bc5917b9fd2c394f2ca"},
-    {file = "mypy-2.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7406f4d048e71e576f5356d317e5b0a9e666dfd966bd99f9d14ca06e1a341538"},
-    {file = "mypy-2.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e0210d626fc8b31ccc90233754c7bc90e1f43205e85d96387f7db1285b55c398"},
-    {file = "mypy-2.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3712c20deed54e814eaaa825603bada8ea1c390670a397c95b98405347acc563"},
-    {file = "mypy-2.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:fcaa0e479066e31f7cceb6a3bea39cb22b2ff51a6b2f24f193d19179ba17c389"},
-    {file = "mypy-2.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:0b1a5260c95aa443083f9ed3592662941951bca3d4ca224a5dc517c38b7cf666"},
-    {file = "mypy-2.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:244358bf1c0da7722230bce60683d52e8e9fd030554926f15b747a84efb5b3af"},
-    {file = "mypy-2.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4ec7c57657493c7a75534df2751c8ae2cda383c16ecc55d2106c54476b1b16f6"},
-    {file = "mypy-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8161b6ff4392410023224f0969d17db93e1e154bc3e4ba62598e720723ae211"},
-    {file = "mypy-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bf03e12003084a67395184d3eb8cbd6a489dc3655b5664b28c210a9e2403ab0b"},
-    {file = "mypy-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:20509760fd791c51579d573153407d226385ec1f8bcce55d730b354f3336bc22"},
-    {file = "mypy-2.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:6753d0c1fdd6b1a23b9e4f283ce80b2153b724adcb2653b20b85a8a28ac6436b"},
-    {file = "mypy-2.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:98ebb6589bb3b6d0c6f0c459d53ca55b8091fbc13d277c4041c885392e8195e8"},
-    {file = "mypy-2.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:35aac3bb114e03888f535d5eb51b8bafbb3266586b599da1940f9b1be3ec5bd5"},
-    {file = "mypy-2.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8de55a8c861f2a49331f807be98d90caeceeef520bde13d43a160207f8af613e"},
-    {file = "mypy-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5fdf2941a07434af755837d9880f7d7d25f1dacb1af9dcd4b9b66f2220a3024e"},
-    {file = "mypy-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e195b817c13f02352a9c124301f9f30f078405444679b6753c1b96b6eed37285"},
-    {file = "mypy-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5431d42af987ebd92ba2f71d45c85ed41d8e6ca9f5fd209a69f68f707d2469e5"},
-    {file = "mypy-2.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:767fe8c66dc3e01e19e1737d4c38ebefead16125e1b8e58ad421903b376f5c65"},
-    {file = "mypy-2.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:ecfe70d43775ab99562ab128ce49854a362044c9f894961f68f898c23cb7429d"},
-    {file = "mypy-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:7354c5a7f69d9345c3d6e69921d57088eea3ddeeb6b20d34c1b3855b02c36ec2"},
-    {file = "mypy-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:49890d4f76ac9e06ec117f9e09f3174da70a620a0c300953d8595c926e80947f"},
-    {file = "mypy-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:761be68e023ef5d94678772396a8af1220030f80837a3afd8d0aef3b419666f4"},
-    {file = "mypy-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c90345fc182dc363b891350457ec69c35140858538f38b4540845afcc32b1aef"},
-    {file = "mypy-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b84802e7b5a6daf1f5e15bc9fcd7ddae77be13981ffab037f1c67bb84d67d135"},
-    {file = "mypy-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:022c771234936ceac541ebaf836fe9e2abeb3f5e09aff21588fe543ff006fe21"},
-    {file = "mypy-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:498207db725cec88829a6a5c2fc771205fd043719ef98bc49aba8fb9fc4e6d57"},
-    {file = "mypy-2.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7d5e5cad0efeba72b93cd17490cc0d69c5ac9ca132994fe3fb0314808aeeb83e"},
-    {file = "mypy-2.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ff715050c127d724fd260a2e666e7747fdd83511c0c47d449d98238970aef780"},
-    {file = "mypy-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:82208da9e09414d520e912d3e462d454854bed0810b71540bb016dcbca7308fd"},
-    {file = "mypy-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e79ebc1b904b84f0310dff7469655a9c36c7a68bddb37bdd42b67a332df61d08"},
-    {file = "mypy-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e583edc957cfb0deb142079162ae826f58449b116c1d442f2d91c69d9fced081"},
-    {file = "mypy-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b33b6cd332695bba180d55e717a79d3038e479a2c49cc5eb3d53603409b9a5d7"},
-    {file = "mypy-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:4f910fe825376a7b66ef7ca8c98e5a149e8cd64c19ae71d84047a74ee060d4e6"},
-    {file = "mypy-2.1.0-py3-none-any.whl", hash = "sha256:a663814603a5c563fb87a4f96fb473eeb30d1f5a4885afcf44f9db000a366289"},
-    {file = "mypy-2.1.0.tar.gz", hash = "sha256:81e76ad12c2d804512e9b13240d1588316531bfba07558286078bfbce9613633"},
+    {file = "mypy-2.2.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:97d21f3a1582ef30d0b77f9ca3ad88b4263f3c5aea9e7380cb5d7175160aec7e"},
+    {file = "mypy-2.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2529017942b951cc43db2e2712b71cc3aa7e9d90567630c03ed63d430aeec61a"},
+    {file = "mypy-2.2.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0823d7f273f3b4a49df7573eac271ddbf77a0e5f53e24d294a4f0f77ad22e1d7"},
+    {file = "mypy-2.2.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d78a0fc90704894bc9948d78affad14b882b08183a7c30412d185748aaa9418b"},
+    {file = "mypy-2.2.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:6efab25fa3568569fda06928743382900860c48be9200c1758ef5ce94b532714"},
+    {file = "mypy-2.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:daeaf5287091d68f674c91416cabab0f80f36e347ed17fded38d7ebde682e9d1"},
+    {file = "mypy-2.2.0-cp310-cp310-win_arm64.whl", hash = "sha256:f8d97940a0259e09c219903579720b2df12170c0c3a3b3799837c1fb63deb44e"},
+    {file = "mypy-2.2.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ea6fe1a30f3e7dc574d641497ffead2428046b0f8bc5804d13b4e4392fdc317b"},
+    {file = "mypy-2.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6965829a6d847a0925f51149472bbeb7a39332fb4801972fdfd9cedd9f8d43a4"},
+    {file = "mypy-2.2.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5a906bfc9c4c5de3ece6dc4726f8076d56ce9be1720baf0c6f84e926c10262a4"},
+    {file = "mypy-2.2.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:91df92625cb3452758f27f4965b000fb05ad89b00c282cc3430a7bd6b0e5389e"},
+    {file = "mypy-2.2.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d42893d15894fd34f395090e2d78315ba7c637d5ee221683e02893f578c2f548"},
+    {file = "mypy-2.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:d3abaeec02cdc72e30a147d99eb81852b6b745a2c8d19607e25241d79b1abbce"},
+    {file = "mypy-2.2.0-cp311-cp311-win_arm64.whl", hash = "sha256:c39bdb7ceab252d15011e26d3a254b4aaa3bbf121b551febfa301df9b0c69abe"},
+    {file = "mypy-2.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:484a2be712b245ac6e89847141f1f50c612b0a924aa25917e63e6cfcf4da07cd"},
+    {file = "mypy-2.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fb0a020dc68480d40e484675558ed637140df1ccbf896a81ba68bca85f2b50a0"},
+    {file = "mypy-2.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc361340732ce7108fa0308812caf02bb6868f16112f1efd35bcad88badf3327"},
+    {file = "mypy-2.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b0179a3a0b833f724a65f22613607cf7ea941ab17ec34fa283f8d6dfe21d9fa9"},
+    {file = "mypy-2.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9e0899b13da1e4ba44b880550f247402ce90ffecc71c54b220bcbe7ecb34f394"},
+    {file = "mypy-2.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:511320b17467402e2906130e185abffffa3d7648aff1444fc2abb61f4c8a087d"},
+    {file = "mypy-2.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:7589f370b33dcdd95708f5340f13a67c2c49140957f934b42ef63064d343cca0"},
+    {file = "mypy-2.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6968f27347ef539c443ddfd6897e79db525ddb8c856aa8fbf14c34f310ca5193"},
+    {file = "mypy-2.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3df226d2a0ae2c3b03845af217800a68e2965d4b14914c99b78d3a2c8ae23299"},
+    {file = "mypy-2.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fc53553996aca2094216ad9306a6f06c5265d206c1bcb54dd367560bd3557825"},
+    {file = "mypy-2.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:996abf2f0bebf572556c60720e8dc0cf5292b64060fa68d7f2bc9caa48e01b6f"},
+    {file = "mypy-2.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ec287c2381898c652bf8ff79448627fe1a9ee76d22005181fac7315a485c7108"},
+    {file = "mypy-2.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:c2c967a7685fa93fcf1a778b3ebe76e756b28ba14655f539d7b61ff3da69352a"},
+    {file = "mypy-2.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:d59a4b80351ec92e5f7415fcdd008bd77fcbefc7adf9cbc7ffe4eb9f71617734"},
+    {file = "mypy-2.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1f6c3d76853071409ac58fc0aadfb276a22af5f190fdaa02152a858088a39ebd"},
+    {file = "mypy-2.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bdaa177e80cc3292824d4ef3670b5b58771ee8d57c290e0c9c89e7968212332c"},
+    {file = "mypy-2.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:80923e6d6e7878291f537ee11052f974954c20cb569798429a5dc265eb780b47"},
+    {file = "mypy-2.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f24bd465a09077c8d64be8f19a6646db467a55490fd315fe7871afe6bb9645"},
+    {file = "mypy-2.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:db34595464869f474708e769413d1d739fc33a69850f253757b9a4cc20bc1fec"},
+    {file = "mypy-2.2.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:b48092132c7b0ef4322773fecae62fc5b0bc339be348badeec8af502122a4a51"},
+    {file = "mypy-2.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:6fc0e98b95e31755ca06d89f75fafa7820fbb3ea2caace6d83cba17625cd0acb"},
+    {file = "mypy-2.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:bc73a5b4d40e8a3e6b12ef82eb0c90430964e34016a36c2aff4e3bfe37ba41f0"},
+    {file = "mypy-2.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:6257bd4b4c0ae2148548b869a1ff3758e38645b92c8fe65eca401866c3c551c1"},
+    {file = "mypy-2.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:dfa22b3ae862ac1ce76f5976ddd402651b5f090bcfd49c6d0484b8983a29eaf8"},
+    {file = "mypy-2.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30a430bf26fe8cf372f3933fbd83e633d6561868803645a20e4e6d4523f52a3b"},
+    {file = "mypy-2.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d58655a60e823b1a4c9ebcda072897fb0193c2f3e6f8e7c433e152aa4cb00233"},
+    {file = "mypy-2.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d4452c955caf14e28bb046cbd0c3671272e6381630a8b81b0da9713558148890"},
+    {file = "mypy-2.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:68f5b7f7f755200f68c7181e3dfb28be9858162257690e539759c9f57721e388"},
+    {file = "mypy-2.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:78d201accfafce3801d978f2b8dbbd473a9ce364cc0a0dfd9192fe47d977e129"},
+    {file = "mypy-2.2.0-py3-none-any.whl", hash = "sha256:ecc138da861e932d1344214da4bae866b21900a9c2778824b51fe2fb47f5180e"},
+    {file = "mypy-2.2.0.tar.gz", hash = "sha256:2cdd99d48590dce6f6b7f1961eda75386364398fcdaad86923bc0f0231bf9baf"},
 ]
 
 [package.dependencies]
-ast-serialize = ">=0.3.0,<1.0.0"
-librt = {version = ">=0.11.0", markers = "platform_python_implementation != \"PyPy\""}
+ast-serialize = ">=0.6.0,<1.0.0"
+librt = {version = ">=0.12.0", markers = "platform_python_implementation != \"PyPy\""}
 mypy_extensions = ">=1.0.0"
 pathspec = ">=1.0.0"
 tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
@@ -2368,30 +2374,30 @@ files = [
 
 [[package]]
 name = "ruff"
-version = "0.15.20"
+version = "0.15.21"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
 files = [
-    {file = "ruff-0.15.20-py3-none-linux_armv6l.whl", hash = "sha256:00e188c53e499c3c1637f73c91dcf2fb56d576cab76ce1be50a27c4e80e37078"},
-    {file = "ruff-0.15.20-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9ebd1fd9b9c95fc0bd7b2761aebec1f030013d2e193a2901b224af68fe47251b"},
-    {file = "ruff-0.15.20-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5b16cdd67ca108185cd36dce98c576350c03b1660a751de725fb049193a0632"},
-    {file = "ruff-0.15.20-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3413bb3c3d2ca6a8208f1f4809cd2dca3c6de6d0b491c0e70847672bde6e6efd"},
-    {file = "ruff-0.15.20-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bd7ec42b3bb3da066488db093308a69c4ac5ee6d2af333a86ba6e2eb2e7dd44b"},
-    {file = "ruff-0.15.20-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1a36ad0eb77fba9aabfb69ede54de6f376d04ac18ebea022847046d340a8267"},
-    {file = "ruff-0.15.20-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b6df3b1e4610432f0386dba04d853b5f08cbbc903410c6fcc02f620f05aff53c"},
-    {file = "ruff-0.15.20-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e89f198a1ea6ef0d727c1cf16088bc91a6cb0ab947dedc966715691647186eae"},
-    {file = "ruff-0.15.20-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:309809086c2acb67624950a3c8133e80f32d0d3e27106c0cd60ff26657c9f24b"},
-    {file = "ruff-0.15.20-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2d2374caa2f2c2f9e2b7da0a50802cfb8b79f55a9b5e49379f564544fbf56487"},
-    {file = "ruff-0.15.20-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a1ed17b65293e0c2f22fc387bc13198a5de94bf4429589b0ff6946b0feaf21a3"},
-    {file = "ruff-0.15.20-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f701305e66b38ea6c91882490eb73459796808e4c6362a1b765255e0cdcd4053"},
-    {file = "ruff-0.15.20-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5b9c0c367ad8e5d0d5b5b8537864c469a0a0e55417aadfbeca41fa61333be9f4"},
-    {file = "ruff-0.15.20-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:01cc00dd58f0df339d0e902219dd53990ea99996a0344e5d9cc8d45d5307e460"},
-    {file = "ruff-0.15.20-py3-none-win32.whl", hash = "sha256:ed65ef510e43a137207e0f01cfcf998aeddb1aeeda5c9d35023e910284d7cf21"},
-    {file = "ruff-0.15.20-py3-none-win_amd64.whl", hash = "sha256:a525c81c70fb0380344dd1d8745d8cc1c890b7fc94a58d5a07bd8eb9557b8415"},
-    {file = "ruff-0.15.20-py3-none-win_arm64.whl", hash = "sha256:2f5b2a6d614e8700388806a14996c40fab2c47b819ef57d790a34878858ed9ca"},
-    {file = "ruff-0.15.20.tar.gz", hash = "sha256:1416eb04349192646b54de98f146c4f59afe37d0decfc02c3cbbf396f3a28566"},
+    {file = "ruff-0.15.21-py3-none-linux_armv6l.whl", hash = "sha256:63ea0e965e5d73c90e95b2434beeafc70820536717f561b32ab6e777cb9bdf5d"},
+    {file = "ruff-0.15.21-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0f212c5d7d54c01bbfe6dcab02b724a39300f3e34ed7acbe995ccb320a2c58bd"},
+    {file = "ruff-0.15.21-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e6312e41bc96791299614995ea3a977c5857c3b5662b1ecef6755b02b87cb646"},
+    {file = "ruff-0.15.21-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:01d65b4831c6b2a4ba8ee6faa84049d44d982b7a706e622c4094c509e51673be"},
+    {file = "ruff-0.15.21-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2c5a913a589120ce67933d5d05fd6ddbcc2481c6a054980ee767f7414c72b4fd"},
+    {file = "ruff-0.15.21-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5ef04b681d02ad4dc9620f00f83ac5c22f652d0e9a9cfe431d219b16ad5ccc41"},
+    {file = "ruff-0.15.21-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:16d090c0740916594157e75b80d666eab8e78083b39b3b0e1d698f4670a17b86"},
+    {file = "ruff-0.15.21-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3a10e74757dd65004d779b73e2f3c5210156d9980b41224d50d2ebcf1db51e67"},
+    {file = "ruff-0.15.21-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bab0905d2f29e0d9fbc3c373ed23db0095edaa3f71f1f4f519ec15134d9e85c8"},
+    {file = "ruff-0.15.21-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:00eca240af5789fec6fe7df74c088cc1f9644ed83027113468efba7c92b94075"},
+    {file = "ruff-0.15.21-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:262ab31557a75141325e32d3357f3597645a7f084e732b6b054dde428ecd9341"},
+    {file = "ruff-0.15.21-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:659c4e7a4212f83306045ec7c5e5a356d16d9a6ef4ae0c7a4d872914fc655d9d"},
+    {file = "ruff-0.15.21-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9e866eab611a5f959d36df2d10e446973a3610bc42b0c15b31dc27977d59c233"},
+    {file = "ruff-0.15.21-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e89bc93c0d3803ba870b55c29671bad9dc6d94bb1eb181b056b52eb05b52854f"},
+    {file = "ruff-0.15.21-py3-none-win32.whl", hash = "sha256:01f8d5be84823c172b389e123174f781f9daf86d6c58719d603f941932195cdd"},
+    {file = "ruff-0.15.21-py3-none-win_amd64.whl", hash = "sha256:d4b8d9a2f0f12b816b50447f6eccb9f4bb01a6b82c86b50fb3b5354b458dc6d3"},
+    {file = "ruff-0.15.21-py3-none-win_arm64.whl", hash = "sha256:6e83115d4b9377c1cbc13abf0e051f069fab0ef815ea0504a8a008cee24dd0a8"},
+    {file = "ruff-0.15.21.tar.gz", hash = "sha256:d0cfc841c572283c36548f82664a54ce6565567f1b0d5b4cf2caac693d8b7500"},
 ]
 
 [[package]]

--- a/source/pyproject.toml
+++ b/source/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "claude-code-with-bedrock"
-version = "2.5.1"
+version = "2.5.2"
 description = "Deploy and manage Claude Code on Amazon Bedrock"
 authors = ["Claude Code Team <claude-code@example.com>"]
 readme = "../README.md"

--- a/source/tests/cli/commands/test_deploy_orphan_partition.py
+++ b/source/tests/cli/commands/test_deploy_orphan_partition.py
@@ -1,0 +1,88 @@
+# ABOUTME: Tests that the orphaned-stack check never probes across partitions and
+# ABOUTME: never aborts a deploy on network/SSL failures (advisory check only).
+
+"""Orphaned-stack check partition/resilience regression tests.
+
+The check probes CloudFormation for every stack type NOT in the deploy plan.
+websearch defaults to us-east-1 (the connector is commercial-only), so a
+GovCloud deploy probed a commercial-partition endpoint — unreachable in
+typical GovCloud/air-gapped environments, surfacing as an SSL error that
+crashed `ccwb deploy` right after the deployment plan printed
+(get_stack_status only handles ClientError, so connection errors propagate).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from claude_code_with_bedrock.cli.commands.deploy import DeployCommand
+from claude_code_with_bedrock.config import Profile
+
+
+class _NullConsole:
+    def print(self, *args, **kwargs):
+        pass
+
+
+def _profile(region: str) -> Profile:
+    return Profile(
+        name="orphan-test",
+        provider_domain="company.okta.com",
+        client_id="client-123",
+        credential_storage="session",
+        aws_region=region,
+        identity_pool_name="orphan-pool",
+        auth_type="oidc",
+        monitoring_enabled=True,
+        monitoring_mode="sidecar",
+    )
+
+
+def _run_check(profile, cf_manager, deploying=(("auth", "x"), ("dashboard", "x"))):
+    return DeployCommand()._check_orphaned_stacks(list(deploying), profile, cf_manager, _NullConsole())
+
+
+class TestCrossPartitionProbing:
+    def test_govcloud_deploy_never_probes_commercial_regions(self):
+        """The regression: websearch's home region is us-east-1, a different
+        PARTITION from a GovCloud profile — no client may be created for it
+        and no status call may be made against it."""
+        cf_manager = MagicMock()
+        cf_manager.get_stack_status.return_value = None
+
+        with patch("claude_code_with_bedrock.cli.commands.deploy.CloudFormationManager") as manager_cls:
+            _run_check(_profile("us-gov-west-1"), cf_manager)
+
+        cross_partition = [call for call in manager_cls.call_args_list if "us-gov" not in call.kwargs.get("region", "")]
+        assert not cross_partition, f"probed commercial regions from GovCloud: {cross_partition}"
+
+    def test_commercial_deploy_still_probes_websearch_region(self):
+        """Same-partition cross-region checks must keep working (that's how
+        cross-region websearch/codebuild orphans are detected at all)."""
+        cf_manager = MagicMock()
+        cf_manager.get_stack_status.return_value = None
+
+        with patch("claude_code_with_bedrock.cli.commands.deploy.CloudFormationManager") as manager_cls:
+            manager_cls.return_value.get_stack_status.return_value = None
+            _run_check(_profile("us-west-2"), cf_manager)
+
+        probed_regions = [call.kwargs.get("region") for call in manager_cls.call_args_list]
+        assert "us-east-1" in probed_regions, f"websearch region not probed: {probed_regions}"
+
+
+class TestAdvisoryCheckResilience:
+    def test_connection_errors_do_not_abort_deploy(self):
+        """get_stack_status raising (SSL/connect errors are not ClientError)
+        must degrade to a skipped check, not a crashed deploy."""
+        cf_manager = MagicMock()
+        cf_manager.get_stack_status.side_effect = OSError("SSL: CERTIFICATE_VERIFY_FAILED")
+
+        orphaned = _run_check(_profile("us-gov-west-1"), cf_manager)
+        assert orphaned == []
+
+    def test_orphans_still_detected(self):
+        cf_manager = MagicMock()
+        cf_manager.get_stack_status.side_effect = lambda name: "CREATE_COMPLETE" if name.endswith("-quota") else None
+
+        orphaned = _run_check(_profile("us-gov-west-1"), cf_manager)
+        assert ("quota", "orphan-pool-quota", "CREATE_COMPLETE") in orphaned

--- a/source/tests/cli/commands/test_init_extra_files.py
+++ b/source/tests/cli/commands/test_init_extra_files.py
@@ -1,0 +1,226 @@
+# ABOUTME: Tests for the init wizard extra_files step and its round-trip wiring
+# ABOUTME: Covers add/edit/remove/cancel flows and _check_existing_deployment restore
+
+"""Tests for the `ccwb init` extra_files step.
+
+The wizard step (`_configure_extra_files`) must:
+- add, edit, and remove entries;
+- validate each entry and reject bad ones without saving;
+- preserve the existing list on cancel / non-interactive (prompt returns None);
+- round-trip through save (_save_configuration) and reload
+  (_check_existing_deployment) without drift.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+# ruff: noqa: E402
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+from claude_code_with_bedrock.cli.commands.init import InitCommand
+from claude_code_with_bedrock.config import Config, Profile
+
+
+class _FakeAsk:
+    """Stand-in for a questionary object whose .ask() returns a queued value."""
+
+    def __init__(self, value):
+        self._value = value
+
+    def ask(self):
+        return self._value
+
+
+def _make_profile(extra_files=None) -> Profile:
+    return Profile(
+        name="test",
+        provider_domain="example.okta.com",
+        client_id="0oa1234567890",
+        identity_pool_name="claude-code-auth",
+        credential_storage="keyring",
+        aws_region="us-east-1",
+        extra_files=extra_files or [],
+    )
+
+
+def _rebuild_config(profile: Profile) -> dict:
+    command = InitCommand()
+    fake_config = Config()
+    with (
+        patch.object(Config, "load", return_value=fake_config),
+        patch.object(fake_config, "get_profile", return_value=profile),
+        patch.object(InitCommand, "_stack_exists", side_effect=Exception("no creds")),
+    ):
+        return command._check_existing_deployment("test")
+
+
+class TestExtraFilesRoundTrip:
+    """_check_existing_deployment must restore extra_files from the profile."""
+
+    def test_rerun_preserves_extra_files(self):
+        entries = [
+            {"name": "certs", "targets": "all", "from": "~/secure/certs"},
+            {"name": "pre.sh", "targets": ["macos"], "from": "~/x/pre.sh"},
+        ]
+        rebuilt = _rebuild_config(_make_profile(entries))
+        assert rebuilt["extra_files"] == entries
+
+    def test_rerun_empty_extra_files(self):
+        rebuilt = _rebuild_config(_make_profile([]))
+        assert rebuilt["extra_files"] == []
+
+
+class TestConfigureExtraFiles:
+    """Drive the interactive loop with mocked questionary prompts."""
+
+    def _run(self, existing, confirm, selects, texts, checkboxes):
+        """Run _configure_extra_files with queued prompt responses.
+
+        confirm    -> the single top-level questionary.confirm value
+        selects    -> queued questionary.select return values (actions + pickers)
+        texts      -> queued questionary.text return values (from, name)
+        checkboxes -> queued questionary.checkbox return values (targets)
+        """
+        command = InitCommand()
+        select_iter = iter(selects)
+        text_iter = iter(texts)
+        checkbox_iter = iter(checkboxes)
+        # Record the choices passed to each checkbox call so tests can assert
+        # the pre-checked state (the real Add-vs-Edit default bug).
+        self.checkbox_choices = []
+
+        def _capture_checkbox(*a, **k):
+            self.checkbox_choices.append(k.get("choices", []))
+            return _FakeAsk(next(checkbox_iter))
+
+        with (
+            patch("questionary.confirm", return_value=_FakeAsk(confirm)),
+            patch("questionary.select", side_effect=lambda *a, **k: _FakeAsk(next(select_iter))),
+            patch("questionary.text", side_effect=lambda *a, **k: _FakeAsk(next(text_iter))),
+            patch("questionary.checkbox", side_effect=_capture_checkbox),
+            # Source-exists warning must not depend on the filesystem.
+            patch.object(Path, "exists", return_value=True),
+        ):
+            return command._configure_extra_files(existing)
+
+    def test_decline_keeps_existing(self):
+        existing = [{"name": "certs", "targets": "all", "from": "~/c"}]
+        result = self._run(existing, confirm=False, selects=[], texts=[], checkboxes=[])
+        assert result == existing
+
+    def test_confirm_none_keeps_existing(self):
+        existing = [{"name": "certs", "targets": "all", "from": "~/c"}]
+        result = self._run(existing, confirm=None, selects=[], texts=[], checkboxes=[])
+        assert result == existing
+
+    def test_add_entry(self):
+        result = self._run(
+            existing=[],
+            confirm=True,
+            selects=["Add", "Done"],
+            texts=["~/ccwb-extras/pre.sh", "pre.sh"],
+            checkboxes=[["macos"]],
+        )
+        assert result == [{"name": "pre.sh", "targets": ["macos"], "from": "~/ccwb-extras/pre.sh"}]
+
+    def test_add_prechecks_nothing(self):
+        """Regression: a new Add must start with no target pre-checked, so a
+        sticky 'all' default can't silently subsume the admin's selection."""
+        self._run(
+            existing=[],
+            confirm=True,
+            selects=["Add", "Done"],
+            texts=["~/x/pre.sh", "pre.sh"],
+            checkboxes=[["macos"]],
+        )
+        choices = self.checkbox_choices[0]
+        assert all(not c.checked for c in choices), "Add must not pre-check any target"
+
+    def test_edit_prechecks_existing_targets(self):
+        """Editing pre-checks exactly the entry's current targets."""
+        existing = [{"name": "certs", "targets": ["macos", "linux"], "from": "~/c"}]
+        self._run(
+            existing=existing,
+            confirm=True,
+            selects=["Edit", 0, "Done"],
+            texts=["~/c", "certs"],
+            checkboxes=[["macos", "linux"]],
+        )
+        checked = {c.value for c in self.checkbox_choices[0] if c.checked}
+        assert checked == {"macos", "linux"}
+
+    def test_add_saves_checked_targets_verbatim(self):
+        """Regression: selections are saved exactly as checked, with no collapse.
+
+        The earlier bug flattened any selection containing 'all' down to ['all'],
+        discarding the specific platforms the admin had also checked.
+        """
+        result = self._run(
+            existing=[],
+            confirm=True,
+            selects=["Add", "Done"],
+            texts=["~/secure/certs", "certs"],
+            checkboxes=[["all", "macos", "linux", "windows"]],
+        )
+        assert result == [{"name": "certs", "targets": ["all", "macos", "linux", "windows"], "from": "~/secure/certs"}]
+
+    def test_add_specific_platforms_only(self):
+        """Checking specific platforms (no 'all') saves exactly those."""
+        result = self._run(
+            existing=[],
+            confirm=True,
+            selects=["Add", "Done"],
+            texts=["~/x/pre.sh", "pre.sh"],
+            checkboxes=[["macos", "windows"]],
+        )
+        assert result == [{"name": "pre.sh", "targets": ["macos", "windows"], "from": "~/x/pre.sh"}]
+
+    def test_invalid_entry_not_saved(self):
+        """A zip-slip name is rejected; nothing is added."""
+        result = self._run(
+            existing=[],
+            confirm=True,
+            selects=["Add", "Done"],
+            texts=["~/x", "../escape"],
+            checkboxes=[["all"]],
+        )
+        assert result == []
+
+    def test_remove_entry(self):
+        existing = [
+            {"name": "certs", "targets": "all", "from": "~/c"},
+            {"name": "pre.sh", "targets": ["macos"], "from": "~/p"},
+        ]
+        # confirm=True, then select "Remove", picker returns index 0, then "Done".
+        result = self._run(
+            existing=existing,
+            confirm=True,
+            selects=["Remove", 0, "Done"],
+            texts=[],
+            checkboxes=[],
+        )
+        assert result == [{"name": "pre.sh", "targets": ["macos"], "from": "~/p"}]
+
+    def test_edit_entry(self):
+        existing = [{"name": "certs", "targets": "all", "from": "~/c"}]
+        # "Edit", picker index 0, new from/name, new targets.
+        result = self._run(
+            existing=existing,
+            confirm=True,
+            selects=["Edit", 0, "Done"],
+            texts=["~/new/certs", "certs"],
+            checkboxes=[["linux", "macos"]],
+        )
+        assert result == [{"name": "certs", "targets": ["linux", "macos"], "from": "~/new/certs"}]
+
+    def test_add_cancel_source_keeps_list(self):
+        """Cancelling the source prompt (None) drops back to the menu."""
+        result = self._run(
+            existing=[],
+            confirm=True,
+            selects=["Add", "Done"],
+            texts=[None],
+            checkboxes=[],
+        )
+        assert result == []

--- a/source/tests/cli/commands/test_init_session_duration.py
+++ b/source/tests/cli/commands/test_init_session_duration.py
@@ -1,0 +1,179 @@
+# ABOUTME: Regression test ensuring ccwb init lets you set max_session_duration and retains it
+# ABOUTME: Guards against the hardcoded clobber that reset the value on every re-run
+
+"""Regression tests: `ccwb init` must let users set max_session_duration and
+must not reset a previously configured value when re-run.
+
+The OIDC step of `_gather_configuration` used to unconditionally overwrite
+``config["max_session_duration"]`` with a federation-type default (43200 for
+direct STS, 28800 for Cognito). That silently discarded any custom value on
+every re-run and gave users no way to change it. These tests drive the OIDC
+step and inspect the config captured at the ``oidc_complete`` checkpoint.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ruff: noqa: E402
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+
+import questionary
+
+from claude_code_with_bedrock.cli.commands.init import InitCommand
+
+
+class _StopAtOidcComplete(Exception):
+    """Raised from progress.save_step once the OIDC step finishes."""
+
+
+def _run_oidc_step(existing_config=None, duration_answer=None):
+    """Drive `_gather_configuration` through the OIDC step for an Okta provider.
+
+    Returns the in-memory config dict captured when the wizard reaches the
+    ``oidc_complete`` checkpoint (right after max_session_duration is resolved).
+
+    Args:
+        existing_config: if provided, seeds the wizard as an update-in-place run.
+        duration_answer: value the "Max session duration" prompt returns. When
+            None, the prompt returns its own default (simulates pressing Enter).
+    """
+    captured = {}
+
+    progress = MagicMock()
+    progress.get_last_step.return_value = None
+    progress.get_saved_data.return_value = {}
+
+    def save_step(step, data=None, *a, **k):
+        if step == "oidc_complete":
+            captured["config"] = dict(data)
+            raise _StopAtOidcComplete()
+
+    progress.save_step.side_effect = save_step
+
+    def fake_select(message, *a, **k):
+        m = MagicMock()
+        text = str(message)
+        if "authentication method" in text:
+            m.ask.return_value = "oidc"
+        elif "credential" in text.lower() or "storage" in text.lower():
+            m.ask.return_value = "keyring"
+        elif "Federation type" in text:
+            m.ask.return_value = "direct"
+        else:
+            m.ask.return_value = None
+        return m
+
+    def fake_text(message, *a, **k):
+        m = MagicMock()
+        text = str(message)
+        if "Max session duration" in text:
+            m.ask.return_value = duration_answer if duration_answer is not None else k.get("default")
+        elif "provider domain" in text:
+            m.ask.return_value = "company.okta.com"
+        elif "Client ID" in text:
+            m.ask.return_value = "0oa1234567890xyz"
+        else:
+            m.ask.return_value = k.get("default", "")
+        return m
+
+    def fake_confirm(*a, **k):
+        m = MagicMock()
+        m.ask.return_value = False
+        return m
+
+    cmd = InitCommand()
+    with (
+        patch.object(questionary, "select", fake_select),
+        patch.object(questionary, "text", fake_text),
+        patch.object(questionary, "confirm", fake_confirm),
+    ):
+        try:
+            cmd._gather_configuration(progress, existing_config=existing_config)
+        except _StopAtOidcComplete:
+            pass
+
+    assert "config" in captured, "wizard never reached the oidc_complete checkpoint"
+    return captured["config"]
+
+
+def test_can_set_custom_max_session_duration():
+    """A user-entered duration must be written to config, not the hardcoded default."""
+    config = _run_oidc_step(duration_answer="21600")
+    assert config["max_session_duration"] == 21600
+
+
+def test_rerun_retains_custom_max_session_duration():
+    """Re-running init and accepting the default must keep the existing value."""
+    existing = {
+        "okta": {"domain": "company.okta.com", "client_id": "0oa1234567890xyz"},
+        "max_session_duration": 14400,
+    }
+    # duration_answer=None -> prompt returns its own default, i.e. the user
+    # presses Enter to accept. The default must be the existing 14400.
+    config = _run_oidc_step(existing_config=existing, duration_answer=None)
+    assert config["max_session_duration"] == 14400
+
+
+@pytest.mark.parametrize("federation,expected", [("direct", 43200), ("cognito", 28800)])
+def test_default_duration_follows_federation_type(federation, expected):
+    """With no prior value, the prompt default matches the federation recommendation."""
+
+    def fake_select(message, *a, **k):
+        m = MagicMock()
+        text = str(message)
+        if "authentication method" in text:
+            m.ask.return_value = "oidc"
+        elif "credential" in text.lower() or "storage" in text.lower():
+            m.ask.return_value = "keyring"
+        elif "Federation type" in text:
+            m.ask.return_value = federation
+        else:
+            m.ask.return_value = None
+        return m
+
+    captured = {}
+    progress = MagicMock()
+    progress.get_last_step.return_value = None
+    progress.get_saved_data.return_value = {}
+
+    def save_step(step, data=None, *a, **k):
+        if step == "oidc_complete":
+            captured["config"] = dict(data)
+            raise _StopAtOidcComplete()
+
+    progress.save_step.side_effect = save_step
+
+    def fake_text(message, *a, **k):
+        m = MagicMock()
+        text = str(message)
+        if "Max session duration" in text:
+            # Accept whatever default the wizard proposes.
+            m.ask.return_value = k.get("default")
+        elif "provider domain" in text:
+            m.ask.return_value = "company.okta.com"
+        elif "Client ID" in text:
+            m.ask.return_value = "0oa1234567890xyz"
+        else:
+            m.ask.return_value = k.get("default", "")
+        return m
+
+    def fake_confirm(*a, **k):
+        m = MagicMock()
+        m.ask.return_value = False
+        return m
+
+    cmd = InitCommand()
+    with (
+        patch.object(questionary, "select", fake_select),
+        patch.object(questionary, "text", fake_text),
+        patch.object(questionary, "confirm", fake_confirm),
+    ):
+        try:
+            cmd._gather_configuration(progress)
+        except _StopAtOidcComplete:
+            pass
+
+    assert captured["config"]["max_session_duration"] == expected

--- a/source/tests/cli/commands/test_installer_launcher.py
+++ b/source/tests/cli/commands/test_installer_launcher.py
@@ -16,6 +16,8 @@ with the launcher as optional, and, for bash, that both the installer and the
 launcher it writes are syntactically valid shell.
 """
 
+import json
+import os
 import shutil
 import subprocess
 import sys
@@ -185,3 +187,105 @@ class TestWindowsInstallerLauncher:
         assert "claude-bedrock.cmd" in content
         # The old "run the launcher, NOT 'claude' directly" framing must be gone.
         assert "NOT 'claude' directly" not in content
+
+
+class TestWindowsInstallerSettingsMerge:
+    """Regression tests for merging claude-settings/settings.json into an
+    existing %USERPROFILE%\\.claude\\settings.json.
+
+    The original merge one-liner rendered with DOUBLED braces (f-string
+    `{{{{` -> `{{` in the .bat), so PowerShell parsed the foreach body as a
+    scriptblock LITERAL that was never invoked — the existing file was
+    rewritten unchanged and the new settings were silently dropped.
+    """
+
+    def _generate(self) -> str:
+        cmd = PackageCommand()
+        out = Path(tempfile.mkdtemp())
+        path = cmd._create_windows_installer(out, _idc_profile())
+        return path.read_text(encoding="utf-8")
+
+    def _merge_command(self, content: str) -> str:
+        """Extract the PowerShell merge command from the generated install.bat."""
+        for line in content.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("powershell") and "$ErrorActionPreference" in stripped:
+                # Strip `powershell -NoProfile -Command "` prefix and closing quote.
+                # The command body uses only single-quoted strings, so the outer
+                # double quotes delimit it unambiguously.
+                start = stripped.index('"') + 1
+                return stripped[start:-1]
+        raise AssertionError("merge powershell command not found in install.bat")
+
+    def test_merge_command_has_no_doubled_braces(self):
+        """`{{` in the emitted batch means the foreach body is a scriptblock
+        literal (a no-op) — the exact bug that made the merge do nothing."""
+        content = self._generate()
+        assert "{{" not in content, "install.bat must not contain doubled braces (PowerShell no-op scriptblock)"
+        merge = self._merge_command(content)
+        assert "foreach ($prop in $incoming.PSObject.Properties) {" in merge
+
+    def test_merge_deep_merges_env(self):
+        """Top-level Add-Member -Force would replace the whole `env` object,
+        wiping user-added env vars. The merge must descend into `env`."""
+        merge = self._merge_command(self._generate())
+        assert "$existing.env | Add-Member" in merge
+
+    def test_merge_failure_is_detectable(self):
+        """The merge runs inside a parenthesized batch block, where %errorlevel%
+        expands at PARSE time (always the pre-block value). The check must use
+        delayed expansion, and the command must exit non-zero on failure."""
+        content = self._generate()
+        assert "if !errorlevel! equ 0 (" in content
+        merge = self._merge_command(content)
+        assert "$ErrorActionPreference = 'Stop'" in merge
+        assert "exit 1" in merge
+
+    def test_overwrite_choice_actually_overwrites(self):
+        """Answering 'y' to 'Merge failed. Overwrite?' previously did nothing:
+        the write branch also required the settings file to NOT exist. The
+        rewritten flow funnels both paths through a delayed-expansion flag."""
+        content = self._generate()
+        assert 'if "!WRITE_SETTINGS!"=="true" (' in content
+        assert 'if /i "!OVERWRITE!"=="y" (' in content
+
+    @pytest.mark.skipif(sys.platform != "win32", reason="executes the merge under real PowerShell")
+    def test_merge_executes_and_preserves_user_settings(self, tmp_path):
+        """Functional check on Windows CI: run the extracted merge command and
+        assert (1) new keys land, (2) placeholders are resolved, (3) the user's
+        pre-existing top-level keys and custom env vars survive."""
+        merge = self._merge_command(self._generate())
+
+        userprofile = tmp_path / "home"
+        (userprofile / ".claude").mkdir(parents=True)
+        existing = {"model": "opus", "env": {"MY_CUSTOM_VAR": "keep-me"}}
+        (userprofile / ".claude" / "settings.json").write_text(json.dumps(existing), encoding="utf-8")
+
+        workdir = tmp_path / "package"
+        (workdir / "claude-settings").mkdir(parents=True)
+        incoming = {
+            "env": {"CLAUDE_CODE_USE_BEDROCK": "1", "AWS_PROFILE": "idc-test"},
+            "otelHeadersHelper": "__OTEL_HELPER_PATH__ --profile idc-test",
+            "awsAuthRefresh": "__CREDENTIAL_PROCESS_PATH__ --login --profile idc-test",
+        }
+        (workdir / "claude-settings" / "settings.json").write_text(json.dumps(incoming), encoding="utf-8")
+
+        env = dict(os.environ, USERPROFILE=str(userprofile))
+        result = subprocess.run(
+            ["powershell", "-NoProfile", "-Command", merge],
+            cwd=workdir,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"merge command failed: {result.stderr}"
+
+        merged = json.loads((userprofile / ".claude" / "settings.json").read_text(encoding="utf-8"))
+        # New settings applied (the original bug: nothing changed at all).
+        assert merged["env"]["CLAUDE_CODE_USE_BEDROCK"] == "1"
+        assert "otel-helper.cmd --profile idc-test" in merged["otelHeadersHelper"].replace("\\\\", "\\")
+        assert "__OTEL_HELPER_PATH__" not in merged["otelHeadersHelper"]
+        assert "__CREDENTIAL_PROCESS_PATH__" not in merged["awsAuthRefresh"]
+        # User customizations preserved (top-level and inside env).
+        assert merged["model"] == "opus"
+        assert merged["env"]["MY_CUSTOM_VAR"] == "keep-me"

--- a/source/tests/cli/commands/test_package.py
+++ b/source/tests/cli/commands/test_package.py
@@ -201,3 +201,67 @@ class TestResolveFederation:
         assert identity_pool_id is None
         assert federated_role_arn is None
         mock_stack.assert_not_called()
+
+
+class TestPackageCommandOtelDefaults:
+    """Tests for the default OTEL_RESOURCE_ATTRIBUTES written into settings.json."""
+
+    def _make_monitoring_profile(self):
+        return Profile(
+            name="test",
+            provider_domain="test.okta.com",
+            client_id="test-client",
+            credential_storage="session",
+            aws_region="us-east-1",
+            identity_pool_name="test-pool",
+            allowed_bedrock_regions=["us-east-1"],
+            monitoring_enabled=True,
+            stack_names={"monitoring": "test-otel-collector"},
+        )
+
+    def _render_settings(self, otel_resource_attributes=None):
+        """Drive _create_claude_settings with a mocked monitoring stack endpoint."""
+        command = PackageCommand()
+        profile = self._make_monitoring_profile()
+
+        fake_outputs = json.dumps(
+            [{"OutputKey": "CollectorEndpoint", "OutputValue": "https://otel.example.com"}]
+        )
+        completed = MagicMock(returncode=0, stdout=fake_outputs)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            with patch(
+                "claude_code_with_bedrock.cli.commands.package.subprocess.run",
+                return_value=completed,
+            ):
+                command._create_claude_settings(
+                    output_dir,
+                    profile,
+                    include_coauthored_by=True,
+                    profile_name="test",
+                    otel_resource_attributes=otel_resource_attributes,
+                )
+
+            settings_path = output_dir / "claude-settings" / "settings.json"
+            with open(settings_path, encoding="utf-8") as f:
+                return json.load(f)
+
+    def test_default_department_is_default_not_engineering(self):
+        """Regression: the default department must be 'default', not 'engineering'.
+
+        'engineering' is not a safe assumption for every deployment, so the
+        baseline OTEL attributes should be neutral and overridable.
+        """
+        settings = self._render_settings()
+        attrs = settings["env"]["OTEL_RESOURCE_ATTRIBUTES"]
+
+        assert "department=default" in attrs
+        assert "department=engineering" not in attrs
+
+    def test_configured_attributes_override_default(self):
+        """An explicit OTEL_RESOURCE_ATTRIBUTES value takes precedence over the default."""
+        settings = self._render_settings(otel_resource_attributes="department=research,team.id=ml")
+        attrs = settings["env"]["OTEL_RESOURCE_ATTRIBUTES"]
+
+        assert attrs == "department=research,team.id=ml"

--- a/source/tests/cli/commands/test_package.py
+++ b/source/tests/cli/commands/test_package.py
@@ -224,9 +224,7 @@ class TestPackageCommandOtelDefaults:
         command = PackageCommand()
         profile = self._make_monitoring_profile()
 
-        fake_outputs = json.dumps(
-            [{"OutputKey": "CollectorEndpoint", "OutputValue": "https://otel.example.com"}]
-        )
+        fake_outputs = json.dumps([{"OutputKey": "CollectorEndpoint", "OutputValue": "https://otel.example.com"}])
         completed = MagicMock(returncode=0, stdout=fake_outputs)
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -265,6 +263,8 @@ class TestPackageCommandOtelDefaults:
         attrs = settings["env"]["OTEL_RESOURCE_ATTRIBUTES"]
 
         assert attrs == "department=research,team.id=ml"
+
+
 class TestCopyExtraFiles:
     """Tests for _copy_extra_files — the package-side extra-files copy step."""
 

--- a/source/tests/cli/commands/test_package.py
+++ b/source/tests/cli/commands/test_package.py
@@ -219,7 +219,7 @@ class TestPackageCommandOtelDefaults:
             stack_names={"monitoring": "test-otel-collector"},
         )
 
-    def _render_settings(self, otel_resource_attributes=None):
+    def _render_settings(self, otel_resource_attributes=None, settings_version=None):
         """Drive _create_claude_settings with a mocked monitoring stack endpoint."""
         command = PackageCommand()
         profile = self._make_monitoring_profile()
@@ -239,6 +239,7 @@ class TestPackageCommandOtelDefaults:
                     include_coauthored_by=True,
                     profile_name="test",
                     otel_resource_attributes=otel_resource_attributes,
+                    settings_version=settings_version,
                 )
 
             settings_path = output_dir / "claude-settings" / "settings.json"
@@ -263,6 +264,62 @@ class TestPackageCommandOtelDefaults:
         attrs = settings["env"]["OTEL_RESOURCE_ATTRIBUTES"]
 
         assert attrs == "department=research,team.id=ml"
+
+    def test_settings_version_appended_to_default_attributes(self):
+        """The dist-folder timestamp is stamped as settings_version for telemetry."""
+        settings = self._render_settings(settings_version="2026-07-08-120000")
+        attrs = settings["env"]["OTEL_RESOURCE_ATTRIBUTES"]
+
+        assert attrs.endswith(",settings_version=2026-07-08-120000")
+        assert "department=default" in attrs
+
+    def test_settings_version_appended_to_custom_attributes(self):
+        """settings_version is stamped even when the admin customizes attributes."""
+        settings = self._render_settings(
+            otel_resource_attributes="department=research,team.id=ml",
+            settings_version="2026-07-08-120000",
+        )
+        attrs = settings["env"]["OTEL_RESOURCE_ATTRIBUTES"]
+
+        assert attrs == "department=research,team.id=ml,settings_version=2026-07-08-120000"
+
+    def test_no_settings_version_omits_attribute(self):
+        """Without a version (backward compat), the attribute is absent entirely."""
+        settings = self._render_settings()
+        attrs = settings["env"]["OTEL_RESOURCE_ATTRIBUTES"]
+
+        assert "settings_version" not in attrs
+
+    def test_cowork_package_stamps_settings_version(self):
+        """Parity: the CodeBuild package variant stamps settings_version too."""
+        from claude_code_with_bedrock.cli.commands.package_cb import PackageCbCommand
+
+        command = PackageCbCommand()
+        profile = self._make_monitoring_profile()
+
+        fake_outputs = json.dumps([{"OutputKey": "CollectorEndpoint", "OutputValue": "https://otel.example.com"}])
+        completed = MagicMock(returncode=0, stdout=fake_outputs)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            with patch(
+                "claude_code_with_bedrock.cli.commands.package_cb.subprocess.run",
+                return_value=completed,
+            ):
+                command._create_claude_settings(
+                    output_dir,
+                    profile,
+                    include_coauthored_by=True,
+                    profile_name="test",
+                    settings_version="2026-07-08-120000",
+                )
+
+            settings_path = output_dir / "claude-settings" / "settings.json"
+            with open(settings_path, encoding="utf-8") as f:
+                settings = json.load(f)
+
+        attrs = settings["env"]["OTEL_RESOURCE_ATTRIBUTES"]
+        assert attrs.endswith(",settings_version=2026-07-08-120000")
 
 
 class TestCopyExtraFiles:

--- a/source/tests/cli/commands/test_package.py
+++ b/source/tests/cli/commands/test_package.py
@@ -340,3 +340,63 @@ class TestCopyExtraFiles:
         result = PackageCommand()._copy_extra_files(profile, out, MagicMock())
         assert result is not None
         assert (out / "hooks" / "pre.sh").read_text() == "hook"
+
+    def test_target_platform_filters_non_matching_extras(self, tmp_path):
+        """Regression: --target-platform macos must not copy windows-only extras."""
+        for fname in ("hook-win.bat", "hook-mac.sh", "ca.pem"):
+            (tmp_path / fname).write_text(fname)
+        out = tmp_path / "out"
+        out.mkdir()
+        profile = self._profile(
+            [
+                {"name": "ca.pem", "targets": "all", "from": str(tmp_path / "ca.pem")},
+                {
+                    "name": "hook-mac.sh",
+                    "targets": ["macos", "macos-arm64", "macos-intel"],
+                    "from": str(tmp_path / "hook-mac.sh"),
+                },
+                {
+                    "name": "hook-win.bat",
+                    "targets": ["windows"],
+                    "from": str(tmp_path / "hook-win.bat"),
+                },
+            ]
+        )
+
+        result = PackageCommand()._copy_extra_files(profile, out, MagicMock(), ["macos-arm64"])
+
+        assert result is not None
+        assert (out / "ca.pem").exists()
+        assert (out / "hook-mac.sh").exists()
+        assert not (out / "hook-win.bat").exists()
+        names = {name for name, _ in result}
+        assert names == {"ca.pem", "hook-mac.sh"}
+
+    def test_skipped_extra_does_not_require_source(self, tmp_path):
+        """A filtered-out entry's missing 'from' source must not fail the build."""
+        out = tmp_path / "out"
+        out.mkdir()
+        profile = self._profile(
+            [{"name": "win-only.bat", "targets": "windows", "from": str(tmp_path / "does-not-exist.bat")}]
+        )
+        result = PackageCommand()._copy_extra_files(profile, out, MagicMock(), ["macos-arm64"])
+        assert result == []
+
+    def test_applicable_extra_missing_source_still_fails(self, tmp_path):
+        out = tmp_path / "out"
+        out.mkdir()
+        profile = self._profile(
+            [{"name": "mac-only.sh", "targets": "macos", "from": str(tmp_path / "does-not-exist.sh")}]
+        )
+        result = PackageCommand()._copy_extra_files(profile, out, MagicMock(), ["macos-arm64"])
+        assert result is None
+
+    def test_no_platform_filter_copies_everything(self, tmp_path):
+        """platforms_to_build=None keeps the pre-filter superset behavior."""
+        (tmp_path / "w.bat").write_text("w")
+        out = tmp_path / "out"
+        out.mkdir()
+        profile = self._profile([{"name": "w.bat", "targets": "windows", "from": str(tmp_path / "w.bat")}])
+        result = PackageCommand()._copy_extra_files(profile, out, MagicMock())
+        assert result is not None
+        assert (out / "w.bat").exists()

--- a/source/tests/cli/commands/test_package.py
+++ b/source/tests/cli/commands/test_package.py
@@ -265,3 +265,78 @@ class TestPackageCommandOtelDefaults:
         attrs = settings["env"]["OTEL_RESOURCE_ATTRIBUTES"]
 
         assert attrs == "department=research,team.id=ml"
+class TestCopyExtraFiles:
+    """Tests for _copy_extra_files — the package-side extra-files copy step."""
+
+    def _profile(self, extra_files):
+        return Profile(
+            name="test",
+            provider_domain="test.okta.com",
+            client_id="test-client-id",
+            credential_storage="keyring",
+            aws_region="us-east-1",
+            identity_pool_name="test-pool",
+            monitoring_enabled=False,
+            extra_files=extra_files,
+        )
+
+    def test_empty_list_returns_empty(self, tmp_path):
+        command = PackageCommand()
+        profile = self._profile([])
+        result = command._copy_extra_files(profile, tmp_path, MagicMock())
+        assert result == []
+
+    def test_copies_file_and_folder(self, tmp_path):
+        # Source file
+        src_file = tmp_path / "src" / "preinstall.sh"
+        src_file.parent.mkdir(parents=True)
+        src_file.write_text("#!/bin/bash\necho hi")
+        # Source folder
+        src_dir = tmp_path / "src" / "certs"
+        src_dir.mkdir()
+        (src_dir / "ca.pem").write_text("CERT")
+
+        out = tmp_path / "out"
+        out.mkdir()
+        profile = self._profile(
+            [
+                {"name": "preinstall.sh", "targets": "macos", "from": str(src_file)},
+                {"name": "certs", "targets": "all", "from": str(src_dir)},
+            ]
+        )
+
+        result = PackageCommand()._copy_extra_files(profile, out, MagicMock())
+
+        assert (out / "preinstall.sh").read_text() == "#!/bin/bash\necho hi"
+        assert (out / "certs" / "ca.pem").read_text() == "CERT"
+        names = {name for name, _ in result}
+        assert names == {"preinstall.sh", "certs"}
+
+    def test_missing_source_fails(self, tmp_path):
+        out = tmp_path / "out"
+        out.mkdir()
+        profile = self._profile([{"name": "missing.sh", "targets": "all", "from": str(tmp_path / "nope.sh")}])
+        result = PackageCommand()._copy_extra_files(profile, out, MagicMock())
+        assert result is None
+        assert not (out / "missing.sh").exists()
+
+    def test_validation_error_fails_and_copies_nothing(self, tmp_path):
+        src = tmp_path / "cfg"
+        src.write_text("x")
+        out = tmp_path / "out"
+        out.mkdir()
+        # 'config.json' collides with a generated artifact → validation error
+        profile = self._profile([{"name": "config.json", "targets": "all", "from": str(src)}])
+        result = PackageCommand()._copy_extra_files(profile, out, MagicMock())
+        assert result is None
+        assert not (out / "config.json").exists()
+
+    def test_nested_name_creates_parent_dirs(self, tmp_path):
+        src = tmp_path / "hook.sh"
+        src.write_text("hook")
+        out = tmp_path / "out"
+        out.mkdir()
+        profile = self._profile([{"name": "hooks/pre.sh", "targets": "all", "from": str(src)}])
+        result = PackageCommand()._copy_extra_files(profile, out, MagicMock())
+        assert result is not None
+        assert (out / "hooks" / "pre.sh").read_text() == "hook"

--- a/source/tests/cli/commands/test_package_idc_otel_helper.py
+++ b/source/tests/cli/commands/test_package_idc_otel_helper.py
@@ -93,13 +93,13 @@ def _generate(profile: Profile) -> dict:
 class TestOtelHeadersHelperWiring:
     def test_oidc_wires_helper(self):
         settings = _generate(_oidc_profile())
-        assert settings.get("otelHeadersHelper") == "__OTEL_HELPER_PATH__"
+        assert settings.get("otelHeadersHelper") == "__OTEL_HELPER_PATH__ --profile test"
 
     def test_idc_with_binary_wires_helper(self):
         """The bug: IDC + binary previously skipped the helper, so dashboards
         attributed every IDC user to one static identity."""
         settings = _generate(_idc_with_binary_profile())
-        assert settings.get("otelHeadersHelper") == "__OTEL_HELPER_PATH__", (
+        assert settings.get("otelHeadersHelper") == "__OTEL_HELPER_PATH__ --profile test", (
             "IDC with credential-process binary must wire otelHeadersHelper for per-user attribution"
         )
 

--- a/source/tests/e2e/test_cowork_dashboard_filters.py
+++ b/source/tests/e2e/test_cowork_dashboard_filters.py
@@ -3,6 +3,8 @@
 
 """Tests for CoWork dashboard metric filter schema coverage."""
 
+import json
+import re
 from pathlib import Path
 
 import pytest
@@ -133,4 +135,83 @@ class TestCoWorkDashboardMetricFilters:
             for transform in res["Properties"]["MetricTransformations"]:
                 assert transform["MetricNamespace"] == "ClaudeCoWork", (
                     f"{name}: expected ClaudeCoWork namespace, got {transform['MetricNamespace']}"
+                )
+
+
+class TestCoWorkDashboardBody:
+    """Verify the CloudWatch DashboardBody widgets pass CloudWatch validation.
+
+    Regression: PromQL queries (properties.data.queries) are only valid for the
+    newer "chart" widget type. When such a query lived on a "metric" widget,
+    CloudWatch rejected the dashboard with "Should have required property
+    'metrics'" (18 validation errors), breaking `ccwb deploy` of the
+    cowork-dashboard stack.
+    """
+
+    @pytest.fixture(autouse=True)
+    def load_body(self):
+        text = DASHBOARD_PATH.read_text()
+        # Extract the DashboardBody block that follows `DashboardBody: !Sub |`
+        marker = "DashboardBody: !Sub |"
+        block = text[text.index(marker) :].splitlines()[1:]
+        body_lines = []
+        for line in block:
+            if line.strip() == "":
+                body_lines.append("")
+            elif line.startswith("        "):
+                body_lines.append(line[8:])
+            else:
+                break
+        raw = "\n".join(body_lines)
+        # Neutralize the !Sub variable so the block is parseable JSON.
+        raw = re.sub(r"\$\{[^}]+\}", "us-east-1", raw)
+        self.body = json.loads(raw)
+        self.widgets = self.body["widgets"]
+
+    def test_body_is_valid_json(self):
+        """DashboardBody must be valid JSON (this fixture would raise otherwise)."""
+        assert isinstance(self.widgets, list) and self.widgets
+
+    def test_promql_queries_only_on_chart_widgets(self):
+        """PromQL data.queries are only valid on 'chart' widgets, never 'metric'.
+
+        A 'metric' widget carrying data.queries has neither a `metrics` array
+        nor `annotations`, which CloudWatch rejects at deploy time.
+        """
+        for i, widget in enumerate(self.widgets):
+            props = widget.get("properties", {})
+            if "data" in props and "queries" in props["data"]:
+                assert widget["type"] == "chart", (
+                    f"widget {i} ({props.get('title')!r}) uses data.queries (PromQL) "
+                    f"but has type {widget['type']!r}; PromQL requires type 'chart'"
+                )
+
+    def test_metric_widgets_have_metrics_array(self):
+        """Every 'metric' widget must define a metrics array (CloudWatch requirement)."""
+        for i, widget in enumerate(self.widgets):
+            if widget["type"] == "metric":
+                props = widget.get("properties", {})
+                assert "metrics" in props, (
+                    f"widget {i} ({props.get('title')!r}) is a metric widget without a "
+                    "'metrics' array; CloudWatch will reject the dashboard"
+                )
+
+    def test_chart_widgets_do_not_use_metric_only_view_or_stacked(self):
+        """Chart widgets use chart views (line/number/pie/bar), not metric-only keys.
+
+        `singleValue`/`timeSeries` views and the top-level `stacked` flag belong to
+        'metric' widgets; on a chart widget they are the fingerprint of a
+        mis-typed PromQL widget.
+        """
+        metric_only_views = {"singleValue", "timeSeries"}
+        for i, widget in enumerate(self.widgets):
+            if widget["type"] == "chart":
+                props = widget.get("properties", {})
+                assert props.get("view") not in metric_only_views, (
+                    f"widget {i} ({props.get('title')!r}) is a chart widget using "
+                    f"metric-only view {props.get('view')!r}"
+                )
+                assert "stacked" not in props, (
+                    f"widget {i} ({props.get('title')!r}) uses top-level 'stacked'; "
+                    "chart widgets stack via plotOptions.style.lineOptions.stacked"
                 )

--- a/source/tests/integration/test_package_structure.py
+++ b/source/tests/integration/test_package_structure.py
@@ -234,7 +234,7 @@ class TestClaudeSettingsGeneration:
                 settings = json.load(f)
 
             assert "otelHeadersHelper" in settings, "otelHeadersHelper must be configured when monitoring is enabled"
-            assert settings["otelHeadersHelper"] == "__OTEL_HELPER_PATH__"
+            assert settings["otelHeadersHelper"] == "__OTEL_HELPER_PATH__ --profile ClaudeCode"
             assert settings["env"]["CLAUDE_CODE_ENABLE_TELEMETRY"] == "1"
             assert settings["env"]["OTEL_EXPORTER_OTLP_ENDPOINT"] == "https://collector.example.com:4318"
 

--- a/source/tests/test_bedrock_region_expansion.py
+++ b/source/tests/test_bedrock_region_expansion.py
@@ -1,0 +1,62 @@
+# ABOUTME: Regression tests that the "all-commercial" region sentinel never
+# ABOUTME: reaches the AllowedBedrockRegions CFN param / aws:RequestedRegion IAM condition.
+
+"""Regression: global-model region sentinel must not deny Bedrock invokes.
+
+A profile whose selected model is a *global* inference profile stores
+``allowed_bedrock_regions = ["all-commercial"]`` (the model's destination-region
+sentinel). Before the fix, that string was passed verbatim as the
+``AllowedBedrockRegions`` CloudFormation parameter, which becomes the federated
+role's ``aws:RequestedRegion`` StringEquals condition. ``"all-commercial"``
+equals no real region, so every ``bedrock:InvokeModelWithResponseStream`` call
+was denied with AccessDenied even though auth succeeded.
+
+These tests assert the sentinel is expanded into concrete regions at every
+CFN-parameter boundary.
+"""
+
+from unittest.mock import patch
+
+from claude_code_with_bedrock.config import Config, Profile
+
+
+def _global_profile() -> Profile:
+    """A Google-federated profile pinned to a global model, as saved by init."""
+    return Profile(
+        name="aws-demo",
+        provider_domain="accounts.google.com",
+        client_id="319-abc.apps.googleusercontent.com",
+        credential_storage="session",
+        aws_region="us-east-1",
+        identity_pool_name="claude-code-auth",
+        provider_type="google",
+        federation_type="direct",
+        selected_model="global.anthropic.claude-sonnet-4-6",
+        allowed_bedrock_regions=["all-commercial"],
+    )
+
+
+def test_get_aws_config_expands_all_commercial():
+    """Config.get_aws_config_for_profile must not emit the raw sentinel."""
+    profile = _global_profile()
+    cfg = Config()
+    with patch.object(cfg, "get_profile", return_value=profile):
+        aws_config = cfg.get_aws_config_for_profile("aws-demo")
+
+    regions = aws_config["AllowedBedrockRegions"]
+    assert "all-commercial" not in regions, (
+        "The sentinel leaked into AllowedBedrockRegions — the IAM aws:RequestedRegion "
+        "condition would match no region and deny every Bedrock invoke"
+    )
+    # The customer's request region must be authorized.
+    assert "us-east-1" in regions.split(",")
+
+
+def test_expansion_covers_the_reported_arn_region():
+    """The us-east-1 invoke from the CloudTrail AccessDenied must now be allowed."""
+    from claude_code_with_bedrock.models import expand_bedrock_regions
+
+    expanded = expand_bedrock_regions(["all-commercial"])
+    # inference-profile/global.anthropic.claude-sonnet-* is invoked in us-east-1
+    assert "us-east-1" in expanded
+    assert not any(r.startswith("all-") for r in expanded)

--- a/source/tests/test_config.py
+++ b/source/tests/test_config.py
@@ -224,6 +224,55 @@ class TestCodebuildRegionField:
         assert restored.codebuild_prior_regions == ["ap-southeast-2", "eu-west-1"]
 
 
+class TestExtraFilesField:
+    """Tests for the admin-only extra_files field."""
+
+    def test_defaults_to_empty_list(self):
+        """New field defaults to [] so old profiles load unchanged."""
+        profile = Profile(
+            name="t",
+            provider_domain="test.okta.com",
+            client_id="x",
+            credential_storage="session",
+            aws_region="us-east-1",
+            identity_pool_name="tp",
+        )
+        assert profile.extra_files == []
+        assert "extra_files" in profile.to_dict()
+
+    def test_legacy_config_without_extra_files_loads(self):
+        """A profile.json saved before this field existed loads with []."""
+        profile = Profile.from_dict(
+            {
+                "name": "t",
+                "provider_domain": "test.okta.com",
+                "client_id": "x",
+                "credential_storage": "session",
+                "aws_region": "us-east-1",
+                "identity_pool_name": "tp",
+            }
+        )
+        assert profile.extra_files == []
+
+    def test_round_trip_preserves_entries(self):
+        """extra_files survives a to_dict -> from_dict round-trip."""
+        entries = [
+            {"name": "certs", "targets": "all", "from": "~/secure/certs"},
+            {"name": "preinstall-mac.sh", "targets": ["macos"], "from": "~/x/pre.sh"},
+        ]
+        profile = Profile(
+            name="t",
+            provider_domain="test.okta.com",
+            client_id="x",
+            credential_storage="session",
+            aws_region="us-east-1",
+            identity_pool_name="tp",
+            extra_files=entries,
+        )
+        restored = Profile.from_dict(profile.to_dict())
+        assert restored.extra_files == entries
+
+
 class TestConfigManager:
     """Tests for the Config manager."""
 

--- a/source/tests/test_cost_quota_wiring.py
+++ b/source/tests/test_cost_quota_wiring.py
@@ -1,0 +1,243 @@
+# ABOUTME: Regression tests for cost-based quota wiring: wizard answers must reach
+# ABOUTME: the profile, the stack, and both Lambdas (previously dropped end-to-end).
+
+"""Cost-based quota was half-wired: the wizard asked for $ budgets but the
+answers were dropped at every hop.
+
+- No Profile fields existed for limit type / cost limits → not in the profile
+  JSON, lost on re-init.
+- deploy never passed MonthlyCostLimitUsd / DailyCostLimitUsd; the template
+  declared them but wired them to nothing.
+- quota_check's environment-default policy activated only when
+  MONTHLY_TOKEN_LIMIT > 0 — cost mode zeroes token limits, so cost-mode
+  deployments resolved NO policy and every user was unlimited.
+- quota_monitor alerted `total_tokens > monthly_limit` with no zero guard, so
+  a 0 token limit (cost mode) alert-stormed every active user each scan.
+- The wizard also asked for token counts in cost mode (the mode gate only
+  wrapped a header print) and silently dropped the monthly enforcement answer.
+
+These tests pin every hop of the repaired chain.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+# ruff: noqa: E402
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from claude_code_with_bedrock.cli.commands.init import InitCommand
+from claude_code_with_bedrock.config import Config, Profile
+
+LAMBDA_DIR = Path(__file__).resolve().parents[2] / "deployment" / "infrastructure" / "lambda-functions"
+TEMPLATE = Path(__file__).resolve().parents[2] / "deployment" / "infrastructure" / "quota-monitoring.yaml"
+
+
+def _load_lambda(name: str, env: dict):
+    """Load a Lambda module fresh with the given environment (loader pattern
+    from test_quota_monitor_lambda.py). Restores os.environ afterwards so
+    later tests loading the same Lambdas don't inherit these limits."""
+    base = {
+        "AWS_DEFAULT_REGION": "us-gov-west-1",
+        "QUOTA_TABLE": "TestQuotaTable",
+        "POLICIES_TABLE": "TestPoliciesTable",
+        "SNS_TOPIC_ARN": "arn:aws-us-gov:sns:us-gov-west-1:123456789012:test-alerts",
+    }
+    base.update(env)
+    prior = {key: os.environ.get(key) for key in base}
+    for key, value in base.items():
+        os.environ[key] = str(value)
+    try:
+        module_name = f"{name}_cost_{abs(hash(frozenset((k, str(v)) for k, v in base.items())))}"
+        spec = importlib.util.spec_from_file_location(module_name, LAMBDA_DIR / name / "index.py")
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        for key, value in prior.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+class TestProfileFields:
+    def test_cost_fields_round_trip(self):
+        p = Profile(
+            name="t",
+            provider_domain="d",
+            client_id="c",
+            credential_storage="session",
+            aws_region="us-gov-west-1",
+            identity_pool_name="p",
+            quota_limit_type="cost",
+            monthly_cost_limit_usd=50.0,
+            daily_cost_limit_usd=5.0,
+        )
+        loaded = Profile.from_dict(p.to_dict())
+        assert loaded.quota_limit_type == "cost"
+        assert loaded.monthly_cost_limit_usd == 50.0
+        assert loaded.daily_cost_limit_usd == 5.0
+
+    def test_old_profiles_default_to_token_mode(self):
+        data = Profile(
+            name="t",
+            provider_domain="d",
+            client_id="c",
+            credential_storage="session",
+            aws_region="us-east-1",
+            identity_pool_name="p",
+        ).to_dict()
+        for key in ("quota_limit_type", "monthly_cost_limit_usd", "daily_cost_limit_usd"):
+            data.pop(key)
+        loaded = Profile.from_dict(data)
+        assert loaded.quota_limit_type == "token"
+        assert loaded.monthly_cost_limit_usd == 0
+        assert loaded.daily_cost_limit_usd == 0
+
+
+class TestInitRoundTrip:
+    def _rebuild(self, profile: Profile) -> dict:
+        command = InitCommand()
+        fake_config = Config()
+        with (
+            patch.object(Config, "load", return_value=fake_config),
+            patch.object(fake_config, "get_profile", return_value=profile),
+            patch.object(InitCommand, "_stack_exists", side_effect=Exception("no creds")),
+        ):
+            return command._check_existing_deployment("test")
+
+    def test_rerun_preserves_cost_quota_fields(self):
+        profile = Profile(
+            name="test",
+            provider_domain="example.okta.com",
+            client_id="0oa1234567890",
+            identity_pool_name="claude-code-auth",
+            credential_storage="keyring",
+            aws_region="us-gov-west-1",
+            quota_monitoring_enabled=True,
+            quota_limit_type="cost",
+            monthly_cost_limit_usd=75.0,
+            daily_cost_limit_usd=10.0,
+            monthly_token_limit=0,
+        )
+        quota = self._rebuild(profile)["quota"]
+        assert quota["limit_type"] == "cost"
+        assert quota["monthly_cost_limit"] == 75.0
+        assert quota["daily_cost_limit"] == 10.0
+
+
+def _load_template() -> dict:
+    class CFNLoader(yaml.SafeLoader):
+        pass
+
+    def _cfn(loader, suffix, node):  # noqa: ARG001 - yaml constructor signature
+        if isinstance(node, yaml.ScalarNode):
+            return loader.construct_scalar(node)
+        if isinstance(node, yaml.SequenceNode):
+            return loader.construct_sequence(node)
+        return loader.construct_mapping(node)
+
+    CFNLoader.add_multi_constructor("!", _cfn)
+    return yaml.load(TEMPLATE.read_text(encoding="utf-8"), Loader=CFNLoader)
+
+
+class TestTemplateWiring:
+    def test_cost_params_wired_to_both_lambdas(self):
+        resources = _load_template()["Resources"]
+        for fn in ("QuotaCheckFunction", "QuotaMonitorFunction"):
+            env = resources[fn]["Properties"]["Environment"]["Variables"]
+            assert env.get("MONTHLY_COST_LIMIT_USD") == "MonthlyCostLimitUsd", fn
+            assert env.get("DAILY_COST_LIMIT_USD") == "DailyCostLimitUsd", fn
+
+    def test_monthly_token_limit_accepts_zero(self):
+        """Cost mode passes MonthlyTokenLimit=0; MinValue must allow it."""
+        params = _load_template()["Parameters"]
+        assert params["MonthlyTokenLimit"]["MinValue"] == 0
+
+
+class TestQuotaCheckCostDefaults:
+    def test_cost_only_env_resolves_default_policy(self):
+        """The regression: cost mode (token limit 0) resolved NO policy →
+        every user unlimited. A cost limit alone must activate the default."""
+        mod = _load_lambda(
+            "quota_check",
+            {"MONTHLY_TOKEN_LIMIT": "0", "MONTHLY_COST_LIMIT_USD": "50", "DAILY_COST_LIMIT_USD": "5"},
+        )
+        policy = mod.resolve_quota_for_user("user@example.gov", [])
+        assert policy is not None, "cost-only config must resolve the default policy"
+        assert policy["monthly_cost_limit"] == 50.0
+        assert policy["daily_cost_limit"] == 5.0
+        assert policy["monthly_token_limit"] == 0
+
+    def test_no_limits_resolves_no_policy(self):
+        mod = _load_lambda("quota_check", {"MONTHLY_TOKEN_LIMIT": "0", "MONTHLY_COST_LIMIT_USD": "0"})
+        assert mod.resolve_quota_for_user("user@example.gov", []) is None
+
+
+class TestQuotaMonitorCostAlerts:
+    ENV = {
+        "MONTHLY_TOKEN_LIMIT": "0",
+        "MONTHLY_COST_LIMIT_USD": "100",
+        "DAILY_COST_LIMIT_USD": "10",
+        "ENABLE_FINEGRAINED_QUOTAS": "false",
+    }
+
+    def _alerts(self, mod, *, total_tokens=0, daily_tokens=0, monthly_cost=0.0, daily_cost=0.0):
+        policy = mod.resolve_user_quota("u@example.gov", [], {})
+        return mod.check_limits_and_generate_alerts(
+            email="u@example.gov",
+            total_tokens=total_tokens,
+            daily_tokens=daily_tokens,
+            policy=policy,
+            month_name="July 2026",
+            current_date="2026-07-13",
+            days_remaining=18,
+            days_in_month=31,
+            sent_alerts=set(),
+            monthly_cost=monthly_cost,
+            daily_cost=daily_cost,
+        )
+
+    def test_zero_token_limit_generates_no_token_alerts(self):
+        """The alert-storm regression: with monthly_limit=0, any usage
+        previously produced a 'monthly exceeded' alert every scan."""
+        mod = _load_lambda("quota_monitor", self.ENV)
+        alerts = self._alerts(mod, total_tokens=5_000_000, monthly_cost=1.0)
+        assert not [a for a in alerts if a["alert_type"] == "monthly"], alerts
+
+    def test_cost_warning_and_exceeded_levels(self):
+        mod = _load_lambda("quota_monitor", self.ENV)
+        warn = self._alerts(mod, monthly_cost=85.0)
+        assert [a for a in warn if a["alert_type"] == "monthly_cost" and a["alert_level"] == "warning"]
+        over = self._alerts(mod, monthly_cost=101.0)
+        assert [a for a in over if a["alert_type"] == "monthly_cost" and a["alert_level"] == "exceeded"]
+
+    def test_daily_cost_alert_carries_date(self):
+        mod = _load_lambda("quota_monitor", self.ENV)
+        alerts = self._alerts(mod, daily_cost=11.0)
+        daily = [a for a in alerts if a["alert_type"] == "daily_cost"]
+        assert daily and daily[0]["date"] == "2026-07-13"
+
+    def test_usage_entry_includes_cost_with_stale_day_guard(self):
+        mod = _load_lambda("quota_monitor", self.ENV)
+        item = {
+            "total_tokens": 1000,
+            "daily_tokens": 500,
+            "estimated_cost": 42.5,
+            "daily_cost_usd": 7.5,
+            "daily_date": "2026-07-12",
+        }
+        entry = mod._build_usage_entry(item, "2026-07-13")
+        assert entry["monthly_cost"] == 42.5
+        assert entry["daily_cost"] == 0, "stale-day guard must reset the daily cost counter"
+        entry_today = mod._build_usage_entry({**item, "daily_date": "2026-07-13"}, "2026-07-13")
+        assert entry_today["daily_cost"] == 7.5

--- a/source/tests/test_cowork_credential_helper.py
+++ b/source/tests/test_cowork_credential_helper.py
@@ -98,6 +98,22 @@ class TestBuildMdmConfigCredentialHelper:
         )
         assert config["inferenceCredentialHelper"].startswith("__CCWB_HOME__/")
 
+    def test_helper_mode_declares_credential_kind(self):
+        """Helper mode ships both inferenceCredentialHelper and inferenceBedrockProfile
+        (the latter as an SDK-level region/metadata fallback). Without an explicit
+        inferenceCredentialKind, Claude Desktop logs "Multiple credential methods
+        configured (vendor-profile, helper-script); using vendor-profile" and
+        silently authenticates via the unsupported SDK profile path instead of the
+        helper — producing repeated "Authentication Failed" for the user even though
+        credential-process itself works fine. Setting the key removes the ambiguity.
+        """
+        config = build_mdm_config(
+            bedrock_region="us-west-2",
+            model_aliases=["sonnet"],
+            profile_name="Test",
+        )
+        assert config["inferenceCredentialKind"] == "helper-script"
+
 
 class TestBuildMdmConfigProfileMode:
     """Test build_mdm_config with credential_mode='profile' (legacy)."""
@@ -114,6 +130,20 @@ class TestBuildMdmConfigProfileMode:
         assert "inferenceCredentialHelper" not in config
         assert "inferenceCredentialHelperTtlSec" not in config
         assert "inferenceCredentialHelperSilentRefreshEnabled" not in config
+
+    def test_profile_mode_omits_credential_kind(self):
+        """Profile mode sets only inferenceBedrockProfile, so there is no
+        credential-method ambiguity for Claude Desktop to resolve. Deliberately
+        do NOT emit inferenceCredentialKind here — its name/values are inferred
+        from a Desktop log string, unverified against any published schema, and
+        should not be shipped to a mode with no reported bug to fix."""
+        config = build_mdm_config(
+            bedrock_region="us-west-2",
+            model_aliases=["opus"],
+            profile_name="LegacyProfile",
+            credential_mode="profile",
+        )
+        assert "inferenceCredentialKind" not in config
 
     def test_profile_mode_backward_compatible(self):
         """Legacy mode output should match previous behavior exactly."""

--- a/source/tests/test_cowork_credential_helper.py
+++ b/source/tests/test_cowork_credential_helper.py
@@ -6,11 +6,32 @@
 import json
 
 from claude_code_with_bedrock.cli.utils.cowork_3p import (
+    _to_windows_credential_helper,
     build_mdm_config,
+    generate_all,
     generate_intune_script,
     generate_json,
     generate_reg_file,
 )
+
+
+class TestToWindowsCredentialHelper:
+    """Direct regression tests for the unix->windows helper-path conversion.
+
+    Pins the PR #733 bug class: the value is a bare wrapper path, so the
+    converter must swap .sh->.cmd and rewrite slashes WITHOUT appending .exe or
+    splitting on spaces, and must be a no-op for non-placeholder values.
+    """
+
+    def test_sh_wrapper_becomes_cmd_no_exe(self):
+        out = _to_windows_credential_helper("__CCWB_HOME__/claude-code-with-bedrock/cowork-credential-helper.sh")
+        assert out == "__CCWB_HOME__\\claude-code-with-bedrock\\cowork-credential-helper.cmd"
+        assert ".exe" not in out
+        assert " " not in out  # bare path, no inline args
+
+    def test_noop_for_non_placeholder_value(self):
+        for val in ("C:\\some\\abs\\path.cmd", "/usr/local/bin/helper", ""):
+            assert _to_windows_credential_helper(val) == val
 
 
 class TestBuildMdmConfigCredentialHelper:
@@ -28,15 +49,19 @@ class TestBuildMdmConfigCredentialHelper:
         assert "inferenceCredentialHelperSilentRefreshEnabled" in config
         assert config["inferenceCredentialHelperSilentRefreshEnabled"] == "true"
 
-    def test_helper_mode_path_includes_profile_name(self):
-        """Credential helper path should include --profile <name>."""
+    def test_helper_path_is_bare_wrapper_no_args(self):
+        """Claude Desktop runs the helper 'with no arguments', so the MDM value
+        must be a bare path to the wrapper script — the --desktop/--profile flags
+        live inside the wrapper, not in this value."""
         config = build_mdm_config(
             bedrock_region="us-west-2",
             model_aliases=["sonnet"],
             profile_name="Production",
         )
-        assert "--profile Production" in config["inferenceCredentialHelper"]
-        assert "credential-process" in config["inferenceCredentialHelper"]
+        helper = config["inferenceCredentialHelper"]
+        assert helper.endswith("cowork-credential-helper.sh")
+        assert "--profile" not in helper
+        assert "--desktop" not in helper
 
     def test_helper_mode_ttl_default(self):
         """Default TTL should be 3500s (under 1h STS expiry)."""
@@ -115,11 +140,12 @@ class TestGenerateRegFileCredentialHelper:
     """Test Windows .reg generation with credential helper path rewriting."""
 
     def test_reg_file_rewrites_unix_path_to_windows(self, tmp_path):
-        """Unix path becomes __CCWB_HOME__\\...credential-process.exe (placeholder kept).
+        """Unix wrapper path becomes __CCWB_HOME__\\...cowork-credential-helper.cmd.
 
         The placeholder is NOT %USERPROFILE%: Claude Desktop reads the registry
         value literally and does not expand env vars. install.bat substitutes
-        __CCWB_HOME__ with the absolute home before importing the .reg.
+        __CCWB_HOME__ with the absolute home before importing the .reg. The value
+        is a bare path (no arguments) — Claude Desktop runs it with none.
         """
         config = build_mdm_config(
             bedrock_region="us-west-2",
@@ -131,9 +157,10 @@ class TestGenerateRegFileCredentialHelper:
         # Placeholder kept, env var NOT used
         assert "__CCWB_HOME__" in content
         assert "%USERPROFILE%" not in content
-        # Windows binary form: backslashes + .exe suffix
-        assert "credential-process.exe" in content
-        assert "--profile Test" in content
+        # Windows wrapper form: backslashes + .cmd, no inline args
+        assert "cowork-credential-helper.cmd" in content
+        assert "--profile" not in content
+        assert "--desktop" not in content
 
     def test_reg_file_no_rewrite_for_profile_mode(self, tmp_path):
         """Profile mode should not contain credential helper in .reg file."""
@@ -166,9 +193,10 @@ class TestGenerateIntuneScript:
         content = ps1_path.read_text(encoding="utf-8")
         assert "$ccwbHome = $env:USERPROFILE" in content
         assert ".Replace('__CCWB_HOME__', $ccwbHome)" in content
-        # credential helper converted to the Windows .exe form
-        assert "credential-process.exe" in content
-        assert "--profile Test" in content
+        # credential helper converted to the Windows wrapper (.cmd), no inline args
+        assert "cowork-credential-helper.cmd" in content
+        assert "--profile" not in content
+        assert "--desktop" not in content
         # no emitted registry VALUE carries the unexpanded env var (comments may
         # mention it, so check the Set-ItemProperty lines specifically)
         value_lines = [ln for ln in content.splitlines() if ln.startswith("Set-ItemProperty")]
@@ -188,9 +216,52 @@ class TestGenerateJsonCredentialHelper:
         )
         json_path = generate_json(tmp_path, config)
         data = json.loads(json_path.read_text(encoding="utf-8"))
-        assert (
-            data["inferenceCredentialHelper"]
-            == "__CCWB_HOME__/claude-code-with-bedrock/credential-process --desktop --profile MyProfile"
-        )
+        assert data["inferenceCredentialHelper"] == "__CCWB_HOME__/claude-code-with-bedrock/cowork-credential-helper.sh"
         assert data["inferenceCredentialHelperTtlSec"] == "3500"
         assert data["inferenceCredentialHelperSilentRefreshEnabled"] == "true"
+
+
+class TestGenerateHelperWrappers:
+    """The wrapper scripts bake --desktop/--profile so the MDM value stays bare."""
+
+    def test_wrappers_written_with_profile_and_desktop(self, tmp_path):
+        from claude_code_with_bedrock.cli.utils.cowork_3p import generate_helper_wrappers
+
+        names = generate_helper_wrappers(tmp_path, "MyProfile")
+        assert set(names) == {"cowork-credential-helper.sh", "cowork-credential-helper.cmd"}
+
+        sh = (tmp_path / "cowork-credential-helper.sh").read_text(encoding="utf-8")
+        assert "--desktop --profile MyProfile" in sh
+        assert 'exec "$SCRIPT_DIR/credential-process"' in sh
+
+        # .cmd must be CRLF-terminated and call the co-located .exe via %~dp0
+        cmd_bytes = (tmp_path / "cowork-credential-helper.cmd").read_bytes()
+        assert b"\r\n" in cmd_bytes
+        cmd = cmd_bytes.decode("utf-8")
+        assert '"%~dp0credential-process.exe" --desktop --profile MyProfile' in cmd
+
+    def test_generate_all_emits_wrappers_in_helper_mode(self, tmp_path):
+        from rich.console import Console
+
+        config = build_mdm_config(
+            bedrock_region="us-west-2",
+            model_aliases=["sonnet"],
+            profile_name="P",
+        )
+        generated = generate_all(tmp_path, config, Console())
+        assert "cowork-credential-helper.sh" in generated
+        assert "cowork-credential-helper.cmd" in generated
+        assert (tmp_path / "cowork-credential-helper.sh").exists()
+
+    def test_generate_all_skips_wrappers_in_profile_mode(self, tmp_path):
+        from rich.console import Console
+
+        config = build_mdm_config(
+            bedrock_region="us-west-2",
+            model_aliases=["sonnet"],
+            profile_name="P",
+            credential_mode="profile",
+        )
+        generated = generate_all(tmp_path, config, Console())
+        assert "cowork-credential-helper.sh" not in generated
+        assert not (tmp_path / "cowork-credential-helper.sh").exists()

--- a/source/tests/test_distribute.py
+++ b/source/tests/test_distribute.py
@@ -270,6 +270,78 @@ class TestCreatePerOsArchives:
         assert archives[0][0] == "linux-x64"
 
 
+class TestExtraFilesInArchives:
+    """Tests for admin-defined extra_files across the three archive builders."""
+
+    @pytest.fixture
+    def package_with_extras(self, package_dir):
+        """Add extra files (a folder + two OS-specific scripts) into the build dir."""
+        certs = package_dir / "certs"
+        certs.mkdir()
+        (certs / "ca.pem").write_text("CERT")
+        (package_dir / "preinstall-mac.sh").write_text("#!/bin/bash")
+        (package_dir / "preinstall-windows.ps1").write_text("# ps1")
+        return package_dir
+
+    _EXTRAS = [
+        {"name": "certs", "targets": "all", "from": "~/x/certs"},
+        {"name": "preinstall-mac.sh", "targets": "macos", "from": "~/x/pre.sh"},
+        {"name": "preinstall-windows.ps1", "targets": "windows", "from": "~/x/pre.ps1"},
+    ]
+
+    def test_all_os_archive_contains_every_extra(self, cmd, package_with_extras):
+        archive = cmd._create_archive(package_with_extras, self._EXTRAS)
+        with zipfile.ZipFile(archive, "r") as zf:
+            names = zf.namelist()
+        assert "claude-code-package/certs/ca.pem" in names
+        assert "claude-code-package/preinstall-mac.sh" in names
+        assert "claude-code-package/preinstall-windows.ps1" in names
+
+    def test_all_os_archive_without_extras_unchanged(self, cmd, package_with_extras):
+        """No extra_files arg → extras present in the build dir are NOT auto-added."""
+        archive = cmd._create_archive(package_with_extras)
+        with zipfile.ZipFile(archive, "r") as zf:
+            names = zf.namelist()
+        assert "claude-code-package/certs/ca.pem" not in names
+        assert "claude-code-package/preinstall-mac.sh" not in names
+
+    def test_per_os_filters_by_platform(self, cmd, package_with_extras):
+        archives = cmd._create_per_os_archives(package_with_extras, self._EXTRAS)
+        by_platform = {p: a for p, _label, a in archives}
+
+        with zipfile.ZipFile(by_platform["macos-arm64"], "r") as zf:
+            mac_names = zf.namelist()
+        assert "claude-code-package/certs/ca.pem" in mac_names  # all
+        assert "claude-code-package/preinstall-mac.sh" in mac_names  # macos
+        assert "claude-code-package/preinstall-windows.ps1" not in mac_names  # windows excluded
+
+        with zipfile.ZipFile(by_platform["windows"], "r") as zf:
+            win_names = zf.namelist()
+        assert "claude-code-package/certs/ca.pem" in win_names  # all
+        assert "claude-code-package/preinstall-windows.ps1" in win_names  # windows
+        assert "claude-code-package/preinstall-mac.sh" not in win_names  # macos excluded
+
+    def test_per_os_arch_target_lands_in_family_zip(self, cmd, package_dir):
+        """An arch-specific target (macos-arm64) belongs in the macos-arm64 per-OS zip."""
+        (package_dir / "arm-only.sh").write_text("arm")
+        entries = [{"name": "arm-only.sh", "targets": "macos-arm64", "from": "~/x"}]
+        archives = cmd._create_per_os_archives(package_dir, entries)
+        by_platform = {p: a for p, _label, a in archives}
+
+        with zipfile.ZipFile(by_platform["macos-arm64"], "r") as zf:
+            assert "claude-code-package/arm-only.sh" in zf.namelist()
+        with zipfile.ZipFile(by_platform["macos-intel"], "r") as zf:
+            assert "claude-code-package/arm-only.sh" not in zf.namelist()
+
+    def test_invalid_entries_skipped_silently(self, cmd, package_with_extras):
+        """A colliding/invalid entry must not crash or ship — package fails fast upstream."""
+        bad = [{"name": "config.json", "targets": "all", "from": "~/x"}]
+        archive = cmd._create_archive(package_with_extras, bad)
+        with zipfile.ZipFile(archive, "r") as zf:
+            # config.json is the generated one, not clobbered by the extra
+            assert "claude-code-package/config.json" in zf.namelist()
+
+
 class TestCalculateChecksum:
     """Tests for _calculate_checksum."""
 

--- a/source/tests/test_extra_files.py
+++ b/source/tests/test_extra_files.py
@@ -1,0 +1,185 @@
+"""Unit tests for the declarative extra_files matcher and validator.
+
+The matcher (`extra_applies_to`) is the highest-risk piece of the feature: it
+reconciles three different platform vocabularies (per-OS arch tokens, landing
+families, and the all-OS archive). These tests pin the full truth table.
+"""
+
+import pytest
+
+from claude_code_with_bedrock.extra_files import (
+    VALID_TARGET_TOKENS,
+    extra_applies_to,
+    normalize_targets,
+    validate_extra_files,
+)
+
+# Every token used by _create_per_os_archives (PLATFORM_FILES keys).
+PER_OS_TOKENS = ["windows", "linux-x64", "linux-arm64", "macos-arm64", "macos-intel"]
+# Every token used by _upload_landing_page_packages.
+LANDING_TOKENS = ["windows", "linux", "mac"]
+
+
+class TestNormalizeTargets:
+    def test_single_string(self):
+        assert normalize_targets("macos") == ["macos"]
+
+    def test_list(self):
+        assert normalize_targets(["macos", "LINUX"]) == ["macos", "linux"]
+
+    def test_whitespace_and_case(self):
+        assert normalize_targets("  Windows ") == ["windows"]
+
+    def test_invalid_type(self):
+        assert normalize_targets(None) == []
+        assert normalize_targets(42) == []
+
+
+class TestExtraAppliesToAll:
+    @pytest.mark.parametrize("platform", PER_OS_TOKENS + LANDING_TOKENS)
+    def test_all_matches_every_platform(self, platform):
+        assert extra_applies_to("all", platform) is True
+
+    @pytest.mark.parametrize("platform", PER_OS_TOKENS + LANDING_TOKENS)
+    def test_all_in_list_matches(self, platform):
+        assert extra_applies_to(["all", "windows"], platform) is True
+
+
+class TestExtraAppliesToExact:
+    @pytest.mark.parametrize("token", PER_OS_TOKENS)
+    def test_exact_per_os(self, token):
+        assert extra_applies_to(token, token) is True
+
+    def test_windows_exact(self):
+        assert extra_applies_to("windows", "windows") is True
+
+
+class TestExtraAppliesToFamily:
+    def test_macos_family_matches_both_arches(self):
+        assert extra_applies_to("macos", "macos-arm64") is True
+        assert extra_applies_to("macos", "macos-intel") is True
+
+    def test_linux_family_matches_both_arches(self):
+        assert extra_applies_to("linux", "linux-x64") is True
+        assert extra_applies_to("linux", "linux-arm64") is True
+
+    def test_macos_family_matches_landing_mac(self):
+        assert extra_applies_to("macos", "mac") is True
+
+    def test_linux_family_matches_landing_linux(self):
+        assert extra_applies_to("linux", "linux") is True
+
+    def test_family_does_not_cross_families(self):
+        assert extra_applies_to("macos", "linux-x64") is False
+        assert extra_applies_to("linux", "macos-arm64") is False
+        assert extra_applies_to("macos", "windows") is False
+
+
+class TestExtraAppliesToArch:
+    def test_arch_matches_own_per_os(self):
+        assert extra_applies_to("macos-arm64", "macos-arm64") is True
+
+    def test_arch_excludes_sibling_arch_per_os(self):
+        # An arch-specific extra must NOT land in the sibling arch's per-os zip.
+        assert extra_applies_to("macos-arm64", "macos-intel") is False
+        assert extra_applies_to("linux-x64", "linux-arm64") is False
+
+    def test_arch_matches_landing_family(self):
+        # Landing families have no arch split, so an arch extra must appear there.
+        assert extra_applies_to("macos-arm64", "mac") is True
+        assert extra_applies_to("linux-arm64", "linux") is True
+
+    def test_arch_excludes_wrong_landing_family(self):
+        assert extra_applies_to("macos-arm64", "windows") is False
+        assert extra_applies_to("linux-x64", "mac") is False
+
+
+class TestExtraAppliesToList:
+    def test_list_of_families(self):
+        targets = ["macos", "linux"]
+        assert extra_applies_to(targets, "macos-arm64") is True
+        assert extra_applies_to(targets, "linux-x64") is True
+        assert extra_applies_to(targets, "windows") is False
+        assert extra_applies_to(targets, "mac") is True
+
+    def test_empty_targets_matches_nothing(self):
+        assert extra_applies_to([], "windows") is False
+
+
+class TestValidateExtraFiles:
+    def test_empty_is_valid(self):
+        assert validate_extra_files([]) == []
+        assert validate_extra_files(None) == []
+
+    def test_valid_entries(self):
+        entries = [
+            {"name": "certs", "targets": "all", "from": "~/secure/certs"},
+            {"name": "preinstall-mac.sh", "targets": ["macos"], "from": "~/x/pre.sh"},
+        ]
+        assert validate_extra_files(entries) == []
+
+    def test_not_a_list(self):
+        assert validate_extra_files({"name": "x"}) != []
+
+    def test_entry_not_a_dict(self):
+        errors = validate_extra_files(["nope"])
+        assert any("must be an object" in e for e in errors)
+
+    def test_missing_keys(self):
+        errors = validate_extra_files([{"name": "x"}])
+        assert any("missing key" in e for e in errors)
+
+    def test_unexpected_key(self):
+        errors = validate_extra_files([{"name": "x", "targets": "all", "from": "~/x", "mode": "755"}])
+        assert any("unexpected key" in e for e in errors)
+
+    def test_unknown_target_token(self):
+        errors = validate_extra_files([{"name": "x", "targets": "solaris", "from": "~/x"}])
+        assert any("unknown target" in e for e in errors)
+
+    def test_empty_from(self):
+        errors = validate_extra_files([{"name": "x", "targets": "all", "from": ""}])
+        assert any("'from'" in e for e in errors)
+
+    @pytest.mark.parametrize(
+        "bad_name",
+        ["../escape", "/etc/passwd", "C:\\Windows\\x", "a/../../b", "sub\\..\\evil"],
+    )
+    def test_zip_slip_names_rejected(self, bad_name):
+        errors = validate_extra_files([{"name": bad_name, "targets": "all", "from": "~/x"}])
+        assert errors, f"expected {bad_name!r} to be rejected"
+
+    @pytest.mark.parametrize(
+        "reserved",
+        ["config.json", "install.sh", "install.bat", "README.md", "collector-config.yaml"],
+    )
+    def test_reserved_name_collision(self, reserved):
+        errors = validate_extra_files([{"name": reserved, "targets": "all", "from": "~/x"}])
+        assert any("collides" in e for e in errors)
+
+    def test_reserved_dir_collision(self):
+        errors = validate_extra_files([{"name": "claude-settings/foo.json", "targets": "all", "from": "~/x"}])
+        assert any("collides" in e for e in errors)
+
+    def test_reserved_binary_prefix_collision(self):
+        errors = validate_extra_files([{"name": "credential-process-macos-arm64", "targets": "all", "from": "~/x"}])
+        assert any("collides" in e for e in errors)
+
+    def test_nested_name_allowed(self):
+        # A safe nested path that does not collide is fine.
+        assert validate_extra_files([{"name": "certs/ca.pem", "targets": "all", "from": "~/x"}]) == []
+
+
+class TestTokenSet:
+    def test_valid_tokens_are_stable(self):
+        # Guards against accidental token-set drift.
+        assert VALID_TARGET_TOKENS == {
+            "all",
+            "macos",
+            "linux",
+            "windows",
+            "macos-arm64",
+            "macos-intel",
+            "linux-x64",
+            "linux-arm64",
+        }

--- a/source/tests/test_extra_files.py
+++ b/source/tests/test_extra_files.py
@@ -10,6 +10,7 @@ import pytest
 from claude_code_with_bedrock.extra_files import (
     VALID_TARGET_TOKENS,
     extra_applies_to,
+    extra_applies_to_any,
     normalize_targets,
     validate_extra_files,
 )
@@ -104,6 +105,40 @@ class TestExtraAppliesToList:
 
     def test_empty_targets_matches_nothing(self):
         assert extra_applies_to([], "windows") is False
+
+
+class TestExtraAppliesToAny:
+    """Matcher used by ``package`` to filter extras against --target-platform.
+
+    Regression: a windows-only extra must not land in a macos-only build."""
+
+    def test_windows_extra_excluded_from_macos_build(self):
+        assert extra_applies_to_any("windows", ["macos-arm64"]) is False
+        assert extra_applies_to_any(["windows"], ["macos-arm64", "macos-intel"]) is False
+
+    def test_all_matches_any_build(self):
+        assert extra_applies_to_any("all", ["macos-arm64"]) is True
+        assert extra_applies_to_any("all", ["windows"]) is True
+
+    def test_family_target_matches_arch_build(self):
+        assert extra_applies_to_any("macos", ["macos-arm64"]) is True
+        assert extra_applies_to_any(["macos", "macos-arm64", "macos-intel"], ["macos-arm64"]) is True
+
+    def test_arch_target_matches_generic_family_build(self):
+        # The non-Go build path can produce generic "macos"/"linux" tokens;
+        # arch-targeted extras must still ship in those builds.
+        assert extra_applies_to_any("macos-arm64", ["macos"]) is True
+        assert extra_applies_to_any("linux-arm64", ["linux"]) is True
+
+    def test_arch_target_excluded_from_sibling_arch_build(self):
+        assert extra_applies_to_any("macos-intel", ["macos-arm64"]) is False
+
+    def test_matches_when_any_platform_applies(self):
+        assert extra_applies_to_any("windows", ["macos-arm64", "windows"]) is True
+
+    def test_empty_platforms_matches_nothing(self):
+        assert extra_applies_to_any("all", []) is False
+        assert extra_applies_to_any("all", None) is False
 
 
 class TestValidateExtraFiles:

--- a/source/tests/test_google_client_secret.py
+++ b/source/tests/test_google_client_secret.py
@@ -5,9 +5,17 @@ which use PKCE-only for native apps). Google documents this secret as non-confid
 for installed applications, so it's stored in config.json rather than the OS keyring.
 """
 
+import sys
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
+
+# ruff: noqa: E402
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from claude_code_with_bedrock.cli.commands.init import InitCommand
+from claude_code_with_bedrock.config import Config, Profile
 
 
 class TestGoogleClientSecretConfig:
@@ -36,16 +44,18 @@ class TestGoogleClientSecretConfig:
         )
 
     def test_init_wizard_prompts_google_secret(self):
-        """The init wizard must prompt for client_secret when provider is Google."""
+        """The init wizard must have a Google branch that writes client_secret to config."""
         init_py = (
             Path(__file__).resolve().parents[2] / "source" / "claude_code_with_bedrock" / "cli" / "commands" / "init.py"
         )
         content = init_py.read_text(encoding="utf-8")
-        # Verify Google-specific handling exists in init wizard
-        assert 'provider_type = "google"' in content
-        # client_secret is stored in OS keyring, not written to config file
-        assert "client_secret" in content, (
-            "Init wizard must handle client_secret for Google provider (stored in keyring)"
+        # A Google-specific provider branch must exist (distinct from the Azure branch)
+        # and must persist the secret to the config dict (not the keyring).
+        assert 'elif provider_type == "google":' in content, (
+            "Init wizard must have a Google branch that collects the OAuth client secret"
+        )
+        assert 'config["client_secret"] = client_secret' in content, (
+            "Google branch must persist client_secret to config.json (non-confidential)"
         )
 
     def test_package_includes_google_client_secret(self):
@@ -81,3 +91,75 @@ class TestGoogleClientSecretConfig:
                     f"Line {i + 1}: Google client_secret should be stored in config.json, "
                     f"not OS keyring (Google documents it as non-confidential)"
                 )
+
+
+class TestGoogleClientSecretRoundTrip:
+    """Re-running init must preserve a saved Google client_secret (config-sync.md)."""
+
+    @staticmethod
+    def _google_profile() -> Profile:
+        return Profile(
+            name="google-test",
+            provider_domain="accounts.google.com",
+            client_id="319-abc.apps.googleusercontent.com",
+            identity_pool_name="claude-code-auth",
+            credential_storage="session",
+            aws_region="us-east-1",
+            provider_type="google",
+            client_secret="GOCSPX-secret-value",
+            federation_type="direct",
+            federated_role_arn="arn:aws:iam::123456789012:role/BedrockGoogleFederatedRole",
+        )
+
+    def test_rerun_preserves_google_client_secret(self):
+        """_check_existing_deployment must restore client_secret from the saved profile."""
+        command = InitCommand()
+        fake_config = Config()
+        profile = self._google_profile()
+        with (
+            patch.object(Config, "load", return_value=fake_config),
+            patch.object(fake_config, "get_profile", return_value=profile),
+            patch.object(InitCommand, "_stack_exists", side_effect=Exception("no creds")),
+        ):
+            rebuilt = command._check_existing_deployment("google-test")
+        assert rebuilt.get("client_secret") == "GOCSPX-secret-value", (
+            "Re-running init dropped the Google client_secret — it must survive the "
+            "profile -> config rebuild so the value pre-fills instead of resetting"
+        )
+
+    def test_save_configuration_persists_client_secret(self):
+        """_save_configuration must write client_secret into the saved Profile."""
+        command = InitCommand()
+        fake_config = Config()
+        saved = {}
+
+        def _capture(profile):
+            saved["profile"] = profile
+
+        config_data = {
+            "provider_type": "google",
+            "client_secret": "GOCSPX-secret-value",
+            "sso_enabled": True,
+            "credential_storage": "session",
+            "okta": {"domain": "accounts.google.com", "client_id": "319-abc.apps.googleusercontent.com"},
+            "aws": {
+                "region": "us-east-1",
+                "identity_pool_name": "claude-code-auth",
+                "stacks": {},
+                "allowed_bedrock_regions": ["us-east-1"],
+            },
+            "monitoring": {"enabled": False},
+            "federation_type": "direct",
+        }
+        with (
+            patch.object(Config, "load", return_value=fake_config),
+            patch.object(fake_config, "get_profile", return_value=None),
+            patch.object(fake_config, "add_profile", side_effect=_capture),
+            patch.object(fake_config, "set_active_profile"),
+            patch.object(fake_config, "save"),
+        ):
+            command._save_configuration(config_data, "google-test")
+
+        assert saved["profile"].client_secret == "GOCSPX-secret-value", (
+            "_save_configuration must persist the Google client_secret to the profile"
+        )

--- a/source/tests/test_govcloud_model_selection.py
+++ b/source/tests/test_govcloud_model_selection.py
@@ -1,0 +1,95 @@
+# ABOUTME: Tests for GovCloud model support — Opus 4.8 registry entry, partition-aware
+# ABOUTME: wizard filtering, and us-gov tier/alias resolution (no commercial fallback).
+
+"""GovCloud model selection tests.
+
+Claude Opus 4.8 is available in AWS GovCloud (announced 2026-05; in-region in
+us-gov-west-1, geo-routed from us-gov-east-1 via the us-gov CRIS prefix).
+These tests pin:
+
+- the opus-4-8-govcloud registry entry,
+- the wizard offering ONLY partition-compatible models (GovCloud regions see
+  us-gov models; commercial regions never see them),
+- tier resolution for the us-gov prefix (DEFAULT_*_MODEL aliases), including
+  the GovCloud haiku→sonnet fallback and NO fallback to commercial CRIS —
+  us-gov is a separate partition, a commercial model ID can never work there.
+"""
+
+from __future__ import annotations
+
+from claude_code_with_bedrock.cli.commands.init import _model_keys_for_region
+from claude_code_with_bedrock.models import (
+    CLAUDE_MODELS,
+    get_claude_code_alias,
+    resolve_model_for_tier,
+)
+
+
+class TestOpusGovCloudRegistryEntry:
+    def test_entry_exists_with_us_gov_profile(self):
+        model = CLAUDE_MODELS["opus-4-8-govcloud"]
+        profile = model["profiles"]["us-gov"]
+        assert profile["model_id"] == "us-gov.anthropic.claude-opus-4-8"
+        assert set(profile["source_regions"]) == {"us-gov-west-1", "us-gov-east-1"}
+
+    def test_all_govcloud_entries_use_us_gov_prefix(self):
+        for key, model in CLAUDE_MODELS.items():
+            if not key.endswith("-govcloud"):
+                continue
+            for profile in model["profiles"].values():
+                assert profile["model_id"].startswith("us-gov."), (
+                    f"{key} must use the us-gov CRIS prefix, got {profile['model_id']}"
+                )
+
+
+class TestWizardPartitionFiltering:
+    def test_govcloud_region_offers_only_govcloud_models(self):
+        keys = _model_keys_for_region("us-gov-west-1")
+        assert "opus-4-8-govcloud" in keys
+        assert "sonnet-4-5-govcloud" in keys
+        assert not [k for k in keys if not k.endswith("-govcloud")], (
+            f"commercial models offered for a GovCloud region: {keys}"
+        )
+
+    def test_commercial_region_hides_govcloud_models(self):
+        keys = _model_keys_for_region("us-east-1")
+        assert "opus-4-8" in keys
+        assert not [k for k in keys if k.endswith("-govcloud")], (
+            f"GovCloud models offered for a commercial region: {keys}"
+        )
+
+    def test_unknown_or_missing_region_defaults_to_commercial(self):
+        assert "opus-4-8-govcloud" not in _model_keys_for_region(None)
+        assert "opus-4-8-govcloud" not in _model_keys_for_region("")
+
+
+class TestUsGovTierResolution:
+    def test_opus_tier_resolves_govcloud_opus(self):
+        assert resolve_model_for_tier("opus", "us-gov") == "us-gov.anthropic.claude-opus-4-8"
+
+    def test_sonnet_tier_resolves_govcloud_sonnet(self):
+        assert resolve_model_for_tier("sonnet", "us-gov") == "us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0"
+
+    def test_haiku_tier_falls_back_to_govcloud_sonnet(self):
+        """GovCloud has no Haiku — the haiku tier must fall through to the
+        GovCloud Sonnet, never to a commercial model."""
+        resolved = resolve_model_for_tier("haiku", "us-gov")
+        assert resolved is not None
+        assert resolved.startswith("us-gov.")
+
+    def test_us_gov_never_falls_back_to_commercial(self):
+        """us-gov is a data-residency AND partition boundary: any resolution
+        for the us-gov prefix must yield a us-gov.* ID or nothing."""
+        for tier in ("haiku", "sonnet", "opus", "fable"):
+            resolved = resolve_model_for_tier(tier, "us-gov")
+            assert resolved is None or resolved.startswith("us-gov."), (
+                f"tier {tier!r} resolved commercial model {resolved!r} for us-gov"
+            )
+
+    def test_commercial_tiers_unchanged_by_govcloud_entries(self):
+        assert resolve_model_for_tier("opus", "us") == "us.anthropic.claude-opus-4-8"
+        assert resolve_model_for_tier("sonnet", "us").startswith("us.anthropic.claude-sonnet-5")
+
+    def test_alias_for_govcloud_model_ids(self):
+        assert get_claude_code_alias("us-gov.anthropic.claude-opus-4-8") == "opus"
+        assert get_claude_code_alias("us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0") == "sonnet"

--- a/source/tests/test_models.py
+++ b/source/tests/test_models.py
@@ -535,3 +535,51 @@ class TestResolveModelForTier:
                     assert f"{prefix}." in result, (
                         f"resolve_model_for_tier('{tier}', '{prefix}') = '{result}' wrong prefix"
                     )
+
+
+class TestExpandBedrockRegions:
+    """Region sentinels must never reach an IAM aws:RequestedRegion condition.
+
+    A global inference profile stores the sentinel "all-commercial" in its
+    destination_regions. If that string is passed verbatim as the
+    AllowedBedrockRegions CFN parameter, the role's StringEquals condition on
+    aws:RequestedRegion matches no real region and every bedrock:InvokeModel*
+    call is denied with AccessDenied. expand_bedrock_regions() prevents this.
+    """
+
+    def test_all_commercial_expands_to_real_regions(self):
+        from claude_code_with_bedrock.models import expand_bedrock_regions
+
+        result = expand_bedrock_regions(["all-commercial"])
+        assert "all-commercial" not in result, "sentinel must never survive expansion"
+        assert "us-east-1" in result, "commercial expansion must include us-east-1"
+        # Must be actual AWS region tokens, and exclude GovCloud.
+        assert all("gov" not in r for r in result)
+        assert all(r.count("-") >= 2 for r in result), f"non-region token leaked: {result}"
+
+    def test_no_all_star_sentinel_survives(self):
+        from claude_code_with_bedrock.models import expand_bedrock_regions
+
+        # Any all-* sentinel (even an unknown future one) must be dropped.
+        result = expand_bedrock_regions(["all-commercial", "all-something-new"])
+        assert not any(r.startswith("all-") for r in result)
+
+    def test_concrete_regions_pass_through_and_dedupe(self):
+        from claude_code_with_bedrock.models import expand_bedrock_regions
+
+        assert expand_bedrock_regions(["us-east-1", "us-west-2"]) == ["us-east-1", "us-west-2"]
+        # Duplicates collapse; order of first occurrence preserved.
+        assert expand_bedrock_regions(["us-east-1", "us-east-1"]) == ["us-east-1"]
+
+    def test_empty_list_returns_empty(self):
+        from claude_code_with_bedrock.models import expand_bedrock_regions
+
+        assert expand_bedrock_regions([]) == []
+
+    def test_mixed_sentinel_and_concrete_no_duplicates(self):
+        from claude_code_with_bedrock.models import expand_bedrock_regions
+
+        # us-east-1 appears both explicitly and via the expansion — only once.
+        result = expand_bedrock_regions(["us-east-1", "all-commercial"])
+        assert result.count("us-east-1") == 1
+        assert "all-commercial" not in result

--- a/source/tests/test_models.py
+++ b/source/tests/test_models.py
@@ -40,6 +40,7 @@ class TestModelConfiguration:
             "sonnet-5",
             "sonnet-4-6",
             "opus-4-8",
+            "opus-4-8-govcloud",
             "opus-4-7",
             "opus-4-6",
             "opus-4-5",

--- a/source/tests/test_otel_helper_profile.py
+++ b/source/tests/test_otel_helper_profile.py
@@ -1,0 +1,67 @@
+# ABOUTME: Tests for otel-helper profile resolution (--profile flag) across
+# ABOUTME: the cache path, credential-process subprocess, and collector sidecar.
+
+"""Profile resolution regression tests.
+
+The otel-helper previously resolved its profile ONLY from AWS_PROFILE, so a
+Claude Code config pointing the helper at a non-default profile was ignored.
+Resolution order (kept in sync with the Go binary's resolveProfile and the
+.sh/.ps1 wrappers):
+
+    --profile flag > CCWB_PROFILE env > AWS_PROFILE env > "ClaudeCode"
+
+The winner is exported to AWS_PROFILE so every downstream consumer (cache
+path, credential-process subprocess, collector sidecar) resolves the same
+profile.
+"""
+
+import os
+import sys
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clean_profile_env(monkeypatch):
+    """Isolate each test from ambient profile overrides."""
+    monkeypatch.delenv("CCWB_PROFILE", raising=False)
+    monkeypatch.delenv("AWS_PROFILE", raising=False)
+
+
+def _parse(monkeypatch, argv):
+    from otel_helper.__main__ import parse_args
+
+    monkeypatch.setattr(sys, "argv", ["otel-helper"] + argv)
+    return parse_args()
+
+
+class TestProfileResolution:
+    def test_profile_flag_overrides_env(self, monkeypatch):
+        monkeypatch.setenv("CCWB_PROFILE", "CcwbProfile")
+        monkeypatch.setenv("AWS_PROFILE", "EnvProfile")
+        _parse(monkeypatch, ["--profile", "FlagProfile"])
+        # The flag must be exported so cache path, credential-process, and the
+        # collector sidecar all resolve the SAME profile.
+        assert os.environ["AWS_PROFILE"] == "FlagProfile"
+
+    def test_ccwb_profile_beats_aws_profile(self, monkeypatch):
+        # CCWB_PROFILE is the ccwb-specific override (same convention as
+        # credential-process) and must win over the ambient AWS_PROFILE.
+        monkeypatch.setenv("CCWB_PROFILE", "CcwbProfile")
+        monkeypatch.setenv("AWS_PROFILE", "EnvProfile")
+        _parse(monkeypatch, [])
+        assert os.environ["AWS_PROFILE"] == "CcwbProfile"
+
+    def test_no_flag_leaves_env_untouched(self, monkeypatch):
+        monkeypatch.setenv("AWS_PROFILE", "EnvProfile")
+        _parse(monkeypatch, [])
+        assert os.environ["AWS_PROFILE"] == "EnvProfile"
+
+    def test_cache_path_follows_profile_flag(self, monkeypatch, tmp_path):
+        from otel_helper.__main__ import get_cache_path
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
+        monkeypatch.setenv("AWS_PROFILE", "EnvProfile")
+        _parse(monkeypatch, ["--profile", "FlagProfile"])
+        assert get_cache_path().name == "FlagProfile-otel-headers.json"

--- a/source/tests/test_otel_helper_profile.py
+++ b/source/tests/test_otel_helper_profile.py
@@ -1,7 +1,7 @@
-# ABOUTME: Tests for otel-helper profile resolution (--profile flag) across
-# ABOUTME: the cache path, credential-process subprocess, and collector sidecar.
+# ABOUTME: Tests for otel-helper profile resolution (--profile flag) and the
+# ABOUTME: collector sidecar's separate stdout/stderr log files.
 
-"""Profile resolution regression tests.
+"""Profile resolution and collector-launch regression tests.
 
 The otel-helper previously resolved its profile ONLY from AWS_PROFILE, so a
 Claude Code config pointing the helper at a non-default profile was ignored.
@@ -13,10 +13,16 @@ Resolution order (kept in sync with the Go binary's resolveProfile and the
 The winner is exported to AWS_PROFILE so every downstream consumer (cache
 path, credential-process subprocess, collector sidecar) resolves the same
 profile.
+
+The collector sidecar must also write stdout and stderr to SEPARATE files:
+Windows does not support redirecting both streams into one file, which made
+the PowerShell fallback silently never start the collector.
 """
 
 import os
+import signal
 import sys
+import time
 
 import pytest
 
@@ -65,3 +71,56 @@ class TestProfileResolution:
         monkeypatch.setenv("AWS_PROFILE", "EnvProfile")
         _parse(monkeypatch, ["--profile", "FlagProfile"])
         assert get_cache_path().name == "FlagProfile-otel-headers.json"
+
+
+class TestCollectorSeparateLogFiles:
+    @pytest.mark.skipif(sys.platform == "win32", reason="uses a shell-script stand-in for otelcol")
+    def test_collector_stdout_stderr_go_to_separate_files(self, monkeypatch, tmp_path):
+        from otel_helper.__main__ import ensure_collector_running
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
+        monkeypatch.setenv("AWS_PROFILE", "TestProfile")
+
+        install_dir = tmp_path / "claude-code-with-bedrock"
+        install_dir.mkdir()
+        otelcol = install_dir / "otelcol"
+        otelcol.write_text(
+            '#!/bin/sh\necho "stdout-marker sdkconfig=$AWS_SDK_LOAD_CONFIG"\necho stderr-marker >&2\nsleep 10\n',
+            encoding="utf-8",
+        )
+        otelcol.chmod(0o755)
+        (install_dir / "collector-config.yaml").write_text("receivers:\n", encoding="utf-8")
+
+        ensure_collector_running()
+
+        pid_file = install_dir / "collector.pid"
+        assert pid_file.exists(), "collector.pid must be written"
+        pid = int(pid_file.read_text().strip())
+        try:
+            cache_dir = tmp_path / ".claude-code-session"
+            log_file = cache_dir / "collector.log"
+            err_file = cache_dir / "collector.err"
+            deadline = time.time() + 3
+            while time.time() < deadline:
+                if (
+                    log_file.exists()
+                    and "stdout-marker" in log_file.read_text()
+                    and err_file.exists()
+                    and "stderr-marker" in err_file.read_text()
+                ):
+                    break
+                time.sleep(0.02)
+            assert log_file.exists() and "stdout-marker" in log_file.read_text()
+            assert err_file.exists() and "stderr-marker" in err_file.read_text(), (
+                "collector stderr must go to its own file — Windows cannot redirect both streams into one"
+            )
+            assert "stderr-marker" not in log_file.read_text()
+            # aws-sdk-go v1 components (awsemf exporter) can't read the
+            # -collector profile from ~/.aws/config without this.
+            assert "sdkconfig=1" in log_file.read_text(), "collector must run with AWS_SDK_LOAD_CONFIG=1"
+        finally:
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except OSError:
+                pass

--- a/source/tests/test_packaging_validators.py
+++ b/source/tests/test_packaging_validators.py
@@ -1,0 +1,58 @@
+# ABOUTME: Tests for the package-time profile validators (cli/validators.py) —
+# ABOUTME: the monitoring endpoint check must not fire for sidecar mode.
+
+"""validate_profile_for_packaging regression tests.
+
+The monitoring-consistency check warned "Monitoring enabled but no
+otel_collector_endpoint configured" for EVERY sidecar package: sidecar
+profiles never have that field (the endpoint is hardcoded to
+http://localhost:4318 at package time; there is no ALB). The warning's advice
+— deploy the central monitoring stack — is exactly what sidecar mode must not
+do. The check now applies to central mode only.
+"""
+
+from __future__ import annotations
+
+from claude_code_with_bedrock.cli.validators import validate_profile_for_packaging
+from claude_code_with_bedrock.config import Profile
+
+
+def _profile(**overrides) -> Profile:
+    defaults = {
+        "name": "validator-test",
+        "provider_domain": "company.okta.com",
+        "client_id": "client-123",
+        "credential_storage": "session",
+        "aws_region": "us-gov-west-1",
+        "identity_pool_name": "pool",
+        "auth_type": "oidc",
+        "monitoring_enabled": True,
+        "allowed_bedrock_regions": ["us-gov-west-1", "us-gov-east-1"],
+    }
+    defaults.update(overrides)
+    return Profile(**defaults)
+
+
+def _endpoint_warnings(profile):
+    return [e for e in validate_profile_for_packaging(profile) if e.field == "otel_collector_endpoint"]
+
+
+class TestMonitoringEndpointCheck:
+    def test_sidecar_without_endpoint_is_clean(self):
+        """The regression: sidecar mode has no ALB endpoint by design."""
+        profile = _profile(monitoring_mode="sidecar", otel_collector_endpoint=None)
+        assert _endpoint_warnings(profile) == []
+
+    def test_central_without_endpoint_warns(self):
+        profile = _profile(monitoring_mode="central", otel_collector_endpoint=None)
+        warnings = _endpoint_warnings(profile)
+        assert len(warnings) == 1
+        assert warnings[0].severity == "warning"
+
+    def test_central_with_endpoint_is_clean(self):
+        profile = _profile(monitoring_mode="central", otel_collector_endpoint="https://collector.example.com:4318")
+        assert _endpoint_warnings(profile) == []
+
+    def test_monitoring_disabled_is_clean(self):
+        profile = _profile(monitoring_enabled=False, monitoring_mode="central")
+        assert _endpoint_warnings(profile) == []

--- a/source/tests/test_packaging_validators.py
+++ b/source/tests/test_packaging_validators.py
@@ -56,3 +56,33 @@ class TestMonitoringEndpointCheck:
     def test_monitoring_disabled_is_clean(self):
         profile = _profile(monitoring_enabled=False, monitoring_mode="central")
         assert _endpoint_warnings(profile) == []
+
+
+def _region_warnings(profile):
+    return [e for e in validate_profile_for_packaging(profile) if e.field == "aws_region"]
+
+
+class TestAllowedRegionSentinelCheck:
+    """The aws_region check must expand "all-commercial" before comparing.
+
+    A global-model profile legitimately stores allowed_bedrock_regions =
+    ["all-commercial"]. Comparing aws_region against the raw sentinel warned
+    spuriously ("Region 'us-east-1' not in allowed_bedrock_regions:
+    ['all-commercial']") even though the region is authorized once the sentinel
+    is expanded at the CFN-param boundary.
+    """
+
+    def test_all_commercial_does_not_warn_for_commercial_region(self):
+        profile = _profile(aws_region="us-east-1", allowed_bedrock_regions=["all-commercial"])
+        assert _region_warnings(profile) == []
+
+    def test_concrete_region_mismatch_still_warns(self):
+        # Genuine misconfiguration must still surface.
+        profile = _profile(aws_region="us-east-1", allowed_bedrock_regions=["eu-west-1"])
+        warnings = _region_warnings(profile)
+        assert len(warnings) == 1
+        assert warnings[0].severity == "warning"
+
+    def test_concrete_region_match_is_clean(self):
+        profile = _profile(aws_region="us-east-1", allowed_bedrock_regions=["us-east-1", "us-west-2"])
+        assert _region_warnings(profile) == []

--- a/source/tests/test_questionary_none_choice.py
+++ b/source/tests/test_questionary_none_choice.py
@@ -1,0 +1,119 @@
+# ABOUTME: Regression tests for questionary's value=None title-fallback corrupting
+# ABOUTME: profiles ("Disabled" leaked into distribution_type, flipping deploys on).
+
+"""questionary.Choice(value=None) falls back to the choice TITLE.
+
+The init wizard's "Disabled"/"Skip" choices were built with value=None, so
+selecting them returned the title string ("Disabled", "Skip CodeBuild (...)",
+"Skip (no Route53 managed domain)") instead of None. Selecting "Disabled" for
+distribution therefore saved enable_distribution=True with
+distribution_type="Disabled" — and sidecar deploys scheduled the networking
+and distribution stacks the user had explicitly declined.
+
+Covers: the questionary behavior itself (so a library change is noticed), the
+Profile.from_dict heal for already-corrupted profiles, the deploy-side effect,
+and a source guard so value=None choices can't creep back into the wizard.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import questionary
+
+from claude_code_with_bedrock.cli.commands.deploy import DeployCommand
+from claude_code_with_bedrock.config import Profile
+
+INIT_PY = Path(__file__).resolve().parents[1] / "claude_code_with_bedrock" / "cli" / "commands" / "init.py"
+
+
+class _NullConsole:
+    def print(self, *args, **kwargs):
+        pass
+
+
+def _profile_dict(**overrides) -> dict:
+    base = {
+        "name": "heal-test",
+        "provider_domain": "company.okta.com",
+        "client_id": "client-123",
+        "credential_storage": "session",
+        "aws_region": "us-gov-west-1",
+        "identity_pool_name": "gov-pool",
+        "auth_type": "oidc",
+        "monitoring_enabled": True,
+        "monitoring_mode": "sidecar",
+        "analytics_enabled": False,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestQuestionaryTitleFallback:
+    def test_choice_value_none_falls_back_to_title(self):
+        """Pin the library behavior this whole bug class rests on. If a
+        questionary upgrade changes this, the wizard sentinels can be removed."""
+        assert questionary.Choice("Disabled", value=None).value == "Disabled"
+
+    def test_init_wizard_has_no_none_valued_choices(self):
+        """Source guard: every 'Disabled'/'Skip' Choice must carry an explicit
+        sentinel (see _CHOICE_NONE in init.py), never value=None."""
+        source = INIT_PY.read_text(encoding="utf-8")
+        offenders = [
+            line.strip() for line in source.splitlines() if re.search(r"questionary\.Choice\(.*value=None", line)
+        ]
+        assert not offenders, (
+            "questionary.Choice(value=None) returns the choice TITLE, not None — "
+            f"use _CHOICE_NONE and map it back after .ask(): {offenders}"
+        )
+
+
+class TestProfileHeal:
+    def test_corrupted_distribution_type_heals_to_disabled(self):
+        loaded = Profile.from_dict(_profile_dict(enable_distribution=True, distribution_type="Disabled"))
+        assert loaded.enable_distribution is False
+        assert loaded.distribution_type is None
+
+    def test_valid_distribution_types_untouched(self):
+        for dist_type in ("presigned-s3", "landing-page"):
+            loaded = Profile.from_dict(_profile_dict(enable_distribution=True, distribution_type=dist_type))
+            assert loaded.enable_distribution is True
+            assert loaded.distribution_type == dist_type
+
+    def test_legacy_enabled_without_type_still_migrates(self):
+        """Pre-distribution_type profiles must keep migrating to presigned-s3."""
+        loaded = Profile.from_dict(_profile_dict(enable_distribution=True))
+        assert loaded.enable_distribution is True
+        assert loaded.distribution_type == "presigned-s3"
+
+    def test_corrupted_codebuild_region_heals(self):
+        loaded = Profile.from_dict(
+            _profile_dict(
+                enable_codebuild=True,
+                codebuild_region="Skip CodeBuild (build Windows binaries manually)",
+            )
+        )
+        assert loaded.codebuild_region is None
+
+    def test_valid_codebuild_region_untouched(self):
+        loaded = Profile.from_dict(_profile_dict(enable_codebuild=True, codebuild_region="us-east-1"))
+        assert loaded.codebuild_region == "us-east-1"
+
+    def test_corrupted_hosted_zone_heals(self):
+        loaded = Profile.from_dict(_profile_dict(distribution_hosted_zone_id="Skip (no Route53 managed domain)"))
+        assert loaded.distribution_hosted_zone_id is None
+
+    def test_valid_hosted_zone_untouched(self):
+        loaded = Profile.from_dict(_profile_dict(distribution_hosted_zone_id="Z0123456789ABCDEF"))
+        assert loaded.distribution_hosted_zone_id == "Z0123456789ABCDEF"
+
+
+class TestDeployEffect:
+    def test_healed_profile_schedules_no_networking_or_distribution(self):
+        """The user-visible regression: a sidecar profile corrupted by the
+        'Disabled' choice scheduled networking + distribution stacks."""
+        profile = Profile.from_dict(_profile_dict(enable_distribution=True, distribution_type="Disabled"))
+        stacks = [s for s, _ in DeployCommand()._select_full_deploy_stacks(profile, _NullConsole())]
+        assert "networking" not in stacks, f"networking scheduled for disabled distribution: {stacks}"
+        assert "distribution" not in stacks, f"distribution scheduled despite 'Disabled': {stacks}"

--- a/source/tests/test_quota_check_lambda.py
+++ b/source/tests/test_quota_check_lambda.py
@@ -581,3 +581,99 @@ class TestIdcUsernameIdentity:
         # Non-SSO role without email should be blocked
         assert body.get("reason") == "missing_identity"
         assert body["allowed"] is False
+
+
+class TestCostBasedEnforcement:
+    """Tests that cost-based quota enforcement reads the correct DDB attributes.
+
+    Regression tests for issue #746: monthly cost enforcement was broken because:
+    1. get_user_usage() didn't include cost fields in its return dict
+    2. get_policy() didn't include monthly_cost_limit/daily_cost_limit
+    3. The lookup key was 'cost_usd' but DDB attribute is 'estimated_cost'
+    """
+
+    def _make_module(self, base_env):
+        env = {
+            **base_env,
+            "ENABLE_FINEGRAINED_QUOTAS": "true",
+        }
+        return _load_quota_check(env)
+
+    def _patch_tables(
+        self,
+        mod,
+        estimated_cost: float,
+        monthly_cost_limit: float,
+        daily_cost_usd: float = 0,
+        daily_cost_limit: float = 0,
+    ):
+        """Mock both quota_table and policies_table with correct call sequence."""
+        from datetime import datetime, timezone
+
+        current_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+        mod.quota_table = MagicMock()
+        # Call 1: get_unblock_status -> no unblock
+        # Call 2: get_user_usage -> usage with estimated_cost
+        mod.quota_table.get_item.side_effect = [
+            {},  # unblock check: no item
+            {
+                "Item": {
+                    "total_tokens": 100000,
+                    "daily_tokens": 1000,
+                    "daily_date": current_date,
+                    "input_tokens": 60000,
+                    "output_tokens": 40000,
+                    "cache_tokens": 0,
+                    "estimated_cost": estimated_cost,
+                    "daily_cost_usd": daily_cost_usd,
+                }
+            },
+        ]
+
+        mod.policies_table = MagicMock()
+        mod.policies_table.get_item.return_value = {
+            "Item": {
+                "pk": "POLICY#default#default",
+                "sk": "CURRENT",
+                "policy_type": "default",
+                "identifier": "default",
+                "monthly_token_limit": 0,
+                "monthly_cost_limit": monthly_cost_limit,
+                "daily_cost_limit": daily_cost_limit,
+                "enforcement_mode": "block",
+                "daily_enforcement_mode": "block",
+                "enabled": True,
+            }
+        }
+
+    def test_monthly_cost_blocks_when_exceeded(self, base_env):
+        """When estimated_cost exceeds monthly_cost_limit, access must be denied."""
+        mod = self._make_module(base_env)
+        self._patch_tables(mod, estimated_cost=95.0, monthly_cost_limit=90.0)
+
+        body = _parse(mod.lambda_handler(_build_event(), None))
+        assert body["allowed"] is False, (
+            "Monthly cost enforcement failed: estimated_cost ($95) > limit ($90) but access was allowed. "
+            "Check that get_user_usage includes 'estimated_cost' and get_policy includes 'monthly_cost_limit'."
+        )
+        assert body["reason"] == "monthly_cost_exceeded"
+
+    def test_monthly_cost_allows_when_within_limit(self, base_env):
+        """When estimated_cost is below monthly_cost_limit, access is granted."""
+        mod = self._make_module(base_env)
+        self._patch_tables(mod, estimated_cost=45.0, monthly_cost_limit=90.0)
+
+        body = _parse(mod.lambda_handler(_build_event(), None))
+        assert body["allowed"] is True
+
+    def test_daily_cost_blocks_when_exceeded(self, base_env):
+        """When daily_cost_usd exceeds daily_cost_limit, access must be denied."""
+        mod = self._make_module(base_env)
+        self._patch_tables(
+            mod, estimated_cost=10.0, monthly_cost_limit=90.0, daily_cost_usd=12.0, daily_cost_limit=10.0
+        )
+
+        body = _parse(mod.lambda_handler(_build_event(), None))
+        assert body["allowed"] is False
+        assert body["reason"] == "daily_cost_exceeded"

--- a/source/tests/test_quota_monitor_lambda.py
+++ b/source/tests/test_quota_monitor_lambda.py
@@ -228,3 +228,67 @@ class TestCostEstimateTokenTypes:
         ]
         users = self._run_cost(mod, vector)
         assert users["a@b.com"]["cost_usd"] == pytest.approx(5.00 + 25.00 + 0.50 + 6.25)
+
+
+class TestPromQLAggregationFunction:
+    """Regression: token.usage is a Counter exported with DELTA temporality.
+
+    increase() assumes cumulative temporality and misreads the delta sawtooth's
+    down-steps as counter resets, returning empty/understated results. That froze
+    the DynamoDB row and surfaced as "Daily Tokens: 0" in `ccwb quota usage` while
+    Athena/CloudWatch (which sum the deltas) stayed correct. Aggregation MUST use
+    sum_over_time(). The existing tests mock fetch_usage_from_promql out entirely,
+    so the query construction — where the bug lived — was never exercised.
+    """
+
+    def _capture_queries(self, mod, primary_total="531643"):
+        """Monkeypatch _promql_query to record every query string it receives.
+
+        Returns the list that accumulates the queries. Only the primary
+        per-user total query gets a non-empty vector so the aggregation has
+        something to fold in; the rest return empty so cost/CoWork paths no-op.
+        """
+        captured = []
+
+        def fake_query(query, time_param=None):
+            captured.append(query)
+            is_primary = 'sum by ("user.email")' in query and ", type" not in query and ", model" not in query
+            if is_primary and "claude_code.token.usage" in query:
+                return [{"metric": {"user.email": "a@b.com"}, "value": [0, primary_total]}]
+            return []
+
+        mod._promql_query = fake_query
+        return captured
+
+    def test_claude_code_queries_use_sum_over_time_not_increase(self, base_env):
+        mod = _load_quota_monitor(base_env)
+        captured = self._capture_queries(mod)
+
+        mod.fetch_usage_from_promql()
+
+        cc_queries = [q for q in captured if "claude_code.token.usage" in q]
+        assert cc_queries, "expected at least one claude_code.token.usage query"
+        for q in cc_queries:
+            assert "sum_over_time(" in q, f"delta metric must use sum_over_time: {q}"
+            assert "increase(" not in q, f"increase() is wrong for a delta metric: {q}"
+
+    def test_cowork_queries_use_sum_over_time_not_increase(self, base_env):
+        mod = _load_quota_monitor(base_env)
+        captured = self._capture_queries(mod)
+
+        mod.fetch_usage_from_promql()
+
+        cowork_queries = [q for q in captured if "ClaudeCoWork" in q]
+        assert cowork_queries, "expected CoWork token.usage queries"
+        for q in cowork_queries:
+            assert "sum_over_time(" in q, f"CoWork delta metric must use sum_over_time: {q}"
+            assert "increase(" not in q, f"increase() is wrong for a delta metric: {q}"
+
+    def test_aggregated_total_flows_through(self, base_env):
+        """A non-empty primary vector must be recorded (not skipped as delta<=0)."""
+        mod = _load_quota_monitor(base_env)
+        self._capture_queries(mod, primary_total="531643")
+
+        users = mod.fetch_usage_from_promql()
+
+        assert users.get("a@b.com", {}).get("total_tokens") == 531643

--- a/source/tests/test_quota_monitor_lambda.py
+++ b/source/tests/test_quota_monitor_lambda.py
@@ -166,3 +166,65 @@ class TestStaleDailyReset:
         }
         entry = mod._build_usage_entry(item, _today())
         assert entry["daily_tokens"] == 3_355_533
+
+
+class TestCostEstimateTokenTypes:
+    """Regression: cost must price all four token types, including cacheCreation.
+
+    The metric's `type` dimension is camelCase (input/output/cacheRead/
+    cacheCreation) but the rate tables use snake_case keys (input/output/
+    cache_read/cache_write). The old code only rewrote cacheRead->cache_read, so
+    cacheCreation looked up a non-existent key and priced at $0 — dropping the
+    cache-write share of the cost, which is usually the majority of tokens.
+    """
+
+    def _run_cost(self, mod, type_model_vector):
+        """Drive fetch_usage_from_promql with a canned type+model breakdown.
+
+        Only the (user.email, type, model) query returns data; the primary
+        total, type-only, and CoWork queries return empty so we isolate the
+        cost calculation. Returns the users dict.
+        """
+
+        def fake_query(query, time_param=None):
+            if ", type, model)" in query and "claude_code.token.usage" in query:
+                return type_model_vector
+            return []
+
+        mod._promql_query = fake_query
+        return mod.fetch_usage_from_promql()
+
+    def test_cache_creation_is_priced(self, base_env):
+        """A cacheCreation-only breakdown must produce a non-zero cost."""
+        mod = _load_quota_monitor(base_env)
+        # opus cache_write rate = 6.25 / 1M tokens; 1,000,000 tokens -> $6.25
+        vector = [
+            {
+                "metric": {"user.email": "a@b.com", "type": "cacheCreation", "model": "claude-opus-4-8"},
+                "value": [0, "1000000"],
+            }
+        ]
+        users = self._run_cost(mod, vector)
+        assert users["a@b.com"]["cost_usd"] == pytest.approx(6.25)
+
+    def test_all_four_types_priced(self, base_env):
+        """input/output/cacheRead/cacheCreation each contribute to the cost."""
+        mod = _load_quota_monitor(base_env)
+        # opus rates per 1M: input 5.00, output 25.00, cache_read 0.50, cache_write 6.25
+        vector = [
+            {"metric": {"user.email": "a@b.com", "type": "input", "model": "claude-opus-4-8"}, "value": [0, "1000000"]},
+            {
+                "metric": {"user.email": "a@b.com", "type": "output", "model": "claude-opus-4-8"},
+                "value": [0, "1000000"],
+            },
+            {
+                "metric": {"user.email": "a@b.com", "type": "cacheRead", "model": "claude-opus-4-8"},
+                "value": [0, "1000000"],
+            },
+            {
+                "metric": {"user.email": "a@b.com", "type": "cacheCreation", "model": "claude-opus-4-8"},
+                "value": [0, "1000000"],
+            },
+        ]
+        users = self._run_cost(mod, vector)
+        assert users["a@b.com"]["cost_usd"] == pytest.approx(5.00 + 25.00 + 0.50 + 6.25)

--- a/source/tests/test_silent_refresh.py
+++ b/source/tests/test_silent_refresh.py
@@ -101,7 +101,7 @@ def auth_instance(tmp_path):
 
 
 class TestSilentRefresh:
-    """Tests for _try_silent_refresh method."""
+    """Tests for the two-phase silent refresh (token load, then exchange)."""
 
     def test_silent_refresh_succeeds_with_valid_id_token(self, auth_instance):
         """When a valid id_token is cached, silent refresh should return new AWS creds."""
@@ -114,12 +114,14 @@ class TestSilentRefresh:
             patch.object(auth_instance, "save_credentials") as mock_save,
             patch.object(auth_instance, "save_monitoring_token") as mock_save_token,
         ):
-            creds, returned_token, returned_claims = auth_instance._try_silent_refresh()
+            returned_token, returned_claims = auth_instance._get_cached_token_for_silent_refresh()
+            assert returned_token == id_token
+            assert returned_claims["sub"] == claims["sub"]
+
+            creds = auth_instance._try_silent_refresh(returned_token, returned_claims)
 
             assert creds is not None
             assert creds["AccessKeyId"] == aws_creds["AccessKeyId"]
-            assert returned_token == id_token
-            assert returned_claims["sub"] == claims["sub"]
             mock_get_creds.assert_called_once()
             mock_save.assert_called_once_with(aws_creds)
             # Verify the id_token is re-persisted so the next refresh also works
@@ -127,14 +129,13 @@ class TestSilentRefresh:
 
     def test_silent_refresh_returns_none_when_id_token_expired(self, auth_instance):
         """When cached id_token is within the 60-second expiry buffer, get_monitoring_token
-        returns None and silent refresh must not attempt an STS exchange."""
+        returns None and the token-load phase must not surface a token."""
         with (
             patch.object(auth_instance, "get_monitoring_token", return_value=None) as mock_get_token,
             patch.object(auth_instance, "get_aws_credentials") as mock_get_creds,
         ):
-            creds, id_token, token_claims = auth_instance._try_silent_refresh()
+            id_token, token_claims = auth_instance._get_cached_token_for_silent_refresh()
 
-            assert creds is None
             assert id_token is None
             assert token_claims is None
             mock_get_token.assert_called_once()
@@ -142,25 +143,19 @@ class TestSilentRefresh:
             mock_get_creds.assert_not_called()
 
     def test_silent_refresh_returns_none_when_no_cached_token(self, auth_instance):
-        """When no id_token is cached, silent refresh should return None."""
+        """When no id_token is cached, the token-load phase should return None."""
         with patch.object(auth_instance, "get_monitoring_token", return_value=None):
-            creds, id_token, token_claims = auth_instance._try_silent_refresh()
-            assert creds is None
+            id_token, token_claims = auth_instance._get_cached_token_for_silent_refresh()
             assert id_token is None
             assert token_claims is None
 
     def test_silent_refresh_returns_none_when_sts_exchange_fails(self, auth_instance):
         """When id_token is valid but STS exchange fails, should return None (fallback to browser)."""
-        id_token, _ = _make_id_token(exp_offset=3600)
+        id_token, claims = _make_id_token(exp_offset=3600)
 
-        with (
-            patch.object(auth_instance, "get_monitoring_token", return_value=id_token),
-            patch.object(auth_instance, "get_aws_credentials", side_effect=Exception("STS error")),
-        ):
-            creds, returned_token, returned_claims = auth_instance._try_silent_refresh()
+        with patch.object(auth_instance, "get_aws_credentials", side_effect=Exception("STS error")):
+            creds = auth_instance._try_silent_refresh(id_token, claims)
             assert creds is None
-            assert returned_token is None
-            assert returned_claims is None
 
     def test_silent_refresh_not_called_when_aws_creds_valid(self, auth_instance):
         """When AWS credentials are still valid, silent refresh should not be attempted."""
@@ -168,6 +163,7 @@ class TestSilentRefresh:
 
         with (
             patch.object(auth_instance, "get_cached_credentials", return_value=aws_creds),
+            patch.object(auth_instance, "_get_cached_token_for_silent_refresh") as mock_load_token,
             patch.object(auth_instance, "_try_silent_refresh") as mock_silent,
             patch.object(auth_instance, "_should_recheck_quota", return_value=False),
         ):
@@ -175,16 +171,19 @@ class TestSilentRefresh:
             with patch("builtins.print"):
                 auth_instance.run()
 
+            mock_load_token.assert_not_called()
             mock_silent.assert_not_called()
 
     def test_run_uses_silent_refresh_before_browser(self, auth_instance):
         """When AWS creds expired but id_token valid, run() should use silent refresh."""
+        id_token, claims = _make_id_token(exp_offset=3600)
         aws_creds = _make_aws_credentials(exp_offset=3600)
 
         with (
             patch.object(auth_instance, "get_cached_credentials", return_value=None),
             patch("socket.socket") as mock_socket_cls,
-            patch.object(auth_instance, "_try_silent_refresh", return_value=(aws_creds, None, None)),
+            patch.object(auth_instance, "_get_cached_token_for_silent_refresh", return_value=(id_token, claims)),
+            patch.object(auth_instance, "_try_silent_refresh", return_value=aws_creds),
             patch.object(auth_instance, "_should_check_quota", return_value=False),
             patch.object(auth_instance, "authenticate_oidc") as mock_browser,
             patch("builtins.print"),
@@ -206,7 +205,7 @@ class TestSilentRefresh:
         with (
             patch.object(auth_instance, "get_cached_credentials", return_value=None),
             patch("socket.socket") as mock_socket_cls,
-            patch.object(auth_instance, "_try_silent_refresh", return_value=(None, None, None)),
+            patch.object(auth_instance, "_get_cached_token_for_silent_refresh", return_value=(None, None)),
             patch.object(auth_instance, "authenticate_oidc", return_value=(id_token, claims)) as mock_browser,
             patch.object(auth_instance, "_should_check_quota", return_value=False),
             patch.object(auth_instance, "get_aws_credentials", return_value=aws_creds),
@@ -221,3 +220,70 @@ class TestSilentRefresh:
 
             assert result == 0
             mock_browser.assert_called_once()
+
+
+class TestQuotaBeforeSTSOnSilentRefresh:
+    """Regression tests for #761: quota must be enforced BEFORE the STS
+    exchange on the silent-refresh path, so an over-quota user never mints
+    or caches fresh credentials."""
+
+    def test_quota_blocked_prevents_sts_exchange(self, auth_instance):
+        """Quota blocked → run() must exit via the blocked handler WITHOUT
+        calling get_aws_credentials or save_credentials. Before the fix,
+        _try_silent_refresh exchanged and saved credentials first."""
+        id_token, claims = _make_id_token(exp_offset=3600)
+
+        with (
+            patch.object(auth_instance, "get_cached_credentials", return_value=None),
+            patch("socket.socket") as mock_socket_cls,
+            patch.object(auth_instance, "get_monitoring_token", return_value=id_token),
+            patch.object(auth_instance, "_should_check_quota", return_value=True),
+            patch.object(auth_instance, "_check_quota", return_value={"allowed": False, "reason": "quota_exceeded"}),
+            patch.object(auth_instance, "_save_quota_check_timestamp"),
+            patch.object(auth_instance, "_handle_quota_blocked", return_value=1) as mock_blocked,
+            patch.object(auth_instance, "get_aws_credentials") as mock_get_creds,
+            patch.object(auth_instance, "save_credentials") as mock_save,
+            patch.object(auth_instance, "authenticate_oidc") as mock_browser,
+            patch("builtins.print"),
+        ):
+            mock_socket = MagicMock()
+            mock_socket_cls.return_value = mock_socket
+
+            result = auth_instance.run()
+
+            assert result == 1
+            mock_blocked.assert_called_once()
+            # The heart of #761: no STS exchange, no cached credentials, no browser
+            mock_get_creds.assert_not_called()
+            mock_save.assert_not_called()
+            mock_browser.assert_not_called()
+
+    def test_quota_allowed_proceeds_to_sts_exchange(self, auth_instance):
+        """Quota allowed → the exchange runs and credentials are emitted."""
+        id_token, claims = _make_id_token(exp_offset=3600)
+        aws_creds = _make_aws_credentials()
+
+        with (
+            patch.object(auth_instance, "get_cached_credentials", return_value=None),
+            patch("socket.socket") as mock_socket_cls,
+            patch.object(auth_instance, "get_monitoring_token", return_value=id_token),
+            patch.object(auth_instance, "_should_check_quota", return_value=True),
+            patch.object(auth_instance, "_check_quota", return_value={"allowed": True}) as mock_quota,
+            patch.object(auth_instance, "_save_quota_check_timestamp"),
+            patch.object(auth_instance, "_handle_quota_warning"),
+            patch.object(auth_instance, "get_aws_credentials", return_value=aws_creds) as mock_get_creds,
+            patch.object(auth_instance, "save_credentials") as mock_save,
+            patch.object(auth_instance, "save_monitoring_token"),
+            patch.object(auth_instance, "authenticate_oidc") as mock_browser,
+            patch("builtins.print"),
+        ):
+            mock_socket = MagicMock()
+            mock_socket_cls.return_value = mock_socket
+
+            result = auth_instance.run()
+
+            assert result == 0
+            mock_quota.assert_called_once()
+            mock_get_creds.assert_called_once()
+            mock_save.assert_called_once_with(aws_creds)
+            mock_browser.assert_not_called()


### PR DESCRIPTION
## Why

This release improves the reliability and accuracy of quota enforcement, credential lifecycle management, and cross-platform packaging. Users benefit from more predictable cost controls, smoother credential recovery after quota events, and support for air-gapped deployment environments.

## What's Included

### Bug Fixes (19)
- **fix(cowork):** declare `inferenceCredentialKind` to resolve credential-method ambiguity (#791)
- **fix(deploy):** expand "all-commercial" region sentinel before IAM condition (#790)
- **fix(init):** collect and persist Google OAuth `client_secret` in wizard (#789)
- **fix(otel):** start collector sidecar from Go helper, split log files on Windows (#774)
- **fix(init):** 'Disabled'/'Skip' wizard choices saved their titles, not None (#775)
- **fix(deploy):** orphaned-stack check crashed GovCloud deploys via us-east-1 probe (#777)
- **fix(quota):** wire cost-based quota end-to-end (wizard answers were dropped) (#778)
- **fix(package):** don't warn about missing collector endpoint in sidecar mode (#779)
- **fix(cowork):** point `inferenceCredentialHelper` at a wrapper script (no inline args) (#787)
- **fix(auth):** grant `bedrock:CallWithBearerToken` on Google federated role (#785)
- **fix(otel):** honor supplied `--profile` across all otel-helper variants (#766)
- **fix(package):** make `install.bat` actually merge existing Claude settings (#765)
- **fix(credential-process):** quota-blocked users recover automatically — remove `~/.aws/credentials` stanza instead of writing EXPIRED placeholder (#768)
- **fix(quota):** enforce quota before STS exchange on silent refresh paths (#762)
- **fix(quota):** aggregate token usage with `sum_over_time`, not `increase` (delta metric) (#754)
- **fix(quota):** price cache-write (`cacheCreation`) tokens in cost estimate (#756)
- **fix(quota):** cost-based enforcement reads correct DDB attributes (#748)
- **fix(otel):** resolve OIDC provider type before `--get-monitoring-token` so silent bearer refresh works (#749)
- **fix(package):** filter `extra_files` by `--target-platform` (#763)
- **fix:** cowork-dashboard deploy fails — PromQL widgets typed as "metric" not "chart" (#760)

### Features (5)
- **feat(models):** Claude Opus 4.8 in GovCloud + partition-aware model wizard (#776)
- **feat(credential-process):** add `--show-claims` IdP claim diagnostic (#780)
- **feat(package):** add `--prepare-offline` flag for air-gapped builds (#753)
- **feat(package):** stamp `settings_version` into `OTEL_RESOURCE_ATTRIBUTES` (#764)
- **feat:** declarative `extra_files` for package + distribute (#744)

### Improvements (3)
- **fix(init):** let users set `max_session_duration` and retain it on re-run (#745)
- **chore:** target dependabot PRs to beta branch (#772)
- **chore:** bump version to 2.5.2, fix stable badge filter

### Documentation (1)
- **docs(websearch):** fix WEB_SEARCH.md committed as a git-show dump (#788)

### Dependencies
- **chore(deps):** bump `actions/setup-go` from 6 to 7 (#792)
- **chore(deps):** bump pip-version-updates group in /source with 4 updates (#793)
- **chore(deps):** bump pip-version-updates group in /source with 4 updates (#769)

## CI Status
- ✅ pytest-ci (all platforms)
- ✅ integration-tests (Go binaries)
- ✅ E2E matrix (16/16 profiles)

## Testing
All 1300+ unit tests pass. E2E quota enforcement validated against real Lambda + DynamoDB infrastructure.

## Thank You 🙏

This release wouldn't be possible without the contributions and validation from the community:

- @scouturier — cowork credential helper, Google federation fixes, credential-kind resolution, docs cleanup
- @adiospeds — quota enforcement accuracy, offline packaging, OTEL improvements
- @wantmys2000 — otel-helper profile handling, Windows installer fixes, GovCloud support, cost quota wiring, sidecar improvements, IdP diagnostics, Google OAuth wizard, region sentinel fix
- @sg-nitd — credential recovery improvements
- @qing-at-work — cowork dashboard fixes

Thank you all for your time, testing, and contributions!