### PR TITLE
fix(quota): wire cost-based quota end-to-end (wizard answers were dropped)

### DIFF
--- a/deployment/infrastructure/lambda-functions/quota_check/index.py
+++ b/deployment/infrastructure/lambda-functions/quota_check/index.py
@@ -24,6 +24,11 @@ ERROR_HANDLING_MODE = os.environ.get("ERROR_HANDLING_MODE", "fail_closed")
 ENABLE_FINEGRAINED_QUOTAS = os.environ.get("ENABLE_FINEGRAINED_QUOTAS", "false").lower() == "true"
 MONTHLY_TOKEN_LIMIT = int(os.environ.get("MONTHLY_TOKEN_LIMIT", "0"))
 DAILY_TOKEN_LIMIT = int(os.environ.get("DAILY_TOKEN_LIMIT", "0"))
+# Cost-based limits ($/user). 0 disables. When configured, the cost checks in
+# the enforcement section take precedence over token checks; the wizard's cost
+# mode also sets the token limits to 0 so cost is the sole control.
+MONTHLY_COST_LIMIT_USD = float(os.environ.get("MONTHLY_COST_LIMIT_USD", "0") or 0)
+DAILY_COST_LIMIT_USD = float(os.environ.get("DAILY_COST_LIMIT_USD", "0") or 0)
 MONTHLY_ENFORCEMENT_MODE = os.environ.get("MONTHLY_ENFORCEMENT_MODE", "block")
 DAILY_ENFORCEMENT_MODE = os.environ.get("DAILY_ENFORCEMENT_MODE", "alert")
 WARNING_THRESHOLD_80 = int(os.environ.get("WARNING_THRESHOLD_80", "240000000"))
@@ -332,13 +337,18 @@ def resolve_quota_for_user(email: str, groups: list) -> dict | None:
     Returns:
         Policy dict or None if no policy applies (unlimited).
     """
-    if not ENABLE_FINEGRAINED_QUOTAS and MONTHLY_TOKEN_LIMIT > 0:
+    # Cost mode sets token limits to 0, so the default policy must also
+    # activate when only a cost limit is configured — otherwise cost-based
+    # deployments resolved no policy at all and every user was unlimited.
+    if not ENABLE_FINEGRAINED_QUOTAS and (MONTHLY_TOKEN_LIMIT > 0 or MONTHLY_COST_LIMIT_USD > 0):
         # Return default limits from environment
         return {
             "policy_type": "default",
             "identifier": "environment",
             "monthly_token_limit": MONTHLY_TOKEN_LIMIT,
             "daily_token_limit": DAILY_TOKEN_LIMIT if DAILY_TOKEN_LIMIT > 0 else None,
+            "monthly_cost_limit": MONTHLY_COST_LIMIT_USD,
+            "daily_cost_limit": DAILY_COST_LIMIT_USD,
             "warning_threshold_80": WARNING_THRESHOLD_80,
             "warning_threshold_90": WARNING_THRESHOLD_90,
             "enforcement_mode": MONTHLY_ENFORCEMENT_MODE,

--- a/deployment/infrastructure/lambda-functions/quota_monitor/index.py
+++ b/deployment/infrastructure/lambda-functions/quota_monitor/index.py
@@ -27,6 +27,10 @@ METRICS_REGION = os.environ.get("METRICS_REGION", os.environ.get("AWS_REGION", "
 MONTHLY_TOKEN_LIMIT = int(os.environ.get("MONTHLY_TOKEN_LIMIT", "300000000"))
 WARNING_THRESHOLD_80 = int(os.environ.get("WARNING_THRESHOLD_80", "240000000"))
 WARNING_THRESHOLD_90 = int(os.environ.get("WARNING_THRESHOLD_90", "270000000"))
+# Cost-based limits ($/user). 0 disables. Cost mode sets the token limits to 0
+# (token alerts are skipped at 0 — see check_limits_and_generate_alerts).
+MONTHLY_COST_LIMIT_USD = float(os.environ.get("MONTHLY_COST_LIMIT_USD", "0") or 0)
+DAILY_COST_LIMIT_USD = float(os.environ.get("DAILY_COST_LIMIT_USD", "0") or 0)
 
 # DynamoDB tables
 quota_table = dynamodb.Table(QUOTA_TABLE)
@@ -259,15 +263,20 @@ def _build_usage_entry(item, current_date):
     (UTC), the daily counter belongs to a prior day and must be treated as 0.
     Otherwise an idle user whose daily_tokens froze above the limit gets a fresh
     "daily exceeded" alert every new UTC day even though they had no activity.
-    Monthly (total_tokens) is unaffected — it accumulates across the whole month.
+    Monthly (total_tokens / estimated_cost) is unaffected — it accumulates
+    across the whole month. The same guard applies to the daily cost counter.
     """
     daily_tokens = float(item.get("daily_tokens", 0))
+    daily_cost = float(item.get("daily_cost_usd", 0))
     daily_date = item.get("daily_date")
     if daily_date != current_date:
         daily_tokens = 0
+        daily_cost = 0
     return {
         "total_tokens": float(item.get("total_tokens", 0)),
         "daily_tokens": daily_tokens,
+        "monthly_cost": float(item.get("estimated_cost", 0)),
+        "daily_cost": daily_cost,
     }
 
 
@@ -295,7 +304,7 @@ def lambda_handler(event, context):
         # guard that quota_check uses (quota_check/index.py). Without it, an idle
         # user's frozen daily_tokens is read verbatim and re-alerted every new UTC
         # day even though they had no activity.
