### PR TITLE
feat(credential-process): add --show-claims IdP claim diagnostic

### DIFF
--- a/source/go/cmd/credential-process/main.go
+++ b/source/go/cmd/credential-process/main.go
@@ -50,6 +50,7 @@ func main() {
 	checkExpiration := flag.Bool("check-expiration", false, "Check if credentials are expired")
 	refreshIfNeeded := flag.Bool("refresh-if-needed", false, "Refresh credentials if expired")
 	showTags := flag.Bool("show-tags", false, "Print the https://aws.amazon.com/tags claim from the cached ID token (debug)")
+	showClaims := flag.Bool("show-claims", false, "Print ALL claims from the ID token as JSON (diagnostic: shows exactly what the IdP is sending — groups, department, custom claims). Uses the cached token; signs in only when none is cached.")
 	getTag := flag.String("get-tag", "", "Print the value of a single principal tag from the cached ID token (e.g. --get-tag Zone). Exit codes: 0 hit, 2 absent, 4 expired.")
 	login := flag.Bool("login", false, "Interactively sign in (IDC: run device authorization and cache the SSO token), then exit. Use this once on headless/SSH hosts before Claude Code runs.")
 	setClientSecret := flag.Bool("set-client-secret", false, "Store Azure AD client secret in OS secure storage. Set CCWB_CLIENT_SECRET env var for non-interactive use, or enter it at the prompt.")
@@ -125,6 +126,9 @@ func main() {
 	}
 	if *showTags {
 		os.Exit(app.showTags())
+	}
+	if *showClaims {
+		os.Exit(app.showClaims())
 	}
 	if *getTag != "" {
 		os.Exit(app.getTag(*getTag))
@@ -455,6 +459,50 @@ func (a *credentialApp) showTags() int {
 	pretty, err := json.MarshalIndent(summary, "", "  ")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Could not format tags claim: %v\n", err)
+		return 1
+	}
+	fmt.Println(string(pretty))
+	return 0
+}
+
+// showClaims prints ALL claims from the ID token as JSON. It is the
+// full-token sibling of showTags: it answers "what is my IdP actually
+// sending?" when wiring group-based quota policies or attribution
+// (groups, department, custom claims) without hand-decoding JWTs. Same
+// token acquisition as showTags: cached monitoring token first, fresh
+// OIDC flow only when nothing is cached.
+//
+// The Python provider's equivalent is the COGNITO_AUTH_DEBUG=1 claim dump
+// during auth (credential-helper-parity: both variants expose the claims).
+// Note: prints the token's real claims (email, sub, groups) — it is a local
+// diagnostic of the caller's own identity, same exposure as --show-tags.
+func (a *credentialApp) showClaims() int {
+	token, _ := storage.GetMonitoringToken(a.profile, a.cfg.CredentialStorage)
+	var claims jwt.Claims
+	if token != "" {
+		if c, err := jwt.DecodePayload(token); err == nil {
+			claims = c
+		}
+	}
+	if claims == nil {
+		debugPrint("No cached monitoring token; running OIDC flow to read claims")
+		authResult, err := a.authenticate()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			return 1
+		}
+		claims = authResult.TokenClaims
+		a.saveMonitoringTokenAndHeaders(authResult.IDToken, map[string]interface{}(claims))
+	}
+	if len(claims) == 0 {
+		fmt.Fprintln(os.Stderr, "No ID token claims available for this profile.")
+		fmt.Fprintln(os.Stderr, "(IDC auth has no JWT — identity comes from the IAM ARN, not IdP claims.)")
+		return 1
+	}
+
+	pretty, err := json.MarshalIndent(map[string]interface{}(claims), "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not format claims: %v\n", err)
 		return 1
 	}
 	fmt.Println(string(pretty))

--- a/source/go/cmd/credential-process/show_claims_test.go
+++ b/source/go/cmd/credential-process/show_claims_test.go
@@ -1,0 +1,82 @@
+// ABOUTME: Tests for --show-claims — full ID-token claim dump for IdP diagnostics
+// ABOUTME: (what groups/department/custom claims is Okta actually sending?).
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"ccwb-go/internal/config"
+)
+
+// TestShowClaims_CachedToken verifies the full claim set of a cached token is
+// printed as JSON without any browser/network side effects.
+func TestShowClaims_CachedToken(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("USERPROFILE", tmpDir) // Windows
+	t.Setenv("CLAUDE_CODE_MONITORING_TOKEN", "")
+
+	profile := "test-show-claims"
+	token := fakeJWT(t, map[string]interface{}{
+		"email":             "user@example.com",
+		"sub":               "00u1abcd",
+		"groups":            []string{"engineering", "platform-team"},
+		"custom:department": "R&D",
+		"exp":               time.Now().Unix() + 3600,
+	})
+	writeMonitoringToken(t, tmpDir, profile, token, time.Now().Unix()+3600)
+
+	cfg := &config.ProfileConfig{
+		ClientID:          "test-client",
+		ProviderDomain:    "test.example.com",
+		CredentialStorage: "session",
+		SsoEnabled:        boolPtr(true),
+	}
+	app := &credentialApp{profile: profile, cfg: cfg, providerType: "okta"}
+
+	r, w, _ := os.Pipe()
+	old := os.Stdout
+	os.Stdout = w
+	code := app.showClaims()
+	w.Close()
+	os.Stdout = old
+
+	if code != 0 {
+		t.Fatalf("showClaims exit = %d, want 0", code)
+	}
+
+	var buf [16384]byte
+	n, _ := r.Read(buf[:])
+	out := string(buf[:n])
+
+	var claims map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &claims); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
+	}
+	if claims["email"] != "user@example.com" {
+		t.Errorf("email claim = %v", claims["email"])
+	}
+	if claims["custom:department"] != "R&D" {
+		t.Errorf("custom claim missing: %v", claims["custom:department"])
+	}
+	groups, _ := claims["groups"].([]interface{})
+	if len(groups) != 2 {
+		t.Errorf("groups claim = %v, want 2 entries", claims["groups"])
+	}
+}
+
+// TestShowClaims_HelpTextAdvertisesDiagnostic pins the flag registration so
+// the diagnostic stays discoverable via --help.
+func TestShowClaims_HelpTextAdvertisesDiagnostic(t *testing.T) {
+	src, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(src), `flag.Bool("show-claims"`) {
+		t.Fatal("--show-claims flag registration missing from main.go")
+	}
+}


### PR DESCRIPTION
## Why
Admins wiring group-based quota policies, cost attribution, or OTEL identity mapping need to answer "what claims is my IdP actually sending — is `groups` present, and under which claim name?" The Go credential-process only exposes slices of the ID token (`--show-tags` for the principal-tags claim, `--get-tag` for one tag), so the current workaround is hand-decoding JWTs. The Python provider already dumps the full claim set under `COGNITO_AUTH_DEBUG=1` — a credential-helper-parity gap.

## What
New `--show-claims` flag: prints **all** ID-token claims as pretty JSON on stdout (pipe-friendly for `jq`). Token acquisition mirrors `--show-tags` exactly — cached monitoring token first, fresh OIDC sign-in only when nothing is cached. IDC profiles get a clear "IDC has no JWT" explanation instead of an empty dump. Follows the cmd conventions: flag not subcommand, dispatched in the early-exit section, no change to the `--explain` contract.

## Testing
Tests cover the cached-token path (full claim set surfaces including `groups` and `custom:*` claims, valid JSON, no network/browser) and pin the flag registration. Full Go suite and Python suite (1692) pass; windows/darwin cross-compiles verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)