### PR TITLE
fix(cowork): sign Bedrock bearer token with empty-payload SHA-256, not UNSIGNED-PAYLOAD

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -307,6 +307,26 @@
         "is_secret": false
       }
     ],
+    "source/go/cmd/credential-process/bedrock_token.go": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "source/go/cmd/credential-process/bedrock_token.go",
+        "hashed_secret": "244f421f896bdcdd2784dccf4eaf7c8dfd5189b5",
+        "is_verified": false,
+        "line_number": 27,
+        "is_secret": false
+      }
+    ],
+    "source/go/cmd/credential-process/bedrock_token_test.go": [
+      {
+        "type": "Secret Keyword",
+        "filename": "source/go/cmd/credential-process/bedrock_token_test.go",
+        "hashed_secret": "92e2c153a730c3d1eeffce95c4e480ec200edad9",
+        "is_verified": false,
+        "line_number": 19,
+        "is_secret": false
+      }
+    ],
     "source/go/cmd/credential-process/config_fixtures_test.go": [
       {
         "type": "Base64 High Entropy String",
@@ -537,5 +557,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-18T02:06:29Z"
+  "generated_at": "2026-07-20T19:06:03Z"
 }

--- a/source/go/cmd/credential-process/bedrock_token.go
+++ b/source/go/cmd/credential-process/bedrock_token.go
@@ -19,6 +19,12 @@ const (
 	authPrefix     = "bedrock-api-key-"
 	tokenVersion   = "&Version=1"
 	tokenExpirySec = 43200 // 12 hours
+
+	// emptySHA256Hash is the SHA-256 digest of an empty payload. SigV4 presigned
+	// requests have no body, but the canonical request must hash it explicitly —
+	// "UNSIGNED-PAYLOAD" is only valid for services (like S3) that permit an
+	// unknown/streamed body, and Bedrock rejects signatures built that way.
+	emptySHA256Hash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 )
 
 // generateBedrockToken creates a presigned Bedrock bearer token from AWS credentials.
@@ -65,8 +71,8 @@ func generateBedrockToken(accessKeyID, secretAccessKey, sessionToken, region str
 	}
 
 	// Canonical request
-	canonicalRequest := fmt.Sprintf("POST\n/\n%s\nhost:%s\n\nhost\nUNSIGNED-PAYLOAD",
-		canonicalQuery.String(), bedrockHost)
+	canonicalRequest := fmt.Sprintf("POST\n/\n%s\nhost:%s\n\nhost\n%s",
+		canonicalQuery.String(), bedrockHost, emptySHA256Hash)
 
 	// String to sign
 	stringToSign := fmt.Sprintf("AWS4-HMAC-SHA256\n%s\n%s/%s/%s/aws4_request\n%s",

--- a/source/go/cmd/credential-process/bedrock_token_test.go
+++ b/source/go/cmd/credential-process/bedrock_token_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"encoding/base64"
+	"net/url"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestGenerateBedrockToken_SignsEmptyPayload guards against regressing to the
+// "UNSIGNED-PAYLOAD" sentinel. AWS's reference token generator
+// (aws-bedrock-token-generator-python, via botocore's SigV4QueryAuth) signs
+// the SHA-256 of an empty POST body -- "UNSIGNED-PAYLOAD" is only valid for
+// services like S3 that permit an unknown/streamed body, and Bedrock rejects
+// signatures built that way. This recomputes the signature independently
+// using the correct empty-payload hash and confirms it matches the token.
+func TestGenerateBedrockToken_SignsEmptyPayload(t *testing.T) {
+	const secretAccessKey = "secretkeyexample"
+
+	token, err := generateBedrockToken("AKIAEXAMPLE", secretAccessKey, "sessiontokenexample", "us-east-1")
+	if err != nil {
+		t.Fatalf("generateBedrockToken() error = %v", err)
+	}
+	if !strings.HasPrefix(token, authPrefix) {
+		t.Fatalf("token missing prefix %q: %s", authPrefix, token)
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(token, authPrefix))
+	if err != nil {
+		t.Fatalf("failed to decode token: %v", err)
+	}
+	presignedURL := strings.TrimSuffix(string(decoded), tokenVersion)
+
+	parts := strings.SplitN(presignedURL, "?", 2)
+	if len(parts) != 2 || parts[0] != bedrockHost+"/" {
+		t.Fatalf("unexpected presigned URL host/path: %s", presignedURL)
+	}
+
+	query, err := url.ParseQuery(parts[1])
+	if err != nil {
+		t.Fatalf("failed to parse query: %v", err)
+	}
+
+	amzDate := query.Get("X-Amz-Date")
+	credential := query.Get("X-Amz-Credential")
+	signature := query.Get("X-Amz-Signature")
+	if amzDate == "" || credential == "" || signature == "" {
+		t.Fatalf("missing required SigV4 query params: %s", presignedURL)
+	}
+
+	credParts := strings.Split(credential, "/")
+	if len(credParts) != 5 {
+		t.Fatalf("unexpected credential scope: %s", credential)
+	}
+	dateStamp, region, service := credParts[1], credParts[2], credParts[3]
+
+	// Recompute the canonical query string the same way generateBedrockToken
+	// does, excluding the signature itself (it isn't part of what gets signed).
+	query.Del("X-Amz-Signature")
+	sortedKeys := make([]string, 0, len(query))
+	for k := range query {
+		sortedKeys = append(sortedKeys, k)
+	}
+	sort.Strings(sortedKeys)
+	var canonicalQuery strings.Builder
+	for i, k := range sortedKeys {
+		if i > 0 {
+			canonicalQuery.WriteByte('&')
+		}
+		canonicalQuery.WriteString(url.QueryEscape(k))
+		canonicalQuery.WriteByte('=')
+		canonicalQuery.WriteString(url.QueryEscape(query.Get(k)))
+	}
+
+	canonicalRequest := "POST\n/\n" + canonicalQuery.String() + "\nhost:" + bedrockHost + "\n\nhost\n" + emptySHA256Hash
+	stringToSign := "AWS4-HMAC-SHA256\n" + amzDate + "\n" + dateStamp + "/" + region + "/" + service +
+		"/aws4_request\n" + sha256Hex(canonicalRequest)
+	signingKey := deriveSigningKey(secretAccessKey, dateStamp, region, service)
+	expectedSignature := hmacSHA256Hex(signingKey, stringToSign)
+
+	if signature != expectedSignature {
+		t.Fatalf("signature mismatch: token was not signed with the empty-payload SHA-256 hash\ngot:  %s\nwant: %s",
+			signature, expectedSignature)
+	}
+}


### PR DESCRIPTION
## Why

CoWork 3P's `credential-process --desktop` (#733) mints a Bedrock bearer
token for Claude Desktop's `inferenceCredentialHelper` by hand-rolling a
SigV4 presigned request. The canonical request used the `UNSIGNED-PAYLOAD`
sentinel, which is only valid for services (S3, S3 Express) whose presigned-URL
auth classes explicitly override `payload()` to return it. Bedrock's
`CallWithBearerToken` signer does not use that override — AWS's own reference
generator (`aws-bedrock-token-generator-python`, via botocore's
`SigV4QueryAuth`) signs the SHA-256 hash of the empty POST body instead.

Because a SigV4 signature is a keyed hash over the exact canonical-request
bytes, this mismatch means every bearer token minted via `--desktop` carries
an invalid signature — Bedrock would reject it.

This was flagged by a user via an AI assistant transcript; verified independently
against botocore's `auth.py` source before fixing (see `EMPTY_SHA256_HASH` /
`SigV4Auth.payload()`).

## What

- Replace the `UNSIGNED-PAYLOAD` literal with the well-known SHA-256 digest of
  an empty payload (`e3b0c442...b855`) in the canonical request.
- Add a regression test (`bedrock_token_test.go`) that independently
  recomputes the expected SigV4 signature from the token's own presigned URL
  and fails if the canonical request reverts to `UNSIGNED-PAYLOAD`. Verified
  it fails on the pre-fix code and passes on the fix.

## Scope

Go only, `--desktop` flag path (CoWork 3P / Claude Desktop helper-script mode).
Claude Code CLI is unaffected — it uses the default (non-`--desktop`)
credential-process output, which is AWS SDK–signed, not this hand-rolled path.

## Testing

- `go test ./... -race -count=1` — all packages pass
- `go vet ./...` — clean
- New test verified red (with `UNSIGNED-PAYLOAD`) → green (with the fix)