### PR TITLE
fix(models): add au CRIS for Opus 5, remove unconfirmed GovCloud

### DIFF
--- a/source/claude_code_with_bedrock/models.py
+++ b/source/claude_code_with_bedrock/models.py
@@ -284,17 +284,11 @@ _CLAUDE_MODELS_RAW = {
                     "eu-west-3",
                 ],
             },
-        },
-    },
-    "opus-5-govcloud": {
-        "name": "Claude Opus 5 (GovCloud)",
-        "base_model_id": "anthropic.claude-opus-5",
-        "profiles": {
-            "us-gov": {
-                "model_id": "us-gov.anthropic.claude-opus-5",
-                "description": "US GovCloud regions",
-                "source_regions": ["us-gov-west-1", "us-gov-east-1"],
-                "destination_regions": ["us-gov-west-1", "us-gov-east-1"],
+            "au": {
+                "model_id": "au.anthropic.claude-opus-5",
+                "description": "AU CRIS - Australia regions",
+                "source_regions": ["ap-southeast-2", "ap-southeast-4"],
+                "destination_regions": ["ap-southeast-2", "ap-southeast-4"],
             },
         },
     },
@@ -1802,7 +1796,6 @@ MODEL_TIER_PREFERENCES = {
     ],
     "opus": [
         "opus-5",
-        "opus-5-govcloud",
         "opus-4-8",
         "opus-4-8-govcloud",
         "opus-4-7",
@@ -1897,7 +1890,6 @@ def resolve_model_for_tier(tier: str, cris_prefix: str) -> str | None:
         all_model_keys = [
             "sonnet-5",
             "opus-5",
-            "opus-5-govcloud",
             "opus-4-8",
             "opus-4-8-govcloud",
             "opus-4-7",

--- a/source/tests/test_govcloud_model_selection.py
+++ b/source/tests/test_govcloud_model_selection.py
@@ -65,7 +65,7 @@ class TestWizardPartitionFiltering:
 
 class TestUsGovTierResolution:
     def test_opus_tier_resolves_govcloud_opus(self):
-        assert resolve_model_for_tier("opus", "us-gov") == "us-gov.anthropic.claude-opus-5"
+        assert resolve_model_for_tier("opus", "us-gov") == "us-gov.anthropic.claude-opus-4-8"
 
     def test_sonnet_tier_resolves_govcloud_sonnet(self):
         assert resolve_model_for_tier("sonnet", "us-gov") == "us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0"
@@ -91,6 +91,5 @@ class TestUsGovTierResolution:
         assert resolve_model_for_tier("sonnet", "us").startswith("us.anthropic.claude-sonnet-5")
 
     def test_alias_for_govcloud_model_ids(self):
-        assert get_claude_code_alias("us-gov.anthropic.claude-opus-5") == "opus"
         assert get_claude_code_alias("us-gov.anthropic.claude-opus-4-8") == "opus"
         assert get_claude_code_alias("us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0") == "sonnet"

--- a/source/tests/test_models.py
+++ b/source/tests/test_models.py
@@ -40,7 +40,6 @@ class TestModelConfiguration:
             "sonnet-5",
             "sonnet-4-6",
             "opus-5",
-            "opus-5-govcloud",
             "opus-4-8",
             "opus-4-8-govcloud",
             "opus-4-7",


### PR DESCRIPTION
Follow-up to #808.

Per the [official AWS model card](https://docs.aws.amazon.com/bedrock/latest/userguide/model-card-anthropic-claude-opus-5.html), Opus 5 geo inference IDs are:
- `us.anthropic.claude-opus-5` ✅
- `eu.anthropic.claude-opus-5` ✅
- `au.anthropic.claude-opus-5` ✅ (was missing)
- `global.anthropic.claude-opus-5` ✅

GovCloud (`us-gov.anthropic.claude-opus-5`) is **not listed** in the model card. Removed the unconfirmed entry; GovCloud opus tier correctly falls back to `opus-4-8-govcloud`.

## Changes
- Added `au` CRIS profile (ap-southeast-2, ap-southeast-4)
- Removed `opus-5-govcloud` entry
- Updated MODEL_TIER_PREFERENCES and fallback list
- Updated tests