### PR TITLE
fix(init): collect and persist Google OAuth client_secret in wizard

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -793,6 +793,27 @@ class InitCommand(Command):
                 config["client_certificate_path"] = client_certificate_path
                 config["client_certificate_key_path"] = client_certificate_key_path
 
+            elif provider_type == "google":
+                # Google's installed-app OAuth flow requires a client_secret for the
+                # token exchange (PKCE alone is insufficient). Google documents this
+                # secret as NON-confidential for installed apps, so — unlike Azure —
+                # it is stored in config.json and shipped to end users by `ccwb
+                # package`, not held in the OS keyring. See config-sync.md.
+                console.print("\n[bold]Google OAuth Client Secret[/bold]")
+                console.print(
+                    "Google's installed-app flow requires the OAuth client secret\n"
+                    "(the GOCSPX-… value from your Google Cloud OAuth client).\n"
+                )
+                client_secret = questionary.password(
+                    "Enter your Google OAuth client secret:",
+                    validate=lambda x: bool(x) or "Client secret cannot be empty",
+                    default=config.get("client_secret", "") or "",
+                ).ask()
+                if not client_secret:
+                    return None
+                config["client_secret"] = client_secret
+                console.print("[dim]  ✓ Client secret saved to profile (shipped to users by 'ccwb package')[/dim]")
+
             # Credential Storage Method
             from claude_code_with_bedrock.cli.utils.helpers import is_keyring_available, is_wsl
 
@@ -2856,6 +2877,9 @@ class InitCommand(Command):
             "idc_permission_set_name": config_data.get("idc_permission_set_name"),
             "sso_region": config_data.get("sso_region"),
             "azure_auth_mode": config_data.get("azure_auth_mode"),
+            # Google's client_secret is non-confidential and persisted in config.json
+            # (Azure's confidential secret lives in the OS keyring and stays None here).
+            "client_secret": config_data.get("client_secret"),
             "client_certificate_path": config_data.get("client_certificate_path"),
             "client_certificate_key_path": config_data.get("client_certificate_key_path"),
             "enable_codebuild": config_data.get("codebuild", {}).get("enabled", False),
@@ -3330,9 +3354,13 @@ class InitCommand(Command):
                 existing_config["analytics"] = {"enabled": profile.analytics_enabled}
 
             # Preserve confidential client configuration if present
-            # client_secret is never written to config — it lives in the OS keyring
+            # Azure's client_secret lives in the OS keyring (never in config); Google's
+            # client_secret is non-confidential and persisted in the profile — restore
+            # it so re-running init pre-fills the value instead of losing it.
             if getattr(profile, "azure_auth_mode", None):
                 existing_config["azure_auth_mode"] = profile.azure_auth_mode
+            if getattr(profile, "client_secret", None):
+                existing_config["client_secret"] = profile.client_secret
             if getattr(profile, "client_certificate_path", None):
                 existing_config["client_certificate_path"] = profile.client_certificate_path
                 existing_config["client_certificate_key_path"] = profile.client_certificate_key_path

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -136,7 +136,11 @@ class Profile:
     # If azure_auth_mode == "certificate", certificate paths are stored in config.json
     #   and used to build a signed JWT assertion.
     azure_auth_mode: str | None = None  # "public", "secret", or "certificate"
-    client_secret: str | None = None  # In-memory only — loaded from OS keyring at runtime
+    # Azure (azure_auth_mode == "secret"): confidential — loaded from OS keyring at runtime,
+    #   never written to config.json.
+    # Google: non-confidential per Google's installed-app OAuth docs — persisted in
+    #   config.json and shipped to end users by `ccwb package`. See config-sync.md.
+    client_secret: str | None = None
     client_certificate_path: str | None = None  # Path to PEM certificate file
     client_certificate_key_path: str | None = None  # Path to PEM private key file
 