-        projection = "email, total_tokens, daily_tokens, daily_date"
+        projection = "email, total_tokens, daily_tokens, daily_date, estimated_cost, daily_cost_usd"
         response = quota_table.scan(
             FilterExpression=Attr("sk").eq(f"MONTH#{current_month}") & Attr("pk").begins_with("USER#"),
             ProjectionExpression=projection,
@@ -344,6 +353,7 @@ def lambda_handler(event, context):
                 email=email, total_tokens=total_tokens, daily_tokens=daily_tokens,
                 policy=policy, month_name=month_name, current_date=current_date,
                 days_remaining=days_remaining, days_in_month=days_in_month, sent_alerts=sent_alerts,
+                monthly_cost=usage.get("monthly_cost", 0), daily_cost=usage.get("daily_cost", 0),
             )
 
             monthly_pct = (total_tokens / policy["monthly_token_limit"]) * 100 if policy["monthly_token_limit"] > 0 else 0
@@ -390,6 +400,8 @@ def load_all_policies():
                     "policy_type": pt, "identifier": ident,
                     "monthly_token_limit": int(item.get("monthly_token_limit", 0)),
                     "daily_token_limit": int(item.get("daily_token_limit", 0)) if item.get("daily_token_limit") else None,
+                    "monthly_cost_limit": float(item.get("monthly_cost_limit", 0) or 0),
+                    "daily_cost_limit": float(item.get("daily_cost_limit", 0) or 0),
                     "warning_threshold_80": int(item.get("warning_threshold_80", 0)),
                     "warning_threshold_90": int(item.get("warning_threshold_90", 0)),
                     "enforcement_mode": item.get("enforcement_mode", "alert"),
@@ -420,6 +432,7 @@ def resolve_user_quota(email, groups, policies_cache):
         return {
             "policy_type": "default", "identifier": "environment",
             "monthly_token_limit": MONTHLY_TOKEN_LIMIT, "daily_token_limit": None,
+            "monthly_cost_limit": MONTHLY_COST_LIMIT_USD, "daily_cost_limit": DAILY_COST_LIMIT_USD,
             "warning_threshold_80": WARNING_THRESHOLD_80, "warning_threshold_90": WARNING_THRESHOLD_90,
             "enforcement_mode": "alert", "enabled": True,
         }
@@ -437,8 +450,9 @@ def resolve_user_quota(email, groups, policies_cache):
 
 
 def check_limits_and_generate_alerts(email, total_tokens, daily_tokens, policy,
-                                     month_name, current_date, days_remaining, days_in_month, sent_alerts):
-    """Check limits and generate alert dicts."""
+                                     month_name, current_date, days_remaining, days_in_month, sent_alerts,
+                                     monthly_cost=0.0, daily_cost=0.0):
+    """Check limits and generate alert dicts (token- and cost-denominated)."""
     alerts = []
     policy_info = f"{policy['policy_type']}:{policy['identifier']}"
     enforcement_mode = policy.get("enforcement_mode", "alert")
