### PR TITLE
fix(init): 'Disabled'/'Skip' wizard choices saved their titles, not None

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -31,6 +31,14 @@ from claude_code_with_bedrock.cli.utils.validators import (
 )
 from claude_code_with_bedrock.config import WEBSEARCH_SUPPORTED_REGIONS, Config, Profile
 
+# questionary.Choice treats value=None as "no value given" and FALLS BACK TO
+# THE TITLE STRING — so a "Disabled"/"Skip" choice built with value=None
+# returns its title (e.g. "Disabled") from .ask(), which is truthy and leaks
+# into the profile (enable_distribution flipped on, title strings stored as
+# codebuild region / hosted zone ID). Use this sentinel for "none" choices and
+# map it back to None right after .ask().
+_CHOICE_NONE = "__none__"
+
 
 def validate_identity_pool_name(value: str) -> bool | str:
     """Validate identity pool name format.
@@ -1445,9 +1453,11 @@ class InitCommand(Command):
                     choices=[
                         questionary.Choice(nearest_label, value=nearest),
                         *[questionary.Choice(r, value=r) for r in CODEBUILD_WINDOWS_REGIONS if r != nearest],
-                        questionary.Choice("Skip CodeBuild (build Windows binaries manually)", value=None),
+                        questionary.Choice("Skip CodeBuild (build Windows binaries manually)", value=_CHOICE_NONE),
                     ],
                 ).ask()
+                if cb_choice == _CHOICE_NONE:
+                    cb_choice = None
 
                 prior_region = config["codebuild"].get("region")
                 config["codebuild"]["region"] = cb_choice
@@ -1655,7 +1665,7 @@ class InitCommand(Command):
         distribution_choices = [
             questionary.Choice("Presigned S3 URLs (simple, no authentication)", value="presigned-s3"),
             questionary.Choice("Authenticated Landing Page (IdP + ALB)", value="landing-page"),
-            questionary.Choice("Disabled", value=None),
+            questionary.Choice("Disabled", value=_CHOICE_NONE),
         ]
 
         # Get saved value or default to None
@@ -1667,6 +1677,8 @@ class InitCommand(Command):
             choices=distribution_choices,
             default=default_choice,
         ).ask()
+        if distribution_type == _CHOICE_NONE:
+            distribution_type = None
 
         # Preserve existing distribution settings, only update enabled/type
         if "distribution" not in config:
@@ -1954,7 +1966,7 @@ class InitCommand(Command):
                         )
                         for zone in hosted_zones
                     ]
-                    zone_choices.append(questionary.Choice("Skip (no Route53 managed domain)", value=None))
+                    zone_choices.append(questionary.Choice("Skip (no Route53 managed domain)", value=_CHOICE_NONE))
 
                     # Find the default choice based on existing zone
                     default_choice = None
@@ -1969,6 +1981,8 @@ class InitCommand(Command):
                         choices=zone_choices,
                         default=default_choice if default_choice else zone_choices[0],
                     ).ask()
+                    if hosted_zone_id == _CHOICE_NONE:
+                        hosted_zone_id = None
                 else:
                     console.print("[yellow]No Route53 hosted zones found in this account[/yellow]")
                     console.print("You can still use custom domain if it's managed externally")

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -282,6 +282,22 @@ class Profile:
                 except Exception:
                     pass  # Leave provider_type unset if parsing fails
 
+        # Heal profiles corrupted by questionary's value=None fallback: Choice
+        # values of None fall back to the choice TITLE, so the wizard's
+        # "Disabled" option saved enable_distribution=True with
+        # distribution_type="Disabled" — making sidecar deploys schedule the
+        # networking + distribution stacks. The same fallback could store
+        # choice titles as the CodeBuild region or Route53 hosted zone ID
+        # (titles contain spaces; valid values never do). Must run BEFORE the
+        # legacy migration below, which would otherwise legitimize the value.
+        if data.get("distribution_type") not in (None, "presigned-s3", "landing-page"):
+            data["distribution_type"] = None
+            data["enable_distribution"] = False
+        if data.get("codebuild_region") and " " in str(data["codebuild_region"]):
+            data["codebuild_region"] = None
+        if data.get("distribution_hosted_zone_id") and " " in str(data["distribution_hosted_zone_id"]):
+            data["distribution_hosted_zone_id"] = None
+
         # Migrate legacy distribution configuration
         if "enable_distribution" in data and data.get("enable_distribution"):
             # If distribution was enabled but no type specified, default to presigned-s3

--- a/source/tests/test_questionary_none_choice.py
+++ b/source/tests/test_questionary_none_choice.py
@@ -1,0 +1,119 @@
+# ABOUTME: Regression tests for questionary's value=None title-fallback corrupting
+# ABOUTME: profiles ("Disabled" leaked into distribution_type, flipping deploys on).
+
+"""questionary.Choice(value=None) falls back to the choice TITLE.
+
+The init wizard's "Disabled"/"Skip" choices were built with value=None, so
+selecting them returned the title string ("Disabled", "Skip CodeBuild (...)",
+"Skip (no Route53 managed domain)") instead of None. Selecting "Disabled" for
+distribution therefore saved enable_distribution=True with
+distribution_type="Disabled" — and sidecar deploys scheduled the networking
+and distribution stacks the user had explicitly declined.
+
+Covers: the questionary behavior itself (so a library change is noticed), the
+Profile.from_dict heal for already-corrupted profiles, the deploy-side effect,
+and a source guard so value=None choices can't creep back into the wizard.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import questionary
+
+from claude_code_with_bedrock.cli.commands.deploy import DeployCommand
+from claude_code_with_bedrock.config import Profile
+
+INIT_PY = Path(__file__).resolve().parents[1] / "claude_code_with_bedrock" / "cli" / "commands" / "init.py"
+
+
+class _NullConsole:
+    def print(self, *args, **kwargs):
+        pass
+
+
+def _profile_dict(**overrides) -> dict:
+    base = {
+        "name": "heal-test",
+        "provider_domain": "company.okta.com",
+        "client_id": "client-123",
+        "credential_storage": "session",
+        "aws_region": "us-gov-west-1",
+        "identity_pool_name": "gov-pool",
+        "auth_type": "oidc",
+        "monitoring_enabled": True,
+        "monitoring_mode": "sidecar",
+        "analytics_enabled": False,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestQuestionaryTitleFallback:
+    def test_choice_value_none_falls_back_to_title(self):
+        """Pin the library behavior this whole bug class rests on. If a
+        questionary upgrade changes this, the wizard sentinels can be removed."""
+        assert questionary.Choice("Disabled", value=None).value == "Disabled"
+
+    def test_init_wizard_has_no_none_valued_choices(self):
+        """Source guard: every 'Disabled'/'Skip' Choice must carry an explicit
+        sentinel (see _CHOICE_NONE in init.py), never value=None."""
+        source = INIT_PY.read_text(encoding="utf-8")
+        offenders = [
+            line.strip() for line in source.splitlines() if re.search(r"questionary\.Choice\(.*value=None", line)
+        ]
+        assert not offenders, (
+            "questionary.Choice(value=None) returns the choice TITLE, not None — "
+            f"use _CHOICE_NONE and map it back after .ask(): {offenders}"
+        )
+
+
+class TestProfileHeal:
+    def test_corrupted_distribution_type_heals_to_disabled(self):
+        loaded = Profile.from_dict(_profile_dict(enable_distribution=True, distribution_type="Disabled"))
+        assert loaded.enable_distribution is False
+        assert loaded.distribution_type is None
+
+    def test_valid_distribution_types_untouched(self):
+        for dist_type in ("presigned-s3", "landing-page"):
+            loaded = Profile.from_dict(_profile_dict(enable_distribution=True, distribution_type=dist_type))
+            assert loaded.enable_distribution is True
+            assert loaded.distribution_type == dist_type
+
+    def test_legacy_enabled_without_type_still_migrates(self):
+        """Pre-distribution_type profiles must keep migrating to presigned-s3."""
+        loaded = Profile.from_dict(_profile_dict(enable_distribution=True))
+        assert loaded.enable_distribution is True
+        assert loaded.distribution_type == "presigned-s3"
+
+    def test_corrupted_codebuild_region_heals(self):
+        loaded = Profile.from_dict(
+            _profile_dict(
+                enable_codebuild=True,
+                codebuild_region="Skip CodeBuild (build Windows binaries manually)",
+            )
+        )
+        assert loaded.codebuild_region is None
+
+    def test_valid_codebuild_region_untouched(self):
+        loaded = Profile.from_dict(_profile_dict(enable_codebuild=True, codebuild_region="us-east-1"))
+        assert loaded.codebuild_region == "us-east-1"
+
+    def test_corrupted_hosted_zone_heals(self):
+        loaded = Profile.from_dict(_profile_dict(distribution_hosted_zone_id="Skip (no Route53 managed domain)"))
+        assert loaded.distribution_hosted_zone_id is None
+
+    def test_valid_hosted_zone_untouched(self):
+        loaded = Profile.from_dict(_profile_dict(distribution_hosted_zone_id="Z0123456789ABCDEF"))
+        assert loaded.distribution_hosted_zone_id == "Z0123456789ABCDEF"
+
+
+class TestDeployEffect:
+    def test_healed_profile_schedules_no_networking_or_distribution(self):
+        """The user-visible regression: a sidecar profile corrupted by the
+        'Disabled' choice scheduled networking + distribution stacks."""
+        profile = Profile.from_dict(_profile_dict(enable_distribution=True, distribution_type="Disabled"))
+        stacks = [s for s, _ in DeployCommand()._select_full_deploy_stacks(profile, _NullConsole())]
+        assert "networking" not in stacks, f"networking scheduled for disabled distribution: {stacks}"
+        assert "distribution" not in stacks, f"distribution scheduled despite 'Disabled': {stacks}"


### PR DESCRIPTION
## Why
Selecting **Disabled** for package distribution in `ccwb init` silently enables it. `questionary.Choice` treats `value=None` as "no value given" and falls back to the choice **title**, so the wizard stored `distribution_type="Disabled"` with `enable_distribution=True` — and the next `ccwb deploy` scheduled the networking and distribution stacks the user had explicitly declined (surfacing as sidecar-mode deployments suddenly trying to create a VPC). Two more wizard choices had the same landmine with worse payloads: "Skip CodeBuild" stored its title as the CodeBuild **region**, and the Route53 "Skip" choice stored its title as the **hosted zone ID**.

## What
- Introduce a `_CHOICE_NONE` sentinel for the three "none" choices in the wizard, mapped back to `None` immediately after `.ask()`.
- `Profile.from_dict` heals already-corrupted profiles on load: invalid `distribution_type` values → distribution disabled; title strings (contain spaces) in `codebuild_region` / `distribution_hosted_zone_id` → `None`. Runs **before** the legacy distribution migration, which would otherwise legitimize the corrupt value. Legacy profiles (`enable_distribution=True`, no type) still migrate to `presigned-s3` unchanged.

## Testing
Regression tests (`tests/test_questionary_none_choice.py`) pin:
- the questionary title-fallback behavior itself (so a library change is noticed),
- every heal path plus valid/legacy values passing through untouched,
- the user-visible effect: a corrupted sidecar profile schedules no networking/distribution stacks,
- a source guard failing on any future `questionary.Choice(..., value=None)` in the wizard.

Full suite passes (1702 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)