### PR TITLE
fix(cowork): declare inferenceCredentialKind to resolve credential-method ambiguity

### DIFF
--- a/assets/docs/COWORK_3P.md
+++ b/assets/docs/COWORK_3P.md
@@ -177,6 +177,7 @@ When Claude Cowork starts a session:
 3. The output is cached for `inferenceCredentialHelperTtlSec` seconds (default: 3500, just under the 1h STS token lifetime)
 4. When the cache expires, Claude Desktop automatically re-runs the helper — **no restart required**
 5. If credentials are rejected mid-session, Claude Desktop re-runs with `CLAUDE_HELPER_CONTEXT=mid-session-refresh` for seamless recovery (20s timeout)
+6. Because this mode also sets `inferenceBedrockProfile` (as an AWS SDK region/metadata fallback, not the active auth path), `ccwb package` additionally sets `inferenceCredentialKind` to `helper-script` so Claude Desktop doesn't have to pick between the two — without it, Desktop may prefer the profile instead and authentication fails
 
 The credential-process binary handles the `CLAUDE_HELPER_CONTEXT` environment variable:
 - `interactive` → Full browser-based OIDC authentication

--- a/assets/docs/COWORK_3P.md
+++ b/assets/docs/COWORK_3P.md
@@ -177,7 +177,7 @@ When Claude Cowork starts a session:
 3. The output is cached for `inferenceCredentialHelperTtlSec` seconds (default: 3500, just under the 1h STS token lifetime)
 4. When the cache expires, Claude Desktop automatically re-runs the helper — **no restart required**
 5. If credentials are rejected mid-session, Claude Desktop re-runs with `CLAUDE_HELPER_CONTEXT=mid-session-refresh` for seamless recovery (20s timeout)
-6. Because this mode also sets `inferenceBedrockProfile` (as an AWS SDK region/metadata fallback, not the active auth path), `ccwb package` additionally sets `inferenceCredentialKind` to `helper-script` so Claude Desktop doesn't have to pick between the two — without it, Desktop may prefer the profile instead and authentication fails
+6. Because this mode also sets `inferenceBedrockProfile` (as an AWS SDK region/metadata fallback, not the active auth path), this solution additionally sets `inferenceCredentialKind` to `helper-script` so Claude Desktop doesn't have to pick between the two — without it, Desktop may prefer the profile instead and authentication fails
 
 The credential-process binary handles the `CLAUDE_HELPER_CONTEXT` environment variable:
 - `interactive` → Full browser-based OIDC authentication

