### PR TITLE
fix(cowork): point inferenceCredentialHelper at a wrapper script (no inline args)

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/distribute.py
+++ b/source/claude_code_with_bedrock/cli/commands/distribute.py
@@ -596,6 +596,7 @@ class DistributeCommand(Command):
                 ("README.md", "README.md"),
                 ("cowork-3p.reg", "cowork-3p.reg"),
                 ("cowork-3p-config.json", "cowork-3p-config.json"),
+                ("cowork-credential-helper.cmd", "cowork-credential-helper.cmd"),
             ],
             "linux": [
                 ("credential-process-linux-x64", "credential-process-linux-x64"),
@@ -613,6 +614,7 @@ class DistributeCommand(Command):
                 ("config.json", "config.json"),
                 ("README.md", "README.md"),
                 ("cowork-3p-config.json", "cowork-3p-config.json"),
+                ("cowork-credential-helper.sh", "cowork-credential-helper.sh"),
             ],
             "mac": [
                 ("credential-process-macos-arm64", "credential-process-macos-arm64"),
@@ -628,6 +630,7 @@ class DistributeCommand(Command):
                 ("README.md", "README.md"),
                 ("cowork-3p.mobileconfig", "cowork-3p.mobileconfig"),
                 ("cowork-3p-config.json", "cowork-3p-config.json"),
+                ("cowork-credential-helper.sh", "cowork-credential-helper.sh"),
             ],
         }
 
@@ -1514,6 +1517,8 @@ class DistributeCommand(Command):
             "cowork-3p.reg",
             "cowork-3p.mobileconfig",
             "cowork-3p-config.json",
+            "cowork-credential-helper.sh",
+            "cowork-credential-helper.cmd",
         ]
 
         with zipfile.ZipFile(archive_path, "w", zipfile.ZIP_DEFLATED) as zf:

--- a/source/claude_code_with_bedrock/cli/commands/package.py
+++ b/source/claude_code_with_bedrock/cli/commands/package.py
@@ -3189,6 +3189,16 @@ for _ccwb_mdm in "cowork-3p.mobileconfig" "cowork-3p-config.json"; do
     fi
 done
 
+# Install the CoWork credential-helper wrapper (helper-script mode). Claude
+# Desktop runs inferenceCredentialHelper with no arguments, so the --desktop
+# --profile flags live inside this wrapper, which execs the co-located binary.
+if [ -f "cowork-credential-helper.sh" ]; then
+    cp "cowork-credential-helper.sh" "$ACTUAL_HOME/claude-code-with-bedrock/cowork-credential-helper.sh"
+    chmod +x "$ACTUAL_HOME/claude-code-with-bedrock/cowork-credential-helper.sh"
+    if [ -n "$SUDO_USER" ]; then chown "$ACTUAL_USER" "$ACTUAL_HOME/claude-code-with-bedrock/cowork-credential-helper.sh"; fi
+    echo "OK Installed cowork-credential-helper.sh"
+fi
+
 # macOS Gatekeeper + Keychain notices
 if [[ "$OSTYPE" == "darwin"* ]]; then
     # Remove quarantine flag added by macOS when downloading unsigned binaries.
@@ -3728,6 +3738,14 @@ if exist "cowork-3p.reg" (
     echo Resolving home directory in cowork-3p.reg...
     powershell -NoProfile -Command "$h = $env:USERPROFILE.Replace('\\','\\\\'); (Get-Content 'cowork-3p.reg' -Raw).Replace('__CCWB_HOME__', $h) | Set-Content 'cowork-3p.reg'"
     echo OK Resolved home directory in cowork-3p.reg ^(import it with: reg import cowork-3p.reg, then fully restart Claude^)
+)
+
+REM Install the CoWork credential-helper wrapper (helper-script mode). Claude
+REM Desktop runs inferenceCredentialHelper with no arguments, so the --desktop
+REM --profile flags live inside this wrapper, which calls the co-located binary.
+if exist "cowork-credential-helper.cmd" (
+    copy /Y "cowork-credential-helper.cmd" "%USERPROFILE%\\claude-code-with-bedrock\\cowork-credential-helper.cmd" >nul
+    echo OK Installed cowork-credential-helper.cmd
 )
 
 REM Copy Claude Code settings if they exist

--- a/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
+++ b/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
@@ -117,22 +117,34 @@ def _infer_tier_from_model_id(model_id: str) -> str | None:
     return None
 
 
