### PR TITLE
fix(deploy): orphaned-stack check crashed GovCloud deploys via us-east-1 probe

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -1954,6 +1954,10 @@ class DeployCommand(Command):
         deploying_types = {stack_type for stack_type, _ in stacks_to_deploy}
 
         # Check for orphaned stacks
+        from claude_code_with_bedrock.utils.partition import aws_partition_for_region
+
+        profile_partition = aws_partition_for_region(profile.aws_region)
+
         orphaned = []
         for stack_type in all_stack_types:
             if stack_type not in deploying_types:
@@ -1961,16 +1965,36 @@ class DeployCommand(Command):
                 # CodeBuild and websearch may live in a different region, so
                 # check them there or a cross-region orphan is never detected.
                 stack_name = profile.stack_names.get(stack_type, f"{profile.identity_pool_name}-{stack_type}")
-                mgr = cf_manager
+                check_region = profile.aws_region
                 if stack_type == "codebuild":
-                    cb_region = get_codebuild_region(profile)
-                    if cb_region != profile.aws_region:
-                        mgr = CloudFormationManager(region=cb_region)
+                    check_region = get_codebuild_region(profile)
                 elif stack_type == "websearch":
-                    ws_region = get_websearch_region(profile)
-                    if ws_region != profile.aws_region:
-                        mgr = CloudFormationManager(region=ws_region)
-                status = mgr.get_stack_status(stack_name)
+                    check_region = get_websearch_region(profile)
+
+                # Never probe across partitions: websearch defaults to
+                # us-east-1 (commercial-only service), so a GovCloud deploy
+                # would call a commercial CloudFormation endpoint — typically
+                # unreachable there (SSL/connect errors), and the stack cannot
+                # exist in another partition anyway.
+                if aws_partition_for_region(check_region) != profile_partition:
+                    continue
+
+                mgr = cf_manager
+                if check_region != profile.aws_region:
+                    mgr = CloudFormationManager(region=check_region)
+
+                # Best-effort advisory check: a network/endpoint failure
+                # (air-gapped or proxied environments) must not abort the
+                # deploy — get_stack_status only handles ClientError, so
+                # connection/SSL errors would otherwise propagate.
+                try:
+                    status = mgr.get_stack_status(stack_name)
+                except Exception as e:
+                    console.print(
+                        f"[dim]Skipping orphaned-stack check for {stack_type} "
+                        f"({check_region}): {type(e).__name__}[/dim]"
+                    )
+                    continue
 
                 if status and status not in ["DELETE_COMPLETE", "DELETE_IN_PROGRESS"]:
                     orphaned.append((stack_type, stack_name, status))

