### PR TITLE
fix(cowork): use inferenceBedrockProfile; remove non-functional helper mode

### DIFF
--- a/assets/docs/COWORK_3P.md
+++ b/assets/docs/COWORK_3P.md
@@ -166,40 +166,17 @@ Claude Desktop supports object entries in `inferenceModels` with `anthropicFamil
 
 ### How Credentials Flow
 
-This solution supports two credential modes for CoWork. The **credential helper** mode (default since v2.6.0) is recommended because it gives Claude Desktop direct control over credential lifecycle, eliminating the stale-credential bug that required manual app restarts.
-
-#### Credential Helper Mode (Recommended)
-
-When Claude Cowork starts a session:
-
-1. Claude Desktop reads `inferenceCredentialHelper` from the MDM policy — this points directly at the credential-process binary
-2. Claude Desktop runs the binary and reads temporary AWS credentials from stdout
-3. The output is cached for `inferenceCredentialHelperTtlSec` seconds (default: 3500, just under the 1h STS token lifetime)
-4. When the cache expires, Claude Desktop automatically re-runs the helper — **no restart required**
-5. If credentials are rejected mid-session, Claude Desktop re-runs with `CLAUDE_HELPER_CONTEXT=mid-session-refresh` for seamless recovery (20s timeout)
-
-The credential-process binary handles the `CLAUDE_HELPER_CONTEXT` environment variable:
-- `interactive` → Full browser-based OIDC authentication
-- `mid-session-refresh` → Silent refresh via cached refresh_token (no browser)
-- `background` / `setup-test` → Silent path only, exit non-zero if unavailable
-
-This mode resolves the known issue where CoWork doesn't automatically refresh AWS credentials after token expiry (affecting both IDC and OIDC/Azure AD federated auth users).
-
-Ref: [Claude Desktop Credential Helper documentation](https://claude.com/docs/third-party/claude-desktop/credential-helper)
-
-#### AWS Profile Mode (Legacy)
-
-The legacy flow uses `inferenceBedrockProfile` instead:
+CoWork uses `inferenceBedrockProfile`, the same AWS SDK credential resolution Claude Code CLI uses:
 
 1. Claude Desktop reads `inferenceBedrockProfile` from the applied MDM policy (registry on Windows, managed preference on macOS)
 2. It hands that profile name to the AWS SDK, which resolves the corresponding `[profile <name>]` stanza in `~/.aws/config`
 3. The stanza's `credential_process = .../credential-process --profile <name>` entry runs the bundled credential-process binary
 4. The binary authenticates the user via your OIDC provider (Okta, Azure AD, Auth0, etc.) and returns temporary AWS credentials in the standard AWS `credential_process` JSON format
-5. The AWS SDK signs each Bedrock call with those credentials; caching and refresh are handled automatically by the SDK
-
-To use this mode, set `cowork_credential_mode = "profile"` in your deployment profile before running `ccwb cowork generate`.
+5. The AWS SDK signs each Bedrock call with those credentials
 
 No wrapper script is required — CoWork reuses the same `credential-process` binary and `~/.aws/config` entry that `install.sh` / `install.bat` already configure for Claude Code CLI.
+
+> **Limitation:** Claude Desktop loads the credential once at app launch and does not re-invoke `credential_process` mid-session. When the credential expires, the current turn fails and the user must **fully quit and relaunch** Claude Desktop to recover.
 
 > ⚠️ **boto3 resolves `~/.aws/credentials` before `~/.aws/config`.** If `~/.aws/credentials` contains a `[<profile-name>]` block matching `inferenceBedrockProfile` — whether written by another tool or by this solution in session-storage mode — boto3 uses it directly and does **not** fall through to `credential_process` to refresh it. CoWork works as long as those static credentials remain valid, then fails with `403 The security token included in the request is invalid` the moment they expire (or immediately, if the block contains stale `EXPIRED` placeholders from a past logout). The installer shipped by `ccwb package` purges any such stanza before writing the new profile, and keyring-mode builds never write to `~/.aws/credentials` at all — which is why **Keyring is the recommended credential storage method when CoWork 3P is in scope**.
 

--- a/source/claude_code_with_bedrock/cli/commands/cowork.py
+++ b/source/claude_code_with_bedrock/cli/commands/cowork.py
@@ -118,8 +118,6 @@ class CoworkGenerateCommand(Command):
             model_aliases=model_aliases,
             profile_name=profile_name,
             extra_keys=profile.cowork_3p_extra_keys or None,
-            credential_mode=getattr(profile, "cowork_credential_mode", "helper"),
-            credential_helper_ttl_sec=getattr(profile, "cowork_credential_helper_ttl_sec", 3500),
         )
 
         # Add monitoring OTLP endpoint if available

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -4245,8 +4245,6 @@ Available metrics include:
                 model_aliases=model_aliases,
                 profile_name=profile_name,
                 extra_keys=profile.cowork_3p_extra_keys or None,
-                credential_mode=getattr(profile, "cowork_credential_mode", "helper"),
-                credential_helper_ttl_sec=getattr(profile, "cowork_credential_helper_ttl_sec", 3500),
             )
 
             # Beta features (per-feature managed configuration keys)

--- a/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
+++ b/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
@@ -108,46 +108,18 @@ def _infer_tier_from_model_id(model_id: str) -> str | None:
     return None
 
 
-def _credential_process_path(profile_name: str) -> dict[str, str]:
-    """Return platform-specific credential-process paths for inferenceCredentialHelper.
-
-    The installer places the binary at a predictable location per-platform:
-    - macOS/Linux: ~/claude-code-with-bedrock/credential-process
-    - Windows: %USERPROFILE%\\claude-code-with-bedrock\\credential-process.exe
-
-    For MDM deployment we use the tilde (~) shorthand which Claude Desktop
-    resolves to the user's home directory on all platforms.
-    """
-    return {
-        "unix": f"~/claude-code-with-bedrock/credential-process --profile {profile_name}",
-        "windows": f"%USERPROFILE%\\claude-code-with-bedrock\\credential-process.exe --profile {profile_name}",
-    }
-
-
 def build_mdm_config(
     bedrock_region: str,
     model_aliases: list[str],
     profile_name: str = "ClaudeCode",
     extra_keys: dict[str, str] | None = None,
-    credential_mode: str = "helper",
-    credential_helper_ttl_sec: int = 3500,
 ) -> dict:
     """Build the base CoWork 3P MDM configuration dictionary.
 
-    Supports two credential modes:
-
-    - "helper" (default, recommended): Uses inferenceCredentialHelper, which gives
-      Claude Desktop direct control over the credential lifecycle. The app caches
-      the helper's output for `credential_helper_ttl_sec` seconds and automatically
-      re-runs it on expiry — including mid-session silent refresh. This eliminates
-      the stale-credential bug where CoWork requires a restart after token expiry.
-
-    - "profile" (legacy): Uses inferenceBedrockProfile, which delegates credential
-      resolution to the AWS SDK via ~/.aws/config. This works but credential refresh
-      depends on boto3's internal session caching, which doesn't reliably trigger
-      re-authentication in the CoWork process lifecycle.
-
-    Ref: https://claude.com/docs/third-party/claude-desktop/credential-helper
+    Uses inferenceBedrockProfile: Claude Desktop hands the named profile to the
+    AWS SDK, which resolves the `[profile <name>]` stanza in ~/.aws/config and
+    runs its credential_process entry (the bundled credential-process binary) —
+    the same authentication pipeline Claude Code CLI uses.
 
     Args:
         bedrock_region: AWS region for Bedrock API calls.
@@ -155,10 +127,6 @@ def build_mdm_config(
         profile_name: AWS named profile (matches ~/.aws/config stanza).
         extra_keys: Optional dictionary of additional MDM keys to merge into the
             configuration. Values should be strings (JSON-encoded for complex types).
-        credential_mode: "helper" or "profile" (default: "helper").
-        credential_helper_ttl_sec: Cache TTL for the credential helper output in
-            seconds (default: 3500, slightly under the 1h STS token lifetime to
-            ensure refresh happens before expiry).
 
     Returns:
         Dictionary of MDM configuration key-value pairs.
@@ -166,6 +134,7 @@ def build_mdm_config(
     config = {
         "inferenceProvider": "bedrock",
         "inferenceBedrockRegion": bedrock_region,
+        "inferenceBedrockProfile": profile_name,
         "inferenceModels": build_inference_models(model_aliases),
         "isClaudeCodeForDesktopEnabled": True,
         "isDesktopExtensionEnabled": True,
@@ -173,22 +142,6 @@ def build_mdm_config(
         "isDesktopExtensionSignatureRequired": True,
         "isLocalDevMcpEnabled": True,
     }
-
-    if credential_mode == "helper":
-        # Direct credential helper — Claude Desktop manages the credential lifecycle.
-        # Uses the same credential-process binary but invoked directly by the app
-        # instead of indirectly via the AWS SDK's credential_process chain.
-        paths = _credential_process_path(profile_name)
-        # Use the Unix path by default; installers for Windows will substitute.
-        # MDM platforms (Jamf, Intune) typically deploy platform-specific configs.
-        config["inferenceCredentialHelper"] = paths["unix"]
-        config["inferenceCredentialHelperTtlSec"] = str(credential_helper_ttl_sec)
-        config["inferenceCredentialHelperSilentRefreshEnabled"] = "true"
-        # Keep the AWS profile as fallback for SDK-level operations (region, etc.)
-        config["inferenceBedrockProfile"] = profile_name
-    else:
-        # Legacy profile mode — rely on AWS SDK credential_process chain.
-        config["inferenceBedrockProfile"] = profile_name
 
     if extra_keys:
         config.update(extra_keys)
@@ -337,25 +290,10 @@ def generate_reg_file(output_dir: Path, mdm_config: dict) -> Path:
     All values are stored as REG_SZ strings — booleans, integers, and arrays
     included — matching what Claude Desktop reads from the registry.
 
-    If inferenceCredentialHelper is present and uses a Unix-style path (~/ prefix),
-    it is rewritten to the Windows equivalent (%USERPROFILE%\\ + .exe suffix).
-
     Returns the path to the generated file.
     """
     reg_key = r"HKEY_CURRENT_USER\SOFTWARE\Policies\Claude"
-
-    # Create a copy with Windows-specific credential helper path
     config = dict(mdm_config)
-    helper_key = "inferenceCredentialHelper"
-    if helper_key in config and isinstance(config[helper_key], str) and config[helper_key].startswith("~/"):
-        # Convert ~/claude-code-with-bedrock/credential-process --profile X
-        # to %USERPROFILE%\claude-code-with-bedrock\credential-process.exe --profile X
-        unix_path = config[helper_key]
-        parts = unix_path.split(" ", 1)
-        binary_part = parts[0].replace("~/", "%USERPROFILE%\\").replace("/", "\\")
-        if not binary_part.endswith(".exe"):
-            binary_part += ".exe"
-        config[helper_key] = f"{binary_part} {parts[1]}" if len(parts) > 1 else binary_part
 
     lines = ["Windows Registry Editor Version 5.00", "", f"[{reg_key}]"]
 

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -156,10 +156,6 @@ class Profile:
     cowork_3p_enabled: bool = True  # Generate CoWork 3P MDM configs during packaging
     cowork_3p_extra_keys: dict[str, str] = field(default_factory=dict)  # Custom MDM keys merged into CoWork 3P output
     cowork_service_token: str = ""  # Static token for CoWork ALB auth bypass (set during init)
-    cowork_credential_mode: str = (
-        "helper"  # "helper" (inferenceCredentialHelper) or "profile" (inferenceBedrockProfile)
-    )
-    cowork_credential_helper_ttl_sec: int = 3500  # inferenceCredentialHelperTtlSec (refresh before 1h STS expiry)
     cowork_config_delivery: str = "static"  # "static" | "bootstrap-device-code" | "bootstrap-oidc-bearer"
 
     # Cowork beta features (managed configuration keys)

--- a/source/tests/test_cowork_credential_helper.py
+++ b/source/tests/test_cowork_credential_helper.py
@@ -1,7 +1,13 @@
-# ABOUTME: Tests for CoWork 3P credential helper mode (inferenceCredentialHelper)
-# ABOUTME: Verifies MDM config generation for both "helper" and "profile" modes
+# ABOUTME: Tests for CoWork 3P MDM credential config generation (build_mdm_config)
+# ABOUTME: CoWork uses inferenceBedrockProfile (AWS SDK credential_process); no credential helper
 
-"""Tests for CoWork 3P credential helper mode."""
+"""Tests for CoWork 3P MDM credential configuration.
+
+CoWork authenticates via `inferenceBedrockProfile` — Claude Desktop resolves the
+named AWS profile through the SDK, which runs credential-process. There is no
+`inferenceCredentialHelper` (that MDM key requires a bare-token/`{"token": ...}`
+output that credential-process does not produce).
+"""
 
 import json
 
@@ -12,90 +18,22 @@ from claude_code_with_bedrock.cli.utils.cowork_3p import (
 )
 
 
-class TestBuildMdmConfigCredentialHelper:
-    """Test build_mdm_config with credential_mode='helper' (default)."""
-
-    def test_helper_mode_includes_credential_helper_keys(self):
-        """Default mode should produce inferenceCredentialHelper keys."""
+class TestBuildMdmConfig:
+    def test_uses_bedrock_profile(self):
         config = build_mdm_config(
             bedrock_region="us-west-2",
             model_aliases=["opus", "sonnet", "haiku"],
             profile_name="MyProfile",
         )
-        assert "inferenceCredentialHelper" in config
-        assert "inferenceCredentialHelperTtlSec" in config
-        assert "inferenceCredentialHelperSilentRefreshEnabled" in config
-        assert config["inferenceCredentialHelperSilentRefreshEnabled"] == "true"
-
-    def test_helper_mode_path_includes_profile_name(self):
-        """Credential helper path should include --profile <name>."""
-        config = build_mdm_config(
-            bedrock_region="us-west-2",
-            model_aliases=["sonnet"],
-            profile_name="Production",
-        )
-        assert "--profile Production" in config["inferenceCredentialHelper"]
-        assert "credential-process" in config["inferenceCredentialHelper"]
-
-    def test_helper_mode_ttl_default(self):
-        """Default TTL should be 3500s (under 1h STS expiry)."""
-        config = build_mdm_config(
-            bedrock_region="us-west-2",
-            model_aliases=["sonnet"],
-        )
-        assert config["inferenceCredentialHelperTtlSec"] == "3500"
-
-    def test_helper_mode_custom_ttl(self):
-        """Custom TTL should override default."""
-        config = build_mdm_config(
-            bedrock_region="us-west-2",
-            model_aliases=["sonnet"],
-            credential_helper_ttl_sec=1800,
-        )
-        assert config["inferenceCredentialHelperTtlSec"] == "1800"
-
-    def test_helper_mode_still_includes_bedrock_profile(self):
-        """Helper mode should still include inferenceBedrockProfile for SDK fallback."""
-        config = build_mdm_config(
-            bedrock_region="us-west-2",
-            model_aliases=["sonnet"],
-            profile_name="ClaudeCode",
-        )
-        assert config["inferenceBedrockProfile"] == "ClaudeCode"
-
-    def test_helper_mode_uses_unix_path_by_default(self):
-        """Default path should use ~/ prefix (Unix convention)."""
-        config = build_mdm_config(
-            bedrock_region="us-west-2",
-            model_aliases=["sonnet"],
-            profile_name="Test",
-        )
-        assert config["inferenceCredentialHelper"].startswith("~/")
-
-
-class TestBuildMdmConfigProfileMode:
-    """Test build_mdm_config with credential_mode='profile' (legacy)."""
-
-    def test_profile_mode_uses_bedrock_profile_only(self):
-        """Legacy mode should use inferenceBedrockProfile without credential helper."""
-        config = build_mdm_config(
-            bedrock_region="us-west-2",
-            model_aliases=["opus"],
-            profile_name="LegacyProfile",
-            credential_mode="profile",
-        )
-        assert config["inferenceBedrockProfile"] == "LegacyProfile"
+        assert config["inferenceBedrockProfile"] == "MyProfile"
         assert "inferenceCredentialHelper" not in config
         assert "inferenceCredentialHelperTtlSec" not in config
-        assert "inferenceCredentialHelperSilentRefreshEnabled" not in config
 
-    def test_profile_mode_backward_compatible(self):
-        """Legacy mode output should match previous behavior exactly."""
+    def test_matches_expected_shape(self):
         config = build_mdm_config(
             bedrock_region="eu-west-1",
             model_aliases=["opus", "sonnet", "haiku"],
             profile_name="ClaudeCode",
-            credential_mode="profile",
         )
         assert config == {
             "inferenceProvider": "bedrock",
@@ -109,12 +47,17 @@ class TestBuildMdmConfigProfileMode:
             "isLocalDevMcpEnabled": True,
         }
 
+    def test_extra_keys_merged(self):
+        config = build_mdm_config(
+            bedrock_region="us-west-2",
+            model_aliases=["sonnet"],
+            extra_keys={"coworkWebSearchEnabled": "true"},
+        )
+        assert config["coworkWebSearchEnabled"] == "true"
 
-class TestGenerateRegFileCredentialHelper:
-    """Test Windows .reg generation with credential helper path rewriting."""
 
-    def test_reg_file_rewrites_unix_path_to_windows(self, tmp_path):
-        """Unix ~/... path should become %USERPROFILE%\\... with .exe suffix."""
+class TestGenerateRegFile:
+    def test_reg_has_bedrock_profile_no_helper(self, tmp_path):
         config = build_mdm_config(
             bedrock_region="us-west-2",
             model_aliases=["sonnet"],
@@ -122,28 +65,12 @@ class TestGenerateRegFileCredentialHelper:
         )
         reg_path = generate_reg_file(tmp_path, config)
         content = reg_path.read_text(encoding="utf-8")
-        # Should contain Windows-style path
-        assert "%USERPROFILE%" in content
-        assert "credential-process.exe" in content
-        assert "--profile Test" in content
-
-    def test_reg_file_no_rewrite_for_profile_mode(self, tmp_path):
-        """Profile mode should not contain credential helper in .reg file."""
-        config = build_mdm_config(
-            bedrock_region="us-west-2",
-            model_aliases=["sonnet"],
-            credential_mode="profile",
-        )
-        reg_path = generate_reg_file(tmp_path, config)
-        content = reg_path.read_text(encoding="utf-8")
+        assert "inferenceBedrockProfile" in content
         assert "inferenceCredentialHelper" not in content
 
 
-class TestGenerateJsonCredentialHelper:
-    """Test JSON output includes credential helper keys."""
-
-    def test_json_output_includes_helper_keys(self, tmp_path):
-        """JSON output should include all credential helper keys."""
+class TestGenerateJson:
+    def test_json_includes_bedrock_profile(self, tmp_path):
         config = build_mdm_config(
             bedrock_region="us-west-2",
             model_aliases=["opus", "sonnet"],
@@ -151,6 +78,5 @@ class TestGenerateJsonCredentialHelper:
         )
         json_path = generate_json(tmp_path, config)
         data = json.loads(json_path.read_text(encoding="utf-8"))
-        assert data["inferenceCredentialHelper"] == "~/claude-code-with-bedrock/credential-process --profile MyProfile"
-        assert data["inferenceCredentialHelperTtlSec"] == "3500"
-        assert data["inferenceCredentialHelperSilentRefreshEnabled"] == "true"
+        assert data["inferenceBedrockProfile"] == "MyProfile"
+        assert "inferenceCredentialHelper" not in data


### PR DESCRIPTION
## Why

CoWork 3P defaults to `cowork_credential_mode = "helper"` (#681), which points Claude Desktop's `inferenceCredentialHelper` at `credential-process`. That contract requires stdout to be a bare token or `{"token": "..."}`, but `credential-process` emits AWS SigV4 `credential_process` JSON — so Claude Desktop rejects it and **every CoWork session fails at auth** on a default deployment. Reproduced live against a real Cognito OIDC + Windows Claude Desktop setup.

## What

- Default to `inferenceBedrockProfile` — the AWS SDK `credential_process` path Claude Code CLI already uses (validated end-to-end: CoWork authenticates, Bedrock responds).
- Remove the non-functional helper mode: the `cowork_credential_mode` / `cowork_credential_helper_ttl_sec` fields, the `build_mdm_config` helper branch, `_credential_process_path()`, and the `.reg` helper-path rewrite.
- Update docs and tests to the profile-only flow.

Net −167 lines; no new features (repo is in maintenance mode).

## Scope / safety

- **CoWork 3P only.** Claude Code CLI is unaffected — its `~/.aws/config` credential flow and the credential-process binary are unchanged.
- **Backward compatible:** old `profile.json` files that set `cowork_credential_mode` still load (`Profile.from_dict` filters unknown keys).

## Testing

- `pytest tests/` passes (one pre-existing unrelated failure: `test_installer_launcher`).
- ruff check + format clean.
- Verified live on Windows: profile-mode config authenticates and returns Bedrock responses.

Fixes #782