### PR TITLE
fix(auth): grant bedrock:CallWithBearerToken on Google federated role

### DIFF
--- a/deployment/infrastructure/bedrock-auth-google.yaml
+++ b/deployment/infrastructure/bedrock-auth-google.yaml
@@ -100,6 +100,7 @@ Resources:
             Action:
               - 'bedrock:InvokeModel'
               - 'bedrock:InvokeModelWithResponseStream'
+              - 'bedrock:CallWithBearerToken'
             Resource:
               - !Sub 'arn:${AWS::Partition}:bedrock:*::foundation-model/*'
               - !Sub 'arn:${AWS::Partition}:bedrock:*:*:inference-profile/*'
@@ -111,6 +112,7 @@ Resources:
             Action:
               - 'bedrock:InvokeModel'
               - 'bedrock:InvokeModelWithResponseStream'
+              - 'bedrock:CallWithBearerToken'
             Resource:
               - !Sub 'arn:${AWS::Partition}:bedrock:::foundation-model/*'
           - Sid: AllowBedrockListRegional


### PR DESCRIPTION
## Why

CoWork 3P uses `credential-process --desktop` (#733) to emit a short-term Bedrock bearer token for Claude Desktop's `inferenceCredentialHelper`. Bedrock bearer-token calls require `bedrock:CallWithBearerToken` on the federated role.

`b44bd1d` added that action to the auth templates but missed `bedrock-auth-google.yaml`. Every other provider (Okta, Azure, Auth0, Cognito, generic, IDC) grants it; Google does not — so **Google-auth CoWork deployments fail** with `403 AccessDeniedException — Invalid API Key format`.

## What

Add `bedrock:CallWithBearerToken` to both Bedrock invoke statements (Regional + Global) in `bedrock-auth-google.yaml`, matching the other 7 templates. 2 lines, CFN-only.

## Testing

- `cfn-lint deployment/infrastructure/bedrock-auth-google.yaml` — clean.
- Diff matches the exact placement used in the Okta/Azure/etc. templates.

Fixes #784