### PR TITLE
fix(credential-process): honor AWS_SHARED_CREDENTIALS_FILE in session mode (#797)

### DIFF
--- a/source/claude_code_with_bedrock/cli/utils/helpers.py
+++ b/source/claude_code_with_bedrock/cli/utils/helpers.py
@@ -5,6 +5,7 @@
 
 import configparser
 import logging
+import os
 import platform
 from pathlib import Path
 
@@ -57,7 +58,13 @@ def clear_cached_credentials(profile_name: str) -> bool:
     Co-authored-by: peepeepopapapeepeepo (from PR #330)
     """
     try:
-        cred_path = Path.home() / ".aws" / "credentials"
+        # Honor AWS_SHARED_CREDENTIALS_FILE so `ccwb destroy` clears the section
+        # from the same file the AWS SDK (and credential-process) uses. Otherwise
+        # a relocated credentials file (e.g. via MDM) would leave the ccwb section
+        # behind, permanently shadowing credential_process (#797). Raw resolution,
+        # matching credential-process (no ~/$VAR expansion — use an absolute path).
+        env_path = os.environ.get("AWS_SHARED_CREDENTIALS_FILE")
+        cred_path = Path(env_path) if env_path else Path.home() / ".aws" / "credentials"
         if not cred_path.exists():
             return False
 

--- a/source/credential_provider/__main__.py
+++ b/source/credential_provider/__main__.py
@@ -1116,6 +1116,9 @@ class MultiProviderAuth:
             try:
                 with _os.fdopen(fd, "w", encoding="utf-8") as f:
                     config.write(f)
+                # Match save_to_credentials_file and the Go binary: explicit 0600
+                # (mkstemp already defaults to 0600, but be explicit for parity).
+                _os.chmod(tmp_path, 0o600)
                 _os.replace(tmp_path, str(credentials_path))
             except Exception:
                 try:

--- a/source/credential_provider/__main__.py
+++ b/source/credential_provider/__main__.py
@@ -617,16 +617,13 @@ class MultiProviderAuth:
         # a 403 InvalidClientTokenId.
         if self.credential_storage == "session":
             try:
-                credentials_path = Path.home() / ".aws" / "credentials"
-                if credentials_path.exists():
-                    expired_creds = {
-                        "Version": 1,
-                        "AccessKeyId": "EXPIRED",
-                        "SecretAccessKey": "EXPIRED",
-                        "SessionToken": "EXPIRED",
-                        "Expiration": "2000-01-01T00:00:00Z",
-                    }
-                    self.save_to_credentials_file(expired_creds, self.profile)
+                # DELETE the section rather than writing an "EXPIRED" placeholder.
+                # A static block outranks credential_process in the AWS SDK profile
+                # chain, so a lingering placeholder — once #797 routes writes into
+                # the SDK-read relocated file — would permanently shadow
+                # credential_process. Removing the section lets the SDK fall through
+                # and re-invoke it (parity with the Go binary, #767/#768).
+                if self.remove_from_credentials_file(self.profile):
                     cleared_items.append("credentials file")
             except Exception as e:
                 self._debug_print(f"Could not clear credentials file: {e}")
@@ -688,16 +685,13 @@ class MultiProviderAuth:
             if creds_file.exists():
                 creds_file.unlink()
 
-            # For session storage mode, also clear ~/.aws/credentials
+            # For session storage mode, also clear the AWS shared credentials file.
+            # DELETE the section (don't write an "EXPIRED" placeholder): a static
+            # block outranks credential_process in the AWS SDK profile chain, so a
+            # lingering placeholder in the SDK-read file would shadow it permanently
+            # (#797). Removing it lets the SDK fall through (parity with Go #767/#768).
             if self.credential_storage == "session":
-                expired_creds = {
-                    "Version": 1,
-                    "AccessKeyId": "EXPIRED",
-                    "SecretAccessKey": "EXPIRED",
-                    "SessionToken": "EXPIRED",
-                    "Expiration": "2000-01-01T00:00:00Z",
-                }
-                self.save_to_credentials_file(expired_creds, self.profile)
+                self.remove_from_credentials_file(self.profile)
 
             self._debug_print("Cleared STS credentials (monitoring token preserved)")
         except Exception as e:
@@ -948,8 +942,29 @@ class MultiProviderAuth:
             )
         return None
 
+    @staticmethod
+    def _credentials_file_path():
+        """Return the AWS shared credentials file path this provider read/writes.
+
+        Honors AWS_SHARED_CREDENTIALS_FILE so we target the same file the primary
+        consumer resolves credentials from; otherwise a relocated file (e.g. via
+        MDM) would leave the consumer reading one file while this provider
+        writes/clears another, permanently shadowing credential_process (parity
+        with the Go binary; #797).
+
+        Resolution is raw (no ~ or $VAR expansion), matching the Go/JS SDK
+        shared-config loaders (the JS SDK is Claude Code's consumer). boto3 and
+        the AWS CLI additionally expand ~ and $VAR, so those forms are unsupported
+        here — use an absolute path. Scope is AWS_SHARED_CREDENTIALS_FILE only —
+        NOT AWS_CONFIG_FILE, which points at ~/.aws/config (profile/SSO settings).
+        """
+        env_path = os.environ.get("AWS_SHARED_CREDENTIALS_FILE")
+        if env_path:
+            return Path(env_path)
+        return Path.home() / ".aws" / "credentials"
+
     def save_to_credentials_file(self, credentials, profile="ClaudeCode"):
-        """Save credentials to ~/.aws/credentials file
+        """Save credentials to the AWS shared credentials file
 
         Args:
             credentials: Dict with AccessKeyId, SecretAccessKey, SessionToken, Expiration
@@ -958,7 +973,7 @@ class MultiProviderAuth:
         import tempfile
         from configparser import ConfigParser
 
-        credentials_path = Path.home() / ".aws" / "credentials"
+        credentials_path = self._credentials_file_path()
 
         # Create ~/.aws directory if it doesn't exist
         credentials_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1012,7 +1027,7 @@ class MultiProviderAuth:
             raise Exception(f"Failed to save credentials to file: {str(e)}") from e
 
     def read_from_credentials_file(self, profile="ClaudeCode"):
-        """Read credentials from ~/.aws/credentials file
+        """Read credentials from the AWS shared credentials file
 
         Args:
             profile: Profile name to read from credentials file
@@ -1022,7 +1037,7 @@ class MultiProviderAuth:
         """
         from configparser import ConfigParser
 
-        credentials_path = Path.home() / ".aws" / "credentials"
+        credentials_path = self._credentials_file_path()
 
         if not credentials_path.exists():
             return None
@@ -1061,6 +1076,58 @@ class MultiProviderAuth:
         except Exception as e:
             self._debug_print(f"Error reading credentials from file: {e}")
             return None
+
+    def remove_from_credentials_file(self, profile="ClaudeCode"):
+        """Delete a profile section from the AWS shared credentials file.
+
+        Parity with the Go binary's RemoveFromCredentialsFile (#767/#768): the
+        clear/recovery path must DELETE the section, not overwrite it with an
+        "EXPIRED" static placeholder. A static block outranks credential_process
+        in the AWS SDK profile chain, so a lingering placeholder (once #797
+        routed writes into the SDK-read relocated file) would permanently shadow
+        credential_process — the SDK must instead fall through and re-invoke it.
+
+        Preserves unrelated profiles. Uses an atomic temp-write + replace so a
+        crash mid-write can't corrupt the file. No-op (returns False) if the file
+        or section is absent.
+
+        Returns True if the section was removed, False otherwise.
+        """
+        import os as _os
+        import tempfile
+        from configparser import ConfigParser
+
+        credentials_path = self._credentials_file_path()
+        if not credentials_path.exists():
+            return False
+
+        try:
+            # Disable inline comment characters so keys like 'x-expiration' survive.
+            config = ConfigParser(inline_comment_prefixes=())
+            config.read(credentials_path)
+
+            if profile not in config:
+                return False
+
+            config.remove_section(profile)
+
+            # Atomic replace: write to a temp file in the same dir, then os.replace.
+            fd, tmp_path = tempfile.mkstemp(dir=str(credentials_path.parent), prefix=".credentials-")
+            try:
+                with _os.fdopen(fd, "w", encoding="utf-8") as f:
+                    config.write(f)
+                _os.replace(tmp_path, str(credentials_path))
+            except Exception:
+                try:
+                    _os.unlink(tmp_path)
+                except OSError:
+                    pass
+                raise
+            return True
+
+        except Exception as e:
+            self._debug_print(f"Error removing credentials from file: {e}")
+            return False
 
     def check_credentials_file_expiration(self, profile="ClaudeCode"):
         """Check if credentials in file are expired

--- a/source/go/cmd/credential-process/quota_enforcement_order_test.go
+++ b/source/go/cmd/credential-process/quota_enforcement_order_test.go
@@ -85,6 +85,10 @@ func newQuotaOrderEnv(t *testing.T, stsURL string) string {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 	t.Setenv("USERPROFILE", tmpDir) // Windows
+	// credentialsFilePath now honors AWS_SHARED_CREDENTIALS_FILE (#797); neutralize
+	// it so session read/write stays inside the isolated HOME regardless of the
+	// ambient environment (a dev/CI export would otherwise pollute the real file).
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", "")
 	t.Setenv("CLAUDE_CODE_MONITORING_TOKEN", "")
 	t.Setenv("AWS_ENDPOINT_URL_STS", stsURL)
 	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")

--- a/source/go/internal/storage/session.go
+++ b/source/go/internal/storage/session.go
@@ -100,7 +100,28 @@ func SaveToCredentialsFile(creds *federation.AWSCredentials, profile string) err
 	return nil
 }
 
+// credentialsFilePath returns the path to the AWS shared credentials file that
+// this binary reads, writes, and clears. It honors AWS_SHARED_CREDENTIALS_FILE
+// so the binary targets the same file the primary consumer resolves credentials
+// from. If this binary ignored it (writing/clearing ~/.aws/credentials while the
+// consumer read the relocated file), a stale session-mode static block in the
+// consumer's file could never be refreshed or cleared by this binary —
+// permanently shadowing credential_process (see RemoveFromCredentialsFile below
+// and #797).
+//
+// Resolution is raw (no ~ or $VAR expansion), matching the aws-sdk-go-v2 and
+// aws-sdk-js-v3 shared-config loaders — the JS SDK is Claude Code's credential
+// consumer, so raw passthrough keeps writer and reader aligned. Note: boto3 and
+// the AWS CLI additionally expand ~ and $VAR on this variable, so those forms
+// are unsupported here (use an absolute path).
+//
+// Scope: only AWS_SHARED_CREDENTIALS_FILE. AWS_CONFIG_FILE points at
+// ~/.aws/config (profile/SSO settings, a different file) — writing session
+// credentials there would be wrong, so it is deliberately not consulted here.
 func credentialsFilePath() string {
+	if p := os.Getenv("AWS_SHARED_CREDENTIALS_FILE"); p != "" {
+		return p
+	}
 	home, _ := os.UserHomeDir()
 	return filepath.Join(home, ".aws", "credentials")
 }

--- a/source/go/internal/storage/session_test.go
+++ b/source/go/internal/storage/session_test.go
@@ -1,0 +1,160 @@
+package storage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"ccwb-go/internal/federation"
+)
+
+// makeSessionCreds builds a minimal set of AWS credentials for round-trip tests.
+func makeSessionCreds() *federation.AWSCredentials {
+	return &federation.AWSCredentials{
+		Version:         1,
+		AccessKeyID:     "AKIAEXAMPLE797",
+		SecretAccessKey: "secret797",
+		SessionToken:    "token797",
+		Expiration:      "2099-01-01T00:00:00Z",
+	}
+}
+
+// TestCredentialsFilePath_HonorsEnvVar is the #797 regression guard: when
+// AWS_SHARED_CREDENTIALS_FILE is set, the binary must read/write/clear THAT
+// file — the same one the AWS SDK resolves credentials from. On the unfixed
+// code credentialsFilePath() ignored the env var and always returned
+// ~/.aws/credentials, so save/read/remove targeted a file the SDK never read.
+func TestCredentialsFilePath_HonorsEnvVar(t *testing.T) {
+	custom := filepath.Join(t.TempDir(), "relocated", "credentials")
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", custom)
+
+	if got := credentialsFilePath(); got != custom {
+		t.Fatalf("expected credentialsFilePath to honor env var\n got: %s\nwant: %s", got, custom)
+	}
+}
+
+// TestCredentialsFilePath_FallsBackWhenUnset guards the additive contract:
+// with the env var unset the resolved path must be byte-identical to today's
+// behavior (~/.aws/credentials under the user home). This is what makes the
+// change safe for every existing install (none of which set the env var).
+func TestCredentialsFilePath_FallsBackWhenUnset(t *testing.T) {
+	// Ensure the var is not inherited from the ambient environment.
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", "")
+	os.Unsetenv("AWS_SHARED_CREDENTIALS_FILE")
+
+	home, _ := os.UserHomeDir()
+	want := filepath.Join(home, ".aws", "credentials")
+	if got := credentialsFilePath(); got != want {
+		t.Fatalf("expected fallback to home path\n got: %s\nwant: %s", got, want)
+	}
+}
+
+// isolateHome points HOME/USERPROFILE at a fresh temp dir so a fail-without-fix
+// run (where credentialsFilePath falls back to the home path) cannot touch the
+// developer's real ~/.aws/credentials. Returns the temp home for assertions.
+func isolateHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // Windows
+	return home
+}
+
+// TestSessionRoundTrip_CustomPath exercises the full save -> read -> remove
+// cycle against a relocated credentials file, including auto-creating the
+// parent directory. This mirrors the customer's C:\ProgramData\.aws\credentials
+// scenario (env var pointing outside the user home).
+func TestSessionRoundTrip_CustomPath(t *testing.T) {
+	isolateHome(t)
+	custom := filepath.Join(t.TempDir(), "programdata", ".aws", "credentials")
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", custom)
+
+	const profile = "ClaudeCode"
+	creds := makeSessionCreds()
+
+	// Save must create the parent directory and write to the custom path.
+	if err := SaveToCredentialsFile(creds, profile); err != nil {
+		t.Fatalf("SaveToCredentialsFile: %v", err)
+	}
+	if _, err := os.Stat(custom); err != nil {
+		t.Fatalf("expected credentials written to custom path, stat failed: %v", err)
+	}
+
+	// Read must return the same credentials from the custom path.
+	got, err := ReadFromCredentialsFile(profile)
+	if err != nil {
+		t.Fatalf("ReadFromCredentialsFile: %v", err)
+	}
+	if got == nil || got.AccessKeyID != creds.AccessKeyID || got.SessionToken != creds.SessionToken {
+		t.Fatalf("read-back credentials mismatch: %+v", got)
+	}
+
+	// Remove must clear the section from the custom path — this is the recovery
+	// that un-wedges the SDK once a stale session block expires. On the unfixed
+	// code it operated on ~/.aws/credentials and never touched the SDK's file.
+	if err := RemoveFromCredentialsFile(profile); err != nil {
+		t.Fatalf("RemoveFromCredentialsFile: %v", err)
+	}
+	after, err := ReadFromCredentialsFile(profile)
+	if err != nil {
+		t.Fatalf("ReadFromCredentialsFile after remove: %v", err)
+	}
+	if after != nil {
+		t.Fatalf("expected section cleared from custom path, got: %+v", after)
+	}
+}
+
+// TestSession_HomeFileUntouchedWhenEnvSet is the divergence guard: with
+// AWS_SHARED_CREDENTIALS_FILE set, save and remove must operate ONLY on the
+// relocated file and must NOT touch ~/.aws/credentials. This pins the exact
+// #797 defect (binary writes/clears file A while the SDK reads file B). On the
+// unfixed code save would write the home path, so the pre-seeded home block
+// would be overwritten and this fails.
+func TestSession_HomeFileUntouchedWhenEnvSet(t *testing.T) {
+	home := isolateHome(t)
+	homeCreds := filepath.Join(home, ".aws", "credentials")
+	if err := os.MkdirAll(filepath.Dir(homeCreds), 0700); err != nil {
+		t.Fatalf("mkdir home .aws: %v", err)
+	}
+	// Seed a distinct sentinel block at the home path.
+	const sentinel = "[ClaudeCode]\naws_access_key_id = HOME_SENTINEL\naws_secret_access_key = s\naws_session_token = t\n"
+	if err := os.WriteFile(homeCreds, []byte(sentinel), 0600); err != nil {
+		t.Fatalf("seed home creds: %v", err)
+	}
+
+	custom := filepath.Join(t.TempDir(), "programdata", ".aws", "credentials")
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", custom)
+
+	// Save then remove against the relocated path.
+	if err := SaveToCredentialsFile(makeSessionCreds(), "ClaudeCode"); err != nil {
+		t.Fatalf("SaveToCredentialsFile: %v", err)
+	}
+	if err := RemoveFromCredentialsFile("ClaudeCode"); err != nil {
+		t.Fatalf("RemoveFromCredentialsFile: %v", err)
+	}
+
+	// The home file must be byte-for-byte unchanged.
+	got, err := os.ReadFile(homeCreds)
+	if err != nil {
+		t.Fatalf("read home creds: %v", err)
+	}
+	if string(got) != sentinel {
+		t.Fatalf("home credentials file was modified when env var pointed elsewhere\ngot:\n%s", got)
+	}
+}
+
+// TestSessionRead_NonexistentCustomPath confirms a missing relocated file is
+// treated as "no credentials" (nil, nil) rather than an error — matching the
+// existing IDC tests that point the env var at a noexist path.
+func TestSessionRead_NonexistentCustomPath(t *testing.T) {
+	custom := filepath.Join(t.TempDir(), "noexist", "credentials")
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", custom)
+
+	got, err := ReadFromCredentialsFile("ClaudeCode")
+	if err != nil {
+		t.Fatalf("expected nil error for missing file, got: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil credentials for missing file, got: %+v", got)
+	}
+}

--- a/source/tests/README.md
+++ b/source/tests/README.md
@@ -293,6 +293,7 @@ Tests should be independent and not affect each other:
 import pytest
 from unittest.mock import Mock, patch
 
+
 class TestMyFeature:
     @pytest.fixture(autouse=True)
     def setup(self):

--- a/source/tests/test_shared_credentials_file_env.py
+++ b/source/tests/test_shared_credentials_file_env.py
@@ -19,6 +19,22 @@ from unittest.mock import patch
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def isolate_home(tmp_path, monkeypatch):
+    """Point Path.home() at a throwaway dir for every test in this module.
+
+    Mirrors the Go suite's isolateHome(t): even a fail-without-fix run (where
+    save falls back to the home path) can never touch the developer's real
+    ~/.aws/credentials. Tests that need their own fake home (e.g. the
+    home-untouched divergence guard) re-patch Path.home() and win, since both
+    use monkeypatch.
+    """
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+    return fake_home
+
+
 @pytest.fixture
 def auth():
     """A session-mode MultiProviderAuth instance with config/storage mocked out."""
@@ -96,10 +112,7 @@ def test_home_file_untouched_when_env_set(auth, tmp_path, monkeypatch):
     fake_home = tmp_path / "home"
     (fake_home / ".aws").mkdir(parents=True)
     home_creds = fake_home / ".aws" / "credentials"
-    sentinel = (
-        "[ClaudeCode]\naws_access_key_id = HOME_SENTINEL\n"
-        "aws_secret_access_key = s\naws_session_token = t\n"
-    )
+    sentinel = "[ClaudeCode]\naws_access_key_id = HOME_SENTINEL\naws_secret_access_key = s\naws_session_token = t\n"
     home_creds.write_text(sentinel)
     monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
 
@@ -164,13 +177,27 @@ def test_read_missing_custom_path_returns_none(auth, tmp_path, monkeypatch):
 
 
 def test_go_python_path_parity(auth, tmp_path, monkeypatch):
-    """Go and Python must resolve the identical path for the same env value.
+    """Go and Python must read/write the SAME file for the same env value.
 
-    The Go credentialsFilePath() returns AWS_SHARED_CREDENTIALS_FILE verbatim
-    when set. Python must match exactly (same string), or the two binaries would
-    read/write different files for the same environment.
+    The Go credentialsFilePath() returns AWS_SHARED_CREDENTIALS_FILE *verbatim*;
+    Python routes it through pathlib.Path, which normalizes (collapses '//',
+    strips trailing '/'). For a canonical path the two are byte-identical, and
+    where they differ textually the OS still resolves them to the same file — so
+    what actually matters is that a file Python writes is openable at the raw
+    string Go uses. This asserts that functional parity directly (not just string
+    equality), using a path with a redundant separator to exercise the one place
+    the two representations diverge.
     """
-    custom = tmp_path / "shared" / "credentials"
-    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(custom))
-    # str() of the Python Path must equal the raw env value the Go binary uses.
-    assert str(auth._credentials_file_path()) == str(custom)
+    # Canonical path: byte-identical resolution (the common case).
+    canonical = tmp_path / "shared" / "credentials"
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(canonical))
+    assert str(auth._credentials_file_path()) == str(canonical)
+
+    # Divergent representation: raw string (Go) has a doubled separator that
+    # Path (Python) collapses. Save via Python, then read back the file at the
+    # exact verbatim string Go would open — proving both target one file.
+    raw_go_path = f"{tmp_path}/shared//credentials2"
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", raw_go_path)
+    auth.save_to_credentials_file(_example_creds(), "ClaudeCode")
+    with open(raw_go_path, encoding="utf-8") as f:
+        assert "AKIAEXAMPLE797" in f.read(), "Go's verbatim path must open the file Python wrote"

--- a/source/tests/test_shared_credentials_file_env.py
+++ b/source/tests/test_shared_credentials_file_env.py
@@ -1,0 +1,176 @@
+# ABOUTME: Regression tests for #797 — Python credential provider must honor
+# ABOUTME: AWS_SHARED_CREDENTIALS_FILE (parity with the Go credential-process).
+"""Tests that the Python credential provider honors AWS_SHARED_CREDENTIALS_FILE.
+
+Issue #797: in session-storage mode the provider writes a static profile block
+into the AWS shared credentials file. If the provider ignores
+AWS_SHARED_CREDENTIALS_FILE (writing/clearing ~/.aws/credentials while the AWS
+SDK reads a relocated file, e.g. C:\\ProgramData\\.aws\\credentials), a stale
+block in the SDK's file can never be refreshed or cleared — permanently
+shadowing credential_process.
+
+The Go binary and the Python provider must resolve the identical path for the
+same env value (.claude/rules/credential-helper-parity.md).
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def auth():
+    """A session-mode MultiProviderAuth instance with config/storage mocked out."""
+    config = {
+        "provider_domain": "test.okta.com",
+        "client_id": "test-client-id",
+        "identity_pool_id": "us-east-1:test-pool",
+        "aws_region": "us-east-1",
+        "credential_storage": "session",
+        "provider_type": "okta",
+        "federation_type": "cognito",
+        "max_session_duration": 28800,
+    }
+    with (
+        patch("credential_provider.__main__.MultiProviderAuth._load_config", return_value=config),
+        patch("credential_provider.__main__.MultiProviderAuth._init_credential_storage"),
+    ):
+        from credential_provider.__main__ import MultiProviderAuth
+
+        instance = MultiProviderAuth(profile="ClaudeCode")
+        instance.credential_storage = "session"
+        return instance
+
+
+def test_helper_honors_env_var(auth, tmp_path, monkeypatch):
+    """When AWS_SHARED_CREDENTIALS_FILE is set, the helper returns that path."""
+    custom = tmp_path / "relocated" / "credentials"
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(custom))
+    assert auth._credentials_file_path() == custom
+
+
+def test_helper_falls_back_when_unset(auth, monkeypatch):
+    """Env unset -> byte-identical to the historical ~/.aws/credentials path.
+
+    This is what makes the change safe for existing installs (none set the var).
+    """
+    monkeypatch.delenv("AWS_SHARED_CREDENTIALS_FILE", raising=False)
+    assert auth._credentials_file_path() == Path.home() / ".aws" / "credentials"
+
+
+def _example_creds():
+    return {
+        "Version": 1,
+        "AccessKeyId": "AKIAEXAMPLE797",
+        "SecretAccessKey": "secret797",
+        "SessionToken": "token797",
+        "Expiration": "2099-01-01T00:00:00Z",
+    }
+
+
+def test_save_and_read_round_trip_custom_path(auth, tmp_path, monkeypatch):
+    """save -> read targets the relocated file, creating parent dirs as needed.
+
+    Mirrors the customer's C:\\ProgramData\\.aws\\credentials scenario.
+    """
+    custom = tmp_path / "programdata" / ".aws" / "credentials"
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(custom))
+
+    auth.save_to_credentials_file(_example_creds(), "ClaudeCode")
+
+    assert custom.exists(), "credentials must be written to the relocated path"
+    got = auth.read_from_credentials_file("ClaudeCode")
+    assert got is not None
+    assert got["AccessKeyId"] == "AKIAEXAMPLE797"
+    assert got["SessionToken"] == "token797"
+
+
+def test_home_file_untouched_when_env_set(auth, tmp_path, monkeypatch):
+    """Divergence guard: with the env var set, save must NOT touch ~/.aws/credentials.
+
+    Pins the #797 defect (provider writes file A while the SDK reads file B). On
+    the unfixed code save wrote the home path, overwriting the sentinel -> fails.
+    Uses a fake home so a fail-without-fix run never touches the real file.
+    """
+    fake_home = tmp_path / "home"
+    (fake_home / ".aws").mkdir(parents=True)
+    home_creds = fake_home / ".aws" / "credentials"
+    sentinel = (
+        "[ClaudeCode]\naws_access_key_id = HOME_SENTINEL\n"
+        "aws_secret_access_key = s\naws_session_token = t\n"
+    )
+    home_creds.write_text(sentinel)
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+
+    custom = tmp_path / "programdata" / ".aws" / "credentials"
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(custom))
+
+    auth.save_to_credentials_file(_example_creds(), "ClaudeCode")
+    auth.remove_from_credentials_file("ClaudeCode")
+
+    assert home_creds.read_text() == sentinel, "home credentials file must be untouched"
+
+
+def test_clear_removes_section_from_custom_path(auth, tmp_path, monkeypatch):
+    """The clear/recovery path must DELETE the section from the relocated file.
+
+    Regression for the Python parity gap: the clear path previously wrote an
+    "EXPIRED" static placeholder, which (once routed into the SDK-read relocated
+    file by #797) would permanently shadow credential_process (#767/#768). It must
+    remove the section instead so the SDK falls through and recovers.
+    """
+    custom = tmp_path / "programdata" / ".aws" / "credentials"
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(custom))
+
+    # Seed a stale block in the relocated file.
+    auth.save_to_credentials_file(_example_creds(), "ClaudeCode")
+    assert auth.read_from_credentials_file("ClaudeCode") is not None
+
+    auth.remove_from_credentials_file("ClaudeCode")
+
+    # Section gone -> read returns None, and no "EXPIRED" placeholder remains.
+    assert auth.read_from_credentials_file("ClaudeCode") is None
+    from configparser import ConfigParser
+
+    cfg = ConfigParser(inline_comment_prefixes=())
+    cfg.read(custom)
+    assert "ClaudeCode" not in cfg, "clear must delete the section, not leave an EXPIRED placeholder"
+
+
+def test_clear_preserves_other_profiles(auth, tmp_path, monkeypatch):
+    """Clearing our profile must not disturb unrelated profiles in the same file."""
+    custom = tmp_path / "programdata" / ".aws" / "credentials"
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(custom))
+
+    auth.save_to_credentials_file(_example_creds(), "ClaudeCode")
+    auth.save_to_credentials_file(_example_creds(), "OtherProfile")
+
+    auth.remove_from_credentials_file("ClaudeCode")
+
+    from configparser import ConfigParser
+
+    cfg = ConfigParser(inline_comment_prefixes=())
+    cfg.read(custom)
+    assert "ClaudeCode" not in cfg
+    assert "OtherProfile" in cfg, "unrelated profiles must be preserved"
+
+
+def test_read_missing_custom_path_returns_none(auth, tmp_path, monkeypatch):
+    """A missing relocated file is 'no credentials' (None), not an error."""
+    custom = tmp_path / "noexist" / "credentials"
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(custom))
+    assert auth.read_from_credentials_file("ClaudeCode") is None
+
+
+def test_go_python_path_parity(auth, tmp_path, monkeypatch):
+    """Go and Python must resolve the identical path for the same env value.
+
+    The Go credentialsFilePath() returns AWS_SHARED_CREDENTIALS_FILE verbatim
+    when set. Python must match exactly (same string), or the two binaries would
+    read/write different files for the same environment.
+    """
+    custom = tmp_path / "shared" / "credentials"
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(custom))
+    # str() of the Python Path must equal the raw env value the Go binary uses.
+    assert str(auth._credentials_file_path()) == str(custom)


### PR DESCRIPTION
## Why
With a relocated AWS shared credentials file (e.g. MDM sets `AWS_SHARED_CREDENTIALS_FILE` to `C:\ProgramData\.aws\credentials`), the session-mode credential-process read/wrote/cleared `~/.aws/credentials` while the AWS SDK resolved credentials from the relocated file. A stale static block in the SDK's file — which outranks `credential_process` in the profile chain — could never be refreshed or cleared, permanently shadowing `credential_process` (403 `InvalidClientTokenId`).

Reported by a customer on v2.4.0 (Windows, EntraID/OIDC, Go credential-process).

## What
- **Go + Python** session storage now resolve `AWS_SHARED_CREDENTIALS_FILE` (raw, matching the Go/JS SDK loaders) with byte-identical fallback to `~/.aws/credentials` when unset.
- **Python clear path** now DELETES the profile section instead of writing an `EXPIRED` static placeholder (parity with the Go binary, #767/#768) so the SDK falls through and re-invokes `credential_process`.
- `ccwb destroy` clear path honors the env var too.

## Compatibility
Additive and env-gated: no existing deployment sets the var, so the resolved path is byte-identical to today's `~/.aws/credentials`.

## Tests (fail without fix)
- Go `session_test.go` (5): env-var honored, unset fallback, custom-path round-trip, home-file-untouched divergence guard, missing-file → nil.
- Python `test_shared_credentials_file_env.py` (8): incl. Go↔Python path parity and clear-deletes-section (no `EXPIRED` placeholder left behind).
- All Go storage + credential-process and Python related suites pass; ruff clean.