@@ -447,13 +461,17 @@ def check_limits_and_generate_alerts(email, total_tokens, daily_tokens, policy,
     daily_average = total_tokens / max(1, int(current_date.split("-")[2]))
     projected_total = daily_average * days_in_month
 
+    # Token limits. A limit of 0 means token limits are DISABLED (cost mode
+    # zeroes them) — without this guard every user with any usage generated a
+    # bogus "monthly exceeded" alert on each 15-minute scan.
     level = None
-    if total_tokens > monthly_limit:
-        level = "exceeded"
-    elif total_tokens > policy["warning_threshold_90"]:
-        level = "critical"
-    elif total_tokens > policy["warning_threshold_80"]:
-        level = "warning"
+    if monthly_limit > 0:
+        if total_tokens > monthly_limit:
+            level = "exceeded"
+        elif total_tokens > policy["warning_threshold_90"]:
+            level = "critical"
+        elif total_tokens > policy["warning_threshold_80"]:
+            level = "warning"
 
     if level and f"{email}#monthly#{level}" not in sent_alerts:
         alerts.append({
@@ -482,6 +500,45 @@ def check_limits_and_generate_alerts(email, total_tokens, daily_tokens, policy,
                 "percentage": round(daily_pct, 1), "date": current_date,
                 "policy_info": policy_info, "enforcement_mode": enforcement_mode,
             })
+
+    # Cost limits ($ budgets, cost mode). Same 80/90/100 ladder as tokens;
+    # quota_check does the blocking, these alerts are the early warning.
+    monthly_cost_limit = float(policy.get("monthly_cost_limit", 0) or 0)
+    if monthly_cost_limit > 0:
+        cost_pct = (monthly_cost / monthly_cost_limit) * 100
+        clevel = None
+        if monthly_cost > monthly_cost_limit:
+            clevel = "exceeded"
+        elif monthly_cost > monthly_cost_limit * 0.9:
+            clevel = "critical"
+        elif monthly_cost > monthly_cost_limit * 0.8:
+            clevel = "warning"
+        if clevel and f"{email}#monthly_cost#{clevel}" not in sent_alerts:
+            alerts.append({
+                "user": email, "alert_type": "monthly_cost", "alert_level": clevel,
+                "current_usage": round(monthly_cost, 2), "limit": monthly_cost_limit,
+                "percentage": round(cost_pct, 1), "month": month_name,
+                "days_remaining": days_remaining, "policy_info": policy_info,
+                "enforcement_mode": enforcement_mode,
+            })
+
+    daily_cost_limit = float(policy.get("daily_cost_limit", 0) or 0)
+    if daily_cost_limit > 0:
+        dcost_pct = (daily_cost / daily_cost_limit) * 100
+        dclevel = None
+        if daily_cost > daily_cost_limit:
+            dclevel = "exceeded"
+        elif daily_cost > daily_cost_limit * 0.9:
+            dclevel = "critical"
+        elif daily_cost > daily_cost_limit * 0.8:
+            dclevel = "warning"
+        if dclevel and f"{email}#daily_cost#{current_date}#{dclevel}" not in sent_alerts:
+            alerts.append({
+                "user": email, "alert_type": "daily_cost", "alert_level": dclevel,
+                "current_usage": round(daily_cost, 2), "limit": daily_cost_limit,
+                "percentage": round(dcost_pct, 1), "date": current_date,
+                "policy_info": policy_info, "enforcement_mode": enforcement_mode,
+            })
     return alerts
 
 
@@ -497,7 +554,7 @@ def get_sent_alerts(month_name):
             parts = item["sk"].split("#")
             if len(parts) >= 5:
                 email, atype, alevel = parts[2], parts[3], parts[4]
-                if atype == "daily" and len(parts) >= 6:
+                if atype.startswith("daily") and len(parts) >= 6:
                     sent.add(f"{email}#{atype}#{parts[5]}#{alevel}")
                 else:
                     sent.add(f"{email}#{atype}#{alevel}")
@@ -523,7 +580,7 @@ def record_sent_alert(month_name, email, alert_type, alert_level, alert_data):
     """Record sent alert to prevent duplicates."""
     try:
         month_prefix = datetime.now(timezone.utc).strftime("%Y-%m")
-        if alert_type == "daily":
+        if alert_type.startswith("daily"):
             date = alert_data.get("date", datetime.now(timezone.utc).strftime("%Y-%m-%d"))
             sk = f"{month_prefix}#ALERT#{email}#{alert_type}#{alert_level}#{date}"
         else:
@@ -547,10 +604,19 @@ def send_alerts(alerts):
     for alert in alerts:
         try:
             level_prefix = {"warning": "WARNING", "critical": "CRITICAL", "exceeded": "EXCEEDED"}.get(alert["alert_level"], "ALERT")
-            type_label = {"monthly": "Monthly Token Quota", "daily": "Daily Token Quota"}.get(alert["alert_type"], "Quota")
+            type_label = {
+                "monthly": "Monthly Token Quota",
+                "daily": "Daily Token Quota",
+                "monthly_cost": "Monthly Spend Budget",
+                "daily_cost": "Daily Spend Budget",
+            }.get(alert["alert_type"], "Quota")
+            if "cost" in alert["alert_type"]:
+                usage_str = f"${alert['current_usage']:.2f} / ${alert['limit']:.2f}"
+            else:
+                usage_str = f"{alert['current_usage']:,} / {alert['limit']:,}"
             subject = f"Claude Code {level_prefix} - {type_label} - {alert['percentage']:.0f}%"
             message = (f"USER: {alert['user']}\nALERT: {type_label} - {alert['alert_level'].upper()}\n"
-                       f"Usage: {alert['current_usage']:,} / {alert['limit']:,} ({alert['percentage']:.1f}%)\n"
+                       f"Usage: {usage_str} ({alert['percentage']:.1f}%)\n"
                        f"Policy: {alert.get('policy_info', 'default')}\n"
                        f"Enforcement: {alert.get('enforcement_mode', 'alert')}")
             sns_client.publish(TopicArn=SNS_TOPIC_ARN, Subject=subject, Message=message)

--- a/deployment/infrastructure/quota-monitoring.yaml
+++ b/deployment/infrastructure/quota-monitoring.yaml
@@ -5,8 +5,10 @@ Parameters:
   MonthlyTokenLimit:
     Type: Number
     Default: 10000000
-    Description: Default monthly token limit per user (10M tokens) - used when no policy is defined
-    MinValue: 1000000
+    Description: >-
+      Default monthly token limit per user (10M tokens) - used when no policy
+      is defined. 0 disables token-denominated limits (cost-based quota mode).
+    MinValue: 0
     MaxValue: 1000000000
 
   WarningThreshold80:
@@ -265,6 +267,8 @@ Resources:
           DAILY_ENFORCEMENT_MODE: !Ref DailyEnforcementMode
           MONTHLY_ENFORCEMENT_MODE: !Ref MonthlyEnforcementMode
           ENABLE_FINEGRAINED_QUOTAS: !Ref EnableFinegrainedQuotas
+          MONTHLY_COST_LIMIT_USD: !Ref MonthlyCostLimitUsd
+          DAILY_COST_LIMIT_USD: !Ref DailyCostLimitUsd
           METRICS_REGION: !Ref 'AWS::Region'
       Code: ./lambda-functions/quota_monitor/
 
@@ -435,6 +439,8 @@ Resources:
           POLICIES_TABLE: !Ref QuotaPolicies
           MONTHLY_TOKEN_LIMIT: !Ref MonthlyTokenLimit
           DAILY_TOKEN_LIMIT: !Ref DailyTokenLimit
+          MONTHLY_COST_LIMIT_USD: !Ref MonthlyCostLimitUsd
+          DAILY_COST_LIMIT_USD: !Ref DailyCostLimitUsd
           DAILY_ENFORCEMENT_MODE: !Ref DailyEnforcementMode
           MONTHLY_ENFORCEMENT_MODE: !Ref MonthlyEnforcementMode
           ENABLE_FINEGRAINED_QUOTAS: !Ref EnableFinegrainedQuotas

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -1323,11 +1323,19 @@ class DeployCommand(Command):
                 # Sidecar bypass detection: opt-in detective control (default off).
                 enable_bypass_detection = getattr(profile, "enable_bypass_detection", False)
 
+                # Cost-based limits ($/user, 0 disables). In cost mode the token
+                # limits above are 0 and the Lambdas skip token checks; cost
+                # enforcement in quota_check takes precedence when configured.
+                monthly_cost_limit = getattr(profile, "monthly_cost_limit_usd", 0) or 0
+                daily_cost_limit = getattr(profile, "daily_cost_limit_usd", 0) or 0
+
                 params = [
                     f"MonthlyTokenLimit={monthly_limit}",
                     f"WarningThreshold80={warning_80}",
                     f"WarningThreshold90={warning_90}",
                     f"DailyTokenLimit={daily_limit or 0}",
+                    f"MonthlyCostLimitUsd={monthly_cost_limit}",
+                    f"DailyCostLimitUsd={daily_cost_limit}",
                     f"DailyEnforcementMode={daily_enforcement}",
                     f"MonthlyEnforcementMode={monthly_enforcement}",
                     f"OidcIssuerUrl={oidc_issuer_url}",
@@ -1743,6 +1751,8 @@ class DeployCommand(Command):
                 f"WarningThreshold80={getattr(profile, 'warning_threshold_80', int(monthly_limit * 0.8))}",
                 f"WarningThreshold90={getattr(profile, 'warning_threshold_90', int(monthly_limit * 0.9))}",
                 f"DailyTokenLimit={daily_limit or 0}",
+                f"MonthlyCostLimitUsd={getattr(profile, 'monthly_cost_limit_usd', 0) or 0}",
+                f"DailyCostLimitUsd={getattr(profile, 'daily_cost_limit_usd', 0) or 0}",
                 f"DailyEnforcementMode={getattr(profile, 'daily_enforcement_mode', 'alert')}",
                 f"MonthlyEnforcementMode={getattr(profile, 'monthly_enforcement_mode', 'block')}",
                 f"OidcIssuerUrl={profile.provider_domain}",

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -1248,75 +1248,80 @@ class InitCommand(Command):
                             "[dim]  \u26a0 Estimates use published on-demand Bedrock rates. Use AWS Cost Explorer for billing truth.[/dim]"
                         )
 
-                        # Set token limits to 0 (disabled) when using cost mode
+                        # Cost mode: token-denominated limits are DISABLED (0).
+                        # The Lambdas skip token checks at 0, so the budgets
+                        # above are the sole control — do NOT prompt for token
+                        # counts (previously the token block below ran anyway
+                        # and overwrote these zeros with a token answer).
                         config["quota"]["monthly_limit"] = 0
                         config["quota"]["daily_limit"] = 0
+                        config["quota"]["warning_threshold_80"] = 0
+                        config["quota"]["warning_threshold_90"] = 0
                         monthly_limit = 0
+                        daily_limit = 0
 
                     else:
                         # Token-based limits (existing behavior)
                         config["quota"]["monthly_cost_limit"] = 0
                         config["quota"]["daily_cost_limit"] = 0
 
-                    # Monthly token limit (only prompted for token mode)
-                    if limit_type == "token":
                         console.print("\n[bold]Monthly Limit[/bold]")
-                    monthly_limit_millions = questionary.text(
-                        "Monthly token limit per user (in millions):",
-                        default=str(config.get("quota", {}).get("monthly_limit_millions", 225)),
-                        validate=lambda x: x.isdigit() and int(x) > 0,
-                    ).ask()
+                        monthly_limit_millions = questionary.text(
+                            "Monthly token limit per user (in millions):",
+                            default=str(config.get("quota", {}).get("monthly_limit_millions", 225)),
+                            validate=lambda x: x.isdigit() and int(x) > 0,
+                        ).ask()
 
-                    monthly_limit = int(monthly_limit_millions) * 1000000
-                    warning_80 = int(monthly_limit * 0.8)
-                    warning_90 = int(monthly_limit * 0.9)
+                        monthly_limit = int(monthly_limit_millions) * 1000000
+                        warning_80 = int(monthly_limit * 0.8)
+                        warning_90 = int(monthly_limit * 0.9)
 
-                    config["quota"]["monthly_limit"] = monthly_limit
-                    config["quota"]["warning_threshold_80"] = warning_80
-                    config["quota"]["warning_threshold_90"] = warning_90
+                        config["quota"]["monthly_limit"] = monthly_limit
+                        config["quota"]["warning_threshold_80"] = warning_80
+                        config["quota"]["warning_threshold_90"] = warning_90
 
-                    console.print(f"  → Monthly limit: {monthly_limit:,} tokens")
-                    console.print(f"  → Warning at 80%: {warning_80:,} tokens")
-                    console.print(f"  → Critical at 90%: {warning_90:,} tokens")
+                        console.print(f"  → Monthly limit: {monthly_limit:,} tokens")
+                        console.print(f"  → Warning at 80%: {warning_80:,} tokens")
+                        console.print(f"  → Critical at 90%: {warning_90:,} tokens")
 
-                    # Daily limit configuration (Bill Shock Protection)
-                    console.print("\n[bold]Daily Limit (Bill Shock Protection)[/bold]")
-                    console.print("Prevent runaway usage by setting a daily limit with a burst buffer.")
+                        # Daily limit configuration (Bill Shock Protection)
+                        console.print("\n[bold]Daily Limit (Bill Shock Protection)[/bold]")
+                        console.print("Prevent runaway usage by setting a daily limit with a burst buffer.")
 
-                    base_daily = monthly_limit / 30
+                        base_daily = monthly_limit / 30
 
-                    # Show burst buffer options
-                    console.print(f"\nBase daily limit (monthly ÷ 30): {int(base_daily):,} tokens")
-                    console.print("\nBurst buffer allows daily variation above the average:")
-                    console.print(f"  • [dim]5%  (strict)[/dim]   → {int(base_daily * 1.05):,}/day")
-                    console.print(f"  • [cyan]10% (default)[/cyan]  → {int(base_daily * 1.10):,}/day")
-                    console.print(f"  • [dim]25% (flexible)[/dim] → {int(base_daily * 1.25):,}/day")
+                        # Show burst buffer options
+                        console.print(f"\nBase daily limit (monthly ÷ 30): {int(base_daily):,} tokens")
+                        console.print("\nBurst buffer allows daily variation above the average:")
+                        console.print(f"  • [dim]5%  (strict)[/dim]   → {int(base_daily * 1.05):,}/day")
+                        console.print(f"  • [cyan]10% (default)[/cyan]  → {int(base_daily * 1.10):,}/day")
+                        console.print(f"  • [dim]25% (flexible)[/dim] → {int(base_daily * 1.25):,}/day")
 
-                    burst_buffer = questionary.text(
-                        "Burst buffer percentage (5-25%):",
-                        default=str(config.get("quota", {}).get("burst_buffer_percent", 10)),
-                        validate=lambda x: x.isdigit() and 5 <= int(x) <= 25,
-                    ).ask()
+                        burst_buffer = questionary.text(
+                            "Burst buffer percentage (5-25%):",
+                            default=str(config.get("quota", {}).get("burst_buffer_percent", 10)),
+                            validate=lambda x: x.isdigit() and 5 <= int(x) <= 25,
+                        ).ask()
 
-                    burst_percent = int(burst_buffer)
-                    calculated_daily = int(base_daily * (1 + burst_percent / 100))
+                        burst_percent = int(burst_buffer)
+                        calculated_daily = int(base_daily * (1 + burst_percent / 100))
 
-                    console.print(f"  → Calculated daily limit: {calculated_daily:,} tokens")
+                        console.print(f"  → Calculated daily limit: {calculated_daily:,} tokens")
 
-                    # Allow custom override
-                    custom_daily = questionary.text(
-                        f"Custom daily limit (Enter to accept {calculated_daily:,}):",
-                        default="",
-                        validate=lambda x: x == "" or (x.isdigit() and int(x) > 0),
-                    ).ask()
+                        # Allow custom override
+                        custom_daily = questionary.text(
+                            f"Custom daily limit (Enter to accept {calculated_daily:,}):",
+                            default="",
+                            validate=lambda x: x == "" or (x.isdigit() and int(x) > 0),
+                        ).ask()
 
-                    daily_limit = int(custom_daily) if custom_daily else calculated_daily
+                        daily_limit = int(custom_daily) if custom_daily else calculated_daily
 
-                    config["quota"]["daily_limit"] = daily_limit
-                    config["quota"]["burst_buffer_percent"] = burst_percent
+                        config["quota"]["daily_limit"] = daily_limit
+                        config["quota"]["burst_buffer_percent"] = burst_percent
 
-                    if custom_daily:
-                        console.print(f"  → Using custom daily limit: {daily_limit:,} tokens")
+                        if custom_daily:
+                            console.print(f"  → Using custom daily limit: {daily_limit:,} tokens")
 
                     # Enforcement mode configuration
                     console.print("\n[bold]Enforcement Modes[/bold]")
@@ -1343,6 +1348,9 @@ class InitCommand(Command):
                     ).ask()
 
                     config["quota"]["daily_enforcement_mode"] = daily_enforcement
+                    # (Previously never saved — the wizard's monthly enforcement
+                    # answer was silently dropped and the default always won.)
+                    config["quota"]["monthly_enforcement_mode"] = monthly_enforcement
 
                     # Quota re-check interval
                     console.print("\n[bold]Quota Re-Check Interval[/bold]")
@@ -1380,9 +1388,18 @@ class InitCommand(Command):
                         config["quota"]["enable_bypass_detection"] = False
 
                     console.print("\n[green]✓[/green] Quota monitoring configured:")
-                    console.print(f"  • Monthly: {monthly_limit:,} tokens ({monthly_enforcement})")
-                    console.print(f"  • Daily:   {daily_limit:,} tokens ({daily_enforcement})")
-                    console.print(f"  • Burst buffer: {burst_percent}%")
+                    if limit_type == "cost":
+                        console.print(
+                            f"  • Monthly budget: ${config['quota']['monthly_cost_limit']:.2f}/user ({monthly_enforcement})"
+                        )
+                        if config["quota"]["daily_cost_limit"] > 0:
+                            console.print(
+                                f"  • Daily cap: ${config['quota']['daily_cost_limit']:.2f}/user ({daily_enforcement})"
+                            )
+                    else:
+                        console.print(f"  • Monthly: {monthly_limit:,} tokens ({monthly_enforcement})")
+                        console.print(f"  • Daily:   {daily_limit:,} tokens ({daily_enforcement})")
+                        console.print(f"  • Burst buffer: {burst_percent}%")
                     console.print(f"  • Re-check interval: {check_interval} minutes")
                     if config["quota"].get("enable_bypass_detection"):
                         console.print("  • Sidecar bypass detection: enabled")
@@ -2825,6 +2842,9 @@ class InitCommand(Command):
             "daily_token_limit": config_data.get("quota", {}).get("daily_limit"),
             "burst_buffer_percent": config_data.get("quota", {}).get("burst_buffer_percent", 10),
             "daily_enforcement_mode": config_data.get("quota", {}).get("daily_enforcement_mode", "alert"),
+            "quota_limit_type": config_data.get("quota", {}).get("limit_type", "token"),
+            "monthly_cost_limit_usd": config_data.get("quota", {}).get("monthly_cost_limit", 0),
+            "daily_cost_limit_usd": config_data.get("quota", {}).get("daily_cost_limit", 0),
             "monthly_enforcement_mode": config_data.get("quota", {}).get("monthly_enforcement_mode", "block"),
             "quota_check_interval": config_data.get("quota", {}).get("check_interval", 30),
             "enable_bypass_detection": config_data.get("quota", {}).get("enable_bypass_detection", False),
@@ -3254,6 +3274,9 @@ class InitCommand(Command):
                     "burst_buffer_percent": getattr(profile, "burst_buffer_percent", 10),
                     "daily_enforcement_mode": getattr(profile, "daily_enforcement_mode", "alert"),
                     "monthly_enforcement_mode": getattr(profile, "monthly_enforcement_mode", "block"),
+                    "limit_type": getattr(profile, "quota_limit_type", "token"),
+                    "monthly_cost_limit": getattr(profile, "monthly_cost_limit_usd", 0),
+                    "daily_cost_limit": getattr(profile, "daily_cost_limit_usd", 0),
                     "check_interval": getattr(profile, "quota_check_interval", 30),
                     "enable_bypass_detection": getattr(profile, "enable_bypass_detection", False),
                 }

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -101,6 +101,12 @@ class Profile:
     quota_fail_mode: str = "open"  # "open" (allow on error) or "closed" (deny on error)
     quota_check_interval: int = 30  # Minutes between quota re-checks (0 = every request)
     enable_bypass_detection: bool = False  # Detect Bedrock use without a running OTEL sidecar (opt-in)