--- a/source/tests/test_google_client_secret.py
+++ b/source/tests/test_google_client_secret.py
@@ -5,9 +5,17 @@ which use PKCE-only for native apps). Google documents this secret as non-confid
 for installed applications, so it's stored in config.json rather than the OS keyring.
 """
 
+import sys
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
+
+# ruff: noqa: E402
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from claude_code_with_bedrock.cli.commands.init import InitCommand
+from claude_code_with_bedrock.config import Config, Profile
 
 
 class TestGoogleClientSecretConfig:
@@ -36,16 +44,18 @@ class TestGoogleClientSecretConfig:
         )
 
     def test_init_wizard_prompts_google_secret(self):
-        """The init wizard must prompt for client_secret when provider is Google."""
+        """The init wizard must have a Google branch that writes client_secret to config."""
         init_py = (
             Path(__file__).resolve().parents[2] / "source" / "claude_code_with_bedrock" / "cli" / "commands" / "init.py"
         )
         content = init_py.read_text(encoding="utf-8")
-        # Verify Google-specific handling exists in init wizard
-        assert 'provider_type = "google"' in content
-        # client_secret is stored in OS keyring, not written to config file
-        assert "client_secret" in content, (
-            "Init wizard must handle client_secret for Google provider (stored in keyring)"
+        # A Google-specific provider branch must exist (distinct from the Azure branch)
+        # and must persist the secret to the config dict (not the keyring).
+        assert 'elif provider_type == "google":' in content, (
+            "Init wizard must have a Google branch that collects the OAuth client secret"
+        )
+        assert 'config["client_secret"] = client_secret' in content, (
+            "Google branch must persist client_secret to config.json (non-confidential)"
         )
 
     def test_package_includes_google_client_secret(self):
@@ -81,3 +91,75 @@ class TestGoogleClientSecretConfig:
                     f"Line {i + 1}: Google client_secret should be stored in config.json, "
                     f"not OS keyring (Google documents it as non-confidential)"
                 )
+
+
+class TestGoogleClientSecretRoundTrip:
+    """Re-running init must preserve a saved Google client_secret (config-sync.md)."""
+
+    @staticmethod
+    def _google_profile() -> Profile:
+        return Profile(
+            name="google-test",
+            provider_domain="accounts.google.com",
+            client_id="319-abc.apps.googleusercontent.com",
+            identity_pool_name="claude-code-auth",
+            credential_storage="session",
+            aws_region="us-east-1",
+            provider_type="google",
+            client_secret="GOCSPX-secret-value",
+            federation_type="direct",
+            federated_role_arn="arn:aws:iam::123456789012:role/BedrockGoogleFederatedRole",
+        )
+
+    def test_rerun_preserves_google_client_secret(self):
+        """_check_existing_deployment must restore client_secret from the saved profile."""
+        command = InitCommand()
+        fake_config = Config()
+        profile = self._google_profile()
+        with (
+            patch.object(Config, "load", return_value=fake_config),
+            patch.object(fake_config, "get_profile", return_value=profile),
+            patch.object(InitCommand, "_stack_exists", side_effect=Exception("no creds")),
+        ):
+            rebuilt = command._check_existing_deployment("google-test")
+        assert rebuilt.get("client_secret") == "GOCSPX-secret-value", (
+            "Re-running init dropped the Google client_secret — it must survive the "
+            "profile -> config rebuild so the value pre-fills instead of resetting"
+        )
+
+    def test_save_configuration_persists_client_secret(self):
+        """_save_configuration must write client_secret into the saved Profile."""
+        command = InitCommand()
+        fake_config = Config()
+        saved = {}
+
+        def _capture(profile):
+            saved["profile"] = profile
+
+        config_data = {
+            "provider_type": "google",
+            "client_secret": "GOCSPX-secret-value",
+            "sso_enabled": True,
+            "credential_storage": "session",
+            "okta": {"domain": "accounts.google.com", "client_id": "319-abc.apps.googleusercontent.com"},
+            "aws": {
+                "region": "us-east-1",
+                "identity_pool_name": "claude-code-auth",
+                "stacks": {},
+                "allowed_bedrock_regions": ["us-east-1"],
+            },
+            "monitoring": {"enabled": False},
+            "federation_type": "direct",
+        }
+        with (
+            patch.object(Config, "load", return_value=fake_config),
+            patch.object(fake_config, "get_profile", return_value=None),
+            patch.object(fake_config, "add_profile", side_effect=_capture),
+            patch.object(fake_config, "set_active_profile"),
+            patch.object(fake_config, "save"),
+        ):
+            command._save_configuration(config_data, "google-test")
+
+        assert saved["profile"].client_secret == "GOCSPX-secret-value", (
+            "_save_configuration must persist the Google client_secret to the profile"
+        )


### PR DESCRIPTION
## Why

Admins using the **Google** provider had to hand-edit `~/.ccwb/profiles/<profile>.json` to add `client_secret`. The Go credential-process reads it from `config.json` and `ccwb package` already ships it — but `ccwb init` never prompted for it. The only `client_secret` prompt was gated on `provider_type == "azure"`. Even a manually added value was silently dropped on save/reload, since it was absent from `_save_configuration`'s `wizard_fields` and not restored by `_check_existing_deployment`.

## What

- **`init.py`** — add a Google branch that prompts for the OAuth client secret and stores it in `config["client_secret"]` (written to `config.json`, **not** the OS keyring — Google documents it as non-confidential for installed apps, per `config-sync.md`).
- **`init.py` `_save_configuration`** — add `client_secret` to `wizard_fields` so it persists. Safe for Azure: that branch never sets `config["client_secret"]`, so it stays `None` and the confidential secret remains keyring-only.
- **`init.py` `_check_existing_deployment`** — restore `client_secret` on reload so re-running init pre-fills instead of losing it (round-trip contract).
- **`config.py`** — correct the `client_secret` field comment to document the Azure-keyring vs Google-config split.

## Testing

- `test_google_client_secret.py`: added save-persist and reload round-trip regression tests — **verified failing without the fix, passing with it**.
- Strengthened the wizard-prompt assertion that previously passed vacuously (it matched Azure's `client_secret` usage).
- Green: `test_google_client_secret.py`, `test_google_provider.py`, `test_confidential_client.py`, `test_init.py`, `test_init_quota_roundtrip.py`, `test_config.py`. `ruff check` clean.
- No Go change needed — `ProfileConfig.ClientSecret` already exists and is read for Google (parity confirmed, not assumed).