### PR TITLE
chore: target dependabot PRs to beta branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "beta"
     schedule:
       interval: "weekly"
     commit-message:
@@ -12,6 +13,7 @@ updates:
 
   - package-ecosystem: "pip"
     directory: "/source"
+    target-branch: "beta"
     schedule:
       interval: "weekly"
     commit-message:


### PR DESCRIPTION
Adds `target-branch: "beta"` to both ecosystem entries in `.github/dependabot.yml` so Dependabot PRs target `beta` instead of `main`.

Note: This file must also exist on `main` for GitHub to read it. After merging to `beta`, the next beta→main sync will carry it over. Alternatively we can cherry-pick to `main` immediately.