### PR TITLE
feat(cli): add configure-saml command for IDC landing page (#751 part 1/6)

### DIFF
--- a/source/claude_code_with_bedrock/cli/__init__.py
+++ b/source/claude_code_with_bedrock/cli/__init__.py
@@ -7,6 +7,7 @@ from cleo.application import Application
 
 from .commands.builds import BuildsCommand
 from .commands.cleanup import CleanupCommand
+from .commands.configure_saml import ConfigureSamlCommand
 from .commands.context import (
     ConfigCommand,
     ConfigExportCommand,
@@ -62,6 +63,7 @@ def create_application() -> Application:
     application.add(DestroyCommand())
     application.add(DoctorCommand())
     application.add(CleanupCommand())
+    application.add(ConfigureSamlCommand())
     application.add(CoworkGenerateCommand())
     # application.add(TokenCommand())  # Temporarily disabled
 

--- a/source/claude_code_with_bedrock/cli/commands/configure_saml.py
+++ b/source/claude_code_with_bedrock/cli/commands/configure_saml.py
@@ -1,0 +1,129 @@
+# ABOUTME: Configure SAML authentication for the IAM Identity Center landing page
+# ABOUTME: Saves the SAML metadata URL to the profile and updates the CloudFormation stack
+
+"""Configure SAML command - Set up SAML authentication for the IDC landing page.
+
+IAM Identity Center has no API to create custom SAML applications, so admins
+must create the SAML app manually in the IDC console (using the ACS URL /
+Audience printed by `ccwb deploy distribution`). Once that's done and IDC
+provides a SAML metadata URL, this command saves it to the profile and
+re-deploys the distribution stack so CloudFormation's IdcSamlIdentityProvider
+resource (conditional on SamlMetadataUrl being set) gets created and wired
+into both the web app client and the bootstrap client.
+"""
+
+from cleo.commands.command import Command
+from cleo.helpers import argument, option
+from rich.console import Console
+from rich.panel import Panel
+
+from claude_code_with_bedrock.cli.utils.aws import get_stack_outputs
+from claude_code_with_bedrock.cli.utils.cloudformation import CloudFormationManager
+from claude_code_with_bedrock.config import Config
+
+
+class ConfigureSamlCommand(Command):
+    """Configure SAML authentication for the IDC landing page."""
+
+    name = "configure-saml"
+    description = "Configure SAML authentication for IAM Identity Center landing page"
+
+    arguments = [
+        argument(
+            "metadata-url",
+            description="SAML metadata URL from the IAM Identity Center application",
+        ),
+    ]
+
+    options = [
+        option(
+            "profile",
+            None,
+            description="Configuration profile to use (defaults to active profile)",
+            flag=False,
+        ),
+    ]
+
+    def handle(self) -> int:
+        """Execute the configure-saml command."""
+        console = Console()
+        metadata_url = self.argument("metadata-url")
+
+        config = Config.load()
+        profile_name = self.option("profile")
+        profile = config.get_profile(profile_name)
+
+        if not profile:
+            console.print("[red]No profile found. Run 'ccwb init' first.[/red]")
+            return 1
+
+        console.print(f"Using profile: [cyan]{profile.name}[/cyan]\n")
+
+        if not profile.is_idc_distribution:
+            console.print(
+                "[red]This command is only for the IAM Identity Center landing page "
+                "(distribution_type='landing-page' with auth_type='idc').[/red]"
+            )
+            console.print(
+                f"[dim]Current: distribution_type={profile.distribution_type}, "
+                f"auth_type={profile.effective_auth_type}[/dim]"
+            )
+            return 1
+
+        # Verify the distribution stack has already been deployed at least once
+        # (the ACS URL / Audience the admin needed to create the SAML app come
+        # from this stack's outputs).
+        stack_name = profile.stack_names.get("distribution", f"{profile.identity_pool_name}-distribution")
+        cf_manager = CloudFormationManager(region=profile.aws_region)
+
+        existing_outputs = get_stack_outputs(stack_name, profile.aws_region)
+
+        if not existing_outputs:
+            console.print(f"[red]Distribution stack '{stack_name}' not found.[/red]")
+            console.print("[dim]Run 'poetry run ccwb deploy distribution' first.[/dim]")
+            return 1
+
+        landing_page_url = existing_outputs.get("DistributionURL", "")
+
+        console.print(
+            Panel(
+                f"[bold]Stack:[/bold] {stack_name}\n"
+                f"[bold]Landing Page:[/bold] {landing_page_url}\n"
+                f"[bold]Metadata URL:[/bold] {metadata_url}",
+                title="SAML Configuration",
+                border_style="cyan",
+            )
+        )
+
+        # Save the metadata URL to the profile and re-deploy. CloudFormation's
+        # conditional IdcSamlIdentityProvider resource (and the callback-updater
+        # custom resource that adds IAMIdentityCenter to both app clients) will
+        # be created/updated as part of this stack update.
+        profile.distribution_saml_metadata_url = metadata_url
+        config.save_profile(profile)
+
+        console.print("\n[yellow]Updating distribution stack with SAML configuration...[/yellow]")
+
+        from claude_code_with_bedrock.cli.commands.deploy import DeployCommand
+
+        deploy_command = DeployCommand()
+        result = deploy_command._deploy_stack("distribution", profile, console, cf_manager)
+
+        if result != 0:
+            console.print("[red]Stack update failed. See errors above.[/red]")
+            return result
+
+        updated_outputs = get_stack_outputs(stack_name, profile.aws_region) or {}
+        saml_status = updated_outputs.get("IdcSamlConfigurationStatus", "")
+
+        console.print(
+            Panel(
+                f"[bold green]SAML Configuration Complete![/bold green]\n\n"
+                f"[bold]Landing Page:[/bold] {landing_page_url}\n"
+                f"{saml_status}\n\n"
+                f"Users can now sign in via IAM Identity Center.",
+                border_style="green",
+            )
+        )
+
+        return 0

--- a/source/claude_code_with_bedrock/cli/commands/configure_saml.py
+++ b/source/claude_code_with_bedrock/cli/commands/configure_saml.py
@@ -12,6 +12,8 @@ resource (conditional on SamlMetadataUrl being set) gets created and wired
 into both the web app client and the bootstrap client.
 """
 
+from urllib.parse import urlparse
+
 from cleo.commands.command import Command
 from cleo.helpers import argument, option
 from rich.console import Console
@@ -48,6 +50,15 @@ class ConfigureSamlCommand(Command):
         """Execute the configure-saml command."""
         console = Console()
         metadata_url = self.argument("metadata-url")
+
+        # Validate URL format and scheme
+        parsed = urlparse(metadata_url)
+        if parsed.scheme != "https" or not parsed.netloc:
+            console.print(
+                "[red]Error:[/red] Metadata URL must be a valid HTTPS URL "
+                "(e.g. https://portal.sso.us-east-1.amazonaws.com/saml/metadata/...)."
+            )
+            return 1
 
         config = Config.load()
         profile_name = self.option("profile")

--- a/source/claude_code_with_bedrock/config.py
+++ b/source/claude_code_with_bedrock/config.py
@@ -216,6 +216,16 @@ class Profile:
             return self.auth_type
         return "oidc" if self.sso_enabled else "none"
 
+    @property
+    def is_idc_distribution(self) -> bool:
+        """True when the distribution is the IAM Identity Center landing page.
+
+        An IDC landing page is distribution_type == "landing-page" with
+        auth_type == "idc" (deployed via landing-page-distribution.yaml with
+        AuthType=idc).
+        """
+        return self.distribution_type == "landing-page" and self.effective_auth_type == "idc"
+
     def to_dict(self) -> dict[str, Any]:
         """Convert profile to dictionary."""
         return asdict(self)

--- a/source/tests/cli/commands/test_configure_saml.py
+++ b/source/tests/cli/commands/test_configure_saml.py
@@ -1,0 +1,241 @@
+# ABOUTME: Tests for `ccwb configure-saml` — saves the SAML metadata URL to the profile
+# ABOUTME: and re-deploys the CFN distribution stack so IdcSamlIdentityProvider gets created
+
+"""Tests for ConfigureSamlCommand (CloudFormation-based implementation).
+
+The IAM Identity Center landing page is distribution_type "landing-page" with
+auth_type "idc" (beta vocabulary), deployed via landing-page-distribution.yaml
+with AuthType=idc — the same template used by the other landing-page IdP types.
+`ccwb configure-saml` doesn't call the Cognito API directly — it saves
+distribution_saml_metadata_url to the profile and triggers a stack update via
+DeployCommand._deploy_stack("distribution", ...), letting CloudFormation's
+conditional IdcSamlIdentityProvider resource (and the callback-updater custom
+resource) do the actual Cognito wiring.
+
+Covers:
+- Guard: command refuses to run for non-IDC profiles
+- Guard: command fails cleanly when the distribution stack hasn't been deployed yet
+- Happy path: saves metadata URL to profile, re-deploys, reports SAML status
+- Stack update failure is surfaced, not swallowed
+- --profile option forwarding
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from cleo.testers.command_tester import CommandTester
+
+from claude_code_with_bedrock.cli.commands.configure_saml import ConfigureSamlCommand
+from claude_code_with_bedrock.config import Profile
+
+
+def _profile(**overrides) -> Profile:
+    import dataclasses
+
+    field_names = {f.name for f in dataclasses.fields(Profile)}
+    defaults = {
+        "name": "TestProfile",
+        "provider_domain": "company.okta.com",
+        "client_id": "test-client-id",
+        "credential_storage": "session",
+        "aws_region": "us-east-1",
+        "identity_pool_name": "claude-code-test",
+        "distribution_type": "landing-page",
+        "auth_type": "idc",
+        "enable_distribution": True,
+    }
+    defaults.update(overrides)
+    return Profile(**{k: v for k, v in defaults.items() if k in field_names})
+
+
+def _run(metadata_url="https://portal.sso.us-east-1.amazonaws.com/saml/metadata/xyz", profile_option=None):
+    command = ConfigureSamlCommand()
+    tester = CommandTester(command)
+    args = metadata_url
+    if profile_option:
+        args = f"{args} --profile {profile_option}"
+    tester.execute(args)
+    return tester
+
+
+class TestDistributionTypeGuard:
+    """The command must refuse to run for anything other than the IDC landing page."""
+
+    @patch("claude_code_with_bedrock.config.Config.get_profile")
+    def test_rejects_non_idc_distribution_type(self, mock_get_profile, capsys):
+        # A landing page with OIDC (not IDC) auth must be rejected.
+        mock_get_profile.return_value = _profile(distribution_type="landing-page", auth_type="oidc")
+        tester = _run()
+        assert tester.status_code == 1
+        assert "auth_type='idc'" in capsys.readouterr().out
+
+    @patch("claude_code_with_bedrock.config.Config.get_profile")
+    def test_rejects_none_distribution_type(self, mock_get_profile):
+        mock_get_profile.return_value = _profile(distribution_type=None)
+        tester = _run()
+        assert tester.status_code == 1
+
+    @patch("claude_code_with_bedrock.config.Config.get_profile")
+    def test_no_profile_found(self, mock_get_profile, capsys):
+        mock_get_profile.return_value = None
+        tester = _run()
+        assert tester.status_code == 1
+        assert "No profile found" in capsys.readouterr().out
+
+
+class TestStackExistenceGuard:
+    """The distribution stack must already exist (for its ACS URL/Audience outputs)."""
+
+    @patch("claude_code_with_bedrock.cli.commands.configure_saml.get_stack_outputs")
+    @patch("claude_code_with_bedrock.config.Config.get_profile")
+    def test_missing_stack_fails_cleanly(self, mock_get_profile, mock_get_outputs, capsys):
+        mock_get_profile.return_value = _profile()
+        mock_get_outputs.return_value = None
+
+        tester = _run()
+
+        assert tester.status_code == 1
+        output = capsys.readouterr().out
+        assert "not found" in output
+        assert "deploy distribution" in output
+
+
+class TestSamlConfigurationFlow:
+    """Happy-path: save metadata URL to profile, re-deploy, report SAML status."""
+
+    @patch("claude_code_with_bedrock.cli.commands.deploy.CloudFormationManager")
+    @patch("claude_code_with_bedrock.cli.commands.configure_saml.CloudFormationManager")
+    @patch("claude_code_with_bedrock.cli.commands.deploy.get_stack_outputs")
+    @patch("claude_code_with_bedrock.cli.commands.configure_saml.get_stack_outputs")
+    @patch("claude_code_with_bedrock.config.Config.save_profile")
+    @patch("claude_code_with_bedrock.config.Config.get_profile")
+    def test_saves_metadata_url_and_redeploys(
+        self,
+        mock_get_profile,
+        mock_save_profile,
+        mock_get_outputs_configure_saml,
+        mock_get_outputs_deploy,
+        MockConfigureSamlCFManager,
+        MockDeployCFManager,
+        capsys,
+    ):
+        profile = _profile()
+        mock_get_profile.return_value = profile
+
+        # configure_saml.py calls get_stack_outputs twice: once to verify the
+        # stack exists (pre-SAML), once after redeploying (post-SAML status).
+        mock_get_outputs_configure_saml.side_effect = [
+            {"DistributionURL": "https://downloads.example.com", "IdcSamlAcsUrl": "https://x/saml2/idpresponse"},
+            {
+                "DistributionURL": "https://downloads.example.com",
+                "IdcSamlConfigurationStatus": "✓ SAML identity provider configured",
+            },
+        ]
+        # deploy.py's _deploy_stack("distribution", ...) separately looks up the
+        # networking stack's VpcId/SubnetIds outputs before building CFN params.
+        # The IDC landing page defaults ALBScheme to internal, which requires the
+        # networking stack's NAT-routed PrivateSubnetIds output.
+        mock_get_outputs_deploy.return_value = {
+            "VpcId": "vpc-123",
+            "SubnetIds": "subnet-1,subnet-2",
+            "PrivateSubnetIds": "subnet-priv-1,subnet-priv-2",
+        }
+
+        mock_manager = MagicMock()
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.outputs = {}
+        mock_manager.deploy_stack.return_value = mock_result
+        MockDeployCFManager.return_value = mock_manager
+        MockConfigureSamlCFManager.return_value = mock_manager
+
+        tester = _run(metadata_url="https://portal.sso.us-east-1.amazonaws.com/saml/metadata/abc")
+
+        assert tester.status_code == 0
+
+        # Metadata URL was saved to the profile before redeploying.
+        assert profile.distribution_saml_metadata_url == "https://portal.sso.us-east-1.amazonaws.com/saml/metadata/abc"
+        mock_save_profile.assert_called_once()
+
+        # The stack update actually happened (deploy_stack invoked with the
+        # distribution template and SamlMetadataUrl param). Parameters are
+        # in boto3 ParameterKey/ParameterValue dict format at this point
+        # (deploy.py's _convert_params_to_boto3 already ran).
+        mock_manager.deploy_stack.assert_called_once()
+        call_kwargs = mock_manager.deploy_stack.call_args.kwargs
+        params = call_kwargs.get("parameters") or []
+        assert {
+            "ParameterKey": "SamlMetadataUrl",
+            "ParameterValue": "https://portal.sso.us-east-1.amazonaws.com/saml/metadata/abc",
+        } in params
+
+        output = capsys.readouterr().out
+        assert "SAML Configuration Complete" in output
+        assert "SAML identity provider configured" in output
+
+    @patch("claude_code_with_bedrock.cli.commands.deploy.CloudFormationManager")
+    @patch("claude_code_with_bedrock.cli.commands.configure_saml.CloudFormationManager")
+    @patch("claude_code_with_bedrock.cli.commands.deploy.get_stack_outputs")
+    @patch("claude_code_with_bedrock.cli.commands.configure_saml.get_stack_outputs")
+    @patch("claude_code_with_bedrock.config.Config.save_profile")
+    @patch("claude_code_with_bedrock.config.Config.get_profile")
+    def test_stack_update_failure_is_surfaced(
+        self,
+        mock_get_profile,
+        mock_save_profile,
+        mock_get_outputs_configure_saml,
+        mock_get_outputs_deploy,
+        MockConfigureSamlCFManager,
+        MockDeployCFManager,
+        capsys,
+    ):
+        """A failed stack update must not be reported as success."""
+        profile = _profile()
+        mock_get_profile.return_value = profile
+        mock_get_outputs_configure_saml.return_value = {"DistributionURL": "https://downloads.example.com"}
+        mock_get_outputs_deploy.return_value = {"VpcId": "vpc-123", "SubnetIds": "subnet-1,subnet-2"}
+
+        mock_manager = MagicMock()
+        mock_result = MagicMock()
+        mock_result.success = False
+        mock_result.error = "Stack update failed: some resource error"
+        mock_result.outputs = {}
+        mock_manager.deploy_stack.return_value = mock_result
+        MockDeployCFManager.return_value = mock_manager
+        MockConfigureSamlCFManager.return_value = mock_manager
+
+        tester = _run()
+
+        assert tester.status_code != 0
+        output = capsys.readouterr().out
+        assert "SAML Configuration Complete" not in output
+
+
+class TestProfileOptionOverride:
+    """The --profile option must be forwarded to Config.get_profile() by name."""
+
+    @patch("claude_code_with_bedrock.config.Config.get_profile")
+    def test_explicit_profile_name_passed_through(self, mock_get_profile, capsys):
+        named_profile = _profile(name="other-profile", distribution_type="presigned-s3")
+        mock_get_profile.return_value = named_profile
+
+        tester = _run(profile_option="other-profile")
+
+        mock_get_profile.assert_called_once_with("other-profile")
+        # named_profile has distribution_type="presigned-s3" -> command must reject it,
+        # proving the named profile (not some other profile) was actually used.
+        assert tester.status_code == 1
+        assert "auth_type='idc'" in capsys.readouterr().out
+
+    @patch("claude_code_with_bedrock.config.Config.get_profile")
+    def test_no_profile_option_passes_none(self, mock_get_profile):
+        """Without --profile, get_profile(None) is called, which resolves to the active profile."""
+        mock_get_profile.return_value = _profile(distribution_type="presigned-s3")
+
+        _run(profile_option=None)
+
+        mock_get_profile.assert_called_once_with(None)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/source/tests/cli/commands/test_configure_saml.py
+++ b/source/tests/cli/commands/test_configure_saml.py
@@ -58,6 +58,29 @@ def _run(metadata_url="https://portal.sso.us-east-1.amazonaws.com/saml/metadata/
     return tester
 
 
+class TestUrlValidation:
+    """The command must reject non-HTTPS and malformed metadata URLs."""
+
+    @patch("claude_code_with_bedrock.config.Config.get_profile")
+    def test_rejects_http_url(self, mock_get_profile, capsys):
+        mock_get_profile.return_value = _profile()
+        tester = _run(metadata_url="http://portal.sso.us-east-1.amazonaws.com/saml/metadata/xyz")
+        assert tester.status_code == 1
+        assert "HTTPS" in capsys.readouterr().out or "https" in capsys.readouterr().out.lower()
+
+    @patch("claude_code_with_bedrock.config.Config.get_profile")
+    def test_rejects_empty_url(self, mock_get_profile, capsys):
+        mock_get_profile.return_value = _profile()
+        tester = _run(metadata_url="not-a-url")
+        assert tester.status_code == 1
+
+    @patch("claude_code_with_bedrock.config.Config.get_profile")
+    def test_rejects_ftp_url(self, mock_get_profile, capsys):
+        mock_get_profile.return_value = _profile()
+        tester = _run(metadata_url="ftp://example.com/metadata")
+        assert tester.status_code == 1
+
+
 class TestDistributionTypeGuard:
     """The command must refuse to run for anything other than the IDC landing page."""
 


### PR DESCRIPTION
## What this does

Adds a `ccwb configure-saml <metadata-url>` CLI command that completes the SAML setup for IAM Identity Center landing pages.

**User story:** After deploying the IDC landing page (`ccwb deploy distribution`), admins manually create a SAML application in the IAM Identity Center console (using the ACS URL printed during deploy). Once IDC provides a SAML metadata URL, this command saves it and re-deploys so CloudFormation wires the SAML identity provider into Cognito — enabling SSO sign-in.

**Why it matters:** Without this command, admins would need to manually edit their profile JSON and trigger a re-deploy. This provides a clean one-liner that validates inputs, checks prerequisites, and handles errors gracefully.

## Changes

- `source/claude_code_with_bedrock/cli/commands/configure_saml.py` — new command (129 lines)
- `source/claude_code_with_bedrock/cli/__init__.py` — register the command
- `source/claude_code_with_bedrock/config.py` — add `Profile.is_idc_distribution` helper property
- `source/tests/cli/commands/test_configure_saml.py` — 8 unit tests

## Usage

```bash
# After creating the SAML app in IAM Identity Center:
ccwb configure-saml https://portal.sso.us-east-1.amazonaws.com/saml/metadata/abc123

# With explicit profile:
ccwb configure-saml --profile my-org https://portal.sso.us-east-1.amazonaws.com/saml/metadata/abc123
```

## Guards

- Rejects non-IDC distributions (must be `distribution_type=landing-page` + `auth_type=idc`)
- Verifies the distribution stack has been deployed at least once
- Surfaces CloudFormation update failures clearly

## Context

This is part 1 of a decomposed series from PR #751 (@duttaabh's IAM Identity Center Self-Service Portal). Split into reviewable chunks per maintainer request.

Co-authored-by: duttaabh <duttaabh@users.noreply.github.com>