### PR TITLE
feat(models): Claude Opus 4.8 in GovCloud + partition-aware model wizard

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -32,6 +32,26 @@ from claude_code_with_bedrock.cli.utils.validators import (
 from claude_code_with_bedrock.config import WEBSEARCH_SUPPORTED_REGIONS, Config, Profile
 
 
+def _model_keys_for_region(region: str | None) -> list[str]:
+    """Model registry keys the wizard should offer for a target AWS region.
+
+    GovCloud is a separate partition: only models with a "us-gov" CRIS profile
+    are invokable there, and those profiles are not invokable from commercial
+    regions. Filtering keeps the wizard from offering models the selected
+    region can never serve (previously a GovCloud admin saw every commercial
+    model, and picking one produced a deployment that 400s on invoke).
+    """
+    from claude_code_with_bedrock.models import CLAUDE_MODELS, get_available_profiles_for_model
+    from claude_code_with_bedrock.utils.partition import aws_partition_for_region
+
+    in_govcloud = aws_partition_for_region(region or "") == "aws-us-gov"
+    return [
+        model_key
+        for model_key in CLAUDE_MODELS
+        if ("us-gov" in get_available_profiles_for_model(model_key)) == in_govcloud
+    ]
+
+
 def validate_identity_pool_name(value: str) -> bool | str:
     """Validate identity pool name format.
 
@@ -2034,10 +2054,18 @@ class InitCommand(Command):
                     if saved_model_key:
                         break
 
-            # Step 1: Select Claude model
+            # Step 1: Select Claude model. Offer only models the selected
+            # region's partition can invoke (GovCloud ↔ commercial).
+            offered_model_keys = _model_keys_for_region(config.get("aws", {}).get("region"))
+
             model_choices = []
-            default_model_key = saved_model_key or "sonnet-4-5"
-            for model_key, model_info in CLAUDE_MODELS.items():
+            default_model_key = saved_model_key if saved_model_key in offered_model_keys else None
+            if default_model_key is None:
+                default_model_key = (
+                    "sonnet-4-5-govcloud" if "sonnet-4-5-govcloud" in offered_model_keys else "sonnet-4-5"
+                )
+            for model_key in offered_model_keys:
+                model_info = CLAUDE_MODELS[model_key]
                 # Build region list from available profiles
                 available_profiles = get_available_profiles_for_model(model_key)
                 regions = []
@@ -2045,10 +2073,12 @@ class InitCommand(Command):
                     regions.append("Global")
                 if "us" in available_profiles:
                     regions.append("US")
-                if "europe" in available_profiles:
+                if "eu" in available_profiles or "europe" in available_profiles:
                     regions.append("Europe")
                 if "apac" in available_profiles:
                     regions.append("APAC")
+                if "us-gov" in available_profiles:
+                    regions.append("GovCloud")
                 regions_text = ", ".join(regions)
 
                 choice_text = f"{model_info['name']} ({regions_text})"

--- a/source/claude_code_with_bedrock/models.py
+++ b/source/claude_code_with_bedrock/models.py
@@ -318,6 +318,20 @@ _CLAUDE_MODELS_RAW = {
             },
         },
     },
+    "opus-4-8-govcloud": {
+        "name": "Claude Opus 4.8 (GovCloud)",
+        "base_model_id": "anthropic.claude-opus-4-8",
+        "profiles": {
+            "us-gov": {
+                "model_id": "us-gov.anthropic.claude-opus-4-8",
+                "description": "US GovCloud regions",
+                # Geo CRIS entry points: in-region in us-gov-west-1, geo-routed
+                # from us-gov-east-1 (model hosted in the West region).
+                "source_regions": ["us-gov-west-1", "us-gov-east-1"],
+                "destination_regions": ["us-gov-west-1", "us-gov-east-1"],
+            },
+        },
+    },
     "opus-4-7": {
         "name": "Claude Opus 4.7",
         "base_model_id": "anthropic.claude-opus-4-7",
@@ -1633,9 +1647,21 @@ def get_throttle_metrics() -> list[dict]:
 # Note: Haiku 3.5 is deprecated and not in CLAUDE_MODELS.
 # The "haiku" tier uses Haiku 4.5 first, then falls back to the latest Sonnet.
 MODEL_TIER_PREFERENCES = {
-    "haiku": ["haiku-4-5", "sonnet-4-6", "sonnet-4-5", "sonnet-4", "sonnet-3-7"],
-    "sonnet": ["sonnet-5", "sonnet-4-6", "sonnet-4-5", "sonnet-4", "sonnet-3-7"],
-    "opus": ["opus-4-8", "opus-4-7", "opus-4-6", "opus-4-5", "opus-4-1", "opus-4"],
+    # GovCloud keys are safe to include everywhere: commercial CRIS prefixes
+    # never match their us-gov-only profiles, and the us-gov prefix never
+    # matches commercial models — each partition resolves only its own entries.
+    # GovCloud has no Haiku, so its haiku tier falls through to Sonnet.
+    "haiku": ["haiku-4-5", "sonnet-4-6", "sonnet-4-5", "sonnet-4-5-govcloud", "sonnet-4", "sonnet-3-7"],
+    "sonnet": [
+        "sonnet-5",
+        "sonnet-4-6",
+        "sonnet-4-5",
+        "sonnet-4-5-govcloud",
+        "sonnet-4",
+        "sonnet-3-7",
+        "sonnet-3-7-govcloud",
+    ],
+    "opus": ["opus-4-8", "opus-4-8-govcloud", "opus-4-7", "opus-4-6", "opus-4-5", "opus-4-1", "opus-4"],
     "fable": ["fable-5"],
 }
 
@@ -1650,8 +1676,10 @@ PROFILE_KEY_ALIASES = {
 }
 
 # Data-residency prefixes: must NOT fall back to global/us.
-# These geographies have strict data residency requirements.
-DATA_RESIDENCY_PREFIXES = {"au", "jp", "eu"}
+# These geographies have strict data residency requirements. us-gov is also
+# a separate PARTITION — commercial CRIS profiles aren't invokable from
+# GovCloud at all, so falling back would produce a model ID that can't work.
+DATA_RESIDENCY_PREFIXES = {"au", "jp", "eu", "us-gov"}
 
 # Auto-derived from MODEL_TIER_PREFERENCES: model_key → tier
 MODEL_KEY_TO_TIER: dict[str, str] = {
@@ -1720,15 +1748,18 @@ def resolve_model_for_tier(tier: str, cris_prefix: str) -> str | None:
         all_model_keys = [
             "sonnet-5",
             "opus-4-8",
+            "opus-4-8-govcloud",
             "opus-4-7",
             "sonnet-4-6",
             "sonnet-4-5",
+            "sonnet-4-5-govcloud",
             "sonnet-4",
             "opus-4-6",
             "opus-4-5",
             "haiku-4-5",
             "fable-5",
             "sonnet-3-7",
+            "sonnet-3-7-govcloud",
             "opus-4-1",
             "opus-4",
         ]

--- a/source/tests/test_govcloud_model_selection.py
+++ b/source/tests/test_govcloud_model_selection.py
@@ -1,0 +1,95 @@
+# ABOUTME: Tests for GovCloud model support — Opus 4.8 registry entry, partition-aware
+# ABOUTME: wizard filtering, and us-gov tier/alias resolution (no commercial fallback).
+
+"""GovCloud model selection tests.
+
+Claude Opus 4.8 is available in AWS GovCloud (announced 2026-05; in-region in
+us-gov-west-1, geo-routed from us-gov-east-1 via the us-gov CRIS prefix).
+These tests pin:
+
+- the opus-4-8-govcloud registry entry,
+- the wizard offering ONLY partition-compatible models (GovCloud regions see
+  us-gov models; commercial regions never see them),
+- tier resolution for the us-gov prefix (DEFAULT_*_MODEL aliases), including
+  the GovCloud haiku→sonnet fallback and NO fallback to commercial CRIS —
+  us-gov is a separate partition, a commercial model ID can never work there.
+"""
+
+from __future__ import annotations
+
+from claude_code_with_bedrock.cli.commands.init import _model_keys_for_region
+from claude_code_with_bedrock.models import (
+    CLAUDE_MODELS,
+    get_claude_code_alias,
+    resolve_model_for_tier,
+)
+
+
+class TestOpusGovCloudRegistryEntry:
+    def test_entry_exists_with_us_gov_profile(self):
+        model = CLAUDE_MODELS["opus-4-8-govcloud"]
+        profile = model["profiles"]["us-gov"]
+        assert profile["model_id"] == "us-gov.anthropic.claude-opus-4-8"
+        assert set(profile["source_regions"]) == {"us-gov-west-1", "us-gov-east-1"}
+
+    def test_all_govcloud_entries_use_us_gov_prefix(self):
+        for key, model in CLAUDE_MODELS.items():
+            if not key.endswith("-govcloud"):
+                continue
+            for profile in model["profiles"].values():
+                assert profile["model_id"].startswith("us-gov."), (
+                    f"{key} must use the us-gov CRIS prefix, got {profile['model_id']}"
+                )
+
+
+class TestWizardPartitionFiltering:
+    def test_govcloud_region_offers_only_govcloud_models(self):
+        keys = _model_keys_for_region("us-gov-west-1")
+        assert "opus-4-8-govcloud" in keys
+        assert "sonnet-4-5-govcloud" in keys
+        assert not [k for k in keys if not k.endswith("-govcloud")], (
+            f"commercial models offered for a GovCloud region: {keys}"
+        )
+
+    def test_commercial_region_hides_govcloud_models(self):
+        keys = _model_keys_for_region("us-east-1")
+        assert "opus-4-8" in keys
+        assert not [k for k in keys if k.endswith("-govcloud")], (
+            f"GovCloud models offered for a commercial region: {keys}"
+        )
+
+    def test_unknown_or_missing_region_defaults_to_commercial(self):
+        assert "opus-4-8-govcloud" not in _model_keys_for_region(None)
+        assert "opus-4-8-govcloud" not in _model_keys_for_region("")
+
+
+class TestUsGovTierResolution:
+    def test_opus_tier_resolves_govcloud_opus(self):
+        assert resolve_model_for_tier("opus", "us-gov") == "us-gov.anthropic.claude-opus-4-8"
+
+    def test_sonnet_tier_resolves_govcloud_sonnet(self):
+        assert resolve_model_for_tier("sonnet", "us-gov") == "us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0"
+
+    def test_haiku_tier_falls_back_to_govcloud_sonnet(self):
+        """GovCloud has no Haiku — the haiku tier must fall through to the
+        GovCloud Sonnet, never to a commercial model."""
+        resolved = resolve_model_for_tier("haiku", "us-gov")
+        assert resolved is not None
+        assert resolved.startswith("us-gov.")
+
+    def test_us_gov_never_falls_back_to_commercial(self):
+        """us-gov is a data-residency AND partition boundary: any resolution
+        for the us-gov prefix must yield a us-gov.* ID or nothing."""
+        for tier in ("haiku", "sonnet", "opus", "fable"):
+            resolved = resolve_model_for_tier(tier, "us-gov")
+            assert resolved is None or resolved.startswith("us-gov."), (
+                f"tier {tier!r} resolved commercial model {resolved!r} for us-gov"
+            )
+
+    def test_commercial_tiers_unchanged_by_govcloud_entries(self):
+        assert resolve_model_for_tier("opus", "us") == "us.anthropic.claude-opus-4-8"
+        assert resolve_model_for_tier("sonnet", "us").startswith("us.anthropic.claude-sonnet-5")
+
+    def test_alias_for_govcloud_model_ids(self):
+        assert get_claude_code_alias("us-gov.anthropic.claude-opus-4-8") == "opus"
+        assert get_claude_code_alias("us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0") == "sonnet"

--- a/source/tests/test_models.py
+++ b/source/tests/test_models.py
@@ -40,6 +40,7 @@ class TestModelConfiguration:
             "sonnet-5",
             "sonnet-4-6",
             "opus-4-8",
+            "opus-4-8-govcloud",
             "opus-4-7",
             "opus-4-6",
             "opus-4-5",


### PR DESCRIPTION
## Why
Claude Opus 4.8 is [available in AWS GovCloud (US) as of May 2026](https://aws.amazon.com/about-aws/whats-new/2026/05/claude-opus-4.8-aws-govcloud-us/) — in-region in us-gov-west-1 and geo-routed from us-gov-east-1 via the `us-gov.` CRIS prefix ([regional availability](https://docs.aws.amazon.com/bedrock/latest/userguide/models-region-compatibility.html)) — but the model registry has no entry for it, so GovCloud admins can't select it.

Fixing that surfaced deeper GovCloud gaps in model selection:
- The wizard offers **every commercial model to GovCloud admins** (and the `-govcloud` entries to commercial admins). Picking a cross-partition model deploys fine and then fails on every invoke.
- GovCloud entries render with an **empty region label** (the label builder doesn't know the `us-gov` profile key), and "Europe" never displays (checks the legacy `"europe"` key; profiles use `"eu"`).
- The `-govcloud` keys are absent from `MODEL_TIER_PREFERENCES`, so `DEFAULT_*_MODEL` aliases **never resolve for GovCloud deployments** (this already affected GovCloud Sonnet).

## What
- New `opus-4-8-govcloud` registry entry: `us-gov.anthropic.claude-opus-4-8`, source regions us-gov-west-1/east-1 (mirrors the existing `sonnet-4-5-govcloud` shape and the dateless ID convention of the commercial 4.8 entries).
- Wizard model choices filtered by the selected region's partition, with a partition-appropriate default, a "GovCloud" region label, and the eu/europe label fix. Filtering lives in a testable `_model_keys_for_region()` helper.
- Tier resolution learns `us-gov`: `-govcloud` keys added to the tier preference lists (safe for commercial — CRIS prefixes only match their own partition's profiles), and `us-gov` joins `DATA_RESIDENCY_PREFIXES` since it's a partition boundary — resolution yields a `us-gov.*` ID or nothing, never a commercial fallback that can't work. GovCloud haiku falls through to GovCloud Sonnet, mirroring jp/au.

## Testing
`tests/test_govcloud_model_selection.py` pins the registry entry, wizard filtering in both directions, the us-gov tier chain including the no-commercial-fallback invariant, alias resolution for `us-gov.*` IDs, and that commercial tier resolution is unchanged. Existing model-structure guard test updated. Full suite passes (1703 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)