### PR TITLE
docs: update QUICK_START, README, and COWORK_3P for IDC distribution (#751 part 6/6)

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -521,13 +521,22 @@ How to deliver the installer package to end users:
 | Option | How it works | Best for |
 |---|---|---|
 | **Presigned S3 URLs** | `ccwb distribute` uploads to S3 and generates a time-limited link (48h default) you share via Slack/email | Any team size, no extra infrastructure |
-| **Authenticated Landing Page** | Self-service web portal — users log in with SSO and download the right binary for their OS | Large orgs needing compliance, audit trail, self-service |
+| **Authenticated Landing Page** | Self-service web portal — users log in with an external IdP (Okta/Azure/Auth0/Cognito) and download the right binary for their OS | Large orgs needing compliance, audit trail, self-service |
+| **Self-Service Portal (IAM Identity Center)** | Same ALB + Lambda + S3 CloudFormation stack as the Landing Page (`AuthType=idc`), with native IAM Identity Center SSO via a Cognito SAML bridge. Add an optional separate admin console stack for model/policy/MCP server management and dynamic Claude Desktop config updates via bootstrap. | Orgs already using IAM Identity Center for workforce SSO |
 | **Disabled** | You distribute the `dist/` folder manually (zip + email, shared drive, artifact repo) | Simple pilots, internal testing |
 
 If you choose **Landing Page**, the wizard asks for:
 - IdP provider for the web portal (can be different from your developer IdP)
 - Custom domain for the download portal (e.g. `downloads.company.com`)
 - Route53 hosted zone
+
+The **Self-Service Portal (IAM Identity Center)** is the same **Landing Page** distribution with this profile's `auth_type` set to `idc` — there's no separate distribution choice. When `auth_type` is `idc` and you pick the Landing Page, the wizard asks for:
+- Your IAM Identity Center instance ARN (auto-detected when possible)
+- Your admin group name (default: `Claude-Code-Admins`) — members of this group get access to the optional admin console's `/admin` path
+- ALB scheme (`internal` by default, for SSM-tunnel testing; `internet-facing` for production)
+- The SAML metadata URL (can be left blank on first deploy and set later via `ccwb configure-saml`)
+
+This deploys the same CloudFormation stack as the other landing-page types (with `AuthType=idc`) when you run `ccwb deploy distribution`. After deploying, you'll manually create a Custom SAML 2.0 application in IAM Identity Center, then run `poetry run ccwb configure-saml <metadata-url>` to wire it into Cognito. Optionally run `poetry run ccwb deploy admin-console` afterward to add the `/admin` console. See [assets/docs/distribution/idc-self-service-portal.md](assets/docs/distribution/idc-self-service-portal.md) for the full walkthrough.
 
 ---
 
@@ -731,7 +740,7 @@ This will:
 
 ### Step 6: Distribute Packages to Users
 
-You have three options for sharing packages with users. The distribution method is configured during `ccwb init` (Step 2).
+You have four options for sharing packages with users. The distribution method is configured during `ccwb init` (Step 2).
 
 #### Option 1: Manual Sharing
 
@@ -766,7 +775,7 @@ Generates presigned URLs (default 48-hour expiry) that you share with users via 
 
 #### Option 3: Authenticated Landing Page
 
-Self-service portal with IdP authentication:
+Self-service portal with external IdP authentication:
 
 ```bash
 # Deploy landing page infrastructure (if not done during Step 3)
@@ -781,6 +790,24 @@ Users visit your landing page URL, authenticate with SSO, and download packages 
 **Best for:** Self-service portal with compliance and audit requirements
 
 **Setup:** Select "landing-page" distribution type during `ccwb init` (Step 2), then deploy distribution infrastructure
+
+#### Option 4: Self-Service Portal (IAM Identity Center)
+
+Self-service portal with native IAM Identity Center SSO and an optional admin console for managing models, policies, and MCP servers:
+
+```bash
+# Deploy the distribution stack (if not done during Step 3)
+poetry run ccwb deploy distribution
+
+# Optional: deploy the admin console (separate stack, attaches /admin to the same ALB)
+poetry run ccwb deploy admin-console
+```
+
+Users visit the portal's landing page URL, sign in with IAM Identity Center, and download configs for their platform. Configs also self-update automatically via the bootstrap API — no re-distribution needed for policy or model changes.
+
+**Best for:** Organizations already using IAM Identity Center for workforce SSO who want a persistent admin console instead of redeploying for every config change
+
+**Setup:** With this profile's `auth_type` set to `idc`, select the **Authenticated Landing Page** distribution method during `ccwb init` (Step 2) — the wizard then configures it as the IAM Identity Center portal (SAML). Deploy distribution infrastructure, then create a Custom SAML 2.0 application in IAM Identity Center and run `poetry run ccwb configure-saml <metadata-url>` to complete the Cognito federation. See [assets/docs/distribution/idc-self-service-portal.md](assets/docs/distribution/idc-self-service-portal.md) for the full walkthrough.
 
 See [Distribution Comparison](assets/docs/distribution/comparison.md) for detailed feature comparison and setup guides.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,42 @@
 # Guidance for Claude Code and Cowork on Amazon Bedrock
 
-[![Stable Release](https://img.shields.io/github/v/release/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock?style=for-the-badge&label=stable)](https://github.com/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock/releases/latest)
+[![Stable Release](https://img.shields.io/github/v/release/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock?style=for-the-badge&label=stable&filter=v*.*.*)](https://github.com/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock/releases/latest)
 [![Beta Release](https://img.shields.io/github/v/release/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock?style=for-the-badge&include_prereleases&label=beta)](https://github.com/aws-solutions-library-samples/guidance-for-claude-code-with-amazon-bedrock/tree/beta)
 
 This guidance enables enterprise deployment of Claude Code and Claude Cowork on Amazon Bedrock across command-line (CLI) and desktop surfaces — with secure single sign-on (SSO), usage monitoring, and cost controls.
+
+## ℹ️ Maintenance Mode
+
+**This repository is now in maintenance mode on a best-efforts basis.** It remains available as a reference implementation. New contributions without GitHub issues approved by maintainers will not be accepted.
+
+For new deployments of Claude Apps on Amazon Bedrock, we recommend [Claude Apps Gateway](https://code.claude.com/docs/en/claude-apps-gateway) — a self-hosted service that sits between your Claude clients and your model provider. It is included in the `claude` binary, so the same executable that runs Claude Code also runs the gateway. It provides:
+
+- Corporate SSO (OIDC) with centralized policy enforcement
+- Per-user cost attribution and spend caps
+- Managed settings delivery
+- OTLP telemetry routing
+- Single stateless container deployment
+
+**👉 [Get started with Claude Apps Gateway on AWS](https://github.com/aws-samples/anthropic-on-aws/tree/main/claude-apps-gateway)**
+
+**💻 [Deploying both Claude Code CLI and Claude Desktop? Add the Bootstrap Server](https://github.com/aws-samples/anthropic-on-aws/tree/main/claude-apps-gateway-bootstrap)** — delivers managed settings, organization plugins, and per-user configuration to Claude Desktop at sign-in.
+
+<details>
+<summary><strong>Areas where this reference solution complements Claude Apps Gateway today</strong></summary>
+
+The following capabilities are not yet available in Claude Apps Gateway but may appear on its future roadmap. This solution provides reference patterns in the meantime:
+
+- **Claude Desktop** — spend controls and model discovery may be functional, however configuration and managed settings delivery requires MDM or per-user bootstrap server.
+- **AWS IAM Identity Center** — native IDC authentication without external OIDC
+- **Historical usage analytics** — S3 + Athena for long-term usage queries
+- **Multi-platform packaging** — automated installers for Windows, macOS, Linux (note: Claude Apps Gateway is native to Claude Code and requires no additional client-side packages)
+- **Cost tracking via IAM principal-based cost allocation** — Gateway spend controls are based on cost estimates
+
+As Claude Apps Gateway evolves, check Anthropic's documentation for the latest capabilities.
+
+</details>
+
+---
 
 ## Key Features
 
@@ -13,7 +46,8 @@ This guidance enables enterprise deployment of Claude Code and Claude Cowork on 
 - **Multi-Platform**: Windows, macOS, Linux — Go or Python binaries, pre-built from GitHub Releases
 - **One Deployment, Two Surfaces**: Same infrastructure powers both Claude Code CLI and Claude Desktop (which features Chat, Cowork and Code)
 - **Model Flexibility**: Choose from Opus, Sonnet, Haiku with model aliases (e.g. `opusplan` for Opus planning + Sonnet execution)
-- **Native Desktop Experience**: Deploy and manage Claude Cowork (Claude Desktop) via MDM (Jamf, Intune, Group Policy)
+- **Native Desktop Experience**: Deploy and manage Claude Desktop via MDM (Jamf, Intune, Group Policy)
+- **Dynamic Config Delivery**: Deliver per-user settings and [organization plugins](assets/docs/PLUGINS.md#bootstrap-server-delivery-dynamic) to Claude Desktop at sign-in via a bootstrap server — no MDM re-push needed for config changes
 - **Data Residency**: Select your cross-region inference profile (US, EU, AU) to keep data within your compliance boundary
 - **AWS-Native**: Your data, your AWS account, your compliance controls — no Anthropic licensing required
 
@@ -85,6 +119,7 @@ The architecture is modular — start with authentication, then optionally add [
 | **Quota enforcement** (optional) | Quota check API + DynamoDB policies + per-user/team limits | `ccwb deploy --stack quota` |
 | **Analytics** (optional) | S3 data lake + Athena for historical SQL queries on usage data | `ccwb deploy --stack analytics` |
 | **Distribution** (optional) | S3 presigned URLs or self-service landing page with IdP auth | `ccwb deploy --stack distribution` |
+| **Diagnostics** | Installation health checks + resolved config dump | `ccwb doctor` |
 
 See [Monitoring Guide](assets/docs/MONITORING.md), [Quota Guide](assets/docs/QUOTA_MONITORING.md), [Analytics Guide](assets/docs/ANALYTICS.md), and [Distribution Comparison](assets/docs/distribution/comparison.md) for detailed setup.
 ### Authentication Modes
@@ -139,7 +174,11 @@ flowchart LR
     IDC --> OUT
 ```
 
-The **otel-helper** attaches user identity to telemetry so CloudWatch dashboards can show per-user metrics:
+The **otel-helper** binary attaches per-user identity to telemetry:
+
+- **Header mode** (Claude Code CLI): Called once per OTLP export as a header provider. Returns JSON headers containing user identity (email, team, department) extracted from the cached JWT.
+- **Bootstrap mode** (Claude Desktop, recommended): The [bootstrap server](assets/docs/PLUGINS.md#bootstrap-server-delivery-dynamic) delivers per-user `otlpHeaders` at sign-in. Claude Desktop applies these natively — no proxy or helper needed.
+- **Static MDM** (Claude Desktop, basic): Set `otlpHeaders` in MDM config for device-level identity (not per-user unless you create per-device profiles).
 
 ```mermaid
 flowchart LR
@@ -150,23 +189,23 @@ flowchart LR
 
 ### Usage Monitoring
 
-Both Claude Code (CLI) and Claude Desktop (Cowork) emit OpenTelemetry (OTLP) telemetry. The otel-helper attaches user identity — as a one-shot header provider for Claude Code, or as a local proxy for Claude Desktop — so CloudWatch dashboards show per-user metrics. See [Monitoring Guide](assets/docs/MONITORING.md) for detailed configuration.
+Both Claude Code (CLI) and Claude Desktop emit OpenTelemetry (OTLP) telemetry. For Claude Code, otel-helper provides per-user identity headers. For Claude Desktop, the bootstrap server delivers per-user `otlpHeaders` at sign-in — no local proxy needed. See [Monitoring Guide](assets/docs/MONITORING.md) for detailed configuration.
 
 ```mermaid
 flowchart LR
     CC[Claude Code CLI] -->|OTLP| OH1[otel-helper<br/>header mode]
-    CW[Claude Desktop] -->|OTLP| OH2[otel-helper<br/>proxy mode]
-    OH1 -->|"user identity + Bearer JWT"| COLL[Collector]
-    OH2 -->|"user identity + X-Cowork-Token"| COLL
+    CW[Claude Desktop] -->|OTLP with otlpHeaders| COLL[Collector]
+    OH1 -->|"user identity + Bearer JWT"| COLL
     COLL --> DASH[CloudWatch Dashboards]
 ```
 
-| Surface | How otel-helper is used | Collector mode | Identity in telemetry |
-|---------|------------------------|----------------|----------------------|
-| **Claude Code (CLI)** | Header provider — called once per request, returns JSON headers | Central (ECS/ALB) or Sidecar (local) | User's JWT (email, team, department) |
-| **Claude Desktop (Cowork)** | Local proxy — runs on `localhost:4318`, injects user headers, forwards to collector | Central (ECS/ALB) | Email from IAM ARN (no team/department without OIDC) |
+| Surface | Per-user identity | How | Collector mode |
+|---------|------------------|-----|----------------|
+| **Claude Code (CLI)** | otel-helper (header mode) | Returns identity headers per export | Central or Sidecar |
+| **Claude Desktop (bootstrap)** | Bootstrap server delivers `otlpHeaders` | Per-user from OIDC token at sign-in | Central |
+| **Claude Desktop (static MDM)** | `otlpHeaders` in MDM config | Device-level (not per-user) | Central or Sidecar |
 
-**Local proxy explained:** Claude Desktop doesn't support custom OTLP headers natively. When using a central collector (ECS/ALB), otel-helper runs as a lightweight HTTP proxy on the user's machine. Cowork sends telemetry to `localhost:4318` (configured via MDM), and otel-helper adds user identity headers before forwarding to the remote central collector. This proxy is not needed in sidecar mode, where the local collector reads identity from a cache file directly.
+> **Recommended:** Use the [bootstrap server](assets/docs/PLUGINS.md#bootstrap-server-delivery-dynamic) for per-user Claude Desktop telemetry. It delivers `otlpHeaders` with user identity at sign-in — no local proxy or helper binary needed on the Desktop machine.
 
 **Cost attribution:** Since April 2026, Amazon Bedrock supports [IAM principal cost tracking via CUR 2.0](assets/docs/COST_ATTRIBUTION.md) — per-user costs appear in Cost Explorer automatically from the STS session tags set by credential-process. Note: real-time quota enforcement relies on telemetry emitted from the client rather than actual costs metered by AWS, so figures may differ from CUR.
 
@@ -236,6 +275,7 @@ See [QUICK_START.md](QUICK_START.md#platform-builds) for build configuration.
 
 - [Quick Start Guide](QUICK_START.md) - Step-by-step deployment walkthrough
 - [CLI Reference](assets/docs/CLI_REFERENCE.md) - Complete command reference for the `ccwb` tool
+- [Troubleshooting](assets/docs/TROUBLESHOOTING.md) - Common issues, `ccwb doctor`, and how to file bugs
 - [Workshop: Claude Code on Amazon Bedrock](https://catalog.workshops.aws/claude-code-on-amazon-bedrock/en-US) - Companion hands-on workshop
 - [Claude Code deployment patterns and best practices with Amazon Bedrock](https://aws.amazon.com/blogs/machine-learning/claude-code-deployment-patterns-and-best-practices-with-amazon-bedrock/) - Blog post covering deployment patterns and best practices
 
@@ -243,7 +283,7 @@ See [QUICK_START.md](QUICK_START.md#platform-builds) for build configuration.
 
 - [Architecture Guide](assets/docs/ARCHITECTURE.md) - System architecture and design decisions
 - [Deployment Guide](assets/docs/DEPLOYMENT.md) - Advanced deployment options
-- [Distribution Comparison](assets/docs/distribution/comparison.md) - Presigned URLs vs Landing Page
+- [Distribution Comparison](assets/docs/distribution/comparison.md) - Presigned URLs vs Landing Page vs Self-Service Portal (IAM Identity Center)
 - [Local Testing Guide](assets/docs/LOCAL_TESTING.md) - Testing before deployment
 
 ### Monitoring & Analytics

--- a/assets/docs/COWORK_3P.md
+++ b/assets/docs/COWORK_3P.md
@@ -177,6 +177,7 @@ When Claude Cowork starts a session:
 3. The output is cached for `inferenceCredentialHelperTtlSec` seconds (default: 3500, just under the 1h STS token lifetime)
 4. When the cache expires, Claude Desktop automatically re-runs the helper — **no restart required**
 5. If credentials are rejected mid-session, Claude Desktop re-runs with `CLAUDE_HELPER_CONTEXT=mid-session-refresh` for seamless recovery (20s timeout)
+6. Because this mode also sets `inferenceBedrockProfile` (as an AWS SDK region/metadata fallback, not the active auth path), this solution additionally sets `inferenceCredentialKind` to `helper-script` so Claude Desktop doesn't have to pick between the two — without it, Desktop may prefer the profile instead and authentication fails
 
 The credential-process binary handles the `CLAUDE_HELPER_CONTEXT` environment variable:
 - `interactive` → Full browser-based OIDC authentication
@@ -265,6 +266,8 @@ The full set of MDM configuration keys is documented in the [official Anthropic 
 | `isLocalDevMcpEnabled` | boolean | Permit user-added local MCP servers |
 | `managedMcpServers` | string | JSON array of managed MCP server configs |
 | `disabledBuiltinTools` | string | JSON array of tool names to disable |
+| `builtinToolPolicy` | object | Maps a built-in tool name to `allow`/`ask`/`blocked` (whole-tool policy) |
+| `permissions` | object | Command-level rules with `allow`/`ask`/`deny` arrays (Claude Code syntax, e.g. `Bash(git push:*)`, `Read(./.env)`, or a bare tool name); evaluated deny → ask → allow, first match wins |
 
 ### Telemetry
 
@@ -333,6 +336,55 @@ You can also edit the profile JSON directly at `~/.ccwb/profiles/<name>.json`:
 Custom keys are merged into the generated MDM configuration after the base keys and monitoring configuration, so they can override defaults if needed.
 
 > **Note:** Values should be strings, including for booleans (`"true"`) and arrays (`"[\"item1\"]"`). This matches how MDM systems deliver configuration — all values are stored as strings in the OS preference store.
+
+
+## Web search via AgentCore Gateway
+
+In addition to a self-managed MCP server (such as the `brave-search` example above, which runs locally via `npx` and a third-party API), the solution can provision a **fully managed, AWS-native web search** through an **Amazon Bedrock AgentCore Gateway** with the managed Web Search connector. Queries are served by Amazon's web index and **never leave AWS** — no third-party search API or outbound search credentials are involved.
+
+When enabled, `ccwb package` (and `ccwb cowork generate`) automatically inject a `managedMcpServers` entry named **`agentcore-websearch`** into the generated MDM config — you do **not** add it by hand.
+
+### Enabling it
+
+1. **`ccwb init`** — answer *yes* to the web search question (web search is opt-in, default off).
+2. **`ccwb deploy websearch`** — deploys the AgentCore Gateway + Web Search connector, reusing your existing identity provider for inbound authorization. The gateway endpoint is saved to your profile.
+3. **`ccwb package`** (or `ccwb cowork generate`) — injects the `agentcore-websearch` MCP server into the `.json` / `.mobileconfig` / `.reg` outputs, and `install.sh` drops a small `websearch-headers` helper next to `credential-process`.
+
+The generated entry is a **remote MCP server** pointing at your gateway, authenticated with a `headersHelper` script. It is emitted as a JSON-encoded string, like all array/object MDM values:
+
+```json
+{
+  "name": "agentcore-websearch",
+  "url": "https://<gateway-id>.gateway.bedrock-agentcore.us-east-1.amazonaws.com/mcp",
+  "headersHelper": "/Users/<you>/claude-code-with-bedrock/websearch-headers",
+  "headersHelperTtlSec": 900
+}
+```
+
+Claude Desktop treats this as a generic remote MCP server and speaks standard MCP JSON-RPC, which the AgentCore Gateway understands. (The built-in `server: "websearch"` / `provider: "custom"` connector is **not** used: it sends a request body the gateway cannot parse, which surfaces in Cowork as "No results" even though authentication succeeds.)
+
+### How authentication works
+
+The `headersHelper` is a tiny executable that `ccwb package` installs next to `credential-process` (`<home>/claude-code-with-bedrock/websearch-headers`). On each MCP request — and again every `headersHelperTtlSec` (900s) — Claude Desktop runs it and attaches whatever headers it prints. The helper execs `credential-process --get-mcp-auth-header` (the browserless, Go/Python-parity MCP-header mode) which emits:
+
+```json
+{"Authorization": "Bearer <id_token>"}
+```
+
+That mode reads the cached id_token and silently refreshes it via the stored refresh token when expired; it **never** opens a browser (a headersHelper cannot drive an interactive login). The gateway's `CUSTOM_JWT` authorizer validates that id_token. An OIDC **id_token** carries `aud = clientId` for every provider, so the gateway is deployed with **`AllowedAudience = [clientId]`** (the template default) — there is no provider-specific authorizer to configure. The TTL is kept below the token lifetime (Cognito ~1h) so an expiring bearer is refreshed before it lapses.
+
+> **Absolute paths (important).** Claude Desktop on macOS does **not** expand `~` (or env vars) in MDM string values, so the `headersHelper`/`inferenceCredentialHelper` paths must be absolute. Because the `.mobileconfig` is generated centrally, the macOS paths embed a `__CCWB_HOME__` placeholder and `install.sh` substitutes it with the user's real `$HOME` at install time — one artifact distributes centrally, each machine gets a correct absolute path. Windows uses the native `%USERPROFILE%`. To pin a fixed path yourself, set `websearch_headers_helper_path` on the profile (applied verbatim to every format).
+
+> **Web Fetch.** Web search returns titles, URLs, and snippets; opening those result pages needs sandbox egress, which Cowork blocks by default. When web search is enabled, `ccwb` sets `coworkEgressAllowedHosts=["*"]` automatically (with a warning) so results are usable out of the box. `["*"]` allows egress to **all** hosts — **narrow it to a targeted domain list for production** by setting `coworkEgressAllowedHosts` yourself (e.g. via `cowork_3p_extra_keys`); an admin-provided value is never overwritten.
+
+### Things to know
+
+- **Region:** the managed Web Search connector is currently available in **`us-east-1` only**, so the gateway is deployed there regardless of your other stacks' region.
+- **Data residency:** web search queries (or fragments of user prompts) are processed in `us-east-1`. Review compliance impact for regulated workloads before enabling.
+- **Cost:** approximately **$7 per 1,000 queries**, billed to your AWS account.
+- **Identity providers:** works with the solution's OIDC providers (Amazon Cognito, Microsoft Entra ID, Okta, Auth0, Google, generic OIDC). Because the bearer is an id_token (`aud = clientId`) validated by `AllowedAudience`, **no provider-specific setup is required**. See [Microsoft Entra ID setup → web search](providers/microsoft-entra-id-setup.md#10-web-search-for-claude-cowork-entra-id-notes) for notes.
+
+> **Claude Code & joint documentation.** The equivalent web search capability for the **Claude Code CLI** (injected into `settings.json` via the credential helper) is delivered by a separate contribution and is **not** documented here yet. A single consolidated `WEB_SEARCH.md` covering both surfaces (Claude Code + Cowork) is planned once that work lands. Note: the merged CloudFormation template PR shipped the gateway template only — it did not include a standalone usage doc.
 
 
 ## Verification


### PR DESCRIPTION
## What this does

Minor documentation updates reflecting the IAM Identity Center Self-Service Portal feature across existing docs.

### Changes

- **`QUICK_START.md`** — Mention IDC as a distribution option alongside existing methods
- **`README.md`** — Update feature list to include IDC portal capabilities
- **`COWORK_3P.md`** — Note IDC compatibility for third-party cowork integrations

### Risk Assessment

- **Docs only** — no code changes, no functional impact
- **Additive** — extends existing docs without removing or contradicting current content

### Merge order

This should merge last in the series, after all code PRs have landed, so the docs accurately reflect shipped capabilities.

## Context

Part 6 (final) of decomposed series from PR #751 (@duttaabh's IAM Identity Center Self-Service Portal).

Co-authored-by: duttaabh <duttaabh@users.noreply.github.com>