+    # Cost-based quota (limit_type "cost"): dollar budgets per user, enforced
+    # server-side from per-model Bedrock pricing. In cost mode the token limits
+    # above are set to 0 (disabled) and these become the sole control.
+    quota_limit_type: str = "token"  # "token" (raw counts) or "cost" ($ budgets)
+    monthly_cost_limit_usd: float = 0.0  # Monthly $ budget per user (0 = no cost limit)
+    daily_cost_limit_usd: float = 0.0  # Daily $ cap per user (0 = no daily cap)
 
     # Monitoring endpoint (saved from deploy, avoids re-reading CloudFormation outputs)
     otel_collector_endpoint: str | None = None  # OTel collector ALB endpoint URL

--- a/source/tests/test_cost_quota_wiring.py
+++ b/source/tests/test_cost_quota_wiring.py
@@ -1,0 +1,243 @@
+# ABOUTME: Regression tests for cost-based quota wiring: wizard answers must reach
+# ABOUTME: the profile, the stack, and both Lambdas (previously dropped end-to-end).
+
+"""Cost-based quota was half-wired: the wizard asked for $ budgets but the
+answers were dropped at every hop.
+
+- No Profile fields existed for limit type / cost limits → not in the profile
+  JSON, lost on re-init.
+- deploy never passed MonthlyCostLimitUsd / DailyCostLimitUsd; the template
+  declared them but wired them to nothing.
+- quota_check's environment-default policy activated only when
+  MONTHLY_TOKEN_LIMIT > 0 — cost mode zeroes token limits, so cost-mode
+  deployments resolved NO policy and every user was unlimited.
+- quota_monitor alerted `total_tokens > monthly_limit` with no zero guard, so
+  a 0 token limit (cost mode) alert-stormed every active user each scan.
+- The wizard also asked for token counts in cost mode (the mode gate only
+  wrapped a header print) and silently dropped the monthly enforcement answer.
+
+These tests pin every hop of the repaired chain.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+# ruff: noqa: E402
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from claude_code_with_bedrock.cli.commands.init import InitCommand
+from claude_code_with_bedrock.config import Config, Profile
+
+LAMBDA_DIR = Path(__file__).resolve().parents[2] / "deployment" / "infrastructure" / "lambda-functions"
+TEMPLATE = Path(__file__).resolve().parents[2] / "deployment" / "infrastructure" / "quota-monitoring.yaml"
+
+
+def _load_lambda(name: str, env: dict):
+    """Load a Lambda module fresh with the given environment (loader pattern
+    from test_quota_monitor_lambda.py). Restores os.environ afterwards so
+    later tests loading the same Lambdas don't inherit these limits."""
+    base = {
+        "AWS_DEFAULT_REGION": "us-gov-west-1",
+        "QUOTA_TABLE": "TestQuotaTable",
+        "POLICIES_TABLE": "TestPoliciesTable",
+        "SNS_TOPIC_ARN": "arn:aws-us-gov:sns:us-gov-west-1:123456789012:test-alerts",
+    }
+    base.update(env)
+    prior = {key: os.environ.get(key) for key in base}
+    for key, value in base.items():
+        os.environ[key] = str(value)
+    try:
+        module_name = f"{name}_cost_{abs(hash(frozenset((k, str(v)) for k, v in base.items())))}"
+        spec = importlib.util.spec_from_file_location(module_name, LAMBDA_DIR / name / "index.py")
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        for key, value in prior.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+class TestProfileFields:
+    def test_cost_fields_round_trip(self):
+        p = Profile(
+            name="t",
+            provider_domain="d",
+            client_id="c",
+            credential_storage="session",
+            aws_region="us-gov-west-1",
+            identity_pool_name="p",
+            quota_limit_type="cost",
+            monthly_cost_limit_usd=50.0,
+            daily_cost_limit_usd=5.0,
+        )
+        loaded = Profile.from_dict(p.to_dict())
+        assert loaded.quota_limit_type == "cost"
+        assert loaded.monthly_cost_limit_usd == 50.0
+        assert loaded.daily_cost_limit_usd == 5.0
+
+    def test_old_profiles_default_to_token_mode(self):
+        data = Profile(
+            name="t",
+            provider_domain="d",
+            client_id="c",
+            credential_storage="session",
+            aws_region="us-east-1",
+            identity_pool_name="p",
+        ).to_dict()
+        for key in ("quota_limit_type", "monthly_cost_limit_usd", "daily_cost_limit_usd"):
+            data.pop(key)
+        loaded = Profile.from_dict(data)
+        assert loaded.quota_limit_type == "token"
+        assert loaded.monthly_cost_limit_usd == 0
+        assert loaded.daily_cost_limit_usd == 0
+
+
+class TestInitRoundTrip:
+    def _rebuild(self, profile: Profile) -> dict:
+        command = InitCommand()
+        fake_config = Config()
+        with (
+            patch.object(Config, "load", return_value=fake_config),
+            patch.object(fake_config, "get_profile", return_value=profile),
+            patch.object(InitCommand, "_stack_exists", side_effect=Exception("no creds")),
+        ):
+            return command._check_existing_deployment("test")
+
+    def test_rerun_preserves_cost_quota_fields(self):
+        profile = Profile(
+            name="test",
+            provider_domain="example.okta.com",
+            client_id="0oa1234567890",
+            identity_pool_name="claude-code-auth",
+            credential_storage="keyring",
+            aws_region="us-gov-west-1",
+            quota_monitoring_enabled=True,
+            quota_limit_type="cost",
+            monthly_cost_limit_usd=75.0,
+            daily_cost_limit_usd=10.0,
+            monthly_token_limit=0,
+        )
+        quota = self._rebuild(profile)["quota"]
+        assert quota["limit_type"] == "cost"
+        assert quota["monthly_cost_limit"] == 75.0
+        assert quota["daily_cost_limit"] == 10.0
+
+
+def _load_template() -> dict:
+    class CFNLoader(yaml.SafeLoader):
+        pass
+
+    def _cfn(loader, suffix, node):  # noqa: ARG001 - yaml constructor signature
+        if isinstance(node, yaml.ScalarNode):
+            return loader.construct_scalar(node)
+        if isinstance(node, yaml.SequenceNode):
+            return loader.construct_sequence(node)
+        return loader.construct_mapping(node)
+
+    CFNLoader.add_multi_constructor("!", _cfn)
+    return yaml.load(TEMPLATE.read_text(encoding="utf-8"), Loader=CFNLoader)
+
+
+class TestTemplateWiring:
+    def test_cost_params_wired_to_both_lambdas(self):
+        resources = _load_template()["Resources"]
+        for fn in ("QuotaCheckFunction", "QuotaMonitorFunction"):
+            env = resources[fn]["Properties"]["Environment"]["Variables"]
+            assert env.get("MONTHLY_COST_LIMIT_USD") == "MonthlyCostLimitUsd", fn
+            assert env.get("DAILY_COST_LIMIT_USD") == "DailyCostLimitUsd", fn
+
+    def test_monthly_token_limit_accepts_zero(self):
+        """Cost mode passes MonthlyTokenLimit=0; MinValue must allow it."""
+        params = _load_template()["Parameters"]
+        assert params["MonthlyTokenLimit"]["MinValue"] == 0
+
+
+class TestQuotaCheckCostDefaults:
+    def test_cost_only_env_resolves_default_policy(self):
+        """The regression: cost mode (token limit 0) resolved NO policy →
+        every user unlimited. A cost limit alone must activate the default."""
+        mod = _load_lambda(
+            "quota_check",
+            {"MONTHLY_TOKEN_LIMIT": "0", "MONTHLY_COST_LIMIT_USD": "50", "DAILY_COST_LIMIT_USD": "5"},
+        )
+        policy = mod.resolve_quota_for_user("user@example.gov", [])
+        assert policy is not None, "cost-only config must resolve the default policy"
+        assert policy["monthly_cost_limit"] == 50.0
+        assert policy["daily_cost_limit"] == 5.0
+        assert policy["monthly_token_limit"] == 0
+
+    def test_no_limits_resolves_no_policy(self):
+        mod = _load_lambda("quota_check", {"MONTHLY_TOKEN_LIMIT": "0", "MONTHLY_COST_LIMIT_USD": "0"})
+        assert mod.resolve_quota_for_user("user@example.gov", []) is None
+
+
+class TestQuotaMonitorCostAlerts:
+    ENV = {
+        "MONTHLY_TOKEN_LIMIT": "0",
+        "MONTHLY_COST_LIMIT_USD": "100",
+        "DAILY_COST_LIMIT_USD": "10",
+        "ENABLE_FINEGRAINED_QUOTAS": "false",
+    }
+
+    def _alerts(self, mod, *, total_tokens=0, daily_tokens=0, monthly_cost=0.0, daily_cost=0.0):
+        policy = mod.resolve_user_quota("u@example.gov", [], {})
+        return mod.check_limits_and_generate_alerts(
+            email="u@example.gov",
+            total_tokens=total_tokens,
+            daily_tokens=daily_tokens,
+            policy=policy,
+            month_name="July 2026",
+            current_date="2026-07-13",
+            days_remaining=18,
+            days_in_month=31,
+            sent_alerts=set(),
+            monthly_cost=monthly_cost,
+            daily_cost=daily_cost,
+        )
+
+    def test_zero_token_limit_generates_no_token_alerts(self):
+        """The alert-storm regression: with monthly_limit=0, any usage
+        previously produced a 'monthly exceeded' alert every scan."""
+        mod = _load_lambda("quota_monitor", self.ENV)
+        alerts = self._alerts(mod, total_tokens=5_000_000, monthly_cost=1.0)
+        assert not [a for a in alerts if a["alert_type"] == "monthly"], alerts
+
+    def test_cost_warning_and_exceeded_levels(self):
+        mod = _load_lambda("quota_monitor", self.ENV)
+        warn = self._alerts(mod, monthly_cost=85.0)
+        assert [a for a in warn if a["alert_type"] == "monthly_cost" and a["alert_level"] == "warning"]
+        over = self._alerts(mod, monthly_cost=101.0)
+        assert [a for a in over if a["alert_type"] == "monthly_cost" and a["alert_level"] == "exceeded"]
+
+    def test_daily_cost_alert_carries_date(self):
+        mod = _load_lambda("quota_monitor", self.ENV)
+        alerts = self._alerts(mod, daily_cost=11.0)
+        daily = [a for a in alerts if a["alert_type"] == "daily_cost"]
+        assert daily and daily[0]["date"] == "2026-07-13"
+
+    def test_usage_entry_includes_cost_with_stale_day_guard(self):
+        mod = _load_lambda("quota_monitor", self.ENV)
+        item = {
+            "total_tokens": 1000,
+            "daily_tokens": 500,
+            "estimated_cost": 42.5,
+            "daily_cost_usd": 7.5,
+            "daily_date": "2026-07-12",
+        }
+        entry = mod._build_usage_entry(item, "2026-07-13")
+        assert entry["monthly_cost"] == 42.5
+        assert entry["daily_cost"] == 0, "stale-day guard must reset the daily cost counter"
+        entry_today = mod._build_usage_entry({**item, "daily_date": "2026-07-13"}, "2026-07-13")
+        assert entry_today["daily_cost"] == 7.5


