### PR TITLE
chore: bump version to 2.5.3, fix IdPProvider=None on IDC landing-page deploy

### DIFF
--- a/deployment/infrastructure/landing-page-distribution.yaml
+++ b/deployment/infrastructure/landing-page-distribution.yaml
@@ -56,8 +56,9 @@ Parameters:
 
   IdPProvider:
     Type: String
-    AllowedValues: [okta, azure, auth0, cognito, generic]
-    Description: Identity provider type
+    AllowedValues: [okta, azure, auth0, cognito, generic, ""]
+    Default: ""
+    Description: Identity provider type (empty for IDC-based auth)
 
   # Okta parameters
   OktaDomain:

--- a/source/claude_code_with_bedrock/cli/commands/deploy.py
+++ b/source/claude_code_with_bedrock/cli/commands/deploy.py
@@ -1011,8 +1011,11 @@ class DeployCommand(Command):
                         f"VpcId={vpc_id}",
                         f"PublicSubnetIds={public_subnets}",
                         f"PrivateSubnetIds={private_subnets}",
-                        f"IdPProvider={profile.distribution_idp_provider}",
                     ]
+
+                    # Only add IdPProvider for OIDC-based landing pages (not IDC)
+                    if profile.distribution_idp_provider:
+                        params.append(f"IdPProvider={profile.distribution_idp_provider}")
 
                     # Add IdP-specific parameters
                     if profile.distribution_idp_provider == "okta":
@@ -1789,8 +1792,9 @@ class DeployCommand(Command):
                     f"VpcId=<VpcId from {networking_stack}>",
                     f"PublicSubnetIds=<SubnetIds from {networking_stack}>",
                     f"PrivateSubnetIds=<SubnetIds from {networking_stack}>",
-                    f"IdPProvider={profile.distribution_idp_provider}",
                 ]
+                if profile.distribution_idp_provider:
+                    params.append(f"IdPProvider={profile.distribution_idp_provider}")
             else:
                 template = project_root / "deployment" / "infrastructure" / "presigned-s3-distribution.yaml"
                 params = [f"IdentityPoolName={profile.identity_pool_name}"]

--- a/source/pyproject.toml
+++ b/source/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "claude-code-with-bedrock"
-version = "2.5.2"
+version = "2.5.3"
 description = "Deploy and manage Claude Code on Amazon Bedrock"
 authors = ["Claude Code Team <claude-code@example.com>"]
 readme = "../README.md"

--- a/source/tests/test_generic_oidc_distribution.py
+++ b/source/tests/test_generic_oidc_distribution.py
@@ -202,7 +202,7 @@ class TestGenericDistributionTemplate:
 
     def test_template_allows_generic(self):
         text = LANDING_TEMPLATE.read_text(encoding="utf-8")
-        assert "AllowedValues: [okta, azure, auth0, cognito, generic]" in text
+        assert 'AllowedValues: [okta, azure, auth0, cognito, generic, ""]' in text
 
     def test_template_has_generic_parameters(self):
         text = LANDING_TEMPLATE.read_text(encoding="utf-8")


### PR DESCRIPTION
## Changes

1. **Version bump** — `pyproject.toml` from 2.5.2 → 2.5.3
2. **Fix `IdPProvider=None` on IDC deploy path** — addresses @scouturier's [review comment](https://github.com/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock/pull/752#issuecomment-4973644148):
   - `deploy.py`: Only append `IdPProvider` param when `distribution_idp_provider` is not None (both deploy and print-cmd paths)
   - `landing-page-distribution.yaml`: Add `Default: ""` and allow empty string in `AllowedValues` so IDC deploys pass template validation without an IdP

## Context

The IDC landing-page path doesn't use an external IdP — it uses IAM Identity Center directly. The deploy code was unconditionally passing `IdPProvider=None` (literal string), which failed CFN's `AllowedValues` validation.