--- a/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
+++ b/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
@@ -219,9 +219,13 @@ def build_mdm_config(
         # never the supported one. Setting it explicitly removes the ambiguity.
         config["inferenceCredentialKind"] = "helper-script"
     else:
-        # Legacy profile mode — rely on AWS SDK credential_process chain.
+        # Legacy profile mode — rely on AWS SDK credential_process chain. Only
+        # inferenceBedrockProfile is set here, so there is no ambiguity for
+        # Claude Desktop to resolve — do not add inferenceCredentialKind, whose
+        # name/values are inferred from a Desktop log string and unverified
+        # against any published schema. Confine that unverified key to the one
+        # mode (helper) that has the reported ambiguity bug.
         config["inferenceBedrockProfile"] = profile_name
-        config["inferenceCredentialKind"] = "vendor-profile"
 
     if extra_keys:
         config.update(extra_keys)

--- a/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
+++ b/source/claude_code_with_bedrock/cli/utils/cowork_3p.py
@@ -210,9 +210,18 @@ def build_mdm_config(
         config["inferenceCredentialHelperSilentRefreshEnabled"] = "true"
         # Keep the AWS profile as fallback for SDK-level operations (region, etc.)
         config["inferenceBedrockProfile"] = profile_name
+        # Disambiguate for Claude Desktop: shipping both inferenceCredentialHelper
+        # and inferenceBedrockProfile together is intentional (the profile is a
+        # region/metadata fallback, not the active auth path), but Desktop logs
+        # "Multiple credential methods configured (vendor-profile, helper-script);
+        # using vendor-profile" and silently prefers the WRONG one without this key
+        # — causing repeated "Authentication Failed" since the SDK profile path was
+        # never the supported one. Setting it explicitly removes the ambiguity.
+        config["inferenceCredentialKind"] = "helper-script"
     else:
         # Legacy profile mode — rely on AWS SDK credential_process chain.
         config["inferenceBedrockProfile"] = profile_name
+        config["inferenceCredentialKind"] = "vendor-profile"
 
     if extra_keys:
         config.update(extra_keys)

--- a/source/tests/test_cowork_credential_helper.py
+++ b/source/tests/test_cowork_credential_helper.py
@@ -98,6 +98,22 @@ class TestBuildMdmConfigCredentialHelper:
         )
         assert config["inferenceCredentialHelper"].startswith("__CCWB_HOME__/")
 
+    def test_helper_mode_declares_credential_kind(self):
+        """Helper mode ships both inferenceCredentialHelper and inferenceBedrockProfile
+        (the latter as an SDK-level region/metadata fallback). Without an explicit
+        inferenceCredentialKind, Claude Desktop logs "Multiple credential methods
+        configured (vendor-profile, helper-script); using vendor-profile" and
+        silently authenticates via the unsupported SDK profile path instead of the
+        helper — producing repeated "Authentication Failed" for the user even though
+        credential-process itself works fine. Setting the key removes the ambiguity.
+        """
+        config = build_mdm_config(
+            bedrock_region="us-west-2",
+            model_aliases=["sonnet"],
+            profile_name="Test",
+        )
+        assert config["inferenceCredentialKind"] == "helper-script"
+
 
 class TestBuildMdmConfigProfileMode:
     """Test build_mdm_config with credential_mode='profile' (legacy)."""
@@ -115,6 +131,18 @@ class TestBuildMdmConfigProfileMode:
         assert "inferenceCredentialHelperTtlSec" not in config
         assert "inferenceCredentialHelperSilentRefreshEnabled" not in config
 
+    def test_profile_mode_declares_credential_kind(self):
+        """Legacy/profile mode has no ambiguity (only inferenceBedrockProfile is
+        set), but declaring inferenceCredentialKind explicitly keeps both modes
+        symmetric and future-proofs against Desktop tightening its ambiguity check."""
+        config = build_mdm_config(
+            bedrock_region="us-west-2",
+            model_aliases=["opus"],
+            profile_name="LegacyProfile",
+            credential_mode="profile",
+        )
+        assert config["inferenceCredentialKind"] == "vendor-profile"
+
     def test_profile_mode_backward_compatible(self):
         """Legacy mode output should match previous behavior exactly."""
         config = build_mdm_config(
@@ -127,6 +155,7 @@ class TestBuildMdmConfigProfileMode:
             "inferenceProvider": "bedrock",
             "inferenceBedrockRegion": "eu-west-1",
             "inferenceBedrockProfile": "ClaudeCode",
+            "inferenceCredentialKind": "vendor-profile",
             "inferenceModels": ["opus", "sonnet", "haiku"],
             "isClaudeCodeForDesktopEnabled": True,
             "isDesktopExtensionEnabled": True,

--- a/source/tests/test_cowork_credential_helper.py
+++ b/source/tests/test_cowork_credential_helper.py
@@ -131,17 +131,19 @@ class TestBuildMdmConfigProfileMode:
         assert "inferenceCredentialHelperTtlSec" not in config
         assert "inferenceCredentialHelperSilentRefreshEnabled" not in config
 
-    def test_profile_mode_declares_credential_kind(self):
-        """Legacy/profile mode has no ambiguity (only inferenceBedrockProfile is
-        set), but declaring inferenceCredentialKind explicitly keeps both modes
-        symmetric and future-proofs against Desktop tightening its ambiguity check."""
+    def test_profile_mode_omits_credential_kind(self):
+        """Profile mode sets only inferenceBedrockProfile, so there is no
+        credential-method ambiguity for Claude Desktop to resolve. Deliberately
+        do NOT emit inferenceCredentialKind here — its name/values are inferred
+        from a Desktop log string, unverified against any published schema, and
+        should not be shipped to a mode with no reported bug to fix."""
         config = build_mdm_config(
             bedrock_region="us-west-2",
             model_aliases=["opus"],
             profile_name="LegacyProfile",
             credential_mode="profile",
         )
-        assert config["inferenceCredentialKind"] == "vendor-profile"
+        assert "inferenceCredentialKind" not in config
 
     def test_profile_mode_backward_compatible(self):
         """Legacy mode output should match previous behavior exactly."""
@@ -155,7 +157,6 @@ class TestBuildMdmConfigProfileMode:
             "inferenceProvider": "bedrock",
             "inferenceBedrockRegion": "eu-west-1",
             "inferenceBedrockProfile": "ClaudeCode",
-            "inferenceCredentialKind": "vendor-profile",
             "inferenceModels": ["opus", "sonnet", "haiku"],
             "isClaudeCodeForDesktopEnabled": True,
             "isDesktopExtensionEnabled": True,


### PR DESCRIPTION
## Why

A customer on `cowork_credential_mode="helper"` got repeated **"Authentication Failed"** in Claude Desktop, despite `credential-process` working fine when run directly. The Desktop diagnostic log showed the actual cause:

```
[warn] Multiple credential methods configured (vendor-profile, helper-script);
using vendor-profile. Clear unused fields or set Credential kind explicitly
to avoid ambiguity.
```

Our helper-mode MDM config intentionally ships **both** `inferenceCredentialHelper` (helper-script) and `inferenceBedrockProfile` (vendor-profile, kept only as an SDK-level region/metadata fallback — see the existing code comment). Without an explicit disambiguator, Claude Desktop resolves the ambiguity to `vendor-profile` — the unsupported AWS SDK `credential_process` chain — instead of the intended helper-script path, so auth goes through the wrong path and repeatedly fails/retries before (sometimes) recovering.

## What

- `cowork_3p.py` `build_mdm_config()`: in **helper mode only**, set `config["inferenceCredentialKind"] = "helper-script"`, using the exact vocabulary Desktop's own warning uses, so it never has to guess.
- **Legacy profile mode is intentionally left unchanged** — it sets only `inferenceBedrockProfile`, so there is no ambiguity for Desktop to resolve there, and no reported bug on that path. Scoping the fix to just the mode with the actual bug avoids shipping an unverified, inferred key to a population that has nothing to gain from it (see Verification status below).
- Both `ccwb package` and `ccwb cowork generate` route through this function, so the fix applies to every generated format (JSON, `.mobileconfig`, `.reg`/`.ps1`, ADMX) for helper-mode customers.

## Testing

- `test_cowork_credential_helper.py`:
  - `test_helper_mode_declares_credential_kind` — helper mode emits the key. **Verified failing without the fix, passing with it.**
  - `test_profile_mode_omits_credential_kind` — profile mode does NOT emit the key (negative assertion, guards against re-introducing the dropped scope). **Verified it fails if the key is added back.**
  - Updated `test_profile_mode_backward_compatible`'s exact-dict assertion back to its original shape (no new key in that mode).
- Full cowork suite (35 tests in this file, 85 across cowork-related tests) green, `ruff check` clean.

## Verification status — confirmed

`inferenceCredentialKind` was initially inferred from the exact wording of Claude Desktop's own warning log, not from documentation on hand at the time. Both the key name and the `helper-script` value are now **confirmed against Anthropic's official [Claude Desktop configuration reference](https://claude.com/docs/third-party/claude-desktop/configuration#inferencecredentialkind)**:

> `inferenceCredentialKind` — enum — MDM + Bootstrap — "Selects the credential source. When set, only that source is used (no fallback). One of: `static`, `helper-script`, `interactive`, `vendor-profile`, `oauth`, `workforce`."

This confirms the key/value match the published schema exactly, and the "no fallback" semantics are exactly the disambiguation this fix relies on.

**The affected customer has also confirmed live**, on their own Claude Desktop install: adding `inferenceCredentialKind: "helper-script"` to their existing `cowork-3p-config.json` and re-importing resolved the "Authentication Failed" retry loop.

An independent code review (agent + `/review` skill) additionally flagged the earlier `vendor-profile`/profile-mode addition as unnecessary risk before the docs were confirmed — that scope has been removed (see commit history) since profile mode has no reported ambiguity bug to fix.

## Related

- Same diagnostic bundle also surfaced an unrelated `agentcore-websearch` MCP header-helper path issue (`__CCWB_HOME__` placeholder not resolved for `headersHelper`) — tracked separately, not included here (different root cause, different code path).