+# Wrapper scripts that Claude Desktop invokes as inferenceCredentialHelper.
+# Per Anthropic's contract, Claude Desktop "runs the executable at the configured
+# path with no arguments" — it does NOT parse a command line. So the helper value
+# must be a bare path to a script, and the --desktop/--profile arguments are
+# baked INSIDE the wrapper (which calls the co-located credential-process binary).
+# Pointing inferenceCredentialHelper directly at "credential-process --desktop
+# --profile X" makes Claude Desktop treat the whole string as one filename and
+# fail to spawn it (ENOENT).
+COWORK_HELPER_SCRIPT_UNIX = "cowork-credential-helper.sh"
+COWORK_HELPER_SCRIPT_WINDOWS = "cowork-credential-helper.cmd"
+
+
 def _credential_process_path(profile_name: str) -> dict[str, str]:
-    """Return platform-specific credential-process paths for inferenceCredentialHelper.
+    """Return platform-specific, argument-free wrapper-script paths for
+    inferenceCredentialHelper.
 
-    The installer places the binary at a predictable location per-platform:
-    - macOS/Linux: <home>/claude-code-with-bedrock/credential-process
-    - Windows: <home>\\claude-code-with-bedrock\\credential-process.exe
+    The installer places the wrapper alongside the binary per-platform:
+    - macOS/Linux: <home>/claude-code-with-bedrock/cowork-credential-helper.sh
+    - Windows: <home>\\claude-code-with-bedrock\\cowork-credential-helper.cmd
 
-    Claude Desktop does NOT expand "~"/env vars in MDM values on EITHER platform,
-    so both paths embed CCWB_HOME_PLACEHOLDER. `install.sh` (macOS/Linux) and
-    `install.bat` (Windows) substitute it with the real home at install time —
-    Windows escapes it for the .reg (see generate_reg_file). Using %USERPROFILE%
-    here would NOT work: Claude reads the literal string from the registry.
+    The wrapper hardcodes `--desktop --profile <name>` and execs the co-located
+    credential-process binary. Claude Desktop does NOT expand "~"/env vars in MDM
+    values, so both paths embed CCWB_HOME_PLACEHOLDER; `install.sh`/`install.bat`
+    substitute it with the real home at install time.
     """
     return {
-        "unix": f"{CCWB_HOME_PLACEHOLDER}/claude-code-with-bedrock/credential-process --desktop --profile {profile_name}",
-        "windows": f"{CCWB_HOME_PLACEHOLDER}\\claude-code-with-bedrock\\credential-process.exe --desktop --profile {profile_name}",
+        "unix": f"{CCWB_HOME_PLACEHOLDER}/claude-code-with-bedrock/{COWORK_HELPER_SCRIPT_UNIX}",
+        "windows": f"{CCWB_HOME_PLACEHOLDER}\\claude-code-with-bedrock\\{COWORK_HELPER_SCRIPT_WINDOWS}",
     }
 
 
@@ -537,21 +549,21 @@ def generate_mobileconfig(output_dir: Path, mdm_config: dict) -> Path:
 
 
 def _to_windows_credential_helper(value: str) -> str:
-    """Convert the unix inferenceCredentialHelper path to the Windows form.
+    """Convert the unix inferenceCredentialHelper wrapper path to the Windows form.
 
-    ``__CCWB_HOME__/claude-code-with-bedrock/credential-process --profile X``
-    becomes ``__CCWB_HOME__\\claude-code-with-bedrock\\credential-process.exe --profile X``.
+    ``__CCWB_HOME__/claude-code-with-bedrock/cowork-credential-helper.sh``
+    becomes ``__CCWB_HOME__\\claude-code-with-bedrock\\cowork-credential-helper.cmd``.
     Keeps the ``__CCWB_HOME__`` placeholder (resolved at install/deploy time by
-    install.bat / the Intune .ps1); only rewrites slashes and adds the ``.exe``
-    suffix. No-op when the value is not a placeholder path.
+    install.bat / the Intune .ps1); rewrites slashes and swaps the .sh wrapper
+    for its .cmd counterpart. The value is a bare, argument-free path (Claude
+    Desktop runs it with no arguments). No-op when not a placeholder path.
     """
     if not (isinstance(value, str) and value.startswith(f"{CCWB_HOME_PLACEHOLDER}/")):
         return value
-    parts = value.split(" ", 1)
-    binary_part = parts[0].replace("/", "\\")
-    if not binary_part.endswith(".exe"):
-        binary_part += ".exe"
-    return f"{binary_part} {parts[1]}" if len(parts) > 1 else binary_part
+    windows = value.replace("/", "\\")
+    if windows.endswith(COWORK_HELPER_SCRIPT_UNIX):
+        windows = windows[: -len(COWORK_HELPER_SCRIPT_UNIX)] + COWORK_HELPER_SCRIPT_WINDOWS
+    return windows
 
 
 def generate_reg_file(output_dir: Path, mdm_config: dict) -> Path:
