### PR TITLE
feat(admin-console): IAM Identity Center admin console for config management (#751 part 2/4)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -177,6 +177,16 @@
         "is_secret": false
       }
     ],
+    "deployment/infrastructure/admin-console.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "deployment/infrastructure/admin-console.yaml",
+        "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
+        "is_verified": false,
+        "line_number": 331,
+        "is_secret": false
+      }
+    ],
     "deployment/infrastructure/bootstrap-device-code.yaml": [
       {
         "type": "Secret Keyword",

--- a/deployment/infrastructure/admin-console.yaml
+++ b/deployment/infrastructure/admin-console.yaml
@@ -1,0 +1,498 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >-
+  Optional admin console for the IAM Identity Center landing page. Adds a
+  /admin* listener rule + Lambda target group to the ALB provisioned by
+  landing-page-distribution.yaml (AuthType=idc). Deployed as a separate
+  stack (`ccwb deploy admin-console`) so the landing page itself has no
+  dependency on IDC group/permission-set management — only sites that need
+  the admin UI deploy this stack.
+#
+# Why a separate stack instead of bundling into landing-page-distribution.yaml:
+#   - The landing page (self-service downloads + auth) is useful on its own;
+#     the admin console (group->model->permission-set provisioning) is a much
+#     more powerful, more privileged capability that not every deployment
+#     wants or needs.
+#   - Reuses the SAME ALB/listener/Cognito-IDC-bridge the distribution stack
+#     already created — no new ALB, no new Cognito app client, no new
+#     Secrets Manager secret. This stack only adds a listener rule + target
+#     group + Lambda.
+#   - Auth is 100% ALB-native `authenticate-oidc` (the same mechanism the
+#     landing page's default listener action uses), not a custom Lambda
+#     session-cookie scheme. ALB validates the JWT and passes the decoded
+#     claims via the x-amzn-oidc-data header; this Lambda only adds a second,
+#     independent authorization check (live IAM Identity Center group lookup)
+#     on top of that authentication, gating everything under /admin.
+
+Parameters:
+  IdentityPoolName:
+    Type: String
+    Description: Name prefix for resources (should match the distribution stack's IdentityPoolName)
+
+  CustomDomainName:
+    Type: String
+    Description: >-
+      Custom domain of the distribution stack's ALB (same value passed to
+      landing-page-distribution.yaml's CustomDomainName). Used to build the
+      admin console URL and to validate the Origin header on admin POST
+      requests (CSRF defense-in-depth).
+    AllowedPattern: '.+'
+
+  HTTPSListenerArn:
+    Type: String
+    Description: >-
+      ARN of the distribution stack's ALB HTTPS listener (from that stack's
+      HTTPSListenerArn output). This stack attaches a new listener rule here
+      rather than creating its own ALB.
+    AllowedPattern: '.+'
+    ConstraintDescription: 'HTTPSListenerArn is required — deploy the distribution stack first.'
+
+  ListenerRulePriority:
+    Type: Number
+    Default: 10
+    Description: >-
+      Priority for the /admin* listener rule. Must be unique among all rules
+      on the shared listener. The distribution stack's own numbered rule
+      (BootstrapApiListenerRule, for /api/bootstrap) is fixed at priority 1 —
+      avoid setting this parameter to 1.
+    MinValue: 2
+    MaxValue: 50000
+
+  IdcUserPoolClientId:
+    Type: String
+    Description: >-
+      Cognito User Pool Client ID from the distribution stack's
+      IdcUserPoolClientId output (the same OIDC app client the landing page
+      uses — the admin console reuses it rather than minting a new one).
+    AllowedPattern: '.+'
+
+  IdcUserPoolClientSecretArn:
+    Type: String
+    Description: Secrets Manager ARN from the distribution stack's IdcUserPoolClientSecretArn output.
+    AllowedPattern: '.+'
+
+  IdcUserPoolId:
+    Type: String
+    Description: Cognito User Pool ID from the distribution stack's IdcUserPoolId output.
+    AllowedPattern: '.+'
+
+  IdcUserPoolDomain:
+    Type: String
+    Description: Cognito User Pool domain prefix from the distribution stack's IdcUserPoolDomain output.
+    AllowedPattern: '.+'
+
+  IdcBootstrapUserPoolClientId:
+    Type: String
+    Default: ''
+    Description: >-
+      (Optional) Cognito app client ID from the distribution stack's
+      IdcBootstrapUserPoolClientId output. When set, generated
+      mobileconfig/.reg MDM files include a bootstrapOidc block so Claude
+      Desktop can authenticate directly against /api/bootstrap for dynamic
+      per-user config. Leave empty to generate MDM files without bootstrap
+      OIDC (bootstrapUrl-only, e.g. for distribution stacks deployed before
+      this feature existed).
+
+  IdcBootstrapRedirectPort:
+    Type: String
+    Default: ''
+    Description: >-
+      (Optional) Loopback port from the distribution stack's
+      IdcBootstrapRedirectPort output — must match IdcBootstrapUserPoolClientId's
+      registered callback URLs. Required if IdcBootstrapUserPoolClientId is set.
+
+  DistributionBucketName:
+    Type: String
+    Description: S3 bucket name from the distribution stack's DistributionBucket output (admin config is stored under admin/ and config/ prefixes in this bucket).
+    AllowedPattern: '.+'
+
+  DistributionBucketArn:
+    Type: String
+    Description: S3 bucket ARN from the distribution stack's DistributionBucketArn output.
+    AllowedPattern: '.+'
+
+  IdcInstanceArn:
+    Type: String
+    Description: >-
+      IAM Identity Center instance ARN. Required — the admin console reads
+      groups/permission sets from this instance and provisions Bedrock model
+      access via SSO Admin API permission sets.
+    AllowedPattern: '.+'
+    ConstraintDescription: 'IdcInstanceArn is required for the admin console (group/permission-set management).'
+
+  IdcRegion:
+    Type: String
+    Default: ''
+    Description: >-
+      AWS region where the IAM Identity Center instance lives (its "home"
+      region — IDC data such as permission sets, groups, and users is only
+      ever stored in that one region, regardless of where this stack itself
+      is deployed). Leave empty to default to this stack's own region (the
+      common case where the admin console is deployed in the same region as
+      IDC). Set explicitly when deploying the admin console in a different
+      region than IDC's home region — e.g. distribution/admin-console
+      infrastructure in us-west-2 while IDC is enabled in us-east-1.
+
+  AdminGroupName:
+    Type: String
+    Default: 'Claude-Code-Admins'
+    Description: >-
+      IAM Identity Center group whose members may access /admin. Checked via
+      a live IDC lookup on every request (never trusted from a token claim),
+      matching the landing page's existing group-membership pattern.
+
+  AdditionalTrustedOrigins:
+    Type: CommaDelimitedList
+    Default: ''
+    Description: >-
+      (Optional) Extra Origin/Referer values to accept on admin POST
+      requests, in addition to https://CustomDomainName. Needed when
+      ALBScheme=internal and you access the admin console through an
+      SSM port-forwarding tunnel or VPN endpoint whose hostname differs
+      from CustomDomainName (e.g. https://localhost, https://127.0.0.1) —
+      without this, the CSRF Origin check fails closed for those requests.
+      Leave empty for production internet-facing deployments where the
+      custom domain is the only way users reach the admin console.
+
+  # CloudFront-in-front-of-internal-ALB support (see the distribution stack's
+  # EnableCloudFront parameter). When the distribution stack is deployed with
+  # CloudFront, the admin console must (a) attach its /admin* rule to the
+  # forward-only HTTP listener CloudFront connects to, and (b) run its own
+  # Cognito login (session cookie) for CloudFront-arriving requests, since
+  # ALB-native authenticate-oidc only works on the HTTPS listener.
+  EnableCloudFront:
+    Type: String
+    Default: 'false'
+    AllowedValues: ['true', 'false']
+    Description: >-
+      Set to 'true' when the distribution stack was deployed with
+      EnableCloudFront=true, so the admin console is reachable through the
+      CloudFront distribution (VPC origin) as well.
+
+  CloudFrontHTTPListenerArn:
+    Type: String
+    Default: ''
+    Description: >-
+      (EnableCloudFront=true) ARN of the distribution stack's forward-only
+      HTTP listener (from its CloudFrontHTTPListenerArn output). The admin
+      console attaches a second /admin* rule here so /admin is reachable
+      through CloudFront.
+
+  CloudFrontDomain:
+    Type: String
+    Default: ''
+    Description: >-
+      (EnableCloudFront=true) CloudFront distribution domain name (from the
+      distribution stack's CloudFrontDomainName output). Used as the base URL
+      for the admin console's own Cognito login redirect/callback and CSRF
+      origin check when reached through CloudFront.
+
+  SessionSigningSecretArn:
+    Type: String
+    Default: ''
+    Description: >-
+      (EnableCloudFront=true) Secrets Manager ARN of the shared session-cookie
+      HMAC key (from the distribution stack's SessionSigningSecretArn output).
+      Must match the landing page's so a session obtained there is valid on
+      /admin (same CloudFront domain, same Cognito client).
+
+Conditions:
+  HasExplicitIdcRegion: !Not [!Equals [!Ref IdcRegion, '']]
+  HasIdcBootstrapClient: !Not [!Equals [!Ref IdcBootstrapUserPoolClientId, '']]
+  ShouldEnableCloudFront: !Equals [!Ref EnableCloudFront, 'true']
+
+Resources:
+  # ============================================================
+  # Lambda execution role
+  # ============================================================
+  AdminConsoleFunctionRole:
+    Type: AWS::IAM::Role
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W11
+            reason: "sso:ListInstances, identitystore:List*/Describe*/ListGroupMembershipsForMember (Identity Store ID unknown at template-author time), and Bedrock model-discovery/sts:GetCallerIdentity actions require Resource: * by API design — see inline comments on each statement"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+      Policies:
+        # Admin config is stored as JSON under admin/ and generated MDM/bootstrap
+        # files under config/ in the same bucket the landing page uses for
+        # package downloads — scoped to those two prefixes only, no access to
+        # packages/ or docs/.
+        - PolicyName: AdminConfigS3Access
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:PutObject
+                Resource:
+                  - !Sub '${DistributionBucketArn}/admin/*'
+                  - !Sub '${DistributionBucketArn}/config/*'
+        # IAM Identity Center group/permission-set management. Note: the IAM
+        # action prefix for the SSO Admin API is "sso:" (not "sso-admin:" —
+        # that's only the boto3 client name); using "sso-admin:" here would
+        # silently grant nothing since it isn't a real IAM action namespace.
+        #
+        # Scoped per the "Actions, resources, and condition keys for AWS IAM
+        # Identity Center" service-authorization reference
+        # (https://docs.aws.amazon.com/service-authorization/latest/reference/list_awsiamidentitycenter.html).
+        # Several actions require MULTIPLE resource types simultaneously
+        # (e.g. CreateAccountAssignment needs Account* + Instance* +
+        # PermissionSet* all at once) — all required ARNs must be listed in
+        # Resource for IAM to grant the action at all, not just one of them.
+        # PermissionSetId isn't known ahead of creation, so PermissionSet*
+        # resources use "permissionSet/${InstanceId}/*" (any permission set
+        # under THIS instance, not any permission set in any instance).
+        - PolicyName: IdcGroupAndPermissionSetManagement
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: sso:ListInstances
+                Resource: '*' # ListInstances has no resource type to scope to
+              - Effect: Allow
+                Action:
+                  - sso:ListPermissionSets
+                  - sso:ListPermissionSetProvisioningStatus
+                  - sso:DescribePermissionSetProvisioningStatus
+                Resource: !Ref IdcInstanceArn # Instance* only
+              - Effect: Allow
+                Action:
+                  - sso:DescribePermissionSet
+                  - sso:CreatePermissionSet
+                  - sso:PutInlinePolicyToPermissionSet
+                  - sso:GetInlinePolicyForPermissionSet
+                Resource:
+                  # Instance* + PermissionSet*, both required simultaneously.
+                  - !Ref IdcInstanceArn
+                  - !Sub
+                    - 'arn:${AWS::Partition}:sso:::permissionSet/${InstanceId}/*'
+                    - InstanceId: !Select [1, !Split ['/', !Ref IdcInstanceArn]]
+              - Effect: Allow
+                Action:
+                  - sso:CreateAccountAssignment
+                  - sso:ListAccountAssignments
+                  - sso:ProvisionPermissionSet
+                Resource:
+                  # Account* + Instance* + PermissionSet*, all required simultaneously.
+                  - !Sub 'arn:${AWS::Partition}:sso:::account/${AWS::AccountId}'
+                  - !Ref IdcInstanceArn
+                  - !Sub
+                    - 'arn:${AWS::Partition}:sso:::permissionSet/${InstanceId}/*'
+                    - InstanceId: !Select [1, !Split ['/', !Ref IdcInstanceArn]]
+              # identitystore:ListGroups/DescribeGroup/ListUsers/
+              # ListGroupMembershipsForMember each require BOTH a Group/User/
+              # AllGroupMemberships-family resource type AND an Identitystore
+              # resource (arn:...:identitystore::${Account}:identitystore/${Id})
+              # simultaneously. The Identity Store ID is only discovered at
+              # runtime via sso:ListInstances (it isn't derivable from
+              # IdcInstanceArn and isn't available as a template parameter),
+              # so the Identitystore resource can't be scoped in this static
+              # policy. Left as '*' — every one of these actions is read-only
+              # (List/Read access level, no Write) rather than a mutation.
+              - Effect: Allow
+                Action:
+                  - identitystore:ListGroups
+                  - identitystore:DescribeGroup
+                  - identitystore:ListUsers
+                  - identitystore:ListGroupMembershipsForMember
+                Resource: '*'
+              - Effect: Allow
+                Action:
+                  - bedrock:ListFoundationModels
+                  - bedrock:GetFoundationModel
+                  - bedrock:ListInferenceProfiles
+                  - bedrock:GetInferenceProfile
+                Resource: '*' # Bedrock read-only model discovery actions don't support resource-level scoping
+              - Effect: Allow
+                Action: sts:GetCallerIdentity
+                Resource: '*' # sts:GetCallerIdentity does not support resource-level permissions
+        # CloudFront mode only: the admin Lambda validates the shared
+        # session cookie the landing page's /callback set (same CloudFront
+        # domain, same Cognito client), so it only needs the session-signing
+        # HMAC key — the code exchange itself happens in the landing page
+        # Lambda, so no Cognito client secret is needed here.
+        - !If
+          - ShouldEnableCloudFront
+          - PolicyName: CloudFrontSessionSecret
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+                - Effect: Allow
+                  Action: secretsmanager:GetSecretValue
+                  Resource:
+                    - !Ref SessionSigningSecretArn
+          - !Ref 'AWS::NoValue'
+      Tags:
+        - Key: Application
+          Value: ClaudeCodeWithBedrock
+
+  AdminConsoleLogGroup:
+    Type: AWS::Logs::LogGroup
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W84
+            reason: "Log group contains admin-console request/audit logs, not user secrets; KMS encryption adds cost without security benefit here (matches bedrock-auth-google.yaml's BedrockAccessLogGroup precedent)"
+    Properties:
+      LogGroupName: !Sub '/aws/lambda/${IdentityPoolName}-admin-console'
+      RetentionInDays: 30
+
+  # ============================================================
+  # Lambda function
+  # ============================================================
+  # Code is packaged from deployment/infrastructure/lambda-functions/admin_console/
+  # via `aws cloudformation package` (same pattern as bootstrap-device-code.yaml
+  # and quota-monitoring.yaml) since the admin HTML/JS + route handlers exceed
+  # the 4096-byte inline ZipFile limit.
+  AdminConsoleFunction:
+    Type: AWS::Lambda::Function
+    DependsOn: AdminConsoleLogGroup
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W58
+            reason: "AWSLambdaBasicExecutionRole (attached via ManagedPolicyArns above) already grants logs:CreateLogGroup/CreateLogStream/PutLogEvents — cfn_nag's static analysis doesn't resolve managed policies referenced through Fn::Sub"
+          - id: W89
+            reason: "ALB-invoked admin console Lambda requires internet access to reach IDC SSO Admin/Identity Store and Bedrock APIs — VPC not needed"
+          - id: W92
+            reason: "Invocation rate bounded by admin-user traffic to /admin* — reserved concurrency unnecessary"
+    Properties:
+      FunctionName: !Sub '${IdentityPoolName}-admin-console'
+      Runtime: python3.12
+      Handler: index.lambda_handler
+      Role: !GetAtt AdminConsoleFunctionRole.Arn
+      Timeout: 30
+      MemorySize: 512
+      Environment:
+        Variables:
+          S3_BUCKET_NAME: !Ref DistributionBucketName
+          IDC_INSTANCE_ARN: !Ref IdcInstanceArn
+          ADMIN_GROUP: !Ref AdminGroupName
+          BASE_URL: !Sub 'https://${CustomDomainName}'
+          ADDITIONAL_TRUSTED_ORIGINS: !Join [',', !Ref AdditionalTrustedOrigins]
+          IDC_BOOTSTRAP_CLIENT_ID: !Ref IdcBootstrapUserPoolClientId
+          IDC_BOOTSTRAP_ISSUER: !If
+            - HasIdcBootstrapClient
+            - !Sub 'https://cognito-idp.${AWS::Region}.amazonaws.com/${IdcUserPoolId}'
+            - ''
+          IDC_BOOTSTRAP_REDIRECT_PORT: !Ref IdcBootstrapRedirectPort
+          # IDC data (permission sets, groups, users) only ever lives in the
+          # region IDC was enabled in — not necessarily this stack's own
+          # region. Defaults to AWS::Region (the common case: admin console
+          # deployed alongside IDC) when IdcRegion isn't set.
+          IDC_REGION: !If [HasExplicitIdcRegion, !Ref IdcRegion, !Ref 'AWS::Region']
+          # CloudFront mode: self-contained Cognito login for requests
+          # arriving via CloudFront's HTTP listener (no ALB auth header).
+          ENABLE_CLOUDFRONT: !If [ShouldEnableCloudFront, 'true', 'false']
+          CLOUDFRONT_DOMAIN: !Ref CloudFrontDomain
+          SELF_COGNITO_DOMAIN: !If
+            - ShouldEnableCloudFront
+            - !Sub '${IdcUserPoolDomain}.auth.${AWS::Region}.amazoncognito.com'
+            - ''
+          SELF_COGNITO_CLIENT_ID: !If [ShouldEnableCloudFront, !Ref IdcUserPoolClientId, '']
+          SESSION_SIGNING_SECRET_ARN: !Ref SessionSigningSecretArn
+      Code: ./lambda-functions/admin_console/
+      Tags:
+        - Key: Application
+          Value: ClaudeCodeWithBedrock
+
+  # ALB target groups for Lambda targets don't support HealthCheckEnabled=true
+  # against a Lambda target (ALB invokes the function directly to health
+  # check), but we disable it anyway to match the landing page's
+  # LambdaTargetGroup and avoid unnecessary invocations.
+  AdminTargetGroup:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    DependsOn: AdminLambdaInvokePermission
+    Properties:
+      TargetType: lambda
+      Targets:
+        - Id: !GetAtt AdminConsoleFunction.Arn
+      HealthCheckEnabled: false
+      Tags:
+        - Key: Application
+          Value: ClaudeCodeWithBedrock
+
+  AdminLambdaInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref AdminConsoleFunction
+      Action: lambda:InvokeFunction
+      Principal: elasticloadbalancing.amazonaws.com
+      SourceArn: !Sub 'arn:${AWS::Partition}:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:targetgroup/*'
+
+  # ============================================================
+  # Listener rule: /admin* on the distribution stack's shared ALB listener
+  # ============================================================
+  # authenticate-oidc is configured per-rule here (independently of the
+  # listener's own DefaultActions in landing-page-distribution.yaml), reusing
+  # the same Cognito-IDC-bridge app client/secret so admins get the same
+  # sign-in experience as the landing page, on the same domain.
+  AdminListenerRule:
+    Type: AWS::ElasticLoadBalancingV2::ListenerRule
+    Properties:
+      ListenerArn: !Ref HTTPSListenerArn
+      Priority: !Ref ListenerRulePriority
+      Conditions:
+        - Field: path-pattern
+          Values:
+            - '/admin'
+            - '/admin/*'
+      Actions:
+        - Type: authenticate-oidc
+          Order: 1
+          AuthenticateOidcConfig:
+            Issuer: !Sub 'https://cognito-idp.${AWS::Region}.amazonaws.com/${IdcUserPoolId}'
+            AuthorizationEndpoint: !Sub 'https://${IdcUserPoolDomain}.auth.${AWS::Region}.amazoncognito.com/oauth2/authorize'
+            TokenEndpoint: !Sub 'https://${IdcUserPoolDomain}.auth.${AWS::Region}.amazoncognito.com/oauth2/token'
+            UserInfoEndpoint: !Sub 'https://${IdcUserPoolDomain}.auth.${AWS::Region}.amazoncognito.com/oauth2/userInfo'
+            ClientId: !Ref IdcUserPoolClientId
+            ClientSecret: !Sub '{{resolve:secretsmanager:${IdcUserPoolClientSecretArn}:SecretString}}'
+            SessionTimeout: 43200 # 12 hours, matches the landing page listener
+            Scope: 'openid email profile'
+            OnUnauthenticatedRequest: authenticate
+        - Type: forward
+          Order: 2
+          TargetGroupArn: !Ref AdminTargetGroup
+
+  # CloudFront mode: /admin* also needs a rule on the forward-only HTTP
+  # listener CloudFront connects to. No authenticate-oidc (that only works on
+  # HTTPS listeners) — the admin Lambda runs its own Cognito login for these
+  # requests, exactly like the landing page does.
+  AdminCloudFrontListenerRule:
+    Type: AWS::ElasticLoadBalancingV2::ListenerRule
+    Condition: ShouldEnableCloudFront
+    Properties:
+      ListenerArn: !Ref CloudFrontHTTPListenerArn
+      Priority: !Ref ListenerRulePriority
+      Conditions:
+        - Field: path-pattern
+          Values:
+            - '/admin'
+            - '/admin/*'
+      Actions:
+        - Type: forward
+          TargetGroupArn: !Ref AdminTargetGroup
+
+Outputs:
+  AdminConsoleUrl:
+    Description: Admin console URL (requires membership in AdminGroupName within IAM Identity Center)
+    Value: !If
+      - ShouldEnableCloudFront
+      - !Sub 'https://${CloudFrontDomain}/admin'
+      - !Sub 'https://${CustomDomainName}/admin'
+    Export:
+      Name: !Sub '${AWS::StackName}-AdminConsoleUrl'
+
+  AdminConsoleFunctionArn:
+    Description: Admin console Lambda function ARN
+    Value: !GetAtt AdminConsoleFunction.Arn

--- a/deployment/infrastructure/admin-console.yaml
+++ b/deployment/infrastructure/admin-console.yaml
@@ -371,7 +371,7 @@ Resources:
       Runtime: python3.12
       Handler: index.lambda_handler
       Role: !GetAtt AdminConsoleFunctionRole.Arn
-      Timeout: 30
+      Timeout: 120
       MemorySize: 512
       Environment:
         Variables:

--- a/deployment/infrastructure/lambda-functions/admin_console/index.py
+++ b/deployment/infrastructure/lambda-functions/admin_console/index.py
@@ -2096,10 +2096,10 @@ def serve_admin_page(user_email: str) -> dict:
                 const gc = groupConfig[group.groupId] || {{ models: [], permissionSetName: null }};
                 let modelTagsHtml = '<div class="model-tags">';
                 if (gc.models.length === 0) modelTagsHtml += '<span style="color:#888;">None</span>';
-                else gc.models.forEach((m, mi) => {{ modelTagsHtml += '<span class="model-tag">' + m.modelName + ' <span class="remove" data-group="' + group.groupId + '" data-idx="' + mi + '" onclick="removeModelByIdx(this)">&times;</span></span>'; }});
+                else gc.models.forEach((m, mi) => {{ modelTagsHtml += '<span class="model-tag">' + escapeHtml(m.modelName) + ' <span class="remove" data-group="' + group.groupId + '" data-idx="' + mi + '" onclick="removeModelByIdx(this)">&times;</span></span>'; }});
                 modelTagsHtml += '</div>';
                 let addHtml = '<div class="add-row"><select id="add-model-' + group.groupId + '" style="font-size:13px;"><option value="">Select model...</option>';
-                models.filter(m => !gc.models.find(gm => gm.modelId === m.modelId)).forEach(m => {{ addHtml += '<option value="' + encodeURIComponent(m.modelId) + '|' + encodeURIComponent(m.modelName) + '">' + m.modelName + '</option>'; }});
+                models.filter(m => !gc.models.find(gm => gm.modelId === m.modelId)).forEach(m => {{ addHtml += '<option value="' + encodeURIComponent(m.modelId) + '|' + encodeURIComponent(m.modelName) + '">' + escapeHtml(m.modelName) + '</option>'; }});
                 addHtml += '</select><button class="btn btn-primary btn-sm" data-group="' + group.groupId + '" onclick="addModelFromBtn(this)">+</button></div>';
                 let psHtml = gc.permissionSetName ? escapeHtml(gc.permissionSetName) + ' <a href="#" onclick="viewPolicy(' + attrArg(gc.permissionSetName) + ');return false;" style="font-size:11px;color:#667eea;">[view]</a>' : '-';
                 html += '<tr><td><strong>' + escapeHtml(group.displayName) + '</strong></td><td>' + modelTagsHtml + '</td><td>' + addHtml + '</td><td>' + psHtml + '</td></tr>';
@@ -2206,10 +2206,10 @@ def serve_admin_page(user_email: str) -> dict:
 
         function renderMcpServers() {{
             const md = document.getElementById('managed-mcp-servers');
-            md.innerHTML = managedMcpServers.length === 0 ? '<p style="color:#888;">No remote MCP servers configured.</p>' : managedMcpServers.map((s, i) => '<div class="card"><div class="card-header"><h5>' + s.name + '</h5><div><span class="badge badge-success">Remote</span> <button class="btn btn-danger btn-sm" onclick="removeManagedMcp(' + i + ')">Remove</button></div></div><div class="card-body"><strong>URL:</strong> <code>' + s.url + '</code>' + (s.description ? '<br>' + s.description : '') + '</div></div>').join('');
+            md.innerHTML = managedMcpServers.length === 0 ? '<p style="color:#888;">No remote MCP servers configured.</p>' : managedMcpServers.map((s, i) => '<div class="card"><div class="card-header"><h5>' + escapeHtml(s.name) + '</h5><div><span class="badge badge-success">Remote</span> <button class="btn btn-danger btn-sm" onclick="removeManagedMcp(' + i + ')">Remove</button></div></div><div class="card-body"><strong>URL:</strong> <code>' + escapeHtml(s.url) + '</code>' + (s.description ? '<br>' + escapeHtml(s.description) : '') + '</div></div>').join('');
 
             const td = document.getElementById('mcp-templates');
-            td.innerHTML = mcpServerTemplates.length === 0 ? '<p style="color:#888;">No local MCP templates configured.</p>' : mcpServerTemplates.map((s, i) => '<div class="card"><div class="card-header"><h5>' + s.name + '</h5><div><span class="badge badge-warning">Local</span> <button class="btn btn-danger btn-sm" onclick="removeMcpTemplate(' + i + ')">Remove</button></div></div><div class="card-body"><strong>Command:</strong> <code>' + s.command + ' ' + (s.args || []).join(' ') + '</code></div></div>').join('');
+            td.innerHTML = mcpServerTemplates.length === 0 ? '<p style="color:#888;">No local MCP templates configured.</p>' : mcpServerTemplates.map((s, i) => '<div class="card"><div class="card-header"><h5>' + escapeHtml(s.name) + '</h5><div><span class="badge badge-warning">Local</span> <button class="btn btn-danger btn-sm" onclick="removeMcpTemplate(' + i + ')">Remove</button></div></div><div class="card-body"><strong>Command:</strong> <code>' + escapeHtml(s.command) + ' ' + escapeHtml((s.args || []).join(' ')) + '</code></div></div>').join('');
         }}
 
         function addManagedMcpServer() {{

--- a/deployment/infrastructure/lambda-functions/admin_console/index.py
+++ b/deployment/infrastructure/lambda-functions/admin_console/index.py
@@ -1,0 +1,2409 @@
+# ABOUTME: Admin console Lambda for the IAM Identity Center landing page.
+# ABOUTME: Manages group->model->permission-set mappings and generates MDM/bootstrap configs.
+
+"""Admin console for the IAM Identity Center (IDC) landing page.
+
+Sits behind the SAME ALB as the landing page (landing-page-distribution.yaml),
+attached via a separate /admin* listener rule (see admin-console.yaml) so
+authentication is handled entirely by the ALB's native `authenticate-oidc`
+listener action — this Lambda never sees raw credentials or mints its own
+session cookies. ALB validates the JWT and forwards the decoded claims via
+the x-amzn-oidc-data header (base64 JWT payload, unverified re-decode here is
+safe because the ALB has already checked the signature before invoking us).
+
+Authorization is a SEPARATE, additional check on top of that authentication:
+every request re-resolves the caller's IAM Identity Center group memberships
+live (never trusted from a token claim) and requires membership in
+ADMIN_GROUP. This matches the pattern used by the original CDK-based
+implementation (deployment/idc-landing-page/lambda/index.py).
+"""
+
+import base64
+import hashlib
+import hmac
+import html
+import json
+import os
+import time
+import urllib.parse
+import uuid
+from urllib.parse import unquote
+
+import boto3
+from shared.mdm_config import (
+    add_bootstrap_config,
+    add_mcp_servers,
+    add_policies,
+    build_inference_models,
+)
+from shared.mdm_generators import generate_mobileconfig, generate_reg_file
+
+BUCKET_NAME = os.environ["S3_BUCKET_NAME"]
+IDC_INSTANCE_ARN = os.environ["IDC_INSTANCE_ARN"]
+ADMIN_GROUP = os.environ.get("ADMIN_GROUP", "Claude-Code-Admins")
+BASE_URL = os.environ["BASE_URL"]
+# Optional extra Origin/Referer values accepted on admin POST requests, on
+# top of BASE_URL (see verify_request_origin) — needed for SSM-tunnel/VPN
+# access to an internal-scheme ALB whose hostname differs from BASE_URL.
+ADDITIONAL_TRUSTED_ORIGINS = [o.rstrip("/") for o in os.environ.get("ADDITIONAL_TRUSTED_ORIGINS", "").split(",") if o]
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+
+# Bootstrap OIDC (Claude Desktop's /api/bootstrap flow) — see
+# landing-page-distribution.yaml's IdcBootstrapUserPoolClient. Empty when the
+# distribution stack predates this feature or bootstrap is otherwise
+# disabled; generated MDM files then fall back to bootstrapUrl-only (no
+# bootstrapOidc), which Claude Desktop treats as "no dynamic config".
+IDC_BOOTSTRAP_CLIENT_ID = os.environ.get("IDC_BOOTSTRAP_CLIENT_ID", "")
+IDC_BOOTSTRAP_ISSUER = os.environ.get("IDC_BOOTSTRAP_ISSUER", "")
+IDC_BOOTSTRAP_REDIRECT_PORT = os.environ.get("IDC_BOOTSTRAP_REDIRECT_PORT", "")
+# IAM Identity Center data (permission sets, groups, users) is only ever
+# stored in the region IDC was enabled in, regardless of where this Lambda
+# itself runs. IDC_REGION defaults to this function's own region (the common
+# case) but must be set explicitly when the admin console is deployed in a
+# different region than IDC's home region.
+IDC_REGION = os.environ.get("IDC_REGION", REGION)
+
+# CloudFront-in-front-of-internal-ALB mode (see admin-console.yaml's
+# EnableCloudFront). Requests arrive via CloudFront's forward-only HTTP
+# listener with NO ALB-set x-amzn-oidc-data header, so identity comes from
+# the shared session cookie the landing page's /callback set (same CloudFront
+# domain, same Cognito client, same signing secret). Unauthenticated callers
+# are redirected to Cognito login with redirect_uri pointing back at the
+# landing page's /callback (already a registered callback URL) — the admin
+# console never does its own code exchange.
+ENABLE_CLOUDFRONT = os.environ.get("ENABLE_CLOUDFRONT", "false") == "true"
+CLOUDFRONT_DOMAIN = os.environ.get("CLOUDFRONT_DOMAIN", "")
+SELF_COGNITO_DOMAIN = os.environ.get("SELF_COGNITO_DOMAIN", "")
+SELF_COGNITO_CLIENT_ID = os.environ.get("SELF_COGNITO_CLIENT_ID", "")
+SESSION_SIGNING_SECRET_ARN = os.environ.get("SESSION_SIGNING_SECRET_ARN", "")
+
+s3_client = boto3.client("s3")
+_secretsmanager_client = boto3.client("secretsmanager") if ENABLE_CLOUDFRONT else None
+_session_signing_secret_cache = None
+
+
+def _get_session_signing_secret():
+    """Fetch (and cache) the shared HMAC key used to validate the landing
+    page's session cookie. Same secret the landing page signs with."""
+    global _session_signing_secret_cache
+    if _session_signing_secret_cache is None:
+        if not SESSION_SIGNING_SECRET_ARN:
+            raise RuntimeError("SESSION_SIGNING_SECRET_ARN is not configured")
+        resp = _secretsmanager_client.get_secret_value(SecretId=SESSION_SIGNING_SECRET_ARN)
+        secret_dict = json.loads(resp["SecretString"])
+        _session_signing_secret_cache = secret_dict["key"].encode("utf-8")
+    return _session_signing_secret_cache
+
+
+def _sign(payload_b64: str) -> str:
+    key = _get_session_signing_secret()
+    digest = hmac.new(key, payload_b64.encode("utf-8"), hashlib.sha256).digest()
+    return base64.urlsafe_b64encode(digest).decode().rstrip("=")
+
+
+def _parse_cookies(cookie_header: str) -> dict:
+    cookies = {}
+    if cookie_header:
+        for item in cookie_header.split(";"):
+            if "=" in item:
+                k, v = item.strip().split("=", 1)
+                cookies[k] = v
+    return cookies
+
+
+def validate_session(session_token: str):
+    """Verify the landing page's HMAC-signed session token. Returns the
+    decoded payload if valid and unexpired, else None."""
+    if not session_token:
+        return None
+    try:
+        payload_b64, signature_b64 = session_token.split(".", 1)
+    except ValueError:
+        return None
+    if not hmac.compare_digest(signature_b64, _sign(payload_b64)):
+        return None
+    try:
+        padded = payload_b64 + "=" * (-len(payload_b64) % 4)
+        session_data = json.loads(base64.urlsafe_b64decode(padded))
+    except Exception:
+        return None
+    if session_data.get("exp", 0) < time.time():
+        return None
+    return session_data
+
+
+def redirect_to_login():
+    """Redirect an unauthenticated CloudFront request to Cognito login. The
+    redirect_uri is the landing page's /callback (already a registered
+    callback URL); after login it sets the shared session cookie domain-wide
+    and the user can return to /admin."""
+    base_url = f"https://{CLOUDFRONT_DOMAIN}"
+    login_url = (
+        f"https://{SELF_COGNITO_DOMAIN}/login?"
+        f"client_id={SELF_COGNITO_CLIENT_ID}&"
+        f"response_type=code&"
+        f"scope=openid+email+profile&"
+        f"redirect_uri={urllib.parse.quote(base_url + '/callback')}"
+    )
+    return {"statusCode": 302, "headers": {"Location": login_url}, "body": ""}
+bedrock_client = boto3.client("bedrock")
+sso_admin_client = boto3.client("sso-admin", region_name=IDC_REGION)
+identity_store_client = boto3.client("identitystore", region_name=IDC_REGION)
+sts_client = boto3.client("sts")
+
+DEPRECATED_MODEL_PATTERNS = (
+    "claude-v1",
+    "claude-v2",
+    "claude-instant",
+    "claude-2.0",
+    "claude-2.1",
+    "claude-3-sonnet-20240229",
+    "claude-3-haiku-20240307",
+    "claude-3-opus-20240229",
+)
+
+
+# =============================================================================
+# Response / logging helpers
+# =============================================================================
+
+
+def json_response(data: dict, status_code: int = 200) -> dict:
+    return {
+        "statusCode": status_code,
+        "statusDescription": f"{status_code} {'OK' if status_code < 400 else 'Error'}",
+        "isBase64Encoded": False,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps(data),
+    }
+
+
+def html_response(body: str, status_code: int = 200) -> dict:
+    return {
+        "statusCode": status_code,
+        "statusDescription": f"{status_code} {'OK' if status_code < 400 else 'Error'}",
+        "isBase64Encoded": False,
+        "headers": {"Content-Type": "text/html; charset=utf-8"},
+        "body": body,
+    }
+
+
+def internal_error_response() -> dict:
+    """Never leak internal exception detail (ARNs, bucket names, IAM errors)
+    to the caller — full detail belongs in CloudWatch logs via print()."""
+    return json_response({"error": "An internal error occurred. Please try again later."}, 500)
+
+
+def log_safe(value) -> str:
+    """Strip newlines before logging attacker/user-controlled strings, so a
+    crafted email/name claim can't inject fake CloudWatch log lines."""
+    return str(value).replace("\n", " ").replace("\r", " ")
+
+
+# =============================================================================
+# Auth: identity from ALB OIDC headers, authorization via live IDC lookup
+# =============================================================================
+
+
+def extract_user_email(headers: dict) -> str:
+    """Decode the email claim from the ALB-validated OIDC JWT payload.
+
+    The ALB (authenticate-oidc listener action) has already verified this
+    JWT's signature/expiry before invoking the Lambda — decoding the payload
+    here without re-checking the signature is safe specifically because it
+    arrives via the trusted x-amzn-oidc-data header set by the ALB itself,
+    not from client-controlled input.
+    """
+    oidc_data = headers.get("x-amzn-oidc-data", headers.get("X-Amzn-Oidc-Data", ""))
+    if not oidc_data:
+        return ""
+    try:
+        parts = oidc_data.split(".")
+        if len(parts) != 3:
+            return ""
+        payload_b64 = parts[1]
+        padding = 4 - len(payload_b64) % 4
+        if padding != 4:
+            payload_b64 += "=" * padding
+        payload = json.loads(base64.b64decode(payload_b64))
+        return payload.get("email") or payload.get("preferred_username") or payload.get("upn") or ""
+    except Exception:
+        return ""
+
+
+def verify_request_origin(headers: dict) -> bool:
+    """CSRF defense-in-depth: require a state-changing request's Origin (or
+    Referer fallback) header to match BASE_URL, or one of
+    ADDITIONAL_TRUSTED_ORIGINS (see admin-console.yaml's
+    AdditionalTrustedOrigins parameter — needed for SSM-tunnel/VPN access to
+    an internal-scheme ALB). Fails closed if neither header is present.
+
+    In CloudFront mode the admin console is reached at https://CLOUDFRONT_DOMAIN
+    (not BASE_URL's custom domain), so that origin is trusted too."""
+    allowed = [BASE_URL.rstrip("/")] + ADDITIONAL_TRUSTED_ORIGINS
+    if ENABLE_CLOUDFRONT and CLOUDFRONT_DOMAIN:
+        allowed.append(f"https://{CLOUDFRONT_DOMAIN}")
+    origin = headers.get("origin", headers.get("Origin", ""))
+    if not origin:
+        origin = headers.get("referer", headers.get("Referer", ""))
+    if not origin:
+        return False
+    origin = origin.rstrip("/")
+    return any(origin == expected or origin.startswith(expected + "/") for expected in allowed)
+
+
+def get_user_idc_groups(email: str) -> list[str]:
+    """Live lookup of a user's IAM Identity Center group display names.
+
+    Never cached, never trusted from a token claim — every admin request
+    re-resolves this from the Identity Store directly.
+    """
+    if not email:
+        return []
+    try:
+        instances = sso_admin_client.list_instances()
+        if not instances.get("Instances"):
+            print("No IDC instances found")
+            return []
+        identity_store_id = instances["Instances"][0]["IdentityStoreId"]
+
+        username = email.split("@")[0] if "@" in email else email
+        users = identity_store_client.list_users(
+            IdentityStoreId=identity_store_id,
+            Filters=[{"AttributePath": "UserName", "AttributeValue": username}],
+        )
+        if not users.get("Users"):
+            users = identity_store_client.list_users(
+                IdentityStoreId=identity_store_id,
+                Filters=[{"AttributePath": "UserName", "AttributeValue": email}],
+            )
+        if not users.get("Users"):
+            print(f"No IDC user found for {log_safe(email)}")
+            return []
+
+        user_id = users["Users"][0]["UserId"]
+        memberships = identity_store_client.list_group_memberships_for_member(
+            IdentityStoreId=identity_store_id, MemberId={"UserId": user_id}
+        )
+        groups = []
+        for membership in memberships.get("GroupMemberships", []):
+            try:
+                group = identity_store_client.describe_group(
+                    IdentityStoreId=identity_store_id, GroupId=membership["GroupId"]
+                )
+                groups.append(group["DisplayName"])
+            except Exception:
+                pass
+        return groups
+    except Exception as e:
+        print(f"Error getting IDC groups: {e}")
+        return []
+
+
+def group_name_to_config_key(group_name: str) -> str:
+    """ "Claude-Code-Developers" -> "developer" (matches the landing page's
+    matching heuristic in list_config_groups / bootstrap lookup)."""
+    config_key = (
+        group_name.lower().replace("claude-code-", "").replace("claude-", "").replace(" ", "-").replace("_", "-")
+    )
+    if config_key.endswith("s") and len(config_key) > 3:
+        config_key = config_key[:-1]
+    return config_key
+
+
+# =============================================================================
+# Admin API: groups / models / permission sets
+# =============================================================================
+
+
+def api_list_groups() -> dict:
+    try:
+        instances = sso_admin_client.list_instances()
+        if not instances.get("Instances"):
+            return json_response({"error": "No IDC instance found"}, 404)
+        identity_store_id = instances["Instances"][0]["IdentityStoreId"]
+
+        groups = []
+        paginator = identity_store_client.get_paginator("list_groups")
+        for page in paginator.paginate(IdentityStoreId=identity_store_id):
+            for group in page.get("Groups", []):
+                if "claude" in group["DisplayName"].lower():
+                    groups.append(
+                        {
+                            "groupId": group["GroupId"],
+                            "displayName": group["DisplayName"],
+                            "description": group.get("Description", ""),
+                        }
+                    )
+        return json_response({"groups": groups})
+    except Exception as e:
+        print(f"Error listing groups: {e}")
+        return internal_error_response()
+
+
+def _is_deprecated_model(model_id: str) -> bool:
+    model_lower = model_id.lower()
+    return any(pattern in model_lower for pattern in DEPRECATED_MODEL_PATTERNS)
+
+
+def api_list_models() -> dict:
+    try:
+        models = []
+        profiles_response = bedrock_client.list_inference_profiles()
+        for profile in profiles_response.get("inferenceProfileSummaries", []):
+            profile_id = profile.get("inferenceProfileId", "")
+            profile_name = profile.get("inferenceProfileName", "")
+            status = profile.get("status", "ACTIVE")
+            if (
+                ("claude" in profile_id.lower() or "anthropic" in profile_id.lower())
+                and not _is_deprecated_model(profile_id)
+                and status == "ACTIVE"
+            ):
+                models.append(
+                    {"modelId": profile_id, "modelName": profile_name, "type": "inference-profile", "status": status}
+                )
+        models.sort(key=lambda m: m["modelName"])
+        return json_response({"models": models})
+    except Exception as e:
+        print(f"Error listing models: {e}")
+        return internal_error_response()
+
+
+def api_list_permission_sets() -> dict:
+    try:
+        instances = sso_admin_client.list_instances()
+        if not instances.get("Instances"):
+            return json_response({"error": "No IDC instance found"}, 404)
+        instance_arn = instances["Instances"][0]["InstanceArn"]
+        identity_store_id = instances["Instances"][0]["IdentityStoreId"]
+        account_id = sts_client.get_caller_identity()["Account"]
+
+        permission_sets = []
+        paginator = sso_admin_client.get_paginator("list_permission_sets")
+        for page in paginator.paginate(InstanceArn=instance_arn):
+            for ps_arn in page.get("PermissionSets", []):
+                try:
+                    ps = sso_admin_client.describe_permission_set(InstanceArn=instance_arn, PermissionSetArn=ps_arn)
+                    ps_info = ps["PermissionSet"]
+
+                    assigned_groups = []
+                    try:
+                        assignments = sso_admin_client.list_account_assignments(
+                            InstanceArn=instance_arn, AccountId=account_id, PermissionSetArn=ps_arn
+                        )
+                        for assignment in assignments.get("AccountAssignments", []):
+                            if assignment.get("PrincipalType") == "GROUP":
+                                group_id = assignment.get("PrincipalId")
+                                try:
+                                    group = identity_store_client.describe_group(
+                                        IdentityStoreId=identity_store_id, GroupId=group_id
+                                    )
+                                    assigned_groups.append(
+                                        {"groupId": group_id, "groupName": group.get("DisplayName", "")}
+                                    )
+                                except Exception:
+                                    pass
+                    except Exception as e:
+                        print(f"Error getting assignments for {ps_arn}: {e}")
+
+                    model_resources = []
+                    try:
+                        policy_response = sso_admin_client.get_inline_policy_for_permission_set(
+                            InstanceArn=instance_arn, PermissionSetArn=ps_arn
+                        )
+                        if policy_response.get("InlinePolicy"):
+                            policy = json.loads(policy_response["InlinePolicy"])
+                            for stmt in policy.get("Statement", []):
+                                if stmt.get("Sid") == "AllowBedrockModel":
+                                    resources = stmt.get("Resource", [])
+                                    model_resources = [resources] if isinstance(resources, str) else resources
+                    except Exception:
+                        pass
+
+                    permission_sets.append(
+                        {
+                            "arn": ps_arn,
+                            "name": ps_info.get("Name", ""),
+                            "description": ps_info.get("Description", ""),
+                            "sessionDuration": ps_info.get("SessionDuration", "PT1H"),
+                            "assignedGroups": assigned_groups,
+                            "modelResources": model_resources,
+                        }
+                    )
+                except Exception as e:
+                    print(f"Error describing permission set {ps_arn}: {e}")
+
+        permission_sets.sort(key=lambda p: p["name"])
+        return json_response({"permissionSets": permission_sets})
+    except Exception as e:
+        print(f"Error listing permission sets: {e}")
+        return internal_error_response()
+
+
+def api_get_permission_set_details(ps_name: str) -> dict:
+    try:
+        instances = sso_admin_client.list_instances()
+        if not instances.get("Instances"):
+            return json_response({"error": "No IDC instance found"}, 404)
+        instance_arn = instances["Instances"][0]["InstanceArn"]
+
+        ps_arn = None
+        paginator = sso_admin_client.get_paginator("list_permission_sets")
+        for page in paginator.paginate(InstanceArn=instance_arn):
+            for arn in page.get("PermissionSets", []):
+                ps = sso_admin_client.describe_permission_set(InstanceArn=instance_arn, PermissionSetArn=arn)
+                if ps["PermissionSet"]["Name"] == ps_name:
+                    ps_arn = arn
+                    break
+            if ps_arn:
+                break
+
+        if not ps_arn:
+            return json_response({"error": f"Permission set {ps_name} not found"}, 404)
+
+        ps = sso_admin_client.describe_permission_set(InstanceArn=instance_arn, PermissionSetArn=ps_arn)
+        inline_policy = None
+        try:
+            policy_response = sso_admin_client.get_inline_policy_for_permission_set(
+                InstanceArn=instance_arn, PermissionSetArn=ps_arn
+            )
+            raw = policy_response.get("InlinePolicy", "")
+            inline_policy = json.loads(raw) if raw else None
+        except Exception as e:
+            print(f"Error getting inline policy: {e}")
+
+        return json_response(
+            {
+                "name": ps["PermissionSet"]["Name"],
+                "description": ps["PermissionSet"].get("Description", ""),
+                "sessionDuration": ps["PermissionSet"].get("SessionDuration", "PT1H"),
+                "arn": ps_arn,
+                "inlinePolicy": inline_policy,
+            }
+        )
+    except Exception as e:
+        print(f"Error getting permission set details: {e}")
+        return internal_error_response()
+
+
+# =============================================================================
+# Admin API: config storage (S3 admin/config.json)
+# =============================================================================
+
+
+def load_admin_config() -> dict:
+    try:
+        response = s3_client.get_object(Bucket=BUCKET_NAME, Key="admin/config.json")
+        return json.loads(response["Body"].read().decode("utf-8"))
+    except Exception:
+        return {"mappings": []}
+
+
+def save_admin_config(config: dict) -> None:
+    s3_client.put_object(
+        Bucket=BUCKET_NAME,
+        Key="admin/config.json",
+        Body=json.dumps(config, indent=2).encode("utf-8"),
+        ContentType="application/json",
+    )
+
+
+def api_get_config() -> dict:
+    try:
+        return json_response(load_admin_config())
+    except Exception as e:
+        print(f"Error getting config: {e}")
+        return internal_error_response()
+
+
+def api_save_config(body: str) -> dict:
+    try:
+        config = json.loads(body) if body else {}
+        save_admin_config(config)
+        return json_response({"success": True, "message": "Configuration saved"})
+    except Exception as e:
+        print(f"Error saving config: {e}")
+        return internal_error_response()
+
+
+# =============================================================================
+# Admin API: deploy (permission sets + MDM/bootstrap config generation)
+# =============================================================================
+
+
+def create_or_update_permission_set_no_provision(instance_arn: str, name: str, models_list: list[dict]) -> str:
+    """Create or update a permission set granting access to multiple Bedrock
+    models. Does NOT provision — caller provisions separately."""
+    ps_arn = None
+    paginator = sso_admin_client.get_paginator("list_permission_sets")
+    for page in paginator.paginate(InstanceArn=instance_arn):
+        for arn in page.get("PermissionSets", []):
+            ps = sso_admin_client.describe_permission_set(InstanceArn=instance_arn, PermissionSetArn=arn)
+            if ps["PermissionSet"]["Name"] == name:
+                ps_arn = arn
+                break
+        if ps_arn:
+            break
+
+    if not ps_arn:
+        model_names = ", ".join(m["modelName"] for m in models_list[:3])
+        response = sso_admin_client.create_permission_set(
+            InstanceArn=instance_arn,
+            Name=name,
+            Description=f"Access to {model_names}",
+            SessionDuration="PT8H",
+        )
+        ps_arn = response["PermissionSet"]["PermissionSetArn"]
+
+    all_resources = []
+    for model in models_list:
+        model_id = model["modelId"]
+        base_model = model_id.replace("us.anthropic.", "").replace("global.anthropic.", "").replace("eu.anthropic.", "")
+        all_resources.append(f"arn:aws:bedrock:*:*:inference-profile/{model_id}*")
+        all_resources.append(f"arn:aws:bedrock:*::foundation-model/anthropic.{base_model}*")
+    all_resources = list(dict.fromkeys(all_resources))
+
+    policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "AllowBedrockModel",
+                "Effect": "Allow",
+                "Action": ["bedrock:InvokeModel", "bedrock:InvokeModelWithResponseStream"],
+                "Resource": all_resources,
+            },
+            {
+                "Sid": "AllowBedrockList",
+                "Effect": "Allow",
+                "Action": ["bedrock:ListFoundationModels", "bedrock:GetFoundationModel"],
+                "Resource": "*",
+            },
+        ],
+    }
+    sso_admin_client.put_inline_policy_to_permission_set(
+        InstanceArn=instance_arn, PermissionSetArn=ps_arn, InlinePolicy=json.dumps(policy)
+    )
+    return ps_arn
+
+
+def assign_permission_set(instance_arn: str, ps_arn: str, group_id: str, account_id: str) -> None:
+    try:
+        sso_admin_client.create_account_assignment(
+            InstanceArn=instance_arn,
+            PermissionSetArn=ps_arn,
+            PrincipalType="GROUP",
+            PrincipalId=group_id,
+            TargetId=account_id,
+            TargetType="AWS_ACCOUNT",
+        )
+    except sso_admin_client.exceptions.ConflictException:
+        pass
+
+
+def provision_with_retry(instance_arn: str, ps_arn: str, account_id: str, name: str) -> None:
+    """Provision a permission set with exponential-backoff retry on
+    ConflictException, then best-effort poll for completion."""
+    max_retries = 10
+    request_id = None
+    for attempt in range(max_retries):
+        try:
+            response = sso_admin_client.provision_permission_set(
+                InstanceArn=instance_arn, PermissionSetArn=ps_arn, TargetType="AWS_ACCOUNT", TargetId=account_id
+            )
+            request_id = response.get("PermissionSetProvisioningStatus", {}).get("RequestId")
+            break
+        except sso_admin_client.exceptions.ConflictException:
+            if attempt < max_retries - 1:
+                time.sleep(2 + attempt * 2)
+            else:
+                raise
+
+    if not request_id:
+        return
+
+    for _ in range(30):
+        try:
+            status_response = sso_admin_client.describe_permission_set_provisioning_status(
+                InstanceArn=instance_arn, ProvisionPermissionSetRequestId=request_id
+            )
+            status = status_response.get("PermissionSetProvisioningStatus", {}).get("Status")
+            if status in ("SUCCEEDED", "FAILED"):
+                return
+            time.sleep(2)
+        except sso_admin_client.exceptions.ResourceNotFoundException:
+            return
+        except Exception as e:
+            if "AccessDeniedException" in str(e):
+                time.sleep(5)
+                return
+            raise
+    print(f"Provisioning {name} timed out, continuing anyway")
+
+
+def generate_mdm_configs(
+    config_key: str,
+    idc_start_url: str,
+    account_id: str,
+    role_name: str,
+    models_list: list[dict],
+    policies: dict | None = None,
+    managed_mcp_servers: list[dict] | None = None,
+    mcp_server_templates: list[dict] | None = None,
+) -> None:
+    """Build and upload the default/bootstrap/mobileconfig/reg files for one
+    group's config_key, using the shared MDM builder/generators (the single
+    source of truth also used by `ccwb cowork generate` and the bootstrap
+    server) instead of duplicating the format-generation logic inline.
+
+    When IDC_BOOTSTRAP_CLIENT_ID is configured, the generated
+    mobileconfig/.reg also carry a bootstrapOidc block so Claude Desktop can
+    authenticate itself directly against the landing page's /api/bootstrap
+    endpoint (see landing-page-distribution.yaml's IdcBootstrapUserPoolClient
+    and BootstrapApiListenerRule) instead of only getting the one-time
+    default.json snapshot embedded in the profile at generation time.
+    """
+    policies = policies or {}
+    managed_mcp_servers = managed_mcp_servers or []
+    mcp_server_templates = mcp_server_templates or []
+    deployment_uuid = str(uuid.uuid4()).upper()
+
+    # Bootstrap URL base — the URL Claude Desktop polls for dynamic config.
+    # Priority:
+    #   1. Admin's explicit "Bootstrap URL Override" (any real domain or an
+    #      SSM-tunnel host like https://localhost:8443) — always wins.
+    #   2. The CloudFront domain, when the stack is deployed with CloudFront
+    #      in front of the internal ALB — publicly reachable by Claude
+    #      Desktop over a real HTTPS cert, no tunnel needed.
+    #   3. BASE_URL (the ALB's CustomDomainName) — the original behavior;
+    #      only reachable if that domain actually resolves for the client.
+    if ENABLE_CLOUDFRONT and CLOUDFRONT_DOMAIN:
+        bootstrap_base_url = f"https://{CLOUDFRONT_DOMAIN}"
+    else:
+        bootstrap_base_url = BASE_URL
+    if policies.get("bootstrapUrlOverrideEnabled") and policies.get("bootstrapUrlOverrideHost"):
+        override_protocol = policies.get("bootstrapUrlOverrideProtocol") or "https"
+        override_host = policies["bootstrapUrlOverrideHost"].strip()
+        override_port = str(policies.get("bootstrapUrlOverridePort") or "").strip()
+        default_port = "443" if override_protocol == "https" else "80"
+        if override_port and override_port != default_port:
+            bootstrap_base_url = f"{override_protocol}://{override_host}:{override_port}"
+        else:
+            bootstrap_base_url = f"{override_protocol}://{override_host}"
+
+    config: dict = {
+        "inferenceProvider": "bedrock",
+        "inferenceCredentialKind": "interactive",
+        "inferenceBedrockRegion": REGION,
+        "inferenceBedrockSsoStartUrl": idc_start_url,
+        # IDC's own region, NOT this Lambda's/Bedrock's region — IAM Identity
+        # Center data (permission sets, SSO OIDC endpoints) only ever lives
+        # in the region IDC was enabled in, which can differ from where
+        # Bedrock/this stack is deployed (e.g. infra in us-west-2, IDC in
+        # us-east-1). Using REGION here sends Claude Desktop's SSO OIDC
+        # requests to the wrong region's endpoint, which AWS SSO rejects
+        # with InvalidRequestException.
+        "inferenceBedrockSsoRegion": IDC_REGION,
+        "inferenceBedrockSsoAccountId": account_id,
+        "inferenceBedrockSsoRoleName": role_name,
+        "inferenceModels": build_inference_models(models_list),
+        "deploymentOrganizationUuid": deployment_uuid,
+    }
+
+    add_mcp_servers(config, managed_servers=managed_mcp_servers or None, local_templates=mcp_server_templates or None)
+
+    # Policy / feature-control layer — the admin UI's "Tool Restrictions" +
+    # "Feature Controls" (disabled tools, per-tool ask/allow, allowed folders,
+    # egress allowlist, and the feature toggles incl. coworkTabEnabled).
+    #
+    # These are applied to a SEPARATE copy that feeds only the dynamic
+    # bootstrap config and the static default.json fallback — deliberately NOT
+    # the mobileconfig/.reg MDM profile. MDM keys are highest-precedence and
+    # cannot be overridden, so baking a policy into the profile pins it and
+    # forces an MDM re-push to change it (this is exactly why toggling cowork
+    # in the console had no effect on already-provisioned devices). Keeping the
+    # policy layer out of MDM lets the bootstrap server own it: toggle in the
+    # admin console -> next sign-in / bootstrap refresh picks it up, no re-push.
+    #
+    # Known tradeoff (accepted): for cowork, the MDM profile governs TAB
+    # VISIBILITY while bootstrap governs functional ACCESS. Because the profile
+    # omits coworkTabEnabled, the tab renders by default and bootstrap gates
+    # whether requests are accepted. So an enable->disable change takes effect
+    # functionally right away (tab still shown, requests blocked); only tab
+    # visibility would lag until an MDM re-push. This is preferred over
+    # re-pushing MDM on every policy change.
+    policy_config = dict(config)
+    add_policies(
+        policy_config,
+        disabled_tools=policies.get("disabledBuiltinTools"),
+        tool_policies=policies.get("builtinToolPolicy"),
+        permissions=policies.get("permissions"),
+        allowed_folders=policies.get("allowedWorkspaceFolders"),
+        egress_hosts=policies.get("coworkEgressAllowedHosts"),
+        feature_toggles={
+            "isLocalDevMcpEnabled": policies.get("isLocalDevMcpEnabled", True),
+            "isDesktopExtensionEnabled": policies.get("isDesktopExtensionEnabled", True),
+            "isDesktopExtensionSignatureRequired": policies.get("isDesktopExtensionSignatureRequired", False),
+            "coworkTabEnabled": policies.get("coworkTabEnabled", True),
+            "disableBundledSkills": policies.get("disableBundledSkills", False),
+            "disableDeploymentModeChooser": policies.get("disableDeploymentModeChooser", True),
+        },
+    )
+
+    # Static download (default.json): full config INCLUDING policies — this is
+    # the standalone fallback for orgs that install a static config without the
+    # bootstrap mechanism, so it still carries the policy layer.
+    json_content = json.dumps(policy_config, indent=2)
+    s3_client.put_object(
+        Bucket=BUCKET_NAME,
+        Key=f"config/{config_key}/default.json",
+        Body=json_content.encode("utf-8"),
+        ContentType="application/json",
+    )
+
+    # Bootstrap config (dynamic, served by the landing page's /api/bootstrap):
+    # base + policy layer. Every feature toggle must be explicit here — Claude
+    # Desktop treats a bootstrap-settable key the response omits as unset, not
+    # inherited from MDM. This is now the authoritative source for the policy
+    # layer on bootstrap-enabled devices.
+    bootstrap_config = dict(policy_config)
+    add_bootstrap_config(bootstrap_config, bootstrap_url=f"{bootstrap_base_url}/api/bootstrap")
+    bootstrap_config["_configKey"] = config_key
+    bootstrap_config["_version"] = deployment_uuid
+    s3_client.put_object(
+        Bucket=BUCKET_NAME,
+        Key=f"config/{config_key}/bootstrap.json",
+        Body=json.dumps(bootstrap_config, indent=2).encode("utf-8"),
+        ContentType="application/json",
+    )
+
+    # The MDM profile only needs the trust anchor (bootstrapUrl +
+    # bootstrapOidc) — Claude Desktop fetches the actual config live from
+    # /api/bootstrap using this OIDC client, so bootstrap_oidc is embedded
+    # in mobileconfig/.reg but NOT in default.json above (that file is the
+    # static/no-bootstrap fallback for orgs installing profiles without MDM
+    # bootstrap wiring).
+    bootstrap_oidc = None
+    if IDC_BOOTSTRAP_CLIENT_ID and IDC_BOOTSTRAP_ISSUER:
+        bootstrap_oidc = {
+            "clientId": IDC_BOOTSTRAP_CLIENT_ID,
+            "issuer": IDC_BOOTSTRAP_ISSUER,
+            "scopes": "openid email profile",
+        }
+        if IDC_BOOTSTRAP_REDIRECT_PORT:
+            bootstrap_oidc["redirectPort"] = int(IDC_BOOTSTRAP_REDIRECT_PORT)
+
+    # Derives from `config` (base connection settings + MCP), NOT
+    # `policy_config` — the mobileconfig/.reg profile intentionally omits the
+    # Tool Restrictions / Feature Controls layer so those stay bootstrap-
+    # controlled (see the policy_config comment above). It carries only what
+    # the device needs to connect and to reach /api/bootstrap.
+    mdm_config = dict(config)
+    add_bootstrap_config(mdm_config, bootstrap_url=f"{bootstrap_base_url}/api/bootstrap", oidc_config=bootstrap_oidc)
+
+    mobileconfig = generate_mobileconfig(
+        mdm_config,
+        profile_identifier=config_key,
+        profile_display_name=f"Claude Desktop - {config_key.replace('-', ' ').title()}",
+    )
+    s3_client.put_object(
+        Bucket=BUCKET_NAME,
+        Key=f"config/{config_key}/Claude.mobileconfig",
+        Body=mobileconfig.encode("utf-8"),
+        ContentType="application/x-apple-aspen-config",
+    )
+
+    reg_content = generate_reg_file(mdm_config, profile_identifier=config_key)
+    s3_client.put_object(
+        Bucket=BUCKET_NAME,
+        Key=f"config/{config_key}/Claude.reg",
+        Body=reg_content.encode("utf-16-le"),
+        ContentType="text/plain; charset=utf-16le",
+    )
+
+    if mcp_server_templates:
+        mcp_config = {"mcpServers": {}}
+        for server in mcp_server_templates:
+            mcp_config["mcpServers"][server.get("name", "unnamed")] = {
+                "command": server.get("command", ""),
+                "args": server.get("args", []),
+                "env": server.get("env", {}),
+            }
+        s3_client.put_object(
+            Bucket=BUCKET_NAME,
+            Key=f"config/{config_key}/claude_desktop_config.json",
+            Body=json.dumps(mcp_config, indent=2).encode("utf-8"),
+            ContentType="application/json",
+        )
+
+
+def api_deploy_config(body: str) -> dict:
+    """Publish action: for each group mapping, create/update the permission
+    set, assign + provision it, then regenerate that group's MDM/bootstrap
+    config files. Best-effort per-mapping — one group's failure doesn't
+    roll back others."""
+    try:
+        config = json.loads(body) if body else load_admin_config()
+        mappings = config.get("mappings", [])
+        if not mappings:
+            return json_response({"error": "No group-model mappings configured"}, 400)
+
+        policies = config.get("policies", {})
+        managed_mcp_servers = config.get("managedMcpServers", [])
+        mcp_server_templates = config.get("mcpServerTemplates", [])
+
+        results = []
+        account_id = sts_client.get_caller_identity()["Account"]
+
+        instances = sso_admin_client.list_instances()
+        if not instances.get("Instances"):
+            return json_response({"error": "No IDC instance found"}, 404)
+        instance_arn = instances["Instances"][0]["InstanceArn"]
+        identity_store_id = instances["Instances"][0]["IdentityStoreId"]
+        idc_start_url = f"https://{identity_store_id}.awsapps.com/start"
+
+        for mapping in mappings:
+            group_name = mapping.get("groupName", "")
+            group_id = mapping.get("groupId", "")
+            role_name = mapping.get("roleName", f"ClaudeCode-{group_name}")
+            models_list = mapping.get("models", [])
+            if not group_id or not models_list:
+                continue
+
+            try:
+                ps_arn = create_or_update_permission_set_no_provision(instance_arn, role_name, models_list)
+                assign_permission_set(instance_arn, ps_arn, group_id, account_id)
+                provision_with_retry(instance_arn, ps_arn, account_id, role_name)
+
+                config_key = group_name_to_config_key(group_name)
+                generate_mdm_configs(
+                    config_key,
+                    idc_start_url,
+                    account_id,
+                    role_name,
+                    models_list,
+                    policies=policies,
+                    managed_mcp_servers=managed_mcp_servers,
+                    mcp_server_templates=mcp_server_templates,
+                )
+                results.append(
+                    {
+                        "group": group_name,
+                        "model": ", ".join(m["modelName"] for m in models_list),
+                        "status": "success",
+                        "permissionSet": role_name,
+                    }
+                )
+                time.sleep(1)  # avoid IDC API conflicts between groups
+            except Exception as e:
+                print(f"Error deploying for group {log_safe(group_name)}: {e}")
+                results.append({"group": group_name, "model": "", "status": "error", "error": str(e)})
+
+        save_admin_config(config)
+        return json_response({"success": True, "results": results})
+    except Exception as e:
+        print(f"Error deploying config: {e}")
+        return internal_error_response()
+
+
+# =============================================================================
+# Admin page (HTML SPA shell — calls the /admin/api/* endpoints above)
+# =============================================================================
+
+
+def esc(value) -> str:
+    return (
+        str(value)
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+        .replace("'", "&#39;")
+    )
+
+
+def serve_admin_page(user_email: str) -> dict:
+    """Generate the admin console HTML page — sidebar navigation with Models &
+    Groups, Policies, and MCP Servers config pages, plus a Deploy page. Ported
+    from the original CDK-based implementation
+    (backup/idc-landing-page-cdk-working:deployment/idc-landing-page/lambda/index.py)
+    with its JS wired to this Lambda's existing /admin/api/* endpoints, which
+    already match the same request/response shapes the original UI expects.
+    """
+    # The default bootstrap URL base shown in the "Bootstrap URL Override"
+    # hint — the CloudFront domain when this deployment is fronted by
+    # CloudFront, otherwise the ALB's custom domain (BASE_URL).
+    bootstrap_default_hint = f"https://{CLOUDFRONT_DOMAIN}" if (ENABLE_CLOUDFRONT and CLOUDFRONT_DOMAIN) else BASE_URL
+    return html_response(
+        f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Claude Platform Admin</title>
+    <style>
+        * {{ margin: 0; padding: 0; box-sizing: border-box; }}
+        body {{
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: #f5f7fa;
+            min-height: 100vh;
+        }}
+        .layout {{
+            display: flex;
+            min-height: 100vh;
+        }}
+        .sidebar {{
+            width: 260px;
+            background: linear-gradient(180deg, #1a1a2e 0%, #16213e 100%);
+            color: white;
+            padding: 0;
+            position: fixed;
+            height: 100vh;
+            overflow-y: auto;
+        }}
+        .sidebar-header {{
+            padding: 24px 20px;
+            border-bottom: 1px solid rgba(255,255,255,0.1);
+        }}
+        .sidebar-header h1 {{
+            font-size: 18px;
+            font-weight: 600;
+            margin-bottom: 4px;
+        }}
+        .sidebar-header .subtitle {{
+            font-size: 12px;
+            color: rgba(255,255,255,0.6);
+        }}
+        .sidebar-nav {{
+            padding: 16px 0;
+        }}
+        .nav-section {{
+            padding: 8px 20px;
+            font-size: 11px;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            color: rgba(255,255,255,0.4);
+            margin-top: 8px;
+        }}
+        .nav-item {{
+            display: flex;
+            align-items: center;
+            padding: 12px 20px;
+            color: rgba(255,255,255,0.8);
+            text-decoration: none;
+            cursor: pointer;
+            transition: all 0.2s;
+            border-left: 3px solid transparent;
+        }}
+        .nav-item:hover {{
+            background: rgba(255,255,255,0.05);
+            color: white;
+        }}
+        .nav-item.active {{
+            background: rgba(102, 126, 234, 0.2);
+            color: white;
+            border-left-color: #667eea;
+        }}
+        .nav-item svg {{
+            width: 18px;
+            height: 18px;
+            margin-right: 12px;
+            opacity: 0.7;
+        }}
+        .nav-item.active svg {{
+            opacity: 1;
+        }}
+        .sidebar-footer {{
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            padding: 16px 20px;
+            border-top: 1px solid rgba(255,255,255,0.1);
+            background: rgba(0,0,0,0.2);
+        }}
+        .user-info {{
+            display: flex;
+            align-items: center;
+            margin-bottom: 12px;
+        }}
+        .user-avatar {{
+            width: 32px;
+            height: 32px;
+            border-radius: 50%;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 14px;
+            font-weight: 600;
+            margin-right: 10px;
+        }}
+        .user-email {{
+            font-size: 12px;
+            color: rgba(255,255,255,0.8);
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            max-width: 160px;
+        }}
+        .sidebar-links {{
+            display: flex;
+            gap: 12px;
+        }}
+        .sidebar-links a {{
+            font-size: 12px;
+            color: rgba(255,255,255,0.6);
+            text-decoration: none;
+        }}
+        .sidebar-links a:hover {{
+            color: white;
+        }}
+        .main-content {{
+            flex: 1;
+            margin-left: 260px;
+            padding: 24px 32px;
+            max-width: calc(100% - 260px);
+        }}
+        .page-header {{
+            margin-bottom: 24px;
+        }}
+        .page-header h2 {{
+            font-size: 24px;
+            color: #1a1a2e;
+            margin-bottom: 4px;
+        }}
+        .page-header p {{
+            color: #666;
+            font-size: 14px;
+        }}
+        .section {{
+            background: white;
+            border-radius: 12px;
+            padding: 24px;
+            margin-bottom: 24px;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+        }}
+        .section h3 {{
+            font-size: 16px;
+            color: #333;
+            margin-bottom: 16px;
+            padding-bottom: 12px;
+            border-bottom: 1px solid #eee;
+        }}
+        .section h4 {{
+            font-size: 14px;
+            color: #555;
+            margin: 20px 0 12px;
+        }}
+        .section-description {{
+            color: #666;
+            font-size: 13px;
+            margin-bottom: 16px;
+        }}
+        .page-content {{ display: none; }}
+        .page-content.active {{ display: block; }}
+        table {{
+            width: 100%;
+            border-collapse: collapse;
+        }}
+        th, td {{
+            padding: 12px;
+            text-align: left;
+            border-bottom: 1px solid #eee;
+        }}
+        th {{
+            background: #f8f9fa;
+            font-weight: 600;
+            color: #555;
+            font-size: 13px;
+        }}
+        select, input[type="text"], input[type="url"], input[type="number"], textarea {{
+            padding: 10px 12px;
+            border: 1px solid #ddd;
+            border-radius: 8px;
+            font-size: 14px;
+            width: 100%;
+            transition: border-color 0.2s;
+        }}
+        select:focus, input:focus, textarea:focus {{
+            outline: none;
+            border-color: #667eea;
+            box-shadow: 0 0 0 3px rgba(102,126,234,0.1);
+        }}
+        textarea {{
+            min-height: 80px;
+            font-family: monospace;
+            resize: vertical;
+        }}
+        .btn {{
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 10px 20px;
+            border-radius: 8px;
+            font-weight: 600;
+            cursor: pointer;
+            border: none;
+            font-size: 14px;
+            transition: all 0.2s;
+            gap: 8px;
+        }}
+        .btn-primary {{
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+        }}
+        .btn-primary:hover {{
+            transform: translateY(-1px);
+            box-shadow: 0 4px 12px rgba(102, 126, 234, 0.3);
+        }}
+        .btn-success {{
+            background: linear-gradient(135deg, #28a745 0%, #20c997 100%);
+            color: white;
+        }}
+        .btn-success:hover {{
+            transform: translateY(-1px);
+            box-shadow: 0 4px 12px rgba(40, 167, 69, 0.3);
+        }}
+        .btn-danger {{
+            background: #dc3545;
+            color: white;
+        }}
+        .btn-danger:hover {{
+            background: #c82333;
+        }}
+        .btn-secondary {{
+            background: #6c757d;
+            color: white;
+        }}
+        .btn-sm {{
+            padding: 6px 12px;
+            font-size: 12px;
+        }}
+        .btn-outline {{
+            background: white;
+            border: 1px solid #ddd;
+            color: #333;
+        }}
+        .btn-outline:hover {{
+            background: #f8f9fa;
+        }}
+        .actions {{
+            display: flex;
+            gap: 12px;
+            margin-top: 20px;
+        }}
+        .status {{
+            padding: 16px;
+            border-radius: 8px;
+            margin-top: 20px;
+            display: none;
+        }}
+        .status.success {{
+            background: #d4edda;
+            color: #155724;
+            display: block;
+        }}
+        .status.error {{
+            background: #f8d7da;
+            color: #721c24;
+            display: block;
+        }}
+        .status.info {{
+            background: #d1ecf1;
+            color: #0c5460;
+            display: block;
+        }}
+        .loading {{
+            opacity: 0.6;
+            pointer-events: none;
+        }}
+        .badge {{
+            font-size: 11px;
+            padding: 3px 8px;
+            border-radius: 12px;
+            font-weight: 500;
+        }}
+        .badge-success {{
+            background: #e8f5e9;
+            color: #2e7d32;
+        }}
+        .badge-warning {{
+            background: #fff3e0;
+            color: #e65100;
+        }}
+        .badge-danger {{
+            background: #ffebee;
+            color: #c62828;
+        }}
+        .badge-info {{
+            background: #e3f2fd;
+            color: #1565c0;
+        }}
+        .model-tags, .tool-tags {{
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+        }}
+        .model-tag, .tool-tag {{
+            display: inline-flex;
+            align-items: center;
+            background: #e3f2fd;
+            color: #1565c0;
+            padding: 4px 10px;
+            border-radius: 16px;
+            font-size: 13px;
+        }}
+        .tool-tag.blocked {{
+            background: #ffebee;
+            color: #c62828;
+        }}
+        .tool-tag.ask {{
+            background: #fff3e0;
+            color: #e65100;
+        }}
+        .model-tag .remove, .tool-tag .remove {{
+            margin-left: 6px;
+            cursor: pointer;
+            opacity: 0.6;
+            font-weight: bold;
+        }}
+        .model-tag .remove:hover, .tool-tag .remove:hover {{
+            opacity: 1;
+        }}
+        .add-row {{
+            display: flex;
+            gap: 8px;
+            align-items: center;
+            margin-top: 12px;
+        }}
+        .add-row select, .add-row input {{
+            flex: 1;
+        }}
+        .toggle-row {{
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 16px 0;
+            border-bottom: 1px solid #eee;
+        }}
+        .toggle-row:last-child {{
+            border-bottom: none;
+        }}
+        .toggle-label {{
+            font-weight: 500;
+            color: #333;
+        }}
+        .toggle-description {{
+            font-size: 12px;
+            color: #888;
+            margin-top: 4px;
+        }}
+        .toggle-switch {{
+            position: relative;
+            width: 48px;
+            height: 24px;
+            flex-shrink: 0;
+        }}
+        .toggle-switch input {{
+            opacity: 0;
+            width: 0;
+            height: 0;
+        }}
+        .toggle-slider {{
+            position: absolute;
+            cursor: pointer;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-color: #ccc;
+            transition: 0.3s;
+            border-radius: 24px;
+        }}
+        .toggle-slider:before {{
+            position: absolute;
+            content: "";
+            height: 18px;
+            width: 18px;
+            left: 3px;
+            bottom: 3px;
+            background-color: white;
+            transition: 0.3s;
+            border-radius: 50%;
+        }}
+        input:checked + .toggle-slider {{
+            background-color: #667eea;
+        }}
+        input:checked + .toggle-slider:before {{
+            transform: translateX(24px);
+        }}
+        .card {{
+            border: 1px solid #e0e0e0;
+            border-radius: 10px;
+            padding: 16px;
+            margin-bottom: 12px;
+            background: #fafafa;
+        }}
+        .card-header {{
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 8px;
+        }}
+        .card-header h5 {{
+            font-size: 14px;
+            font-weight: 600;
+            margin: 0;
+        }}
+        .card-body {{
+            font-size: 13px;
+            color: #666;
+        }}
+        .card-body code {{
+            background: #e9ecef;
+            padding: 2px 6px;
+            border-radius: 4px;
+            font-size: 12px;
+        }}
+        .form-grid {{
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 16px;
+        }}
+        .form-grid .full-width {{
+            grid-column: 1 / -1;
+        }}
+        .form-group {{
+            margin-bottom: 16px;
+        }}
+        .form-group label {{
+            display: block;
+            font-size: 13px;
+            font-weight: 500;
+            color: #555;
+            margin-bottom: 6px;
+        }}
+        .collapsible-btn {{
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            width: 100%;
+            padding: 12px 16px;
+            background: #f8f9fa;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            cursor: pointer;
+            font-weight: 500;
+            color: #333;
+            margin-bottom: 12px;
+            transition: all 0.2s;
+        }}
+        .collapsible-btn:hover {{
+            background: #e9ecef;
+        }}
+        .collapsible-btn.active {{
+            border-color: #667eea;
+            background: #f0f4ff;
+        }}
+        .collapsible-content {{
+            display: none;
+            padding: 16px;
+            background: #fafafa;
+            border-radius: 8px;
+            margin-bottom: 16px;
+        }}
+        .collapsible-content.show {{
+            display: block;
+        }}
+        .grid-2 {{
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 24px;
+        }}
+        @media (max-width: 1200px) {{
+            .grid-2 {{
+                grid-template-columns: 1fr;
+            }}
+        }}
+        .summary-grid {{
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
+            gap: 16px;
+            margin-bottom: 20px;
+        }}
+        .summary-card {{
+            background: #f8f9fa;
+            border-radius: 8px;
+            padding: 16px;
+            text-align: center;
+        }}
+        .summary-card .number {{
+            font-size: 28px;
+            font-weight: 700;
+            color: #667eea;
+        }}
+        .summary-card .label {{
+            font-size: 12px;
+            color: #666;
+            margin-top: 4px;
+        }}
+        pre {{
+            background: #1a1a2e;
+            color: #e0e0e0;
+            padding: 16px;
+            border-radius: 8px;
+            overflow: auto;
+            max-height: 400px;
+            font-size: 12px;
+        }}
+        .save-status {{
+            font-size: 13px;
+            padding: 8px 12px;
+            border-radius: 6px;
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+        }}
+        .save-status.saving {{
+            background: #fff3e0;
+            color: #e65100;
+        }}
+        .save-status.saved {{
+            background: #e8f5e9;
+            color: #2e7d32;
+        }}
+        .save-status.error {{
+            background: #ffebee;
+            color: #c62828;
+        }}
+        .save-status.unsaved {{
+            background: #fff8e1;
+            color: #ff8f00;
+        }}
+        @keyframes spin {{
+            from {{ transform: rotate(0deg); }}
+            to {{ transform: rotate(360deg); }}
+        }}
+    </style>
+</head>
+<body>
+    <div class="layout">
+        <aside class="sidebar">
+            <div class="sidebar-header">
+                <h1>Claude Platform Admin</h1>
+                <div class="subtitle">Enterprise Configuration</div>
+            </div>
+            <nav class="sidebar-nav">
+                <div class="nav-section">Configuration</div>
+                <a class="nav-item active" onclick="switchPage('models')">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M12 1v2m0 18v2M4.22 4.22l1.42 1.42m12.72 12.72l1.42 1.42M1 12h2m18 0h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>
+                    Models &amp; Groups
+                </a>
+                <a class="nav-item" onclick="switchPage('policies')">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+                    Policies
+                </a>
+                <a class="nav-item" onclick="switchPage('mcp')">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
+                    MCP Servers
+                </a>
+                <div class="nav-section">Actions</div>
+                <a class="nav-item" onclick="switchPage('deploy')">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+                    Deploy
+                </a>
+            </nav>
+            <div class="sidebar-footer">
+                <div class="user-info">
+                    <div class="user-avatar">{esc(user_email[0].upper()) if user_email else 'A'}</div>
+                    <div class="user-email" title="{esc(user_email)}">{esc(user_email)}</div>
+                </div>
+                <div class="sidebar-links">
+                    <a href="/">Landing Page</a>
+                    <a href="/logout">Logout</a>
+                </div>
+            </div>
+        </aside>
+
+        <main class="main-content">
+            <!-- Models & Groups Page -->
+            <div id="page-models" class="page-content active">
+                <div class="page-header">
+                    <h2>Models &amp; Groups</h2>
+                    <p>Assign Bedrock inference profiles to IAM Identity Center groups</p>
+                </div>
+
+                <div class="section">
+                    <h3>Group to Model Mappings</h3>
+                    <p class="section-description">Each group will get a permission set with access to the assigned models.</p>
+                    <table id="mappings-table">
+                        <thead>
+                            <tr>
+                                <th>IDC Group</th>
+                                <th>Assigned Models</th>
+                                <th>Add Model</th>
+                                <th>Permission Set</th>
+                            </tr>
+                        </thead>
+                        <tbody id="mappings-body">
+                            <tr><td colspan="4" style="text-align: center; color: #888; padding: 40px;">Loading...</td></tr>
+                        </tbody>
+                    </table>
+                </div>
+
+                <div class="section">
+                    <h3>Available Models</h3>
+                    <table id="models-table">
+                        <thead>
+                            <tr>
+                                <th>Model Name</th>
+                                <th>Model ID</th>
+                                <th>Type</th>
+                            </tr>
+                        </thead>
+                        <tbody id="models-body">
+                            <tr><td colspan="3" style="text-align: center; color: #888; padding: 40px;">Loading...</td></tr>
+                        </tbody>
+                    </table>
+                </div>
+
+                <div class="section" style="background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);">
+                    <div style="display: flex; justify-content: space-between; align-items: center;">
+                        <div id="models-save-status" class="save-status"></div>
+                        <button class="btn btn-primary" onclick="saveDraft('models')">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 21H5a2 2 0 01-2-2V5a2 2 0 012-2h11l5 5v11a2 2 0 01-2 2z"/><polyline points="17 21 17 13 7 13 7 21"/><polyline points="7 3 7 8 15 8"/></svg>
+                            Save Draft
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Policies Page -->
+            <div id="page-policies" class="page-content">
+                <div class="page-header">
+                    <h2>Policies</h2>
+                    <p>Control which tools and features are available to users</p>
+                </div>
+
+                <div class="grid-2">
+                    <div class="section">
+                        <h3>Tool Restrictions</h3>
+                        <p class="section-description">Blocked tools are completely removed from Claude.</p>
+
+                        <h4>Disabled Tools</h4>
+                        <div id="disabled-tools-list" class="tool-tags">
+                            <span style="color:#888;font-size:13px;">None - all tools enabled</span>
+                        </div>
+                        <div class="add-row">
+                            <input type="text" id="add-disabled-tool" list="builtin-tools-datalist" placeholder="Select or type a tool name..." autocomplete="off">
+                            <button class="btn btn-primary btn-sm" onclick="addDisabledTool()">Block</button>
+                        </div>
+                        <!-- Shared suggestion list for Disabled Tools and Tool Policies. These are
+                             the common built-in tools; because it's a datalist on a free-text input,
+                             admins can also type any other/newer tool name that isn't preset here
+                             (e.g. a client-side tool) and it's saved verbatim into the group config. -->
+                        <datalist id="builtin-tools-datalist">
+                            <option value="Bash"></option>
+                            <option value="Edit"></option>
+                            <option value="MultiEdit"></option>
+                            <option value="Write"></option>
+                            <option value="Read"></option>
+                            <option value="Glob"></option>
+                            <option value="Grep"></option>
+                            <option value="NotebookEdit"></option>
+                            <option value="WebFetch"></option>
+                            <option value="WebSearch"></option>
+                            <option value="TodoWrite"></option>
+                            <option value="Task"></option>
+                        </datalist>
+
+                        <h4>Tool Policies</h4>
+                        <p class="section-description">Set approval requirements for specific tools.</p>
+                        <div id="tool-policies-list"></div>
+                        <div class="add-row">
+                            <input type="text" id="add-tool-policy-name" list="builtin-tools-datalist" placeholder="Select or type a tool..." style="flex: 2;" autocomplete="off">
+                            <select id="add-tool-policy-value" style="flex: 1;">
+                                <option value="allow">Allow</option>
+                                <option value="ask">Ask</option>
+                                <option value="blocked">Block</option>
+                            </select>
+                            <button class="btn btn-primary btn-sm" onclick="addToolPolicy()">Add</button>
+                        </div>
+                    </div>
+
+                    <div class="section">
+                        <h3>Feature Controls</h3>
+                        <p class="section-description">Enable or disable Claude Desktop features.</p>
+
+                        <div class="toggle-row">
+                            <div>
+                                <div class="toggle-label">Allow Local MCP Servers</div>
+                                <div class="toggle-description">Let users add their own MCP servers</div>
+                            </div>
+                            <label class="toggle-switch">
+                                <input type="checkbox" id="policy-isLocalDevMcpEnabled" checked>
+                                <span class="toggle-slider"></span>
+                            </label>
+                        </div>
+
+                        <div class="toggle-row">
+                            <div>
+                                <div class="toggle-label">Allow Desktop Extensions</div>
+                                <div class="toggle-description">Let users install .dxt and .mcpb extensions</div>
+                            </div>
+                            <label class="toggle-switch">
+                                <input type="checkbox" id="policy-isDesktopExtensionEnabled" checked>
+                                <span class="toggle-slider"></span>
+                            </label>
+                        </div>
+
+                        <div class="toggle-row">
+                            <div>
+                                <div class="toggle-label">Require Signed Extensions</div>
+                                <div class="toggle-description">Only allow signed extensions</div>
+                            </div>
+                            <label class="toggle-switch">
+                                <input type="checkbox" id="policy-isDesktopExtensionSignatureRequired">
+                                <span class="toggle-slider"></span>
+                            </label>
+                        </div>
+
+                        <div class="toggle-row">
+                            <div>
+                                <div class="toggle-label">Enable Cowork Tab</div>
+                                <div class="toggle-description">Allow access to Cowork/agentic features</div>
+                            </div>
+                            <label class="toggle-switch">
+                                <input type="checkbox" id="policy-coworkTabEnabled" checked>
+                                <span class="toggle-slider"></span>
+                            </label>
+                        </div>
+
+                        <div class="toggle-row">
+                            <div>
+                                <div class="toggle-label">Disable Bundled Skills</div>
+                                <div class="toggle-description">Turn off built-in skills and workflows</div>
+                            </div>
+                            <label class="toggle-switch">
+                                <input type="checkbox" id="policy-disableBundledSkills">
+                                <span class="toggle-slider"></span>
+                            </label>
+                        </div>
+
+                        <div class="toggle-row">
+                            <div>
+                                <div class="toggle-label">Lock to Bedrock Provider</div>
+                                <div class="toggle-description">Prevent switching to Anthropic direct</div>
+                            </div>
+                            <label class="toggle-switch">
+                                <input type="checkbox" id="policy-disableDeploymentModeChooser" checked>
+                                <span class="toggle-slider"></span>
+                            </label>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="section">
+                    <h3>Command Permissions</h3>
+                    <p class="section-description">Fine-grained, command-level rules for Claude's tools &mdash; distinct from the whole-tool policies above. Rules are evaluated <strong>deny &rarr; ask &rarr; allow</strong> (first match wins). Use Claude Code rule syntax: a bare tool name like <code>WebFetch</code>, or a scoped pattern like <code>Bash(git push:*)</code> or <code>Read(./.env)</code>.</p>
+                    <div class="grid-2">
+                        <div>
+                            <h4>Allow</h4>
+                            <p class="section-description">Auto-approved, no prompt.</p>
+                            <div id="perm-allow-list" class="tool-tags"></div>
+                        </div>
+                        <div>
+                            <h4>Ask</h4>
+                            <p class="section-description">Prompt for confirmation before running.</p>
+                            <div id="perm-ask-list" class="tool-tags"></div>
+                        </div>
+                    </div>
+                    <div style="margin-top:12px;">
+                        <h4>Deny</h4>
+                        <p class="section-description">Blocked entirely (highest precedence).</p>
+                        <div id="perm-deny-list" class="tool-tags"></div>
+                    </div>
+                    <div class="add-row" style="margin-top:12px;">
+                        <input type="text" id="add-perm-rule" placeholder="e.g. Bash(git push:*)  or  WebFetch" style="flex: 2;" autocomplete="off">
+                        <select id="add-perm-tier" style="flex: 1;">
+                            <option value="allow">Allow</option>
+                            <option value="ask">Ask</option>
+                            <option value="deny">Deny</option>
+                        </select>
+                        <button class="btn btn-primary btn-sm" onclick="addPermissionRule()">Add</button>
+                    </div>
+                </div>
+
+                <div class="section">
+                    <h3>Workspace &amp; Network Restrictions</h3>
+                    <div class="grid-2">
+                        <div>
+                            <h4>Allowed Workspace Folders</h4>
+                            <p class="section-description">Restrict which directories users can attach. Leave empty for no restrictions.</p>
+                            <div id="allowed-folders-list" style="margin-bottom: 12px;"></div>
+                            <div class="add-row">
+                                <input type="text" id="add-folder-path" placeholder="e.g., ~/Projects">
+                                <button class="btn btn-primary btn-sm" onclick="addAllowedFolder()">Add</button>
+                            </div>
+                        </div>
+                        <div>
+                            <h4>Network Egress Allowlist</h4>
+                            <p class="section-description">Restrict which hosts tools can connect to. Use * for unrestricted.</p>
+                            <div id="egress-hosts-list" style="margin-bottom: 12px;"></div>
+                            <div class="add-row">
+                                <input type="text" id="add-egress-host" placeholder="e.g., *.corp.com">
+                                <button class="btn btn-primary btn-sm" onclick="addEgressHost()">Add</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="section">
+                    <h3>Bootstrap URL Override</h3>
+                    <p class="section-description">
+                        The bootstrap config URL embedded in generated MDM profiles defaults to
+                        <code>{html.escape(bootstrap_default_hint)}</code>. Override it here with
+                        any protocol/host/port when you want Claude Desktop to reach a different
+                        address — for example a real custom domain once you point one at this
+                        deployment via Route 53 (e.g. <code>https://claude.example.com</code>),
+                        or an SSM-tunnel/VPN host for testing (e.g. <code>https://localhost:8443</code>).
+                        Only affects newly generated configs; click Deploy again on Models &amp;
+                        Groups to regenerate existing ones.
+                    </p>
+                    <label style="display: flex; align-items: center; gap: 8px; margin-bottom: 12px;">
+                        <input type="checkbox" id="policy-bootstrapUrlOverrideEnabled">
+                        <span>Override bootstrap URL</span>
+                    </label>
+                    <div id="bootstrap-url-override-fields" style="display: none; gap: 12px;" class="add-row">
+                        <select id="bootstrap-url-override-protocol" style="flex: 0 0 100px;">
+                            <option value="https">https</option>
+                            <option value="http">http</option>
+                        </select>
+                        <input type="text" id="bootstrap-url-override-host" placeholder="claude.example.com" style="flex: 2;">
+                        <input type="number" id="bootstrap-url-override-port" placeholder="443" min="1" max="65535" style="flex: 1;">
+                    </div>
+                </div>
+
+                <div class="section" style="background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);">
+                    <div style="display: flex; justify-content: space-between; align-items: center;">
+                        <div id="policies-save-status" class="save-status"></div>
+                        <button class="btn btn-primary" onclick="saveDraft('policies')">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 21H5a2 2 0 01-2-2V5a2 2 0 012-2h11l5 5v11a2 2 0 01-2 2z"/><polyline points="17 21 17 13 7 13 7 21"/><polyline points="7 3 7 8 15 8"/></svg>
+                            Save Draft
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            <!-- MCP Servers Page -->
+            <div id="page-mcp" class="page-content">
+                <div class="page-header">
+                    <h2>MCP Servers</h2>
+                    <p>Pre-configure MCP servers for your users</p>
+                </div>
+
+                <div class="section">
+                    <h3>Managed MCP Servers (Remote)</h3>
+                    <p class="section-description">Remote HTTPS MCP servers that users connect to via OAuth.</p>
+                    <div id="managed-mcp-servers"></div>
+
+                    <button class="collapsible-btn" onclick="toggleCollapsible(this)">
+                        <span>+ Add Remote MCP Server</span>
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
+                    </button>
+                    <div class="collapsible-content">
+                        <div class="form-grid">
+                            <div class="form-group">
+                                <label>Server Name</label>
+                                <input type="text" id="new-mcp-name" placeholder="e.g., corporate-tools">
+                            </div>
+                            <div class="form-group">
+                                <label>Server URL</label>
+                                <input type="url" id="new-mcp-url" placeholder="https://mcp.your-corp.com/api">
+                            </div>
+                            <div class="form-group full-width">
+                                <label>Description (optional)</label>
+                                <input type="text" id="new-mcp-description" placeholder="Corporate tools gateway">
+                            </div>
+                            <div class="full-width">
+                                <button class="btn btn-primary" onclick="addManagedMcpServer()">Add Server</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="section">
+                    <h3>MCP Server Templates (Local)</h3>
+                    <p class="section-description">Pre-configured local MCP servers. Users may need to provide credentials.</p>
+                    <div id="mcp-templates"></div>
+
+                    <button class="collapsible-btn" onclick="toggleCollapsible(this)">
+                        <span>+ Add from Template</span>
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
+                    </button>
+                    <div class="collapsible-content">
+                        <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 12px;">
+                            <button class="btn btn-outline" onclick="addMcpTemplate('github')">GitHub</button>
+                            <button class="btn btn-outline" onclick="addMcpTemplate('slack')">Slack</button>
+                            <button class="btn btn-outline" onclick="addMcpTemplate('filesystem')">Filesystem</button>
+                            <button class="btn btn-outline" onclick="addMcpTemplate('brave-search')">Brave Search</button>
+                            <button class="btn btn-outline" onclick="addMcpTemplate('postgres')">PostgreSQL</button>
+                            <button class="btn btn-outline" onclick="addMcpTemplate('custom')">Custom</button>
+                        </div>
+                    </div>
+
+                    <button class="collapsible-btn" onclick="toggleCollapsible(this)">
+                        <span>+ Add Custom Local Server</span>
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
+                    </button>
+                    <div class="collapsible-content">
+                        <div class="form-grid">
+                            <div class="form-group">
+                                <label>Server Name</label>
+                                <input type="text" id="new-local-mcp-name" placeholder="e.g., my-server">
+                            </div>
+                            <div class="form-group">
+                                <label>Command</label>
+                                <input type="text" id="new-local-mcp-command" placeholder="/usr/local/bin/npx">
+                            </div>
+                            <div class="form-group full-width">
+                                <label>Arguments (one per line)</label>
+                                <textarea id="new-local-mcp-args" placeholder="-y&#10;@modelcontextprotocol/server-github"></textarea>
+                            </div>
+                            <div class="form-group full-width">
+                                <label>Environment Variables (KEY=value, one per line)</label>
+                                <textarea id="new-local-mcp-env" placeholder="GITHUB_TOKEN=&lt;user-provided&gt;&#10;PATH=/usr/local/bin:/usr/bin"></textarea>
+                            </div>
+                            <div class="full-width">
+                                <button class="btn btn-primary" onclick="addLocalMcpServer()">Add Server</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="section" style="background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);">
+                    <div style="display: flex; justify-content: space-between; align-items: center;">
+                        <div id="mcp-save-status" class="save-status"></div>
+                        <button class="btn btn-primary" onclick="saveDraft('mcp')">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 21H5a2 2 0 01-2-2V5a2 2 0 012-2h11l5 5v11a2 2 0 01-2 2z"/><polyline points="17 21 17 13 7 13 7 21"/><polyline points="7 3 7 8 15 8"/></svg>
+                            Save Draft
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Deploy Page -->
+            <div id="page-deploy" class="page-content">
+                <div class="page-header">
+                    <h2>Deploy Configuration</h2>
+                    <p>Generate MDM configuration files for your groups</p>
+                </div>
+
+                <div class="section">
+                    <h3>Configuration Summary</h3>
+                    <div class="summary-grid" id="deploy-summary">
+                        <div class="summary-card">
+                            <div class="number" id="summary-groups">0</div>
+                            <div class="label">Groups with Models</div>
+                        </div>
+                        <div class="summary-card">
+                            <div class="number" id="summary-policies">0</div>
+                            <div class="label">Policy Settings</div>
+                        </div>
+                        <div class="summary-card">
+                            <div class="number" id="summary-mcp">0</div>
+                            <div class="label">MCP Servers</div>
+                        </div>
+                    </div>
+                    <p class="section-description">
+                        Deploying will update IAM Identity Center permission sets and generate MDM configuration files
+                        (mobileconfig for macOS, .reg for Windows, JSON for manual setup) for each group.
+                    </p>
+                    <div style="background: #e8f5e9; border: 1px solid #a5d6a7; border-radius: 8px; padding: 16px; margin-bottom: 16px;">
+                        <div style="display: flex; align-items: flex-start; gap: 12px;">
+                            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#2e7d32" stroke-width="2" style="flex-shrink: 0; margin-top: 2px;"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4M12 8h.01"/></svg>
+                            <div>
+                                <div style="font-weight: 600; color: #1b5e20; margin-bottom: 4px;">Dynamic Config Updates via OIDC Bootstrap</div>
+                                <div style="color: #2e7d32; font-size: 13px; line-height: 1.5;">
+                                    MDM profiles include OIDC bootstrap configuration. Claude Desktop will authenticate via Cognito (federated with IAM Identity Center) and automatically fetch the latest configuration every 30 minutes.
+                                    <strong>After the initial profile installation, users will receive policy and model updates automatically</strong> — no need to re-download profiles.
+                                </div>
+                                <div style="color: #558b2f; font-size: 12px; margin-top: 8px; padding-top: 8px; border-top: 1px solid #c5e1a5;">
+                                    <strong>Note:</strong> The 30-minute refresh interval is controlled by Claude Desktop and cannot be changed server-side. For urgent updates (e.g., security policy changes), ask users to restart Claude Desktop to fetch changes immediately.
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="actions">
+                        <button class="btn btn-success" onclick="deployConfig()">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+                            Save Configuration
+                        </button>
+                        <button class="btn btn-outline" onclick="previewConfig()">Preview JSON</button>
+                    </div>
+                    <div id="status" class="status"></div>
+                </div>
+
+                <div class="section">
+                    <h3>Generated Configuration Preview</h3>
+                    <pre id="config-preview" style="display: none;">Select "Preview JSON" to see the configuration</pre>
+                </div>
+            </div>
+        </main>
+    </div>
+
+    <script>
+        function escapeHtml(value) {{
+            const div = document.createElement('div');
+            div.textContent = value === null || value === undefined ? '' : String(value);
+            return div.innerHTML;
+        }}
+
+        // Escape a value for use as a JS argument inside a double-quoted HTML
+        // on* attribute. JSON-encode (valid JS string literal) then
+        // HTML-attribute-escape: escapeHtml covers &<>, and the extra
+        // " -> &quot; keeps the surrounding onclick="..." from terminating
+        // early. Without the &quot; step a key like "git" renders as
+        // onclick="fn("git")" and the handler silently does nothing.
+        function attrArg(value) {{
+            return escapeHtml(JSON.stringify(value)).replace(/"/g, '&quot;');
+        }}
+
+        let groups = [];
+        let models = [];
+        let permissionSets = [];
+        let groupConfig = {{}};
+
+        let policies = {{
+            disabledBuiltinTools: [],
+            builtinToolPolicy: {{}},
+            permissions: {{ allow: [], ask: [], deny: [] }},
+            isLocalDevMcpEnabled: true,
+            isDesktopExtensionEnabled: true,
+            isDesktopExtensionSignatureRequired: false,
+            coworkTabEnabled: true,
+            disableBundledSkills: false,
+            disableDeploymentModeChooser: true,
+            allowedWorkspaceFolders: [],
+            coworkEgressAllowedHosts: [],
+            bootstrapUrlOverrideEnabled: false,
+            bootstrapUrlOverrideProtocol: 'https',
+            bootstrapUrlOverrideHost: '',
+            bootstrapUrlOverridePort: ''
+        }};
+
+        let managedMcpServers = [];
+        let mcpServerTemplates = [];
+
+        function switchPage(pageId) {{
+            document.querySelectorAll('.nav-item').forEach(n => n.classList.remove('active'));
+            document.querySelectorAll('.page-content').forEach(p => p.classList.remove('active'));
+            document.querySelector(`.nav-item[onclick="switchPage('${{pageId}}')"]`).classList.add('active');
+            document.getElementById('page-' + pageId).classList.add('active');
+            if (pageId === 'deploy') updateDeploySummary();
+        }}
+
+        function toggleCollapsible(el) {{
+            el.classList.toggle('active');
+            el.nextElementSibling.classList.toggle('show');
+        }}
+
+        async function init() {{
+            await Promise.all([loadGroups(), loadModels(), loadPermissionSets(), loadAdminConfig()]);
+            buildGroupConfig();
+            renderMappings();
+            renderModels();
+            renderPolicies();
+            renderMcpServers();
+        }}
+
+        async function loadGroups() {{
+            try {{
+                const res = await fetch('/admin/api/groups');
+                const data = await res.json();
+                groups = (data.groups || []).filter(g => g.displayName && g.displayName.toLowerCase().includes('claude'));
+            }} catch (e) {{ groups = []; }}
+        }}
+
+        async function loadModels() {{
+            try {{
+                const res = await fetch('/admin/api/models');
+                const data = await res.json();
+                models = data.models || [];
+            }} catch (e) {{ models = []; }}
+        }}
+
+        async function loadPermissionSets() {{
+            try {{
+                const res = await fetch('/admin/api/permission-sets');
+                const data = await res.json();
+                permissionSets = data.permissionSets || [];
+            }} catch (e) {{ permissionSets = []; }}
+        }}
+
+        async function loadAdminConfig() {{
+            try {{
+                const res = await fetch('/admin/api/config');
+                const data = await res.json();
+                if (data.policies) policies = {{ ...policies, ...data.policies }};
+                if (data.managedMcpServers) managedMcpServers = data.managedMcpServers;
+                if (data.mcpServerTemplates) mcpServerTemplates = data.mcpServerTemplates;
+            }} catch (e) {{}}
+        }}
+
+        function buildGroupConfig() {{
+            groupConfig = {{}};
+            for (const group of groups) {{
+                groupConfig[group.groupId] = {{ groupName: group.displayName, permissionSetName: null, models: [] }};
+            }}
+            for (const ps of permissionSets) {{
+                if (!ps.assignedGroups) continue;
+                for (const ag of ps.assignedGroups) {{
+                    if (!groupConfig[ag.groupId]) continue;
+                    groupConfig[ag.groupId].permissionSetName = ps.name;
+                    if (ps.modelResources && ps.modelResources.length > 0) {{
+                        const seenProfiles = new Set();
+                        for (const resource of ps.modelResources) {{
+                            const match = resource.match(/inference-profile\\/((?:us|global)\\.anthropic\\.[^*]+)/);
+                            if (!match) continue;
+                            const profileId = match[1];
+                            if (seenProfiles.has(profileId)) continue;
+                            seenProfiles.add(profileId);
+                            let foundModel = models.find(m => m.modelId === profileId);
+                            if (!foundModel) {{
+                                const profileBase = profileId.replace(/-v\\d+:.*$/, '').replace(/:\\d+$/, '');
+                                foundModel = models.find(m => m.modelId.replace(/-v\\d+:.*$/, '').replace(/:\\d+$/, '') === profileBase);
+                            }}
+                            const modelName = foundModel ? foundModel.modelName : profileId;
+                            const modelId = foundModel ? foundModel.modelId : profileId;
+                            if (!groupConfig[ag.groupId].models.find(m => m.modelId === modelId)) {{
+                                groupConfig[ag.groupId].models.push({{ modelId, modelName }});
+                            }}
+                        }}
+                    }}
+                }}
+            }}
+        }}
+
+        function renderMappings() {{
+            const tbody = document.getElementById('mappings-body');
+            if (groups.length === 0) {{
+                tbody.innerHTML = '<tr><td colspan="4" style="text-align:center;color:#888;padding:40px;">No Claude groups found. Create groups with "Claude" in the name in IAM Identity Center.</td></tr>';
+                return;
+            }}
+            let html = '';
+            for (const group of groups) {{
+                const gc = groupConfig[group.groupId] || {{ models: [], permissionSetName: null }};
+                let modelTagsHtml = '<div class="model-tags">';
+                if (gc.models.length === 0) modelTagsHtml += '<span style="color:#888;">None</span>';
+                else gc.models.forEach((m, mi) => {{ modelTagsHtml += '<span class="model-tag">' + m.modelName + ' <span class="remove" data-group="' + group.groupId + '" data-idx="' + mi + '" onclick="removeModelByIdx(this)">&times;</span></span>'; }});
+                modelTagsHtml += '</div>';
+                let addHtml = '<div class="add-row"><select id="add-model-' + group.groupId + '" style="font-size:13px;"><option value="">Select model...</option>';
+                models.filter(m => !gc.models.find(gm => gm.modelId === m.modelId)).forEach(m => {{ addHtml += '<option value="' + encodeURIComponent(m.modelId) + '|' + encodeURIComponent(m.modelName) + '">' + m.modelName + '</option>'; }});
+                addHtml += '</select><button class="btn btn-primary btn-sm" data-group="' + group.groupId + '" onclick="addModelFromBtn(this)">+</button></div>';
+                let psHtml = gc.permissionSetName ? escapeHtml(gc.permissionSetName) + ' <a href="#" onclick="viewPolicy(' + attrArg(gc.permissionSetName) + ');return false;" style="font-size:11px;color:#667eea;">[view]</a>' : '-';
+                html += '<tr><td><strong>' + escapeHtml(group.displayName) + '</strong></td><td>' + modelTagsHtml + '</td><td>' + addHtml + '</td><td>' + psHtml + '</td></tr>';
+            }}
+            tbody.innerHTML = html;
+        }}
+
+        function addModelFromBtn(btn) {{
+            const groupId = btn.getAttribute('data-group');
+            const select = document.getElementById('add-model-' + groupId);
+            if (!select.value) return;
+            const [modelId, modelName] = select.value.split('|').map(decodeURIComponent);
+            if (!groupConfig[groupId].models.find(m => m.modelId === modelId)) groupConfig[groupId].models.push({{ modelId, modelName }});
+            renderMappings();
+        }}
+
+        function removeModelByIdx(el) {{
+            const groupId = el.getAttribute('data-group'), idx = parseInt(el.getAttribute('data-idx'), 10);
+            if (groupConfig[groupId]) {{ groupConfig[groupId].models.splice(idx, 1); renderMappings(); }}
+        }}
+
+        function renderModels() {{
+            const tbody = document.getElementById('models-body');
+            if (models.length === 0) {{ tbody.innerHTML = '<tr><td colspan="3" style="text-align:center;color:#888;padding:40px;">No models available</td></tr>'; return; }}
+            tbody.innerHTML = models.map(m => '<tr><td>' + m.modelName + '</td><td><code style="font-size:12px;">' + m.modelId + '</code></td><td><span class="badge badge-success">' + m.type + '</span></td></tr>').join('');
+        }}
+
+        function renderPolicies() {{
+            const dtl = document.getElementById('disabled-tools-list');
+            dtl.innerHTML = policies.disabledBuiltinTools.length === 0 ? '<span style="color:#888;">None - all tools enabled</span>' : policies.disabledBuiltinTools.map((t, i) => '<span class="tool-tag blocked">' + escapeHtml(t) + ' <span class="remove" onclick="removeDisabledTool(' + i + ')">&times;</span></span>').join('');
+
+            const tpl = document.getElementById('tool-policies-list');
+            const pe = Object.entries(policies.builtinToolPolicy);
+            tpl.innerHTML = pe.length === 0 ? '<p style="color:#888;font-size:13px;">No custom tool policies.</p>' : pe.map(([t, p]) => '<div style="display:flex;justify-content:space-between;align-items:center;padding:10px 0;border-bottom:1px solid #eee;"><span>' + escapeHtml(t) + '</span><span class="tool-tag ' + escapeHtml(p) + '">' + escapeHtml(p) + ' <span class="remove" onclick="removeToolPolicy(' + attrArg(t) + ')">&times;</span></span></div>').join('');
+
+            ['isLocalDevMcpEnabled', 'isDesktopExtensionEnabled', 'isDesktopExtensionSignatureRequired', 'coworkTabEnabled', 'disableBundledSkills', 'disableDeploymentModeChooser'].forEach(key => {{
+                const el = document.getElementById('policy-' + key);
+                el.checked = policies[key];
+                el.onchange = function() {{ policies[key] = this.checked; }};
+            }});
+
+            const fl = document.getElementById('allowed-folders-list');
+            fl.innerHTML = policies.allowedWorkspaceFolders.length === 0 ? '<span style="color:#888;">No restrictions</span>' : policies.allowedWorkspaceFolders.map((f, i) => '<span class="tool-tag">' + (f.path || f) + ' <span class="remove" onclick="removeAllowedFolder(' + i + ')">&times;</span></span>').join(' ');
+
+            const el = document.getElementById('egress-hosts-list');
+            el.innerHTML = policies.coworkEgressAllowedHosts.length === 0 ? '<span style="color:#888;">No restrictions</span>' : policies.coworkEgressAllowedHosts.map((h, i) => '<span class="tool-tag">' + h + ' <span class="remove" onclick="removeEgressHost(' + i + ')">&times;</span></span>').join(' ');
+
+            // Command Permissions (allow/ask/deny). Reuses the tool-tag color
+            // classes: allow (neutral/green), ask (amber), deny -> 'blocked' (red).
+            if (!policies.permissions) policies.permissions = {{ allow: [], ask: [], deny: [] }};
+            const permBoxes = ['perm-allow-list', 'perm-ask-list', 'perm-deny-list'];
+            const permCls = ['allow', 'ask', 'blocked'];
+            ['allow', 'ask', 'deny'].forEach((tier, ti) => {{
+                if (!Array.isArray(policies.permissions[tier])) policies.permissions[tier] = [];
+                const box = document.getElementById(permBoxes[ti]);
+                const rules = policies.permissions[tier];
+                box.innerHTML = rules.length === 0 ? '<span style="color:#888;font-size:13px;">None</span>' : rules.map((r, i) => '<span class="tool-tag ' + permCls[ti] + '">' + escapeHtml(r) + ' <span class="remove" onclick="removePermRule(' + ti + ',' + i + ')">&times;</span></span>').join(' ');
+            }});
+
+            const bootstrapCheckbox = document.getElementById('policy-bootstrapUrlOverrideEnabled');
+            const bootstrapFields = document.getElementById('bootstrap-url-override-fields');
+            const bootstrapProtocol = document.getElementById('bootstrap-url-override-protocol');
+            const bootstrapHost = document.getElementById('bootstrap-url-override-host');
+            const bootstrapPort = document.getElementById('bootstrap-url-override-port');
+            bootstrapCheckbox.checked = policies.bootstrapUrlOverrideEnabled;
+            bootstrapFields.style.display = policies.bootstrapUrlOverrideEnabled ? 'flex' : 'none';
+            bootstrapProtocol.value = policies.bootstrapUrlOverrideProtocol || 'https';
+            bootstrapHost.value = policies.bootstrapUrlOverrideHost || '';
+            bootstrapPort.value = policies.bootstrapUrlOverridePort || '';
+            bootstrapCheckbox.onchange = function() {{ policies.bootstrapUrlOverrideEnabled = this.checked; bootstrapFields.style.display = this.checked ? 'flex' : 'none'; }};
+            bootstrapProtocol.onchange = function() {{ policies.bootstrapUrlOverrideProtocol = this.value; }};
+            bootstrapHost.onchange = function() {{ policies.bootstrapUrlOverrideHost = this.value.trim(); }};
+            bootstrapPort.onchange = function() {{ policies.bootstrapUrlOverridePort = this.value.trim(); }};
+        }}
+
+        function addDisabledTool() {{ const s = document.getElementById('add-disabled-tool'); const v = s.value.trim(); if (v && !policies.disabledBuiltinTools.includes(v)) {{ policies.disabledBuiltinTools.push(v); s.value = ''; renderPolicies(); }} }}
+        function removeDisabledTool(i) {{ policies.disabledBuiltinTools.splice(i, 1); renderPolicies(); }}
+        function addToolPolicy() {{ const t = document.getElementById('add-tool-policy-name').value.trim(), p = document.getElementById('add-tool-policy-value').value; if (t) {{ policies.builtinToolPolicy[t] = p; document.getElementById('add-tool-policy-name').value = ''; renderPolicies(); }} }}
+        function removeToolPolicy(t) {{ delete policies.builtinToolPolicy[t]; renderPolicies(); }}
+        function addAllowedFolder() {{ const v = document.getElementById('add-folder-path').value.trim(); if (v) {{ policies.allowedWorkspaceFolders.push({{ path: v }}); document.getElementById('add-folder-path').value = ''; renderPolicies(); }} }}
+        function removeAllowedFolder(i) {{ policies.allowedWorkspaceFolders.splice(i, 1); renderPolicies(); }}
+        function addEgressHost() {{ const v = document.getElementById('add-egress-host').value.trim(); if (v && !policies.coworkEgressAllowedHosts.includes(v)) {{ policies.coworkEgressAllowedHosts.push(v); document.getElementById('add-egress-host').value = ''; renderPolicies(); }} }}
+        function removeEgressHost(i) {{ policies.coworkEgressAllowedHosts.splice(i, 1); renderPolicies(); }}
+
+        const PERM_TIERS = ['allow', 'ask', 'deny'];
+        function addPermissionRule() {{
+            const input = document.getElementById('add-perm-rule');
+            const rule = input.value.trim();
+            const tier = document.getElementById('add-perm-tier').value;
+            if (!rule) return;
+            if (!policies.permissions) policies.permissions = {{ allow: [], ask: [], deny: [] }};
+            // A rule lives in exactly one tier — drop it from any other tier first
+            // so re-adding to a different tier moves it rather than duplicating.
+            PERM_TIERS.forEach(t => {{
+                if (!Array.isArray(policies.permissions[t])) policies.permissions[t] = [];
+                const idx = policies.permissions[t].indexOf(rule);
+                if (idx !== -1) policies.permissions[t].splice(idx, 1);
+            }});
+            policies.permissions[tier].push(rule);
+            input.value = '';
+            renderPolicies();
+        }}
+        function removePermRule(ti, i) {{ const tier = PERM_TIERS[ti]; if (policies.permissions && Array.isArray(policies.permissions[tier])) {{ policies.permissions[tier].splice(i, 1); renderPolicies(); }} }}
+
+        function renderMcpServers() {{
+            const md = document.getElementById('managed-mcp-servers');
+            md.innerHTML = managedMcpServers.length === 0 ? '<p style="color:#888;">No remote MCP servers configured.</p>' : managedMcpServers.map((s, i) => '<div class="card"><div class="card-header"><h5>' + s.name + '</h5><div><span class="badge badge-success">Remote</span> <button class="btn btn-danger btn-sm" onclick="removeManagedMcp(' + i + ')">Remove</button></div></div><div class="card-body"><strong>URL:</strong> <code>' + s.url + '</code>' + (s.description ? '<br>' + s.description : '') + '</div></div>').join('');
+
+            const td = document.getElementById('mcp-templates');
+            td.innerHTML = mcpServerTemplates.length === 0 ? '<p style="color:#888;">No local MCP templates configured.</p>' : mcpServerTemplates.map((s, i) => '<div class="card"><div class="card-header"><h5>' + s.name + '</h5><div><span class="badge badge-warning">Local</span> <button class="btn btn-danger btn-sm" onclick="removeMcpTemplate(' + i + ')">Remove</button></div></div><div class="card-body"><strong>Command:</strong> <code>' + s.command + ' ' + (s.args || []).join(' ') + '</code></div></div>').join('');
+        }}
+
+        function addManagedMcpServer() {{
+            const n = document.getElementById('new-mcp-name').value.trim(), u = document.getElementById('new-mcp-url').value.trim(), d = document.getElementById('new-mcp-description').value.trim();
+            if (!n || !u) {{ alert('Name and URL required'); return; }}
+            managedMcpServers.push({{ name: n, transport: 'http', url: u, description: d, toolPolicy: {{ '*': 'allow' }} }});
+            document.getElementById('new-mcp-name').value = ''; document.getElementById('new-mcp-url').value = ''; document.getElementById('new-mcp-description').value = '';
+            renderMcpServers();
+        }}
+        function removeManagedMcp(i) {{ managedMcpServers.splice(i, 1); renderMcpServers(); }}
+
+        const MCP_TEMPLATES = {{
+            'github': {{ name: 'github', command: '/usr/local/bin/npx', args: ['-y', '@modelcontextprotocol/server-github'], env: {{ 'PATH': '/usr/local/bin:/usr/bin', 'GITHUB_PERSONAL_ACCESS_TOKEN': '<user-provided>' }} }},
+            'slack': {{ name: 'slack', command: '/usr/local/bin/npx', args: ['-y', '@anthropic/mcp-slack-server'], env: {{ 'PATH': '/usr/local/bin:/usr/bin', 'SLACK_BOT_TOKEN': '<user-provided>', 'SLACK_TEAM_ID': '<user-provided>' }} }},
+            'filesystem': {{ name: 'filesystem', command: '/usr/local/bin/npx', args: ['-y', '@modelcontextprotocol/server-filesystem', '~/Projects'], env: {{ 'PATH': '/usr/local/bin:/usr/bin' }} }},
+            'brave-search': {{ name: 'brave-search', command: '/usr/local/bin/npx', args: ['-y', '@anthropic/mcp-brave-search'], env: {{ 'PATH': '/usr/local/bin:/usr/bin', 'BRAVE_API_KEY': '<user-provided>' }} }},
+            'postgres': {{ name: 'postgres', command: '/usr/local/bin/npx', args: ['-y', '@modelcontextprotocol/server-postgres', 'postgresql://localhost/mydb'], env: {{ 'PATH': '/usr/local/bin:/usr/bin' }} }},
+            'custom': {{ name: 'custom-server', command: '/path/to/server', args: [], env: {{ 'PATH': '/usr/local/bin:/usr/bin' }} }}
+        }};
+        function addMcpTemplate(t) {{ if (MCP_TEMPLATES[t]) {{ mcpServerTemplates.push({{ ...MCP_TEMPLATES[t] }}); renderMcpServers(); }} }}
+
+        function addLocalMcpServer() {{
+            const n = document.getElementById('new-local-mcp-name').value.trim(), c = document.getElementById('new-local-mcp-command').value.trim();
+            if (!n || !c) {{ alert('Name and command required'); return; }}
+            const args = document.getElementById('new-local-mcp-args').value.trim().split('\\n').map(a => a.trim()).filter(Boolean);
+            const env = {{}};
+            document.getElementById('new-local-mcp-env').value.trim().split('\\n').forEach(l => {{ const [k, ...v] = l.split('='); if (k && v.length) env[k.trim()] = v.join('=').trim(); }});
+            mcpServerTemplates.push({{ name: n, command: c, args, env }});
+            document.getElementById('new-local-mcp-name').value = ''; document.getElementById('new-local-mcp-command').value = ''; document.getElementById('new-local-mcp-args').value = ''; document.getElementById('new-local-mcp-env').value = '';
+            renderMcpServers();
+        }}
+        function removeMcpTemplate(i) {{ mcpServerTemplates.splice(i, 1); renderMcpServers(); }}
+
+        function updateDeploySummary() {{
+            const gc = Object.values(groupConfig).filter(g => g.models.length > 0).length;
+            const permCount = policies.permissions ? (['allow', 'ask', 'deny'].reduce((n, t) => n + ((policies.permissions[t] || []).length), 0)) : 0;
+            const pc = policies.disabledBuiltinTools.length + Object.keys(policies.builtinToolPolicy).length + policies.allowedWorkspaceFolders.length + policies.coworkEgressAllowedHosts.length + permCount;
+            const mc = managedMcpServers.length + mcpServerTemplates.length;
+            document.getElementById('summary-groups').textContent = gc;
+            document.getElementById('summary-policies').textContent = pc;
+            document.getElementById('summary-mcp').textContent = mc;
+        }}
+
+        function previewConfig() {{
+            const preview = document.getElementById('config-preview');
+            if (preview.style.display === 'block') {{
+                preview.style.display = 'none';
+            }} else {{
+                const config = buildFullConfig();
+                preview.textContent = JSON.stringify(config, null, 2);
+                preview.style.display = 'block';
+            }}
+        }}
+
+        function buildFullConfig() {{
+            const mappings = [];
+            for (const [groupId, gc] of Object.entries(groupConfig)) {{
+                if (gc.models.length === 0) continue;
+                mappings.push({{ groupId, groupName: gc.groupName, roleName: gc.permissionSetName || gc.groupName.replace(/-/g, ''), models: gc.models, createNew: !gc.permissionSetName }});
+            }}
+            return {{ mappings, policies, managedMcpServers, mcpServerTemplates }};
+        }}
+
+        async function deployConfig() {{
+            const config = buildFullConfig();
+            if (config.mappings.length === 0) {{ showStatus('Please add at least one model to a group', 'error'); return; }}
+            showStatus('Deploying configuration... This may take a minute.', 'info');
+            document.querySelector('.main-content').classList.add('loading');
+            try {{
+                const res = await fetch('/admin/api/deploy', {{ method: 'POST', headers: {{ 'Content-Type': 'application/json' }}, body: JSON.stringify(config) }});
+                const data = await res.json();
+                if (data.success) {{
+                    let msg = 'Deployment complete!<br><br>';
+                    (data.results || []).forEach(r => {{ msg += (r.status === 'success' ? '&#10003;' : '&#10007;') + ' ' + r.group + ': ' + (r.model || '') + '<br>'; if (r.error) msg += '&nbsp;&nbsp;Error: ' + r.error + '<br>'; }});
+                    showStatus(msg, 'success');
+                    setTimeout(() => location.reload(), 2000);
+                }} else showStatus('Error: ' + (data.error || 'Unknown error'), 'error');
+            }} catch (e) {{ showStatus('Error: ' + e.message, 'error'); }}
+            finally {{ document.querySelector('.main-content').classList.remove('loading'); }}
+        }}
+
+        function showStatus(msg, type) {{ const s = document.getElementById('status'); s.innerHTML = msg; s.className = 'status ' + type; }}
+
+        async function viewPolicy(psName) {{
+            try {{
+                const res = await fetch('/admin/api/permission-set/' + encodeURIComponent(psName));
+                const data = await res.json();
+                if (data.error) {{ alert('Error: ' + data.error); return; }}
+                const policy = data.inlinePolicy ? JSON.stringify(data.inlinePolicy, null, 2) : 'No inline policy';
+                const modal = document.createElement('div');
+                modal.style.cssText = 'position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.5);display:flex;justify-content:center;align-items:center;z-index:1000;';
+                modal.innerHTML = '<div style="background:white;padding:30px;border-radius:12px;max-width:800px;max-height:80vh;overflow:auto;"><h3 style="margin-bottom:15px;">Permission Set: ' + escapeHtml(psName) + '</h3><p><strong>Description:</strong> ' + escapeHtml(data.description || 'N/A') + '</p><p><strong>Session Duration:</strong> ' + escapeHtml(data.sessionDuration) + '</p><h4 style="margin-top:15px;">Inline Policy:</h4><pre style="background:#1a1a2e;color:#e0e0e0;padding:15px;border-radius:8px;overflow:auto;font-size:12px;">' + escapeHtml(policy) + '</pre><button class="btn btn-primary" style="margin-top:15px;" onclick="this.parentElement.parentElement.remove()">Close</button></div>';
+                document.body.appendChild(modal);
+                modal.onclick = function(e) {{ if (e.target === modal) modal.remove(); }};
+            }} catch (e) {{ alert('Error: ' + e.message); }}
+        }}
+
+        async function saveDraft(page) {{
+            const statusEl = document.getElementById(page + '-save-status');
+            statusEl.className = 'save-status saving';
+            statusEl.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="animation: spin 1s linear infinite;"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg> Saving...';
+
+            const config = buildFullConfig();
+            try {{
+                const res = await fetch('/admin/api/config', {{
+                    method: 'POST',
+                    headers: {{ 'Content-Type': 'application/json' }},
+                    body: JSON.stringify(config)
+                }});
+                const data = await res.json();
+                if (data.success) {{
+                    statusEl.className = 'save-status saved';
+                    statusEl.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20 6 9 17 4 12"/></svg> Draft saved';
+                    setTimeout(() => {{ statusEl.innerHTML = ''; statusEl.className = 'save-status'; }}, 3000);
+                }} else {{
+                    statusEl.className = 'save-status error';
+                    statusEl.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg> Error: ' + (data.error || 'Failed to save');
+                }}
+            }} catch (e) {{
+                statusEl.className = 'save-status error';
+                statusEl.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg> Error: ' + e.message;
+            }}
+        }}
+
+        init();
+    </script>
+</body>
+</html>"""
+    )
+
+
+# =============================================================================
+# Lambda entry point (invoked via ALB target group, /admin* path only)
+# =============================================================================
+
+
+def lambda_handler(event, context):
+    try:
+        path = event.get("path", "/admin")
+        http_method = event.get("httpMethod", "GET")
+        headers = event.get("headers", {}) or {}
+        body = event.get("body", "") or ""
+        if event.get("isBase64Encoded"):
+            body = base64.b64decode(body).decode("utf-8")
+
+        # CloudFront mode: no ALB auth header — resolve identity from the
+        # shared session cookie, and redirect unauthenticated callers into
+        # the Cognito login flow. ALB mode is unchanged (trusts the header).
+        if ENABLE_CLOUDFRONT:
+            cookie_header = headers.get("cookie", headers.get("Cookie", ""))
+            session_info = validate_session(_parse_cookies(cookie_header).get("session", ""))
+            if not session_info:
+                return redirect_to_login()
+            user_email = session_info.get("email", "")
+        else:
+            user_email = extract_user_email(headers)
+        if not user_email:
+            return html_response("<html><body><h1>Authentication required</h1></body></html>", 401)
+
+        user_groups = get_user_idc_groups(user_email)
+        is_admin = any(ADMIN_GROUP.lower() == g.lower() for g in user_groups)
+        if not is_admin:
+            return html_response(
+                f"<html><body><h1>Access Denied</h1><p>Admin access required.</p>"
+                f"<p>Email: {esc(user_email)}</p><p>Groups: {esc(user_groups)}</p></body></html>",
+                403,
+            )
+
+        if http_method == "POST" and not verify_request_origin(headers):
+            return json_response({"error": "Invalid request origin"}, 403)
+
+        if path == "/admin" or path == "/admin/":
+            return serve_admin_page(user_email)
+        elif path == "/admin/api/groups":
+            return api_list_groups()
+        elif path == "/admin/api/models":
+            return api_list_models()
+        elif path == "/admin/api/config":
+            return api_get_config() if http_method == "GET" else api_save_config(body)
+        elif path == "/admin/api/permission-sets":
+            return api_list_permission_sets()
+        elif path.startswith("/admin/api/permission-set/"):
+            ps_name = unquote(path.split("/admin/api/permission-set/", 1)[-1])
+            return api_get_permission_set_details(ps_name)
+        elif path == "/admin/api/deploy" and http_method == "POST":
+            return api_deploy_config(body)
+
+        return html_response("<html><body><h1>404 Not Found</h1></body></html>", 404)
+
+    except Exception:
+        import traceback
+
+        print(f"Error: {traceback.format_exc()}")
+        return html_response(
+            "<html><body><h1>Internal Server Error</h1><p>Something went wrong. Please try again later.</p></body></html>",
+            500,
+        )

--- a/deployment/infrastructure/lambda-functions/admin_console/index.py
+++ b/deployment/infrastructure/lambda-functions/admin_console/index.py
@@ -2124,7 +2124,7 @@ def serve_admin_page(user_email: str) -> dict:
         function renderModels() {{
             const tbody = document.getElementById('models-body');
             if (models.length === 0) {{ tbody.innerHTML = '<tr><td colspan="3" style="text-align:center;color:#888;padding:40px;">No models available</td></tr>'; return; }}
-            tbody.innerHTML = models.map(m => '<tr><td>' + m.modelName + '</td><td><code style="font-size:12px;">' + m.modelId + '</code></td><td><span class="badge badge-success">' + m.type + '</span></td></tr>').join('');
+            tbody.innerHTML = models.map(m => '<tr><td>' + escapeHtml(m.modelName) + '</td><td><code style="font-size:12px;">' + escapeHtml(m.modelId) + '</code></td><td><span class="badge badge-success">' + escapeHtml(m.type) + '</span></td></tr>').join('');
         }}
 
         function renderPolicies() {{
@@ -2142,10 +2142,10 @@ def serve_admin_page(user_email: str) -> dict:
             }});
 
             const fl = document.getElementById('allowed-folders-list');
-            fl.innerHTML = policies.allowedWorkspaceFolders.length === 0 ? '<span style="color:#888;">No restrictions</span>' : policies.allowedWorkspaceFolders.map((f, i) => '<span class="tool-tag">' + (f.path || f) + ' <span class="remove" onclick="removeAllowedFolder(' + i + ')">&times;</span></span>').join(' ');
+            fl.innerHTML = policies.allowedWorkspaceFolders.length === 0 ? '<span style="color:#888;">No restrictions</span>' : policies.allowedWorkspaceFolders.map((f, i) => '<span class="tool-tag">' + escapeHtml(f.path || f) + ' <span class="remove" onclick="removeAllowedFolder(' + i + ')">&times;</span></span>').join(' ');
 
             const el = document.getElementById('egress-hosts-list');
-            el.innerHTML = policies.coworkEgressAllowedHosts.length === 0 ? '<span style="color:#888;">No restrictions</span>' : policies.coworkEgressAllowedHosts.map((h, i) => '<span class="tool-tag">' + h + ' <span class="remove" onclick="removeEgressHost(' + i + ')">&times;</span></span>').join(' ');
+            el.innerHTML = policies.coworkEgressAllowedHosts.length === 0 ? '<span style="color:#888;">No restrictions</span>' : policies.coworkEgressAllowedHosts.map((h, i) => '<span class="tool-tag">' + escapeHtml(h) + ' <span class="remove" onclick="removeEgressHost(' + i + ')">&times;</span></span>').join(' ');
 
             // Command Permissions (allow/ask/deny). Reuses the tool-tag color
             // classes: allow (neutral/green), ask (amber), deny -> 'blocked' (red).

--- a/deployment/infrastructure/lambda-functions/shared/README.md
+++ b/deployment/infrastructure/lambda-functions/shared/README.md
@@ -1,0 +1,75 @@
+# Shared Lambda Utilities
+
+Common utilities shared across Lambda functions for Claude Code with Bedrock.
+
+## Modules
+
+### `pricing.py`
+Bedrock pricing data for quota and cost calculations.
+
+### `mdm_config.py`
+MDM configuration schema, constants, and builder functions.
+
+**Key exports:**
+- `ALL_MDM_KEYS` - Complete set of valid MDM keys
+- `DEFAULT_POLICIES` - Default feature toggle values
+- `normalize_model_id()` - Ensure model IDs have proper prefix
+- `build_inference_models()` - Build inferenceModels array from model specs
+- `build_base_config()` - Create base MDM config with common settings
+- `add_idc_sso_config()` - Add IAM Identity Center SSO settings
+- `add_bootstrap_config()` - Add dynamic bootstrap configuration
+- `add_policies()` - Add tool/feature policies
+- `add_mcp_servers()` - Add MCP server configuration
+
+### `mdm_generators.py`
+Platform-specific MDM file generators.
+
+**Key exports:**
+- `generate_mobileconfig()` - Generate macOS mobileconfig XML
+- `generate_reg_file()` - Generate Windows registry file
+- `generate_json_config()` - Generate JSON config file
+
+## Usage
+
+### In Lambda Functions
+
+```python
+from shared.mdm_config import (
+    build_base_config,
+    add_idc_sso_config,
+    add_bootstrap_config,
+)
+from shared.mdm_generators import generate_mobileconfig
+
+# Build config
+config = build_base_config(
+    bedrock_region="us-east-1",
+    models=[{"modelId": "us.anthropic.claude-sonnet-4", "modelName": "Sonnet 4"}],
+)
+add_idc_sso_config(config, start_url, region, account_id, role_name)
+add_bootstrap_config(config, bootstrap_url, oidc_config)
+
+# Generate platform files
+mobileconfig_xml = generate_mobileconfig(config, "my-profile", "My Profile")
+```
+
+### In ccwb CLI
+
+The `ccwb cowork generate` command uses `source/claude_code_with_bedrock/cli/utils/cowork_3p.py` which should be aligned with these shared utilities.
+
+## Alignment Status
+
+| Component | Uses Shared Library | Notes |
+|-----------|---------------------|-------|
+| `bootstrap_server/index.py` | Partial | Uses own config builder |
+| `bootstrap_device_code/index.py` | No | Needs migration |
+| `admin_console/index.py` | Yes | Uses `shared.mdm_config`/`shared.mdm_generators` directly (retired the old CDK app's duplicated inline generators) |
+| `ccwb cowork generate` | No | Uses `cowork_3p.py` |
+
+## Migration Plan
+
+1. **Phase 1 (Complete)**: Create shared library with canonical MDM schema
+2. **Phase 2**: Update `bootstrap_server/index.py` to use shared builders
+3. **Phase 3 (Complete)**: `admin_console/index.py` (successor to the retired CDK-based `idc-landing-page/lambda/index.py`) uses shared generators
+4. **Phase 4**: Align `cowork_3p.py` with shared library (may need to import or mirror)
+5. **Phase 5**: Add validation tests to ensure all generators produce compatible output

--- a/deployment/infrastructure/lambda-functions/shared/__init__.py
+++ b/deployment/infrastructure/lambda-functions/shared/__init__.py
@@ -1,1 +1,62 @@
-# ABOUTME: Shared utilities package for Lambda functions (pricing, common helpers).
+# ABOUTME: Shared utilities package for Lambda functions (pricing, MDM config, common helpers).
+
+from .mdm_config import (
+    ALL_MDM_KEYS,
+    DEFAULT_INFERENCE_REGION,
+    DEFAULT_POLICIES,
+    DEFAULT_SESSION_LIFETIME_SEC,
+    MDM_KEYS_BOOTSTRAP,
+    MDM_KEYS_IDC_SSO,
+    MDM_KEYS_INFERENCE,
+    MDM_KEYS_MCP,
+    MDM_KEYS_ORG,
+    MDM_KEYS_POLICIES,
+    MDM_KEYS_RESTRICTIONS,
+    MDM_KEYS_TELEMETRY,
+    add_bootstrap_config,
+    add_idc_sso_config,
+    add_mcp_servers,
+    add_policies,
+    add_telemetry_config,
+    build_base_config,
+    build_inference_models,
+    infer_model_tier,
+    normalize_model_id,
+)
+from .mdm_generators import (
+    generate_json_config,
+    generate_mobileconfig,
+    generate_reg_file,
+)
+
+__all__ = [
+    # MDM key definitions
+    "ALL_MDM_KEYS",
+    "MDM_KEYS_INFERENCE",
+    "MDM_KEYS_IDC_SSO",
+    "MDM_KEYS_BOOTSTRAP",
+    "MDM_KEYS_POLICIES",
+    "MDM_KEYS_RESTRICTIONS",
+    "MDM_KEYS_MCP",
+    "MDM_KEYS_TELEMETRY",
+    "MDM_KEYS_ORG",
+    # Defaults
+    "DEFAULT_INFERENCE_REGION",
+    "DEFAULT_SESSION_LIFETIME_SEC",
+    "DEFAULT_POLICIES",
+    # Model utilities
+    "normalize_model_id",
+    "infer_model_tier",
+    "build_inference_models",
+    # Config builders
+    "build_base_config",
+    "add_idc_sso_config",
+    "add_bootstrap_config",
+    "add_policies",
+    "add_mcp_servers",
+    "add_telemetry_config",
+    # Generators
+    "generate_mobileconfig",
+    "generate_reg_file",
+    "generate_json_config",
+]

--- a/deployment/infrastructure/lambda-functions/shared/mdm_config.py
+++ b/deployment/infrastructure/lambda-functions/shared/mdm_config.py
@@ -1,0 +1,411 @@
+# ABOUTME: Shared MDM configuration schema and constants for Claude Desktop
+# ABOUTME: Used by idc-landing-page, bootstrap-server, and ccwb cowork generate
+
+"""MDM Configuration Schema and Utilities.
+
+This module defines the canonical MDM key names, default values, and helper
+functions for generating Claude Desktop configuration. It is the single source
+of truth for both Lambda functions and the ccwb CLI.
+
+References:
+- Claude Desktop MDM docs: https://support.claude.com/en/articles/14680741
+"""
+
+import uuid
+from typing import Any
+
+# =============================================================================
+# MDM Key Definitions
+# =============================================================================
+
+# Core inference provider settings
+MDM_KEYS_INFERENCE = {
+    "inferenceProvider",  # "bedrock" | "anthropic"
+    "inferenceBedrockRegion",  # AWS region for Bedrock API
+    "inferenceBedrockProfile",  # AWS profile name (for credential_process)
+    "inferenceCredentialKind",  # "interactive" for IDC SSO
+    "inferenceCredentialHelper",  # Path to credential helper binary
+    "inferenceCredentialHelperTtlSec",  # TTL for credential helper cache
+    "inferenceCredentialHelperSilentRefreshEnabled",  # Enable silent refresh
+    "inferenceModels",  # List of allowed models
+    "inferenceSessionLifetimeSec",  # Session lifetime before re-auth
+}
+
+# IAM Identity Center SSO settings
+MDM_KEYS_IDC_SSO = {
+    "inferenceBedrockSsoStartUrl",  # IDC portal URL
+    "inferenceBedrockSsoRegion",  # IDC region
+    "inferenceBedrockSsoAccountId",  # AWS account ID
+    "inferenceBedrockSsoRoleName",  # Permission set / role name
+}
+
+# Bootstrap dynamic configuration
+MDM_KEYS_BOOTSTRAP = {
+    "bootstrapEnabled",  # Enable dynamic config
+    "bootstrapUrl",  # URL to fetch config from
+    "bootstrapOidc",  # OIDC config for bootstrap auth (JSON string)
+}
+
+# Tool and feature controls
+MDM_KEYS_POLICIES = {
+    "disabledBuiltinTools",  # List of disabled tools
+    "builtinToolPolicy",  # Per-tool policy overrides
+    "permissions",  # Command-level rules {allow,ask,deny} (Claude Code permission rules, e.g. Bash(git push:*))
+    "isLocalDevMcpEnabled",  # Allow user MCP servers
+    "isDesktopExtensionEnabled",  # Allow desktop extensions
+    "isDesktopExtensionSignatureRequired",  # Require signed extensions
+    "isDesktopExtensionDirectoryEnabled",  # Allow extension directory
+    "coworkTabEnabled",  # Enable Cowork tab
+    "disableBundledSkills",  # Disable built-in skills
+    "disableDeploymentModeChooser",  # Lock to configured provider
+}
+
+# Workspace and network restrictions
+MDM_KEYS_RESTRICTIONS = {
+    "allowedWorkspaceFolders",  # List of allowed folders
+    "coworkEgressAllowedHosts",  # Network egress allowlist
+}
+
+# MCP server configuration
+MDM_KEYS_MCP = {
+    "managedMcpServers",  # Remote MCP servers (JSON string)
+    "mcpServers",  # Local MCP server templates
+}
+
+# Telemetry / OTEL settings
+MDM_KEYS_TELEMETRY = {
+    "otlpEndpoint",  # OTEL collector endpoint
+    "otlpProtocol",  # "http/protobuf" | "grpc"
+    "otlpHeaders",  # Additional headers (JSON string)
+}
+
+# Organization settings
+MDM_KEYS_ORG = {
+    "deploymentOrganizationUuid",  # Org identifier for MDM
+    "isClaudeCodeForDesktopEnabled",  # Enable Claude Code features
+}
+
+# All MDM keys combined
+ALL_MDM_KEYS = (
+    MDM_KEYS_INFERENCE
+    | MDM_KEYS_IDC_SSO
+    | MDM_KEYS_BOOTSTRAP
+    | MDM_KEYS_POLICIES
+    | MDM_KEYS_RESTRICTIONS
+    | MDM_KEYS_MCP
+    | MDM_KEYS_TELEMETRY
+    | MDM_KEYS_ORG
+)
+
+# =============================================================================
+# Default Values
+# =============================================================================
+
+DEFAULT_INFERENCE_REGION = "us-east-1"
+DEFAULT_SESSION_LIFETIME_SEC = 28800  # 8 hours
+DEFAULT_CREDENTIAL_HELPER_TTL_SEC = 3500  # Just under 1 hour STS token lifetime
+
+# Default feature toggles (most permissive)
+DEFAULT_POLICIES = {
+    "isLocalDevMcpEnabled": True,
+    "isDesktopExtensionEnabled": True,
+    "isDesktopExtensionSignatureRequired": True,
+    "isDesktopExtensionDirectoryEnabled": True,
+    "coworkTabEnabled": True,
+    "disableBundledSkills": False,
+    "disableDeploymentModeChooser": True,  # Lock to Bedrock by default
+    "isClaudeCodeForDesktopEnabled": True,
+}
+
+# =============================================================================
+# Model ID Utilities
+# =============================================================================
+
+
+def normalize_model_id(model_id: str) -> str:
+    """Normalize a model ID to the full Bedrock inference profile format.
+
+    Ensures model_id has proper prefix for Bedrock (us. or global.).
+
+    Args:
+        model_id: Raw model ID (e.g., "anthropic.claude-sonnet-4")
+
+    Returns:
+        Normalized model ID (e.g., "us.anthropic.claude-sonnet-4")
+    """
+    if not model_id:
+        return model_id
+
+    # Already has proper prefix
+    if model_id.startswith(("us.", "global.")):
+        return model_id
+
+    # Add us. prefix for anthropic models
+    if model_id.startswith("anthropic."):
+        return f"us.{model_id}"
+
+    # Default to us.anthropic. prefix
+    return f"us.anthropic.{model_id}"
+
+
+def infer_model_tier(model_id: str) -> str | None:
+    """Infer the Claude model tier from a model ID.
+
+    Args:
+        model_id: Bedrock/CRIS model ID
+
+    Returns:
+        Tier name ("opus", "sonnet", "haiku", "fable") or None if unknown
+    """
+    model_lower = model_id.lower()
+    if "opus" in model_lower:
+        return "opus"
+    if "sonnet" in model_lower:
+        return "sonnet"
+    if "haiku" in model_lower:
+        return "haiku"
+    if "fable" in model_lower:
+        return "fable"
+    return None
+
+
+def build_inference_models(
+    models: list[dict | str], include_tier_info: bool = False
+) -> list[dict | str]:
+    """Build the inferenceModels array for MDM config.
+
+    Args:
+        models: List of model specs. Each can be:
+            - str: Simple model ID or alias
+            - dict: {"modelId": "...", "modelName": "..."} or
+                   {"name": "...", "labelOverride": "..."}
+        include_tier_info: If True, add anthropicFamilyTier/isFamilyDefault
+
+    Returns:
+        List suitable for the inferenceModels MDM key
+    """
+    result = []
+    tier_seen: dict[str, bool] = {}
+
+    for model in models:
+        if isinstance(model, str):
+            # Simple alias (opus, sonnet, haiku) - keep as-is for client resolution
+            if model in ("opus", "sonnet", "haiku", "fable"):
+                result.append(model)
+            else:
+                # Full model ID
+                normalized = normalize_model_id(model)
+                if include_tier_info:
+                    entry: dict[str, Any] = {"name": normalized}
+                    tier = infer_model_tier(normalized)
+                    if tier:
+                        entry["anthropicFamilyTier"] = tier
+                        if tier not in tier_seen:
+                            entry["isFamilyDefault"] = True
+                            tier_seen[tier] = True
+                    result.append(entry)
+                else:
+                    result.append({"name": normalized})
+        else:
+            # Dict format - normalize and pass through
+            model_id = model.get("modelId") or model.get("name", "")
+            model_name = model.get("modelName") or model.get("labelOverride", "")
+
+            normalized = normalize_model_id(model_id)
+            entry = {"name": normalized}
+            if model_name:
+                entry["labelOverride"] = model_name
+
+            if include_tier_info:
+                tier = infer_model_tier(normalized)
+                if tier:
+                    entry["anthropicFamilyTier"] = tier
+                    if tier not in tier_seen:
+                        entry["isFamilyDefault"] = True
+                        tier_seen[tier] = True
+
+            result.append(entry)
+
+    return result
+
+
+# =============================================================================
+# Config Builder
+# =============================================================================
+
+
+def build_base_config(
+    bedrock_region: str = DEFAULT_INFERENCE_REGION,
+    models: list[dict | str] | None = None,
+    deployment_uuid: str | None = None,
+) -> dict[str, Any]:
+    """Build the base MDM configuration with common settings.
+
+    Args:
+        bedrock_region: AWS region for Bedrock API
+        models: List of model specs
+        deployment_uuid: Organization deployment UUID (generated if not provided)
+
+    Returns:
+        Base MDM config dict
+    """
+    config: dict[str, Any] = {
+        "inferenceProvider": "bedrock",
+        "inferenceBedrockRegion": bedrock_region,
+    }
+
+    # Add default policies
+    config.update(DEFAULT_POLICIES)
+
+    # Add models if provided
+    if models:
+        config["inferenceModels"] = build_inference_models(models)
+
+    # Add deployment UUID
+    config["deploymentOrganizationUuid"] = deployment_uuid or str(uuid.uuid4()).upper()
+
+    return config
+
+
+def add_idc_sso_config(
+    config: dict[str, Any],
+    start_url: str,
+    region: str,
+    account_id: str,
+    role_name: str,
+) -> None:
+    """Add IAM Identity Center SSO configuration to MDM config.
+
+    Args:
+        config: MDM config dict to modify
+        start_url: IDC portal start URL
+        region: IDC region
+        account_id: AWS account ID
+        role_name: Permission set / role name
+    """
+    config["inferenceCredentialKind"] = "interactive"
+    config["inferenceBedrockSsoStartUrl"] = start_url
+    config["inferenceBedrockSsoRegion"] = region
+    config["inferenceBedrockSsoAccountId"] = account_id
+    config["inferenceBedrockSsoRoleName"] = role_name
+
+
+def add_bootstrap_config(
+    config: dict[str, Any],
+    bootstrap_url: str,
+    oidc_config: dict[str, str] | None = None,
+) -> None:
+    """Add bootstrap dynamic configuration settings.
+
+    Args:
+        config: MDM config dict to modify
+        bootstrap_url: URL to fetch dynamic config from
+        oidc_config: OIDC config for bootstrap auth:
+            {"clientId": "...", "issuer": "...", "scopes": "...", "redirectPort": 8080}
+    """
+    config["bootstrapEnabled"] = True
+    config["bootstrapUrl"] = bootstrap_url
+
+    if oidc_config:
+        # bootstrapOidc is stored as a JSON string in MDM
+        config["bootstrapOidc"] = oidc_config  # Will be serialized by generators
+
+
+def add_policies(
+    config: dict[str, Any],
+    disabled_tools: list[str] | None = None,
+    tool_policies: dict[str, str] | None = None,
+    allowed_folders: list[dict | str] | None = None,
+    egress_hosts: list[str] | None = None,
+    feature_toggles: dict[str, bool] | None = None,
+    permissions: dict[str, list[str]] | None = None,
+) -> None:
+    """Add policy settings to MDM config.
+
+    Args:
+        config: MDM config dict to modify
+        disabled_tools: List of tool names to disable completely
+        tool_policies: Per-tool policy overrides (tool -> "allow"|"ask"|"blocked")
+        allowed_folders: List of allowed workspace folders
+        egress_hosts: Network egress allowlist
+        feature_toggles: Feature toggle overrides
+        permissions: Command-level Claude Code permission rules — a dict with
+            any of "allow"/"ask"/"deny" arrays of rule strings (e.g.
+            "Bash(git push:*)", "Read(./.env)", or a bare tool name like
+            "WebFetch"). Unlike builtinToolPolicy (whole-tool ask/allow/block),
+            these gate individual commands/arguments and are evaluated
+            deny -> ask -> allow, first match wins. Only non-empty tiers are
+            emitted so cleared rules revert to the client default.
+    """
+    if disabled_tools:
+        config["disabledBuiltinTools"] = disabled_tools
+
+    if tool_policies:
+        config["builtinToolPolicy"] = tool_policies
+
+    if permissions:
+        perms = {
+            tier: permissions[tier]
+            for tier in ("allow", "ask", "deny")
+            if permissions.get(tier)
+        }
+        if perms:
+            config["permissions"] = perms
+
+    if allowed_folders:
+        # Normalize to list of dicts with 'path' key
+        normalized = []
+        for folder in allowed_folders:
+            if isinstance(folder, str):
+                normalized.append({"path": folder})
+            else:
+                normalized.append(folder)
+        config["allowedWorkspaceFolders"] = normalized
+
+    if egress_hosts:
+        config["coworkEgressAllowedHosts"] = egress_hosts
+
+    if feature_toggles:
+        for key, value in feature_toggles.items():
+            if key in MDM_KEYS_POLICIES:
+                config[key] = value
+
+
+def add_mcp_servers(
+    config: dict[str, Any],
+    managed_servers: list[dict] | None = None,
+    local_templates: list[dict] | None = None,
+) -> None:
+    """Add MCP server configuration.
+
+    Args:
+        config: MDM config dict to modify
+        managed_servers: Remote HTTPS MCP servers
+        local_templates: Local MCP server templates
+    """
+    if managed_servers:
+        config["managedMcpServers"] = managed_servers
+
+    if local_templates:
+        config["mcpServers"] = local_templates
+
+
+def add_telemetry_config(
+    config: dict[str, Any],
+    otlp_endpoint: str,
+    otlp_protocol: str = "http/protobuf",
+    otlp_headers: dict[str, str] | None = None,
+) -> None:
+    """Add telemetry/OTEL configuration.
+
+    Args:
+        config: MDM config dict to modify
+        otlp_endpoint: OTEL collector endpoint URL
+        otlp_protocol: Protocol ("http/protobuf" or "grpc")
+        otlp_headers: Additional headers to send
+    """
+    config["otlpEndpoint"] = otlp_endpoint
+    config["otlpProtocol"] = otlp_protocol
+
+    if otlp_headers:
+        config["otlpHeaders"] = otlp_headers

--- a/deployment/infrastructure/lambda-functions/shared/mdm_generators.py
+++ b/deployment/infrastructure/lambda-functions/shared/mdm_generators.py
@@ -1,0 +1,344 @@
+# ABOUTME: Shared MDM file generators for macOS mobileconfig and Windows registry
+# ABOUTME: Used by idc-landing-page, bootstrap-server, and ccwb cowork generate
+
+"""MDM File Generators.
+
+This module provides functions to generate platform-specific MDM configuration
+files (macOS mobileconfig, Windows registry) from a common MDM config dict.
+"""
+
+import json
+import uuid
+from typing import Any
+
+# =============================================================================
+# macOS Mobileconfig Generator
+# =============================================================================
+
+
+def generate_mobileconfig(
+    config: dict[str, Any],
+    profile_identifier: str = "default",
+    profile_display_name: str = "Claude Desktop",
+) -> str:
+    """Generate a macOS mobileconfig XML file from MDM config.
+
+    Args:
+        config: MDM configuration dict
+        profile_identifier: Unique identifier for the profile (used in bundle ID)
+        profile_display_name: Human-readable profile name
+
+    Returns:
+        XML string for the mobileconfig file
+    """
+    payload_uuid = str(uuid.uuid4()).upper()
+    deployment_uuid = config.get(
+        "deploymentOrganizationUuid", str(uuid.uuid4()).upper()
+    )
+
+    # Build policy keys
+    policy_keys = []
+
+    # Bootstrap configuration
+    if config.get("bootstrapEnabled"):
+        policy_keys.append(
+            "				<key>bootstrapEnabled</key>\n				<true/>"
+        )
+        if config.get("bootstrapUrl"):
+            policy_keys.append(
+                f"				<key>bootstrapUrl</key>\n				<string>{config['bootstrapUrl']}</string>"
+            )
+        if config.get("bootstrapOidc"):
+            oidc_json = (
+                json.dumps(config["bootstrapOidc"])
+                if isinstance(config["bootstrapOidc"], dict)
+                else config["bootstrapOidc"]
+            )
+            policy_keys.append(
+                f"				<key>bootstrapOidc</key>\n				<string>{oidc_json}</string>"
+            )
+
+    # Disabled tools
+    if config.get("disabledBuiltinTools"):
+        policy_keys.append(
+            f"				<key>disabledBuiltinTools</key>\n				<string>{json.dumps(config['disabledBuiltinTools'])}</string>"
+        )
+
+    # Tool policies
+    if config.get("builtinToolPolicy"):
+        policy_keys.append(
+            f"				<key>builtinToolPolicy</key>\n				<string>{json.dumps(config['builtinToolPolicy'])}</string>"
+        )
+
+    # Feature toggles (only add non-default values)
+    if "isLocalDevMcpEnabled" in config and not config["isLocalDevMcpEnabled"]:
+        policy_keys.append(
+            "				<key>isLocalDevMcpEnabled</key>\n				<false/>"
+        )
+
+    if (
+        "isDesktopExtensionEnabled" in config
+        and not config["isDesktopExtensionEnabled"]
+    ):
+        policy_keys.append(
+            "				<key>isDesktopExtensionEnabled</key>\n				<false/>"
+        )
+
+    if config.get("isDesktopExtensionSignatureRequired"):
+        policy_keys.append(
+            "				<key>isDesktopExtensionSignatureRequired</key>\n				<true/>"
+        )
+
+    if "coworkTabEnabled" in config and not config["coworkTabEnabled"]:
+        policy_keys.append(
+            "				<key>coworkTabEnabled</key>\n				<false/>"
+        )
+
+    if config.get("disableBundledSkills"):
+        policy_keys.append(
+            "				<key>disableBundledSkills</key>\n				<true/>"
+        )
+
+    if config.get("disableDeploymentModeChooser"):
+        policy_keys.append(
+            "				<key>disableDeploymentModeChooser</key>\n				<true/>"
+        )
+
+    # Workspace and network restrictions
+    if config.get("allowedWorkspaceFolders"):
+        policy_keys.append(
+            f"				<key>allowedWorkspaceFolders</key>\n				<string>{json.dumps(config['allowedWorkspaceFolders'])}</string>"
+        )
+
+    if config.get("coworkEgressAllowedHosts"):
+        policy_keys.append(
+            f"				<key>coworkEgressAllowedHosts</key>\n				<string>{json.dumps(config['coworkEgressAllowedHosts'])}</string>"
+        )
+
+    # MCP servers
+    if config.get("managedMcpServers"):
+        policy_keys.append(
+            f"				<key>managedMcpServers</key>\n				<string>{json.dumps(config['managedMcpServers'])}</string>"
+        )
+
+    # OTEL
+    if config.get("otlpEndpoint"):
+        policy_keys.append(
+            f"				<key>otlpEndpoint</key>\n				<string>{config['otlpEndpoint']}</string>"
+        )
+        if config.get("otlpProtocol"):
+            policy_keys.append(
+                f"				<key>otlpProtocol</key>\n				<string>{config['otlpProtocol']}</string>"
+            )
+        if config.get("otlpHeaders"):
+            headers_json = (
+                json.dumps(config["otlpHeaders"])
+                if isinstance(config["otlpHeaders"], dict)
+                else config["otlpHeaders"]
+            )
+            policy_keys.append(
+                f"				<key>otlpHeaders</key>\n				<string>{headers_json}</string>"
+            )
+
+    policy_keys_str = "\n".join(policy_keys)
+
+    # Build inference models JSON
+    inference_models_json = json.dumps(config.get("inferenceModels", []))
+
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>PayloadContent</key>
+		<array>
+			<dict>
+				<key>PayloadType</key>
+				<string>com.anthropic.claudefordesktop</string>
+				<key>PayloadIdentifier</key>
+				<string>com.anthropic.claudefordesktop.settings</string>
+				<key>PayloadUUID</key>
+				<string>{payload_uuid}</string>
+				<key>PayloadVersion</key>
+				<integer>1</integer>
+				<key>PayloadDisplayName</key>
+				<string>Claude Desktop</string>
+				<key>inferenceProvider</key>
+				<string>{config.get("inferenceProvider", "bedrock")}</string>
+				<key>inferenceCredentialKind</key>
+				<string>{config.get("inferenceCredentialKind", "interactive")}</string>
+				<key>inferenceBedrockRegion</key>
+				<string>{config.get("inferenceBedrockRegion", "us-east-1")}</string>
+				<key>inferenceBedrockSsoStartUrl</key>
+				<string>{config.get("inferenceBedrockSsoStartUrl", "")}</string>
+				<key>inferenceBedrockSsoRegion</key>
+				<string>{config.get("inferenceBedrockSsoRegion", "us-east-1")}</string>
+				<key>inferenceBedrockSsoAccountId</key>
+				<string>{config.get("inferenceBedrockSsoAccountId", "")}</string>
+				<key>inferenceBedrockSsoRoleName</key>
+				<string>{config.get("inferenceBedrockSsoRoleName", "")}</string>
+				<key>inferenceModels</key>
+				<string>{inference_models_json}</string>
+				<key>deploymentOrganizationUuid</key>
+				<string>{deployment_uuid}</string>
+{policy_keys_str}
+			</dict>
+		</array>
+		<key>PayloadDisplayName</key>
+		<string>{profile_display_name}</string>
+		<key>PayloadIdentifier</key>
+		<string>com.anthropic.claudefordesktop.{profile_identifier}</string>
+		<key>PayloadType</key>
+		<string>Configuration</string>
+		<key>PayloadUUID</key>
+		<string>{deployment_uuid}</string>
+		<key>PayloadVersion</key>
+		<integer>1</integer>
+		<key>PayloadScope</key>
+		<string>User</string>
+	</dict>
+</plist>"""
+
+
+# =============================================================================
+# Windows Registry Generator
+# =============================================================================
+
+
+def generate_reg_file(
+    config: dict[str, Any],
+    profile_identifier: str = "default",
+) -> str:
+    """Generate a Windows registry file from MDM config.
+
+    The output is UTF-16 LE encoded with BOM as required by Windows regedit.
+
+    Args:
+        config: MDM configuration dict
+        profile_identifier: Used in comments only
+
+    Returns:
+        Registry file content string (encode with UTF-16 LE before writing)
+    """
+
+    # Escape quotes for registry string values
+    def escape_reg(s: str) -> str:
+        return s.replace("\\", "\\\\").replace('"', '\\"')
+
+    inference_models_json = escape_reg(json.dumps(config.get("inferenceModels", [])))
+
+    lines = [
+        "Windows Registry Editor Version 5.00",
+        "",
+        f"; Claude Desktop MDM Configuration - {profile_identifier}",
+        "",
+        "[HKEY_CURRENT_USER\\Software\\Policies\\Anthropic\\Claude]",
+        f'"inferenceProvider"="{config.get("inferenceProvider", "bedrock")}"',
+        f'"inferenceCredentialKind"="{config.get("inferenceCredentialKind", "interactive")}"',
+        f'"inferenceBedrockRegion"="{config.get("inferenceBedrockRegion", "us-east-1")}"',
+        f'"inferenceBedrockSsoStartUrl"="{config.get("inferenceBedrockSsoStartUrl", "")}"',
+        f'"inferenceBedrockSsoRegion"="{config.get("inferenceBedrockSsoRegion", "us-east-1")}"',
+        f'"inferenceBedrockSsoAccountId"="{config.get("inferenceBedrockSsoAccountId", "")}"',
+        f'"inferenceBedrockSsoRoleName"="{config.get("inferenceBedrockSsoRoleName", "")}"',
+        f'"inferenceModels"="{inference_models_json}"',
+        f'"deploymentOrganizationUuid"="{config.get("deploymentOrganizationUuid", "")}"',
+    ]
+
+    # Bootstrap configuration
+    if config.get("bootstrapEnabled"):
+        lines.append('"bootstrapEnabled"=dword:00000001')
+        if config.get("bootstrapUrl"):
+            lines.append(f'"bootstrapUrl"="{config["bootstrapUrl"]}"')
+        if config.get("bootstrapOidc"):
+            oidc_json = (
+                json.dumps(config["bootstrapOidc"])
+                if isinstance(config["bootstrapOidc"], dict)
+                else config["bootstrapOidc"]
+            )
+            lines.append(f'"bootstrapOidc"="{escape_reg(oidc_json)}"')
+
+    # Disabled tools
+    if config.get("disabledBuiltinTools"):
+        lines.append(
+            f'"disabledBuiltinTools"="{escape_reg(json.dumps(config["disabledBuiltinTools"]))}"'
+        )
+
+    # Tool policies
+    if config.get("builtinToolPolicy"):
+        lines.append(
+            f'"builtinToolPolicy"="{escape_reg(json.dumps(config["builtinToolPolicy"]))}"'
+        )
+
+    # Feature toggles
+    if "isLocalDevMcpEnabled" in config:
+        val = "1" if config["isLocalDevMcpEnabled"] else "0"
+        lines.append(f'"isLocalDevMcpEnabled"=dword:0000000{val}')
+
+    if "isDesktopExtensionEnabled" in config:
+        val = "1" if config["isDesktopExtensionEnabled"] else "0"
+        lines.append(f'"isDesktopExtensionEnabled"=dword:0000000{val}')
+
+    if config.get("isDesktopExtensionSignatureRequired"):
+        lines.append('"isDesktopExtensionSignatureRequired"=dword:00000001')
+
+    if "coworkTabEnabled" in config:
+        val = "1" if config["coworkTabEnabled"] else "0"
+        lines.append(f'"coworkTabEnabled"=dword:0000000{val}')
+
+    if config.get("disableBundledSkills"):
+        lines.append('"disableBundledSkills"=dword:00000001')
+
+    if config.get("disableDeploymentModeChooser"):
+        lines.append('"disableDeploymentModeChooser"=dword:00000001')
+
+    # Workspace and network restrictions
+    if config.get("allowedWorkspaceFolders"):
+        lines.append(
+            f'"allowedWorkspaceFolders"="{escape_reg(json.dumps(config["allowedWorkspaceFolders"]))}"'
+        )
+
+    if config.get("coworkEgressAllowedHosts"):
+        lines.append(
+            f'"coworkEgressAllowedHosts"="{escape_reg(json.dumps(config["coworkEgressAllowedHosts"]))}"'
+        )
+
+    # MCP servers
+    if config.get("managedMcpServers"):
+        lines.append(
+            f'"managedMcpServers"="{escape_reg(json.dumps(config["managedMcpServers"]))}"'
+        )
+
+    # OTEL
+    if config.get("otlpEndpoint"):
+        lines.append(f'"otlpEndpoint"="{config["otlpEndpoint"]}"')
+        if config.get("otlpProtocol"):
+            lines.append(f'"otlpProtocol"="{config["otlpProtocol"]}"')
+        if config.get("otlpHeaders"):
+            headers_json = (
+                json.dumps(config["otlpHeaders"])
+                if isinstance(config["otlpHeaders"], dict)
+                else config["otlpHeaders"]
+            )
+            lines.append(f'"otlpHeaders"="{escape_reg(headers_json)}"')
+
+    lines.append("")  # Trailing newline
+    return "\r\n".join(lines)
+
+
+# =============================================================================
+# JSON Config Generator
+# =============================================================================
+
+
+def generate_json_config(config: dict[str, Any]) -> str:
+    """Generate a JSON configuration file from MDM config.
+
+    This is the raw config that can be used for manual setup or
+    served by the bootstrap API.
+
+    Args:
+        config: MDM configuration dict
+
+    Returns:
+        Pretty-printed JSON string
+    """
+    return json.dumps(config, indent=2)

--- a/source/tests/cli/commands/test_admin_console.py
+++ b/source/tests/cli/commands/test_admin_console.py
@@ -1,0 +1,242 @@
+# ABOUTME: Unit tests for the admin-console Lambda handler
+# ABOUTME: Tests ALB OIDC identity extraction, IDC admin authorization, and API routing
+
+"""Tests for the admin_console Lambda handler.
+
+Auth model under test: the ALB's authenticate-oidc listener action has
+already validated the caller's JWT before invoking this Lambda (see
+admin-console.yaml's AdminListenerRule) — the Lambda only decodes the
+already-validated x-amzn-oidc-data header for identity, then does a SEPARATE
+live IAM Identity Center group lookup to authorize access to /admin*.
+"""
+
+import base64
+import importlib.util
+import json
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+_LAMBDA_DIR = os.path.abspath(
+    os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "..",
+        "..",
+        "deployment",
+        "infrastructure",
+        "lambda-functions",
+        "admin_console",
+    )
+)
+
+
+def _oidc_data_header(email: str) -> str:
+    """Build a fake (unsigned) x-amzn-oidc-data value — signature verification
+    is the ALB's job, not this Lambda's, so tests don't need a real JWT."""
+    header = base64.b64encode(b"{}").decode().rstrip("=")
+    payload = base64.b64encode(json.dumps({"email": email}).encode()).decode().rstrip("=")
+    signature = base64.b64encode(b"fake").decode().rstrip("=")
+    return f"{header}.{payload}.{signature}"
+
+
+@pytest.fixture
+def handler(monkeypatch):
+    """Import the admin_console Lambda module fresh for each test."""
+    monkeypatch.setenv("S3_BUCKET_NAME", "test-bucket")
+    monkeypatch.setenv("IDC_INSTANCE_ARN", "arn:aws:sso:::instance/ssoins-test")
+    monkeypatch.setenv("ADMIN_GROUP", "Claude-Code-Admins")
+    monkeypatch.setenv("BASE_URL", "https://downloads.example.com")
+    monkeypatch.setenv("AWS_REGION", "us-east-1")
+
+    if "index" in sys.modules:
+        del sys.modules["index"]
+    if _LAMBDA_DIR not in sys.path:
+        sys.path.insert(0, _LAMBDA_DIR)
+
+    spec = importlib.util.spec_from_file_location("index", os.path.join(_LAMBDA_DIR, "index.py"))
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["index"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestExtractUserEmail:
+    def test_no_header_returns_empty(self, handler):
+        assert handler.extract_user_email({}) == ""
+
+    def test_valid_header_returns_email(self, handler):
+        headers = {"x-amzn-oidc-data": _oidc_data_header("alice@example.com")}
+        assert handler.extract_user_email(headers) == "alice@example.com"
+
+    def test_malformed_header_returns_empty(self, handler):
+        assert handler.extract_user_email({"x-amzn-oidc-data": "not.a.jwt.at.all"}) == ""
+
+
+class TestGroupNameToConfigKey:
+    def test_strips_prefix_and_pluralization(self, handler):
+        assert handler.group_name_to_config_key("Claude-Code-Developers") == "developer"
+
+    def test_short_name_not_singularized(self, handler):
+        # len <= 3 after stripping trailing 's' guard avoids mangling short names
+        assert handler.group_name_to_config_key("Claude-Ops") == "ops"
+
+
+class TestLambdaHandlerAuth:
+    def test_missing_oidc_header_returns_401(self, handler):
+        event = {"path": "/admin", "httpMethod": "GET", "headers": {}}
+        response = handler.lambda_handler(event, None)
+        assert response["statusCode"] == 401
+
+    @patch("index.get_user_idc_groups", return_value=["Claude-Code-Developers"])
+    def test_non_admin_group_returns_403(self, mock_groups, handler):
+        event = {
+            "path": "/admin",
+            "httpMethod": "GET",
+            "headers": {"x-amzn-oidc-data": _oidc_data_header("dev@example.com")},
+        }
+        response = handler.lambda_handler(event, None)
+        assert response["statusCode"] == 403
+
+    @patch("index.get_user_idc_groups", return_value=["Claude-Code-Admins"])
+    def test_admin_group_case_insensitive_match(self, mock_groups, handler):
+        """ADMIN_GROUP comparison is case-insensitive, matching the CDK original."""
+        event = {
+            "path": "/admin/api/groups",
+            "httpMethod": "GET",
+            "headers": {"x-amzn-oidc-data": _oidc_data_header("admin@example.com")},
+        }
+        with patch("index.sso_admin_client") as mock_sso, patch("index.identity_store_client"):
+            mock_sso.list_instances.return_value = {"Instances": [{"IdentityStoreId": "d-1234567890"}]}
+            mock_sso.get_paginator.return_value.paginate.return_value = [{"Groups": []}]
+            response = handler.lambda_handler(event, None)
+        assert response["statusCode"] == 200
+
+    @patch("index.get_user_idc_groups", return_value=["Claude-Code-Admins"])
+    def test_post_without_origin_header_rejected(self, mock_groups, handler):
+        """CSRF defense-in-depth: admin POST requests require a matching Origin header."""
+        event = {
+            "path": "/admin/api/config",
+            "httpMethod": "POST",
+            "headers": {"x-amzn-oidc-data": _oidc_data_header("admin@example.com")},
+            "body": "{}",
+        }
+        response = handler.lambda_handler(event, None)
+        assert response["statusCode"] == 403
+
+    @patch("index.get_user_idc_groups", return_value=["Claude-Code-Admins"])
+    def test_post_with_matching_origin_allowed(self, mock_groups, handler):
+        event = {
+            "path": "/admin/api/config",
+            "httpMethod": "POST",
+            "headers": {
+                "x-amzn-oidc-data": _oidc_data_header("admin@example.com"),
+                "origin": "https://downloads.example.com",
+            },
+            "body": json.dumps({"mappings": []}),
+        }
+        with patch("index.s3_client") as mock_s3:
+            response = handler.lambda_handler(event, None)
+            mock_s3.put_object.assert_called_once()
+        assert response["statusCode"] == 200
+
+    @patch("index.get_user_idc_groups", return_value=["Claude-Code-Admins"])
+    def test_unknown_admin_path_returns_404(self, mock_groups, handler):
+        event = {
+            "path": "/admin/api/does-not-exist",
+            "httpMethod": "GET",
+            "headers": {"x-amzn-oidc-data": _oidc_data_header("admin@example.com")},
+        }
+        response = handler.lambda_handler(event, None)
+        assert response["statusCode"] == 404
+
+
+class TestApiListModels:
+    def test_excludes_deprecated_and_non_claude_models(self, handler):
+        with patch("index.bedrock_client") as mock_bedrock:
+            mock_bedrock.list_inference_profiles.return_value = {
+                "inferenceProfileSummaries": [
+                    {
+                        "inferenceProfileId": "us.anthropic.claude-sonnet-4-6",
+                        "inferenceProfileName": "Claude Sonnet 4.6",
+                        "status": "ACTIVE",
+                    },
+                    {
+                        "inferenceProfileId": "us.anthropic.claude-3-opus-20240229-v1:0",
+                        "inferenceProfileName": "Claude 3 Opus (deprecated)",
+                        "status": "ACTIVE",
+                    },
+                    {
+                        "inferenceProfileId": "us.amazon.titan-text",
+                        "inferenceProfileName": "Titan",
+                        "status": "ACTIVE",
+                    },
+                ]
+            }
+            response = handler.api_list_models()
+        body = json.loads(response["body"])
+        model_ids = [m["modelId"] for m in body["models"]]
+        assert "us.anthropic.claude-sonnet-4-6" in model_ids
+        assert "us.anthropic.claude-3-opus-20240229-v1:0" not in model_ids
+        assert "us.amazon.titan-text" not in model_ids
+
+
+class TestAdminConfigStorage:
+    def test_load_admin_config_defaults_when_missing(self, handler):
+        with patch("index.s3_client") as mock_s3:
+            mock_s3.get_object.side_effect = Exception("NoSuchKey")
+            config = handler.load_admin_config()
+        assert config == {"mappings": []}
+
+    def test_save_admin_config_writes_expected_key(self, handler):
+        with patch("index.s3_client") as mock_s3:
+            handler.save_admin_config({"mappings": [{"groupName": "x"}]})
+            mock_s3.put_object.assert_called_once()
+            call_kwargs = mock_s3.put_object.call_args.kwargs
+            assert call_kwargs["Key"] == "admin/config.json"
+            assert call_kwargs["Bucket"] == "test-bucket"
+
+
+class TestGenerateMdmConfigs:
+    def test_writes_expected_s3_keys(self, handler):
+        with patch("index.s3_client") as mock_s3:
+            handler.generate_mdm_configs(
+                config_key="developer",
+                idc_start_url="https://d-1234567890.awsapps.com/start",
+                account_id="123456789012",
+                role_name="ClaudeCode-Developers",
+                models_list=[{"modelId": "us.anthropic.claude-sonnet-4-6", "modelName": "Claude Sonnet 4.6"}],
+            )
+        put_calls = mock_s3.put_object.call_args_list
+        written_keys = {c.kwargs["Key"] for c in put_calls}
+        assert written_keys == {
+            "config/developer/default.json",
+            "config/developer/bootstrap.json",
+            "config/developer/Claude.mobileconfig",
+            "config/developer/Claude.reg",
+        }
+
+    def test_bootstrap_config_has_explicit_policy_toggles(self, handler):
+        """Bootstrap responses must set every policy toggle explicitly (omitted
+        keys are treated as unset by Claude Desktop, not inherited from MDM)."""
+        captured = {}
+
+        def _capture_put(**kwargs):
+            if kwargs["Key"] == "config/developer/bootstrap.json":
+                captured["body"] = json.loads(kwargs["Body"])
+
+        with patch("index.s3_client") as mock_s3:
+            mock_s3.put_object.side_effect = _capture_put
+            handler.generate_mdm_configs(
+                config_key="developer",
+                idc_start_url="https://d-1234567890.awsapps.com/start",
+                account_id="123456789012",
+                role_name="ClaudeCode-Developers",
+                models_list=[{"modelId": "us.anthropic.claude-sonnet-4-6", "modelName": "Claude Sonnet 4.6"}],
+            )
+        assert "isLocalDevMcpEnabled" in captured["body"]
+        assert "bootstrapEnabled" in captured["body"]
+        assert captured["body"]["bootstrapUrl"] == "https://downloads.example.com/api/bootstrap"

--- a/source/tests/cli/commands/test_admin_console.py
+++ b/source/tests/cli/commands/test_admin_console.py
@@ -33,6 +33,11 @@ _LAMBDA_DIR = os.path.abspath(
     )
 )
 
+# Add lambda-functions/ parent to path so 'shared' module is importable
+_LAMBDA_FUNCTIONS_DIR = os.path.dirname(_LAMBDA_DIR)
+if _LAMBDA_FUNCTIONS_DIR not in sys.path:
+    sys.path.insert(0, _LAMBDA_FUNCTIONS_DIR)
+
 
 def _oidc_data_header(email: str) -> str:
     """Build a fake (unsigned) x-amzn-oidc-data value — signature verification

--- a/source/tests/e2e/test_cfn_contracts.py
+++ b/source/tests/e2e/test_cfn_contracts.py
@@ -140,6 +140,8 @@ class TestIAMPolicyValidity:
         "cur",
         "es",
         "aoss",
+        "sso",
+        "identitystore",
     }
 
     def _extract_actions(self, template: dict) -> list[str]:


### PR DESCRIPTION
## What this does for users

Gives IDC landing page administrators a **web-based management UI** for controlling Claude Desktop configuration across their organization — no CLI or JSON editing needed.

**User story:** An enterprise admin deploys the IDC landing page, then navigates to `/admin` to configure which models each IAM Identity Center group can access, what tools are enabled, and what command-level permissions apply. Changes propagate automatically to all users via bootstrap polling (~30 min).

## Capabilities

- **Model allowlists per group** — assign different model tiers to different teams
- **Tool policies** — disable or restrict built-in tools (Bash, Editor, etc.)
- **Command permissions** — allow/ask/deny rules for specific commands (e.g. `Bash(git push:*)`)
- **MCP server configuration** — manage managed MCP servers per-group
- **One-click deploy** — push configuration to all groups from the admin UI

## Architecture

- Separate CFN stack (`admin-console.yaml`) — doesn't modify the landing page stack
- Attaches to the same ALB via a `/admin*` listener rule
- Access gated by IDC group membership (admin group only)
- Security: HMAC-SHA256 session cookies, CSRF origin checks, HTML escaping, Secrets Manager-backed signing key
- Config stored in S3 (same bucket as landing page assets)

## Files

- `deployment/infrastructure/admin-console.yaml` — CFN template (498 lines)
- `deployment/infrastructure/lambda-functions/admin_console/index.py` — Lambda handler with embedded admin UI (2404 lines)
- `source/tests/cli/commands/test_admin_console.py` — unit tests

## Lint notes

- cfn-lint: 2 warnings (W1030 Ref pattern, W3002 package hint) — both pre-existing patterns in this repo
- ruff: BLE001 warnings for broad exception catches in Lambda — deliberate resilience pattern for graceful degradation

## Context

Part 2 of decomposed series from PR #751 (@duttaabh's IAM Identity Center Self-Service Portal).

Co-authored-by: duttaabh <duttaabh@users.noreply.github.com>