--- a/source/tests/cli/commands/test_deploy_orphan_partition.py
+++ b/source/tests/cli/commands/test_deploy_orphan_partition.py
@@ -1,0 +1,88 @@
+# ABOUTME: Tests that the orphaned-stack check never probes across partitions and
+# ABOUTME: never aborts a deploy on network/SSL failures (advisory check only).
+
+"""Orphaned-stack check partition/resilience regression tests.
+
+The check probes CloudFormation for every stack type NOT in the deploy plan.
+websearch defaults to us-east-1 (the connector is commercial-only), so a
+GovCloud deploy probed a commercial-partition endpoint — unreachable in
+typical GovCloud/air-gapped environments, surfacing as an SSL error that
+crashed `ccwb deploy` right after the deployment plan printed
+(get_stack_status only handles ClientError, so connection errors propagate).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from claude_code_with_bedrock.cli.commands.deploy import DeployCommand
+from claude_code_with_bedrock.config import Profile
+
+
+class _NullConsole:
+    def print(self, *args, **kwargs):
+        pass
+
+
+def _profile(region: str) -> Profile:
+    return Profile(
+        name="orphan-test",
+        provider_domain="company.okta.com",
+        client_id="client-123",
+        credential_storage="session",
+        aws_region=region,
+        identity_pool_name="orphan-pool",
+        auth_type="oidc",
+        monitoring_enabled=True,
+        monitoring_mode="sidecar",
+    )
+
+
+def _run_check(profile, cf_manager, deploying=(("auth", "x"), ("dashboard", "x"))):
+    return DeployCommand()._check_orphaned_stacks(list(deploying), profile, cf_manager, _NullConsole())
+
+
+class TestCrossPartitionProbing:
+    def test_govcloud_deploy_never_probes_commercial_regions(self):
+        """The regression: websearch's home region is us-east-1, a different
+        PARTITION from a GovCloud profile — no client may be created for it
+        and no status call may be made against it."""
+        cf_manager = MagicMock()
+        cf_manager.get_stack_status.return_value = None
+
+        with patch("claude_code_with_bedrock.cli.commands.deploy.CloudFormationManager") as manager_cls:
+            _run_check(_profile("us-gov-west-1"), cf_manager)
+
+        cross_partition = [call for call in manager_cls.call_args_list if "us-gov" not in call.kwargs.get("region", "")]
+        assert not cross_partition, f"probed commercial regions from GovCloud: {cross_partition}"
+
+    def test_commercial_deploy_still_probes_websearch_region(self):
+        """Same-partition cross-region checks must keep working (that's how
+        cross-region websearch/codebuild orphans are detected at all)."""
+        cf_manager = MagicMock()
+        cf_manager.get_stack_status.return_value = None
+
+        with patch("claude_code_with_bedrock.cli.commands.deploy.CloudFormationManager") as manager_cls:
+            manager_cls.return_value.get_stack_status.return_value = None
+            _run_check(_profile("us-west-2"), cf_manager)
+
+        probed_regions = [call.kwargs.get("region") for call in manager_cls.call_args_list]
+        assert "us-east-1" in probed_regions, f"websearch region not probed: {probed_regions}"
+
+
+class TestAdvisoryCheckResilience:
+    def test_connection_errors_do_not_abort_deploy(self):
+        """get_stack_status raising (SSL/connect errors are not ClientError)
+        must degrade to a skipped check, not a crashed deploy."""
+        cf_manager = MagicMock()
+        cf_manager.get_stack_status.side_effect = OSError("SSL: CERTIFICATE_VERIFY_FAILED")
+
+        orphaned = _run_check(_profile("us-gov-west-1"), cf_manager)
+        assert orphaned == []
+
+    def test_orphans_still_detected(self):
+        cf_manager = MagicMock()
+        cf_manager.get_stack_status.side_effect = lambda name: "CREATE_COMPLETE" if name.endswith("-quota") else None
+
+        orphaned = _run_check(_profile("us-gov-west-1"), cf_manager)
+        assert ("quota", "orphan-pool-quota", "CREATE_COMPLETE") in orphaned


### PR DESCRIPTION
## Why
`ccwb deploy` in AWS GovCloud crashes with an SSL error right after printing the deployment plan. The orphaned-stack check probes CloudFormation for every stack type not in the plan — and `websearch`'s home region defaults to `us-east-1` (the managed connector is commercial-only), so a GovCloud deploy makes a call to a **commercial-partition** endpoint. From typical GovCloud/air-gapped admin environments that endpoint is unreachable (blocked or TLS-intercepted), and since `get_stack_status` handles only `ClientError`, the connection/SSL error propagates and aborts the deploy — an advisory check killing the whole run.

## What
- **Never probe across partitions:** stack types whose home region resolves outside the profile region's partition are skipped — a stack cannot exist in another partition anyway. Same-partition cross-*region* checks (websearch/codebuild orphan detection in commercial deployments) keep working.
- **The check is now advisory in failure too:** any exception probing a single stack degrades to a dim "skipping orphaned-stack check" note instead of aborting the deploy (covers air-gapped/proxied environments generally).

## Testing
Regression tests (`tests/cli/commands/test_deploy_orphan_partition.py`) assert: a GovCloud deploy creates no commercial-region CloudFormation clients; a commercial deploy still probes the websearch region; connection errors don't abort the check; and genuinely orphaned stacks are still detected. Full suite passes (1696 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)