@@ -598,8 +610,48 @@ def generate_reg_file(output_dir: Path, mdm_config: dict) -> Path:
     return reg_path
 
 
+def generate_helper_wrappers(output_dir: Path, profile_name: str) -> list[str]:
+    """Write the argument-free credential-helper wrapper scripts.
+
+    Claude Desktop runs inferenceCredentialHelper "at the configured path with no
+    arguments", so the --desktop/--profile flags live inside these wrappers, which
+    exec the co-located credential-process binary. The installer places them next
+    to the binary; %~dp0 / $(dirname) resolves the binary relative to the wrapper.
+
+    Returns the generated filenames.
+    """
+    sh = (
+        "#!/bin/bash\n"
+        "# ABOUTME: CoWork 3P credential helper — emits a Bedrock bearer token.\n"
+        "# Invoked by Claude Desktop as inferenceCredentialHelper (no arguments).\n"
+        "set -euo pipefail\n"
+        'SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"\n'
+        f'exec "$SCRIPT_DIR/credential-process" --desktop --profile {profile_name}\n'
+    )
+    sh_path = output_dir / COWORK_HELPER_SCRIPT_UNIX
+    with open(sh_path, "w", encoding="utf-8", newline="\n") as f:
+        f.write(sh)
+    try:
+        sh_path.chmod(0o755)
+    except OSError:
+        pass  # no-op on Windows
+
+    cmd = (
+        "@echo off\r\n"
+        "REM CoWork 3P credential helper - emits a Bedrock bearer token.\r\n"
+        "REM Invoked by Claude Desktop as inferenceCredentialHelper (no arguments).\r\n"
+        f'"%~dp0credential-process.exe" --desktop --profile {profile_name}\r\n'
+        "exit /b %errorlevel%\r\n"
+    )
+    cmd_path = output_dir / COWORK_HELPER_SCRIPT_WINDOWS
+    with open(cmd_path, "w", encoding="utf-8", newline="") as f:
+        f.write(cmd)
+
+    return [COWORK_HELPER_SCRIPT_UNIX, COWORK_HELPER_SCRIPT_WINDOWS]
+
+
 def generate_all(output_dir: Path, mdm_config: dict, console: Console) -> list[str]:
-    """Generate all three CoWork 3P MDM configuration files.
+    """Generate all CoWork 3P MDM configuration files (+ helper wrappers).
 
     Args:
         output_dir: Directory to write files to.
