### PR TITLE
fix(deploy): expand "all-commercial" region sentinel before IAM condition

### DIFF
--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -833,11 +833,14 @@ class DeployCommand(Command):
                     template = project_root / "deployment" / "infrastructure" / "bedrock-auth-idc.yaml"
                     stack_name = profile.stack_names.get("auth", f"{profile.identity_pool_name}-stack")
 
-                    from claude_code_with_bedrock.models import get_all_bedrock_regions
+                    from claude_code_with_bedrock.models import expand_bedrock_regions, get_all_bedrock_regions
 
                     bedrock_regions = profile.allowed_bedrock_regions
                     if not bedrock_regions:
                         bedrock_regions = [r for r in get_all_bedrock_regions() if "gov" not in r]
+                    # Expand sentinels (e.g. "all-commercial") into real regions so they
+                    # never land in the role's aws:RequestedRegion IAM condition.
+                    bedrock_regions = expand_bedrock_regions(bedrock_regions)
 
                     idc_role_name = getattr(profile, "idc_permission_set_name", None) or "BedrockIDCFederatedRole"
                     params = [
@@ -947,6 +950,11 @@ class DeployCommand(Command):
                     from claude_code_with_bedrock.models import get_all_bedrock_regions
 
                     bedrock_regions = [r for r in get_all_bedrock_regions() if "gov" not in r]
+                # Expand sentinels (e.g. "all-commercial") into real regions so they
+                # never land in the role's aws:RequestedRegion IAM condition.
+                from claude_code_with_bedrock.models import expand_bedrock_regions
+
+                bedrock_regions = expand_bedrock_regions(bedrock_regions)
 
                 params.extend(
                     [
@@ -1602,11 +1610,14 @@ class DeployCommand(Command):
             console.print("\n[cyan]" + "\n".join(lines) + "[/cyan]")
 
         if stack_type == "auth":
+            from claude_code_with_bedrock.models import expand_bedrock_regions, get_all_bedrock_regions
+
             bedrock_regions = profile.allowed_bedrock_regions
             if not bedrock_regions:
-                from claude_code_with_bedrock.models import get_all_bedrock_regions
-
                 bedrock_regions = [r for r in get_all_bedrock_regions() if "gov" not in r]
+            # Expand sentinels (e.g. "all-commercial") into real regions so they
+            # never land in the role's aws:RequestedRegion IAM condition.
+            bedrock_regions = expand_bedrock_regions(bedrock_regions)
 
             stack_name = profile.stack_names.get("auth", f"{profile.identity_pool_name}-stack")
             auth_type = profile.effective_auth_type

--- a/source/claude_code_with_bedrock/cli/commands/init.py
+++ b/source/claude_code_with_bedrock/cli/commands/init.py
@@ -3049,11 +3049,15 @@ class InitCommand(Command):
         sso_enabled = config.get("sso_enabled", True)
         okta_domain = config.get("okta", {}).get("domain", "none") if sso_enabled else "none"
         okta_client_id = config.get("okta", {}).get("client_id", "none") if sso_enabled else "none"
+        # Expand region sentinels (e.g. "all-commercial") before they reach the
+        # AllowedBedrockRegions CFN param → aws:RequestedRegion IAM condition.
+        from claude_code_with_bedrock.models import expand_bedrock_regions
+
         param_map = {
             "OktaDomain": okta_domain,
             "OktaClientId": okta_client_id,
             "IdentityPoolName": config["aws"]["identity_pool_name"],
-            "AllowedBedrockRegions": ",".join(config["aws"]["allowed_bedrock_regions"]),
+            "AllowedBedrockRegions": ",".join(expand_bedrock_regions(config["aws"]["allowed_bedrock_regions"])),
             "EnableMonitoring": "true" if config["monitoring"]["enabled"] else "false",
             "MaxSessionDuration": "28800",  # 8 hours
         }

--- a/source/claude_code_with_bedrock/cli/validators.py
+++ b/source/claude_code_with_bedrock/cli/validators.py
@@ -41,7 +41,13 @@ def validate_profile_for_packaging(profile) -> list[ValidationError]:
 
     allowed_regions = getattr(profile, "allowed_bedrock_regions", None)
     if allowed_regions and getattr(profile, "aws_region", None):
-        if profile.aws_region not in allowed_regions:
+        # Expand model region sentinels (e.g. "all-commercial") before comparing —
+        # a global-model profile legitimately stores the sentinel, which expands to
+        # include aws_region. Comparing against the raw list warned spuriously.
+        from claude_code_with_bedrock.models import expand_bedrock_regions
+
+        effective_regions = expand_bedrock_regions(allowed_regions)
+        if profile.aws_region not in effective_regions:
             errors.append(
                 ValidationError(
                     "aws_region",

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -591,10 +591,15 @@ class Config:
         if not profile:
             raise ValueError(f"Profile not found: {profile_name}")
 
+        # Expand sentinels (e.g. "all-commercial") into concrete regions — the
+        # value feeds the role's aws:RequestedRegion IAM condition, which would
+        # deny every invoke if handed a sentinel that matches no real region.
+        from claude_code_with_bedrock.models import expand_bedrock_regions
+
         return {
             "OktaDomain": profile.okta_domain,
             "OktaClientId": profile.okta_client_id,
             "IdentityPoolName": profile.identity_pool_name,
-            "AllowedBedrockRegions": ",".join(profile.allowed_bedrock_regions),
+            "AllowedBedrockRegions": ",".join(expand_bedrock_regions(profile.allowed_bedrock_regions)),
             "EnableMonitoring": "true" if profile.monitoring_enabled else "false",
         }

--- a/source/claude_code_with_bedrock/models.py
+++ b/source/claude_code_with_bedrock/models.py
@@ -1590,6 +1590,43 @@ def get_all_bedrock_regions() -> list[str]:
     return sorted(regions)
 
 
+def expand_bedrock_regions(regions: list[str]) -> list[str]:
+    """Expand model destination-region sentinels into concrete AWS regions.
+
+    Global inference profiles carry the sentinel ``"all-commercial"`` in their
+    ``destination_regions`` (see CLAUDE_MODELS). That sentinel is fine as model
+    metadata, but it is NOT a real region — it must never reach an IAM policy's
+    ``aws:RequestedRegion`` condition, where it would match nothing and silently
+    deny every Bedrock invoke (a global model routes to real regions like
+    us-east-1, so the condition value must be those regions, not the sentinel).
+
+    This normalizes a region list for use as the ``AllowedBedrockRegions``
+    CloudFormation parameter:
+    - ``"all-commercial"`` expands to every non-GovCloud Bedrock region.
+    - Any other ``"all-*"`` sentinel is dropped (defensive; only all-commercial
+      exists today) so it can never leak into a policy condition.
+    - Concrete regions pass through unchanged.
+
+    Order is preserved for concrete regions; expanded regions are appended
+    sorted and de-duplicated. Returns a list with no sentinel values.
+    """
+    expanded: list[str] = []
+    seen: set[str] = set()
+    for r in regions:
+        if r == "all-commercial":
+            for cr in get_all_bedrock_regions():  # already excludes all-* sentinels
+                if "gov" not in cr and cr not in seen:
+                    expanded.append(cr)
+                    seen.add(cr)
+        elif r.startswith("all-"):
+            # Unknown sentinel — never emit it into an IAM condition.
+            continue
+        elif r not in seen:
+            expanded.append(r)
+            seen.add(r)
+    return expanded
+
+
 # Default rate limits by model family (TPM = tokens per minute, RPM = requests per minute).
 # These are approximate on-demand defaults; actual limits depend on account quotas.
 MODEL_RATE_LIMITS = {

--- a/source/tests/test_bedrock_region_expansion.py
+++ b/source/tests/test_bedrock_region_expansion.py
@@ -1,0 +1,62 @@
+# ABOUTME: Regression tests that the "all-commercial" region sentinel never
+# ABOUTME: reaches the AllowedBedrockRegions CFN param / aws:RequestedRegion IAM condition.
+
+"""Regression: global-model region sentinel must not deny Bedrock invokes.
+
+A profile whose selected model is a *global* inference profile stores
+``allowed_bedrock_regions = ["all-commercial"]`` (the model's destination-region
+sentinel). Before the fix, that string was passed verbatim as the
+``AllowedBedrockRegions`` CloudFormation parameter, which becomes the federated
+role's ``aws:RequestedRegion`` StringEquals condition. ``"all-commercial"``
+equals no real region, so every ``bedrock:InvokeModelWithResponseStream`` call
+was denied with AccessDenied even though auth succeeded.
+
+These tests assert the sentinel is expanded into concrete regions at every
+CFN-parameter boundary.
+"""
+
+from unittest.mock import patch
+
+from claude_code_with_bedrock.config import Config, Profile
+
+
+def _global_profile() -> Profile:
+    """A Google-federated profile pinned to a global model, as saved by init."""
+    return Profile(
+        name="aws-demo",
+        provider_domain="accounts.google.com",
+        client_id="319-abc.apps.googleusercontent.com",
+        credential_storage="session",
+        aws_region="us-east-1",
+        identity_pool_name="claude-code-auth",
+        provider_type="google",
+        federation_type="direct",
+        selected_model="global.anthropic.claude-sonnet-4-6",
+        allowed_bedrock_regions=["all-commercial"],
+    )
+
+
+def test_get_aws_config_expands_all_commercial():
+    """Config.get_aws_config_for_profile must not emit the raw sentinel."""
+    profile = _global_profile()
+    cfg = Config()
+    with patch.object(cfg, "get_profile", return_value=profile):
+        aws_config = cfg.get_aws_config_for_profile("aws-demo")
+
+    regions = aws_config["AllowedBedrockRegions"]
+    assert "all-commercial" not in regions, (
+        "The sentinel leaked into AllowedBedrockRegions — the IAM aws:RequestedRegion "
+        "condition would match no region and deny every Bedrock invoke"
+    )
+    # The customer's request region must be authorized.
+    assert "us-east-1" in regions.split(",")
+
+
+def test_expansion_covers_the_reported_arn_region():
+    """The us-east-1 invoke from the CloudTrail AccessDenied must now be allowed."""
+    from claude_code_with_bedrock.models import expand_bedrock_regions
+
+    expanded = expand_bedrock_regions(["all-commercial"])
+    # inference-profile/global.anthropic.claude-sonnet-* is invoked in us-east-1
+    assert "us-east-1" in expanded
+    assert not any(r.startswith("all-") for r in expanded)

--- a/source/tests/test_models.py
+++ b/source/tests/test_models.py
@@ -535,3 +535,51 @@ class TestResolveModelForTier:
                     assert f"{prefix}." in result, (
                         f"resolve_model_for_tier('{tier}', '{prefix}') = '{result}' wrong prefix"
                     )
+
+
+class TestExpandBedrockRegions:
+    """Region sentinels must never reach an IAM aws:RequestedRegion condition.
+
+    A global inference profile stores the sentinel "all-commercial" in its
+    destination_regions. If that string is passed verbatim as the
+    AllowedBedrockRegions CFN parameter, the role's StringEquals condition on
+    aws:RequestedRegion matches no real region and every bedrock:InvokeModel*
+    call is denied with AccessDenied. expand_bedrock_regions() prevents this.
+    """
+
+    def test_all_commercial_expands_to_real_regions(self):
+        from claude_code_with_bedrock.models import expand_bedrock_regions
+
+        result = expand_bedrock_regions(["all-commercial"])
+        assert "all-commercial" not in result, "sentinel must never survive expansion"
+        assert "us-east-1" in result, "commercial expansion must include us-east-1"
+        # Must be actual AWS region tokens, and exclude GovCloud.
+        assert all("gov" not in r for r in result)
+        assert all(r.count("-") >= 2 for r in result), f"non-region token leaked: {result}"
+
+    def test_no_all_star_sentinel_survives(self):
+        from claude_code_with_bedrock.models import expand_bedrock_regions
+
+        # Any all-* sentinel (even an unknown future one) must be dropped.
+        result = expand_bedrock_regions(["all-commercial", "all-something-new"])
+        assert not any(r.startswith("all-") for r in result)
+
+    def test_concrete_regions_pass_through_and_dedupe(self):
+        from claude_code_with_bedrock.models import expand_bedrock_regions
+
+        assert expand_bedrock_regions(["us-east-1", "us-west-2"]) == ["us-east-1", "us-west-2"]
+        # Duplicates collapse; order of first occurrence preserved.
+        assert expand_bedrock_regions(["us-east-1", "us-east-1"]) == ["us-east-1"]
+
+    def test_empty_list_returns_empty(self):
+        from claude_code_with_bedrock.models import expand_bedrock_regions
+
+        assert expand_bedrock_regions([]) == []
+
+    def test_mixed_sentinel_and_concrete_no_duplicates(self):
+        from claude_code_with_bedrock.models import expand_bedrock_regions
+
+        # us-east-1 appears both explicitly and via the expansion — only once.
+        result = expand_bedrock_regions(["us-east-1", "all-commercial"])
+        assert result.count("us-east-1") == 1
+        assert "all-commercial" not in result

--- a/source/tests/test_packaging_validators.py
+++ b/source/tests/test_packaging_validators.py
@@ -56,3 +56,33 @@ class TestMonitoringEndpointCheck:
     def test_monitoring_disabled_is_clean(self):
         profile = _profile(monitoring_enabled=False, monitoring_mode="central")
         assert _endpoint_warnings(profile) == []
+
+
+def _region_warnings(profile):
+    return [e for e in validate_profile_for_packaging(profile) if e.field == "aws_region"]
+
+
+class TestAllowedRegionSentinelCheck:
+    """The aws_region check must expand "all-commercial" before comparing.
+
+    A global-model profile legitimately stores allowed_bedrock_regions =
+    ["all-commercial"]. Comparing aws_region against the raw sentinel warned
+    spuriously ("Region 'us-east-1' not in allowed_bedrock_regions:
+    ['all-commercial']") even though the region is authorized once the sentinel
+    is expanded at the CFN-param boundary.
+    """
+
+    def test_all_commercial_does_not_warn_for_commercial_region(self):
+        profile = _profile(aws_region="us-east-1", allowed_bedrock_regions=["all-commercial"])
+        assert _region_warnings(profile) == []
+
+    def test_concrete_region_mismatch_still_warns(self):
+        # Genuine misconfiguration must still surface.
+        profile = _profile(aws_region="us-east-1", allowed_bedrock_regions=["eu-west-1"])
+        warnings = _region_warnings(profile)
+        assert len(warnings) == 1
+        assert warnings[0].severity == "warning"
+
+    def test_concrete_region_match_is_clean(self):
+        profile = _profile(aws_region="us-east-1", allowed_bedrock_regions=["us-east-1", "us-west-2"])
+        assert _region_warnings(profile) == []


### PR DESCRIPTION
## Why

Customers on a **global inference profile** (e.g. `global.anthropic.claude-sonnet-*`) get `403 AccessDenied` on `bedrock:InvokeModelWithResponseStream` **even though authentication succeeds**:

```
User: .../BedrockGoogleFederatedRole/mike@... is not authorized to perform:
bedrock:InvokeModelWithResponseStream on inference-profile/global.anthropic.claude-sonnet-5
because no identity-based policy allows the action
```

Root cause: selecting a global model stores `allowed_bedrock_regions = ["all-commercial"]` (the model's destination-region **sentinel** from the catalog). Deploy passed it **verbatim** as the `AllowedBedrockRegions` CloudFormation parameter, which becomes the federated role's `aws:RequestedRegion` `StringEquals` condition. `"all-commercial"` matches no real region, so every region-scoped invoke statement — including `inference-profile/*` — is dead and every call is denied.

**Not provider-specific.** The affected code (`deploy.py` / `config.py` / `init.py` / `models.py`) and the region-conditioned IAM statement are shared across all providers (Okta, Auth0, Azure, Cognito, generic, Google). Any deployment that selects a global model is affected; the reported case was Google only by coincidence.

**Why it went unnoticed:** regional profiles (`us`, `eu`, …) store concrete regions and work fine — only the newer, less-common global-model path produces the sentinel. The stack also deploys green (CFN accepts the string as a `CommaDelimitedList`); the failure only surfaces at invoke time.

## What

- **`models.py`** — add `expand_bedrock_regions()`: maps `"all-commercial"` → every non-GovCloud Bedrock region, drops any other `all-*` sentinel defensively, passes concrete regions through de-duplicated. The sentinel can never reach an IAM condition.
- Apply it at **every** `AllowedBedrockRegions` param boundary: `deploy.py` (IDC, OIDC, and print-command paths), `config.get_aws_config_for_profile`, and `init._update_parameters_file`. Expanding at **deploy time** also repairs already-saved profiles without requiring re-init.

## Testing

- `test_models.py::TestExpandBedrockRegions` — expansion, sentinel drop, passthrough, dedupe, empty.
- `test_bedrock_region_expansion.py` — integration regression reproducing the reported profile shape; asserts `us-east-1` is authorized and the sentinel never appears in `AllowedBedrockRegions`. **Verified failing without the fix, passing with it.**
- Full run green (98 passed): models, cloudformation, iam_identity_center, config, config_models. `ruff check` clean.

## Operator note

This fixes future deploys. Customers with an **already-deployed** stack must re-run `ccwb deploy` (auth stack) to rewrite the role's region condition — this affects **any provider** on a global model, not just Google.