### PR TITLE
feat(models): add Claude Opus 5 support

### DIFF
--- a/source/claude_code_with_bedrock/models.py
+++ b/source/claude_code_with_bedrock/models.py
@@ -196,6 +196,108 @@ _CLAUDE_MODELS_RAW = {
             },
         },
     },
+    "opus-5": {
+        "name": "Claude Opus 5",
+        "base_model_id": "anthropic.claude-opus-5",
+        "profiles": {
+            "us": {
+                "model_id": "us.anthropic.claude-opus-5",
+                "description": "US CRIS - US and Canada regions",
+                "source_regions": [
+                    "us-east-1",
+                    "us-east-2",
+                    "us-west-1",
+                    "us-west-2",
+                    "ca-central-1",
+                    "ca-west-1",
+                ],
+                "destination_regions": [
+                    "us-east-1",
+                    "us-east-2",
+                    "us-west-2",
+                    "ca-central-1",
+                    "ca-west-1",
+                ],
+            },
+            "global": {
+                "model_id": "global.anthropic.claude-opus-5",
+                "description": "Global CRIS - All commercial AWS regions worldwide",
+                "source_regions": [
+                    # North America
+                    "us-east-1",
+                    "us-east-2",
+                    "us-west-1",
+                    "us-west-2",
+                    "ca-central-1",
+                    "ca-west-1",
+                    # Europe
+                    "eu-central-1",
+                    "eu-central-2",
+                    "eu-north-1",
+                    "eu-south-1",
+                    "eu-south-2",
+                    "eu-west-1",
+                    "eu-west-2",
+                    "eu-west-3",
+                    # Asia Pacific
+                    "ap-east-2",
+                    "ap-northeast-1",
+                    "ap-northeast-2",
+                    "ap-northeast-3",
+                    "ap-south-1",
+                    "ap-south-2",
+                    "ap-southeast-1",
+                    "ap-southeast-2",
+                    "ap-southeast-3",
+                    "ap-southeast-4",
+                    "ap-southeast-5",
+                    "ap-southeast-7",
+                    # Middle East & Africa
+                    "me-south-1",
+                    "me-central-1",
+                    "af-south-1",
+                    "il-central-1",
+                    # South America
+                    "sa-east-1",
+                    # Mexico
+                    "mx-central-1",
+                ],
+                "destination_regions": ["all-commercial"],
+            },
+            "eu": {
+                "model_id": "eu.anthropic.claude-opus-5",
+                "description": "EU CRIS - European regions",
+                "source_regions": [
+                    "eu-central-1",
+                    "eu-north-1",
+                    "eu-south-1",
+                    "eu-south-2",
+                    "eu-west-1",
+                    "eu-west-3",
+                ],
+                "destination_regions": [
+                    "eu-central-1",
+                    "eu-north-1",
+                    "eu-south-1",
+                    "eu-south-2",
+                    "eu-west-1",
+                    "eu-west-3",
+                ],
+            },
+        },
+    },
+    "opus-5-govcloud": {
+        "name": "Claude Opus 5 (GovCloud)",
+        "base_model_id": "anthropic.claude-opus-5",
+        "profiles": {
+            "us-gov": {
+                "model_id": "us-gov.anthropic.claude-opus-5",
+                "description": "US GovCloud regions",
+                "source_regions": ["us-gov-west-1", "us-gov-east-1"],
+                "destination_regions": ["us-gov-west-1", "us-gov-east-1"],
+            },
+        },
+    },
     "opus-4-8": {
         "name": "Claude Opus 4.8",
         "base_model_id": "anthropic.claude-opus-4-8",
@@ -1698,7 +1800,17 @@ MODEL_TIER_PREFERENCES = {
         "sonnet-3-7",
         "sonnet-3-7-govcloud",
     ],
-    "opus": ["opus-4-8", "opus-4-8-govcloud", "opus-4-7", "opus-4-6", "opus-4-5", "opus-4-1", "opus-4"],
+    "opus": [
+        "opus-5",
+        "opus-5-govcloud",
+        "opus-4-8",
+        "opus-4-8-govcloud",
+        "opus-4-7",
+        "opus-4-6",
+        "opus-4-5",
+        "opus-4-1",
+        "opus-4",
+    ],
     "fable": ["fable-5"],
 }
 
@@ -1784,6 +1896,8 @@ def resolve_model_for_tier(tier: str, cris_prefix: str) -> str | None:
         # Search all models (newest first) for ANY model with this prefix
         all_model_keys = [
             "sonnet-5",
+            "opus-5",
+            "opus-5-govcloud",
             "opus-4-8",
             "opus-4-8-govcloud",
             "opus-4-7",

--- a/source/tests/test_govcloud_model_selection.py
+++ b/source/tests/test_govcloud_model_selection.py
@@ -65,7 +65,7 @@ class TestWizardPartitionFiltering:
 
 class TestUsGovTierResolution:
     def test_opus_tier_resolves_govcloud_opus(self):
-        assert resolve_model_for_tier("opus", "us-gov") == "us-gov.anthropic.claude-opus-4-8"
+        assert resolve_model_for_tier("opus", "us-gov") == "us-gov.anthropic.claude-opus-5"
 
     def test_sonnet_tier_resolves_govcloud_sonnet(self):
         assert resolve_model_for_tier("sonnet", "us-gov") == "us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0"
@@ -87,9 +87,10 @@ class TestUsGovTierResolution:
             )
 
     def test_commercial_tiers_unchanged_by_govcloud_entries(self):
-        assert resolve_model_for_tier("opus", "us") == "us.anthropic.claude-opus-4-8"
+        assert resolve_model_for_tier("opus", "us") == "us.anthropic.claude-opus-5"
         assert resolve_model_for_tier("sonnet", "us").startswith("us.anthropic.claude-sonnet-5")
 
     def test_alias_for_govcloud_model_ids(self):
+        assert get_claude_code_alias("us-gov.anthropic.claude-opus-5") == "opus"
         assert get_claude_code_alias("us-gov.anthropic.claude-opus-4-8") == "opus"
         assert get_claude_code_alias("us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0") == "sonnet"

--- a/source/tests/test_models.py
+++ b/source/tests/test_models.py
@@ -39,6 +39,8 @@ class TestModelConfiguration:
             "fable-5",
             "sonnet-5",
             "sonnet-4-6",
+            "opus-5",
+            "opus-5-govcloud",
             "opus-4-8",
             "opus-4-8-govcloud",
             "opus-4-7",


### PR DESCRIPTION
## Summary

Adds Claude Opus 5 model configuration to the model catalog. Opus 5 launched July 24, 2026 on Amazon Bedrock.

## Changes

- Added `opus-5` entry with us, global, and eu CRIS profiles
- Added `opus-5-govcloud` entry with us-gov profile
- Updated `MODEL_TIER_PREFERENCES["opus"]` — Opus 5 is now the default
- Updated `all_model_keys` fallback list for data-residency resolution
- Updated test expected model set

## Model Details

- **Model ID:** `anthropic.claude-opus-5`
- **Context:** 1M tokens input, 128K output
- **Reasoning:** Adaptive thinking (on by default)
- **CRIS profiles:** us, global, eu, us-gov

## Risk

Very low — purely additive data change. No logic changes. Existing models unaffected.