@@ -622,6 +674,12 @@ def generate_all(output_dir: Path, mdm_config: dict, console: Console) -> list[s
     generate_reg_file(output_dir, mdm_config)
     generated.append("cowork-3p.reg")
     console.print("[green]✓[/green] Generated cowork-3p.reg (Windows)")
+
+    # helper-script mode: ship the wrapper scripts Claude Desktop invokes.
+    if "inferenceCredentialHelper" in mdm_config:
+        profile_name = mdm_config.get("inferenceBedrockProfile", "ClaudeCode")
+        generated += generate_helper_wrappers(output_dir, profile_name)
+        console.print("[green]✓[/green] Generated cowork-credential-helper.sh / .cmd")
 
     return generated
 

--- a/source/tests/test_cowork_credential_helper.py
+++ b/source/tests/test_cowork_credential_helper.py
@@ -6,12 +6,32 @@
 import json
 
 from claude_code_with_bedrock.cli.utils.cowork_3p import (
+    _to_windows_credential_helper,
     build_mdm_config,
     generate_all,
     generate_intune_script,
     generate_json,
     generate_reg_file,
 )
+
+
+class TestToWindowsCredentialHelper:
+    """Direct regression tests for the unix->windows helper-path conversion.
+
+    Pins the PR #733 bug class: the value is a bare wrapper path, so the
+    converter must swap .sh->.cmd and rewrite slashes WITHOUT appending .exe or
+    splitting on spaces, and must be a no-op for non-placeholder values.
+    """
+
+    def test_sh_wrapper_becomes_cmd_no_exe(self):
+        out = _to_windows_credential_helper("__CCWB_HOME__/claude-code-with-bedrock/cowork-credential-helper.sh")
+        assert out == "__CCWB_HOME__\\claude-code-with-bedrock\\cowork-credential-helper.cmd"
+        assert ".exe" not in out
+        assert " " not in out  # bare path, no inline args
+
+    def test_noop_for_non_placeholder_value(self):
+        for val in ("C:\\some\\abs\\path.cmd", "/usr/local/bin/helper", ""):
+            assert _to_windows_credential_helper(val) == val
 
 
 class TestBuildMdmConfigCredentialHelper:

--- a/source/tests/test_cowork_credential_helper.py
+++ b/source/tests/test_cowork_credential_helper.py
@@ -7,6 +7,7 @@ import json
 
 from claude_code_with_bedrock.cli.utils.cowork_3p import (
     build_mdm_config,
+    generate_all,
     generate_intune_script,
     generate_json,
     generate_reg_file,
@@ -28,15 +29,19 @@ class TestBuildMdmConfigCredentialHelper:
         assert "inferenceCredentialHelperSilentRefreshEnabled" in config
         assert config["inferenceCredentialHelperSilentRefreshEnabled"] == "true"
 
-    def test_helper_mode_path_includes_profile_name(self):
-        """Credential helper path should include --profile <name>."""
+    def test_helper_path_is_bare_wrapper_no_args(self):
+        """Claude Desktop runs the helper 'with no arguments', so the MDM value
+        must be a bare path to the wrapper script — the --desktop/--profile flags
+        live inside the wrapper, not in this value."""
         config = build_mdm_config(
             bedrock_region="us-west-2",
             model_aliases=["sonnet"],
             profile_name="Production",
         )
-        assert "--profile Production" in config["inferenceCredentialHelper"]
-        assert "credential-process" in config["inferenceCredentialHelper"]
+        helper = config["inferenceCredentialHelper"]
+        assert helper.endswith("cowork-credential-helper.sh")
+        assert "--profile" not in helper
+        assert "--desktop" not in helper
 
     def test_helper_mode_ttl_default(self):
         """Default TTL should be 3500s (under 1h STS expiry)."""
@@ -115,11 +120,12 @@ class TestGenerateRegFileCredentialHelper:
     """Test Windows .reg generation with credential helper path rewriting."""
 
     def test_reg_file_rewrites_unix_path_to_windows(self, tmp_path):
-        """Unix path becomes __CCWB_HOME__\\...credential-process.exe (placeholder kept).
+        """Unix wrapper path becomes __CCWB_HOME__\\...cowork-credential-helper.cmd.
 
         The placeholder is NOT %USERPROFILE%: Claude Desktop reads the registry
         value literally and does not expand env vars. install.bat substitutes
-        __CCWB_HOME__ with the absolute home before importing the .reg.
+        __CCWB_HOME__ with the absolute home before importing the .reg. The value
+        is a bare path (no arguments) — Claude Desktop runs it with none.
         """
         config = build_mdm_config(
             bedrock_region="us-west-2",
@@ -131,9 +137,10 @@ class TestGenerateRegFileCredentialHelper:
         # Placeholder kept, env var NOT used
         assert "__CCWB_HOME__" in content
         assert "%USERPROFILE%" not in content
-        # Windows binary form: backslashes + .exe suffix
-        assert "credential-process.exe" in content
-        assert "--profile Test" in content
+        # Windows wrapper form: backslashes + .cmd, no inline args
+        assert "cowork-credential-helper.cmd" in content
+        assert "--profile" not in content
+        assert "--desktop" not in content
 
     def test_reg_file_no_rewrite_for_profile_mode(self, tmp_path):
         """Profile mode should not contain credential helper in .reg file."""
@@ -166,9 +173,10 @@ class TestGenerateIntuneScript:
         content = ps1_path.read_text(encoding="utf-8")
         assert "$ccwbHome = $env:USERPROFILE" in content
         assert ".Replace('__CCWB_HOME__', $ccwbHome)" in content
-        # credential helper converted to the Windows .exe form
-        assert "credential-process.exe" in content
-        assert "--profile Test" in content
+        # credential helper converted to the Windows wrapper (.cmd), no inline args
+        assert "cowork-credential-helper.cmd" in content
+        assert "--profile" not in content
+        assert "--desktop" not in content
         # no emitted registry VALUE carries the unexpanded env var (comments may
         # mention it, so check the Set-ItemProperty lines specifically)
         value_lines = [ln for ln in content.splitlines() if ln.startswith("Set-ItemProperty")]
@@ -188,9 +196,52 @@ class TestGenerateJsonCredentialHelper:
         )
         json_path = generate_json(tmp_path, config)
         data = json.loads(json_path.read_text(encoding="utf-8"))
-        assert (
-            data["inferenceCredentialHelper"]
-            == "__CCWB_HOME__/claude-code-with-bedrock/credential-process --desktop --profile MyProfile"
-        )
+        assert data["inferenceCredentialHelper"] == "__CCWB_HOME__/claude-code-with-bedrock/cowork-credential-helper.sh"
         assert data["inferenceCredentialHelperTtlSec"] == "3500"
         assert data["inferenceCredentialHelperSilentRefreshEnabled"] == "true"
+
+
+class TestGenerateHelperWrappers:
+    """The wrapper scripts bake --desktop/--profile so the MDM value stays bare."""
+
+    def test_wrappers_written_with_profile_and_desktop(self, tmp_path):
+        from claude_code_with_bedrock.cli.utils.cowork_3p import generate_helper_wrappers
+
+        names = generate_helper_wrappers(tmp_path, "MyProfile")
+        assert set(names) == {"cowork-credential-helper.sh", "cowork-credential-helper.cmd"}
+
+        sh = (tmp_path / "cowork-credential-helper.sh").read_text(encoding="utf-8")
+        assert "--desktop --profile MyProfile" in sh
+        assert 'exec "$SCRIPT_DIR/credential-process"' in sh
+
+        # .cmd must be CRLF-terminated and call the co-located .exe via %~dp0
+        cmd_bytes = (tmp_path / "cowork-credential-helper.cmd").read_bytes()
+        assert b"\r\n" in cmd_bytes
+        cmd = cmd_bytes.decode("utf-8")
+        assert '"%~dp0credential-process.exe" --desktop --profile MyProfile' in cmd
+
+    def test_generate_all_emits_wrappers_in_helper_mode(self, tmp_path):
+        from rich.console import Console
+
+        config = build_mdm_config(
+            bedrock_region="us-west-2",
+            model_aliases=["sonnet"],
+            profile_name="P",
+        )
+        generated = generate_all(tmp_path, config, Console())
+        assert "cowork-credential-helper.sh" in generated
+        assert "cowork-credential-helper.cmd" in generated
+        assert (tmp_path / "cowork-credential-helper.sh").exists()
+
+    def test_generate_all_skips_wrappers_in_profile_mode(self, tmp_path):
+        from rich.console import Console
+
+        config = build_mdm_config(
+            bedrock_region="us-west-2",
+            model_aliases=["sonnet"],
+            profile_name="P",
+            credential_mode="profile",
+        )
+        generated = generate_all(tmp_path, config, Console())
+        assert "cowork-credential-helper.sh" not in generated
+        assert not (tmp_path / "cowork-credential-helper.sh").exists()


### PR DESCRIPTION
## Why

Claude Desktop runs the `inferenceCredentialHelper` executable **at the configured path with no arguments** ([Anthropic docs](https://claude.com/docs/third-party/claude-desktop/credential-helper)). #733 set the value to `credential-process --desktop --profile <name>`, so Claude Desktop treats the whole string as one filename and fails to spawn it:

```
[custom-3p] helper spawn failed: ... ENOENT
Credential helper failed to start (... ENOENT)
```

Helper mode is broken for **every provider and platform** as a result.

## What

Emit a bare, argument-free path to a wrapper script; the wrapper hardcodes `--desktop --profile <name>` and execs the co-located binary.

- `cowork_3p.py`: generate `cowork-credential-helper.sh`/`.cmd`; `_credential_process_path` + `_to_windows_credential_helper` emit/rewrite the wrapper path (keeps the `__CCWB_HOME__` placeholder + .sh→.cmd conversion).
- `package.py`: `install.sh` / `install.bat` copy the wrapper next to the binary.
- `distribute.py`: ship the wrappers in the per-OS and all-files manifests.
- Tests updated for the bare-path/wrapper form (+ wrapper generation coverage).

## Companion to #784 / #785 (Google IAM)

Independent fixes, but for a **Google** CoWork deployment **both are required**: this clears the ENOENT spawn failure; #785 grants `bedrock:CallWithBearerToken` to clear the subsequent 403. They touch disjoint files (Python packaging vs. CFN template) and merge/revert independently.

## Testing

- `pytest tests/` — 1589 passed; ruff check + format clean.
- Wrapper generation, `.reg`/Intune `.ps1` rewriting, and distribution-manifest inclusion covered by tests.
- **Live validation (in progress):** on a Google Bedrock deployment the wrapper spawns and mints a bearer token (`helper ok`); full end-to-end pending the companion IAM change on the deployed role.

Fixes #786