### PR TITLE
fix(package): don't warn about missing collector endpoint in sidecar mode

### DIFF
--- a/source/claude_code_with_bedrock/cli/validators.py
+++ b/source/claude_code_with_bedrock/cli/validators.py
@@ -50,8 +50,12 @@ def validate_profile_for_packaging(profile) -> list[ValidationError]:
                 )
             )
 
-    # Monitoring consistency
-    if getattr(profile, "monitoring_enabled", False):
+    # Monitoring consistency — CENTRAL mode only. Sidecar packages hardcode
+    # the local collector endpoint (http://localhost:4318) at package time and
+    # never have an ALB endpoint in the profile, so this warning was spurious
+    # for every sidecar deployment — and its advice (deploy the central
+    # monitoring stack) is exactly what sidecar mode must NOT do.
+    if getattr(profile, "monitoring_enabled", False) and getattr(profile, "monitoring_mode", "central") == "central":
         endpoint = getattr(profile, "otel_collector_endpoint", None)
         config_mode = getattr(profile, "cowork_config_mode", "static")
         if not endpoint and config_mode != "dynamic":

--- a/source/tests/test_packaging_validators.py
+++ b/source/tests/test_packaging_validators.py
@@ -1,0 +1,58 @@
+# ABOUTME: Tests for the package-time profile validators (cli/validators.py) —
+# ABOUTME: the monitoring endpoint check must not fire for sidecar mode.
+
+"""validate_profile_for_packaging regression tests.
+
+The monitoring-consistency check warned "Monitoring enabled but no
+otel_collector_endpoint configured" for EVERY sidecar package: sidecar
+profiles never have that field (the endpoint is hardcoded to
+http://localhost:4318 at package time; there is no ALB). The warning's advice
+— deploy the central monitoring stack — is exactly what sidecar mode must not
+do. The check now applies to central mode only.
+"""
+
+from __future__ import annotations
+
+from claude_code_with_bedrock.cli.validators import validate_profile_for_packaging
+from claude_code_with_bedrock.config import Profile
+
+
+def _profile(**overrides) -> Profile:
+    defaults = {
+        "name": "validator-test",
+        "provider_domain": "company.okta.com",
+        "client_id": "client-123",
+        "credential_storage": "session",
+        "aws_region": "us-gov-west-1",
+        "identity_pool_name": "pool",
+        "auth_type": "oidc",
+        "monitoring_enabled": True,
+        "allowed_bedrock_regions": ["us-gov-west-1", "us-gov-east-1"],
+    }
+    defaults.update(overrides)
+    return Profile(**defaults)
+
+
+def _endpoint_warnings(profile):
+    return [e for e in validate_profile_for_packaging(profile) if e.field == "otel_collector_endpoint"]
+
+
+class TestMonitoringEndpointCheck:
+    def test_sidecar_without_endpoint_is_clean(self):
+        """The regression: sidecar mode has no ALB endpoint by design."""
+        profile = _profile(monitoring_mode="sidecar", otel_collector_endpoint=None)
+        assert _endpoint_warnings(profile) == []
+
+    def test_central_without_endpoint_warns(self):
+        profile = _profile(monitoring_mode="central", otel_collector_endpoint=None)
+        warnings = _endpoint_warnings(profile)
+        assert len(warnings) == 1
+        assert warnings[0].severity == "warning"
+
+    def test_central_with_endpoint_is_clean(self):
+        profile = _profile(monitoring_mode="central", otel_collector_endpoint="https://collector.example.com:4318")
+        assert _endpoint_warnings(profile) == []
+
+    def test_monitoring_disabled_is_clean(self):
+        profile = _profile(monitoring_enabled=False, monitoring_mode="central")
+        assert _endpoint_warnings(profile) == []


### PR DESCRIPTION
## Why
Every `ccwb package` run for a sidecar-mode profile starts with a spurious warning: *"Monitoring enabled but no otel_collector_endpoint configured (and not using bootstrap server). Run 'ccwb deploy --stack monitoring' first."* Sidecar profiles never have `otel_collector_endpoint` by design — the packaged Claude Code settings hardcode the local collector at `http://localhost:4318`, and there is no ALB endpoint to save. The warning's advice is actively wrong for this mode: it tells admins to deploy the central ECS monitoring stack, which `ccwb deploy` itself correctly refuses in sidecar mode.

## What
Gate the monitoring-consistency check in `validate_profile_for_packaging` on `monitoring_mode == "central"`, where a missing endpoint genuinely indicates the monitoring stack hasn't been deployed yet. Central-mode behavior is unchanged.

## Testing
New `tests/test_packaging_validators.py` (the packaging validators previously had zero coverage): sidecar-without-endpoint is clean, central-without-endpoint still warns, central-with-endpoint is clean, monitoring-disabled is clean. Full suite passes (1696 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)