### PR DESCRIPTION
## Why
The init wizard offers cost-based quota ("Cost-based ($ budget per user) **[recommended]**") and collects monthly/daily budgets — but the answers are dropped at every hop, so choosing the recommended mode silently deploys **no enforcement at all**:

- No `Profile` fields exist for the limit type or cost limits → the values never reach the profile JSON and are lost on re-init.
- `deploy` never passes `MonthlyCostLimitUsd`/`DailyCostLimitUsd`; the template declares them but wires them to nothing (the cfn-lint `W2001 Parameter not used` warnings were the tell).
- `quota_check`'s environment-default policy activates only when `MONTHLY_TOKEN_LIMIT > 0` — cost mode zeroes token limits, so cost-mode deployments resolve **no policy and every user is unlimited**.
- `quota_monitor` has no zero-guard on token alerts — once token limits actually arrive as 0, every active user would get a bogus "monthly exceeded" alert each 15-minute scan.
- Wizard UX bugs: the mode gate only wraps a header print, so cost mode still prompts for token counts (and the answer overwrites the token-limit zeroing); the monthly enforcement answer is never saved.

## What
End-to-end wiring: new `quota_limit_type` / `monthly_cost_limit_usd` / `daily_cost_limit_usd` profile fields (defaults keep old profiles in token mode) with init save + re-init restore; deploy passes the cost params (both deploy and `--show-commands` paths); the template wires `MONTHLY_COST_LIMIT_USD`/`DAILY_COST_LIMIT_USD` env to **both** Lambdas and `MonthlyTokenLimit` accepts 0; `quota_check`'s default policy activates on a cost limit alone (its cost enforcement already existed and takes precedence over token checks); `quota_monitor` gains the 80/90/100% cost alert ladder (`monthly_cost`/`daily_cost` alert types, $-formatted SNS messages, stale-day guard on the daily cost counter) plus the zero-token-limit guard; the wizard prompts token limits only in token mode and actually saves the monthly enforcement answer.

## Testing
`tests/test_cost_quota_wiring.py` pins every hop: profile round-trip + old-profile defaults, re-init restore, template env wiring + MinValue, `quota_check` cost-only default policy (and none-configured → no policy), `quota_monitor` cost alert levels, the zero-token-limit alert-storm guard, and the daily-cost stale-day guard. Full suite passes (1703 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)