### PR TITLE
test: consolidate CloudFormation YAML loading into one shared helper

### DIFF
--- a/source/pyproject.toml
+++ b/source/pyproject.toml
@@ -74,6 +74,9 @@ select = [
     "B",  # flake8-bugbear
     "C4", # flake8-comprehensions
     "UP", # pyupgrade
+    # Single flake8-bandit rule rather than all of "S": the rest of the family
+    # has a known backlog tracked in .github/workflows/bandit.yml.
+    "S506", # unsafe YAML load — use tests/cfn_yaml.py helpers or safe_load
 ]
 ignore = [
     "E501",  # line too long — enforced by formatter, not linter

--- a/source/tests/cfn_yaml.py
+++ b/source/tests/cfn_yaml.py
@@ -1,0 +1,82 @@
+# ABOUTME: Shared CloudFormation-aware YAML loading for the test suite.
+# ABOUTME: Replaces the per-file loader classes that each test used to hand-roll.
+
+"""CloudFormation-aware YAML loading for tests.
+
+CloudFormation templates use short-form intrinsic tags (``!Ref``, ``!Sub``,
+``!GetAtt``) that plain :func:`yaml.safe_load` cannot parse. Two shapes are
+useful when asserting against a template, so this module exposes one loader for
+each:
+
+``load_resolved``
+    Collapses every tag to its payload — ``!Ref Foo`` becomes ``"Foo"`` and
+    ``!GetAtt Alb.DNSName`` becomes ``"Alb.DNSName"``. Convenient for
+    substring and regex assertions over rendered-ish values.
+
+``load_intrinsics``
+    Keeps the canonical long form — ``!Ref Foo`` becomes ``{"Ref": "Foo"}``
+    and ``!GetAtt Alb.DNSName`` becomes ``{"Fn::GetAtt": ["Alb", "DNSName"]}``.
+    Use this when a test must tell an intrinsic apart from a literal string.
+
+Pick deliberately: a test written against one shape will silently change
+meaning under the other.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import cfn_flip
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INFRA_DIR = REPO_ROOT / "deployment" / "infrastructure"
+
+
+def iter_templates(pattern: str = "*.yaml") -> list[Path]:
+    """Return every CloudFormation template in ``deployment/infrastructure``.
+
+    Sorted so that ``pytest.mark.parametrize`` ids stay stable across runs.
+    """
+    return sorted(INFRA_DIR.glob(pattern))
+
+
+class _ResolvedLoader(yaml.SafeLoader):
+    """SafeLoader that also understands CloudFormation short tags."""
+
+
+def _resolve_tag(loader: yaml.SafeLoader, tag_suffix: str, node: yaml.Node) -> Any:
+    """Return a CFN tag's payload, discarding which tag it was."""
+    if isinstance(node, yaml.ScalarNode):
+        return loader.construct_scalar(node)
+    if isinstance(node, yaml.SequenceNode):
+        return loader.construct_sequence(node)
+    if isinstance(node, yaml.MappingNode):
+        return loader.construct_mapping(node)
+    return None
+
+
+_ResolvedLoader.add_multi_constructor("!", _resolve_tag)
+
+
+def load_resolved(path: str | Path) -> Any:
+    """Load a template with each CFN tag collapsed to its payload value."""
+    # Driving the loader directly is what PyYAML's generic load helper does
+    # internally, so this is not a shortcut: _ResolvedLoader derives from
+    # SafeLoader and adds only CFN tag constructors, meaning arbitrary Python
+    # object construction is unreachable either way. Routing through the generic
+    # helper with an explicit Loader= would add nothing but trips static
+    # analysers that match the call by name without resolving which loader it
+    # was handed.
+    loader = _ResolvedLoader(Path(path).read_text(encoding="utf-8"))
+    try:
+        return loader.get_single_data()
+    finally:
+        loader.dispose()
+
+
+def load_intrinsics(path: str | Path) -> Any:
+    """Load a template keeping CFN intrinsics in canonical long form."""
+    # cfn_flip is the parser the CLI itself uses (see cli/utils/cloudformation.py).
+    return cfn_flip.load_yaml(Path(path).read_text(encoding="utf-8"))

--- a/source/tests/e2e/test_cfn_contracts.py
+++ b/source/tests/e2e/test_cfn_contracts.py
@@ -13,34 +13,11 @@ Catches issues like:
 - #398: SSM parameter conflicts on stack updates
 """
 
-import sys
 from pathlib import Path
 
 import pytest
-import yaml
 
-sys.path.insert(0, str(Path(__file__).parent.parent.parent))
-
-INFRA_DIR = Path(__file__).parent.parent.parent.parent / "deployment" / "infrastructure"
-
-
-# CloudFormation-aware YAML loader (handles !Ref, !Sub, !GetAtt, etc.)
-class CFNLoader(yaml.SafeLoader):
-    pass
-
-
-def _cfn_constructor(loader, tag_suffix, node):
-    """Generic constructor for CloudFormation intrinsic functions."""
-    if isinstance(node, yaml.ScalarNode):
-        return loader.construct_scalar(node)
-    elif isinstance(node, yaml.SequenceNode):
-        return loader.construct_sequence(node)
-    elif isinstance(node, yaml.MappingNode):
-        return loader.construct_mapping(node)
-    return None
-
-
-CFNLoader.add_multi_constructor("!", _cfn_constructor)
+from tests.cfn_yaml import INFRA_DIR, iter_templates, load_resolved
 
 
 def _load_template(name: str) -> dict:
@@ -48,8 +25,7 @@ def _load_template(name: str) -> dict:
     path = INFRA_DIR / name
     if not path.exists():
         pytest.skip(f"Template {name} not found")
-    with open(path, encoding="utf-8") as f:
-        return yaml.load(f, Loader=CFNLoader)
+    return load_resolved(path)
 
 
 def _get_template_parameters(template: dict) -> dict:
@@ -61,7 +37,7 @@ def _get_all_templates() -> list[Path]:
     """List all YAML templates in infrastructure directory."""
     if not INFRA_DIR.exists():
         return []
-    return list(INFRA_DIR.glob("*.yaml"))
+    return iter_templates()
 
 
 class TestCloudFormationTemplateValidity:
@@ -70,15 +46,13 @@ class TestCloudFormationTemplateValidity:
     @pytest.mark.parametrize("template_path", _get_all_templates(), ids=lambda p: p.name)
     def test_template_is_valid_yaml(self, template_path):
         """All templates must be parseable YAML (with CloudFormation intrinsics)."""
-        with open(template_path, encoding="utf-8") as f:
-            content = yaml.load(f, Loader=CFNLoader)
+        content = load_resolved(template_path)
         assert isinstance(content, dict), f"{template_path.name} did not parse to a dict"
 
     @pytest.mark.parametrize("template_path", _get_all_templates(), ids=lambda p: p.name)
     def test_template_has_resources(self, template_path):
         """All templates must define at least one Resource."""
-        with open(template_path, encoding="utf-8") as f:
-            content = yaml.load(f, Loader=CFNLoader)
+        content = load_resolved(template_path)
         # Some templates might be utility-only, but most should have Resources
         if "Resources" in content:
             assert len(content["Resources"]) > 0
@@ -86,8 +60,7 @@ class TestCloudFormationTemplateValidity:
     @pytest.mark.parametrize("template_path", _get_all_templates(), ids=lambda p: p.name)
     def test_template_has_description(self, template_path):
         """Templates should have a Description for CloudFormation console."""
-        with open(template_path, encoding="utf-8") as f:
-            content = yaml.load(f, Loader=CFNLoader)
+        content = load_resolved(template_path)
         # Not strictly required but good practice
         if "AWSTemplateFormatVersion" in content:
             assert "Description" in content, f"{template_path.name} missing Description"
@@ -166,8 +139,7 @@ class TestIAMPolicyValidity:
     @pytest.mark.parametrize("template_path", _get_all_templates(), ids=lambda p: p.name)
     def test_iam_actions_use_valid_prefixes(self, template_path):
         """All IAM actions must use valid service prefixes (catches #375)."""
-        with open(template_path, encoding="utf-8") as f:
-            content = yaml.load(f, Loader=CFNLoader)
+        content = load_resolved(template_path)
 
         actions = self._extract_actions(content)
         for action in actions:
@@ -280,8 +252,7 @@ class TestDeployCommandStackNames:
                 continue
 
             # The template should be parseable and have basic structure
-            with open(template_path, encoding="utf-8") as f:
-                content = yaml.load(f, Loader=CFNLoader)
+            content = load_resolved(template_path)
 
             assert "Resources" in content or "AWSTemplateFormatVersion" in content, (
                 f"Template {template_path.name} doesn't look like a valid CloudFormation template"

--- a/source/tests/e2e/test_cowork_dashboard_filters.py
+++ b/source/tests/e2e/test_cowork_dashboard_filters.py
@@ -5,12 +5,12 @@
 
 import json
 import re
-from pathlib import Path
 
 import pytest
-import yaml
 
-DASHBOARD_PATH = Path(__file__).parent.parent.parent.parent / "deployment" / "infrastructure" / "cowork-dashboard.yaml"
+from tests.cfn_yaml import INFRA_DIR, load_resolved
+
+DASHBOARD_PATH = INFRA_DIR / "cowork-dashboard.yaml"
 
 
 class TestCoWorkDashboardMetricFilters:
@@ -18,17 +18,7 @@ class TestCoWorkDashboardMetricFilters:
 
     @pytest.fixture(autouse=True)
     def load_template(self):
-        # Add CloudFormation intrinsic function constructors
-        loader = yaml.SafeLoader
-        for tag in ["!Sub", "!Ref", "!GetAtt", "!If", "!Not", "!Equals", "!Select", "!Join", "!Split"]:
-            loader.add_constructor(
-                tag, lambda l, n: l.construct_scalar(n) if n.id == "scalar" else l.construct_sequence(n)
-            )
-        loader.add_multi_constructor(
-            "!", lambda l, suffix, n: l.construct_scalar(n) if n.id == "scalar" else l.construct_sequence(n)
-        )
-        with open(DASHBOARD_PATH) as f:
-            self.template = yaml.load(f, Loader=loader)
+        self.template = load_resolved(DASHBOARD_PATH)
         self.resources = self.template.get("Resources", {})
 
     def _get_filters(self):
@@ -150,7 +140,7 @@ class TestCoWorkDashboardBody:
 
     @pytest.fixture(autouse=True)
     def load_body(self):
-        text = DASHBOARD_PATH.read_text()
+        text = DASHBOARD_PATH.read_text(encoding="utf-8")
         # Extract the DashboardBody block that follows `DashboardBody: !Sub |`
         marker = "DashboardBody: !Sub |"
         block = text[text.index(marker) :].splitlines()[1:]

--- a/source/tests/e2e/test_cowork_quota_counting.py
+++ b/source/tests/e2e/test_cowork_quota_counting.py
@@ -3,7 +3,7 @@
 
 """Tests for CoWork 3P quota counting in quota_monitor Lambda."""
 
-from pathlib import Path
+from tests.cfn_yaml import INFRA_DIR, REPO_ROOT, load_resolved
 
 
 class TestCoWorkQuotaCounting:
@@ -11,15 +11,8 @@ class TestCoWorkQuotaCounting:
 
     def test_quota_monitor_has_cowork_promql_query(self):
         """The quota_monitor Lambda must query ClaudeCoWork namespace metrics."""
-        lambda_path = (
-            Path(__file__).parent.parent.parent.parent
-            / "deployment"
-            / "infrastructure"
-            / "lambda-functions"
-            / "quota_monitor"
-            / "index.py"
-        )
-        content = lambda_path.read_text()
+        lambda_path = INFRA_DIR / "lambda-functions" / "quota_monitor" / "index.py"
+        content = lambda_path.read_text(encoding="utf-8")
         assert "ClaudeCoWork" in content, "quota_monitor must query ClaudeCoWork namespace"
         assert "token.usage.input" in content, "quota_monitor must query CoWork input tokens"
         assert "token.usage.output" in content, "quota_monitor must query CoWork output tokens"
@@ -27,15 +20,8 @@ class TestCoWorkQuotaCounting:
 
     def test_cowork_query_is_non_fatal(self):
         """CoWork PromQL failure must not crash quota monitoring."""
-        lambda_path = (
-            Path(__file__).parent.parent.parent.parent
-            / "deployment"
-            / "infrastructure"
-            / "lambda-functions"
-            / "quota_monitor"
-            / "index.py"
-        )
-        content = lambda_path.read_text()
+        lambda_path = INFRA_DIR / "lambda-functions" / "quota_monitor" / "index.py"
+        content = lambda_path.read_text(encoding="utf-8")
         # The CoWork query must be wrapped in try/except
         assert "non-fatal" in content.lower() or "non_fatal" in content.lower() or "optional" in content.lower(), (
             "CoWork PromQL query must be wrapped in try/except with non-fatal handling"
@@ -43,17 +29,7 @@ class TestCoWorkQuotaCounting:
 
     def test_cowork_dashboard_has_user_email_dimension(self):
         """CoWork metric filters must include user_email dimension for per-user attribution."""
-        import yaml
-
-        dashboard_path = (
-            Path(__file__).parent.parent.parent.parent / "deployment" / "infrastructure" / "cowork-dashboard.yaml"
-        )
-        loader = yaml.SafeLoader
-        loader.add_multi_constructor(
-            "!", lambda l, suffix, n: l.construct_scalar(n) if n.id == "scalar" else l.construct_sequence(n)
-        )
-        with open(dashboard_path) as f:
-            template = yaml.load(f, Loader=loader)
+        template = load_resolved(INFRA_DIR / "cowork-dashboard.yaml")
 
         resources = template.get("Resources", {})
         api_request_filters = [
@@ -76,7 +52,7 @@ class TestCoWorkQuotaCounting:
 
     def test_cowork_docs_mention_quota_enforcement(self):
         """COWORK_3P.md must document quota enforcement behavior."""
-        docs_path = Path(__file__).parent.parent.parent.parent / "assets" / "docs" / "COWORK_3P.md"
+        docs_path = REPO_ROOT / "assets" / "docs" / "COWORK_3P.md"
         content = docs_path.read_text(encoding="utf-8")
         assert "## Quota Enforcement" in content
         assert "credential-process" in content

--- a/source/tests/e2e/test_quota_api_invoke_policy.py
+++ b/source/tests/e2e/test_quota_api_invoke_policy.py
@@ -3,12 +3,11 @@
 
 """Tests for quota API invoke policy in CloudFormation template."""
 
-from pathlib import Path
-
 import pytest
-import yaml
 
-TEMPLATE_PATH = Path(__file__).parent.parent.parent.parent / "deployment" / "infrastructure" / "quota-monitoring.yaml"
+from tests.cfn_yaml import INFRA_DIR, load_resolved
+
+TEMPLATE_PATH = INFRA_DIR / "quota-monitoring.yaml"
 
 
 class TestQuotaApiInvokePolicy:
@@ -16,16 +15,7 @@ class TestQuotaApiInvokePolicy:
 
     @pytest.fixture(autouse=True)
     def load_template(self):
-        # Add CloudFormation intrinsic function constructors
-        loader = yaml.SafeLoader
-        loader.add_multi_constructor(
-            "!",
-            lambda loader, suffix, node: (
-                loader.construct_scalar(node) if node.id == "scalar" else loader.construct_sequence(node)
-            ),
-        )
-        with open(TEMPLATE_PATH) as f:
-            self.template = yaml.load(f, Loader=loader)
+        self.template = load_resolved(TEMPLATE_PATH)
         self.resources = self.template.get("Resources", {})
         self.outputs = self.template.get("Outputs", {})
 

--- a/source/tests/integration/test_cfn_validation.py
+++ b/source/tests/integration/test_cfn_validation.py
@@ -8,61 +8,10 @@ import subprocess
 from pathlib import Path
 
 import pytest
-import yaml
 
-REPO_ROOT = Path(__file__).parent.parent.parent.parent
-TEMPLATES_DIR = REPO_ROOT / "deployment" / "infrastructure"
+from tests.cfn_yaml import INFRA_DIR, load_intrinsics
 
-
-# --- CFN-aware YAML loader (handles !Ref, !Sub, etc.) ---
-
-
-class _CfnLoader(yaml.SafeLoader):
-    pass
-
-
-def _multi_constructor(tag_name):
-    """Handle CFN tags that can appear as scalar, sequence, or mapping."""
-
-    def constructor(loader, node):
-        if isinstance(node, yaml.ScalarNode):
-            return {tag_name: loader.construct_scalar(node)}
-        elif isinstance(node, yaml.SequenceNode):
-            return {tag_name: loader.construct_sequence(node)}
-        elif isinstance(node, yaml.MappingNode):
-            return {tag_name: loader.construct_mapping(node)}
-
-    return constructor
-
-
-_CFN_TAGS = {
-    "!Ref": "Ref",
-    "!Sub": "Fn::Sub",
-    "!GetAtt": "Fn::GetAtt",
-    "!If": "Fn::If",
-    "!Join": "Fn::Join",
-    "!Select": "Fn::Select",
-    "!Split": "Fn::Split",
-    "!Equals": "Fn::Equals",
-    "!And": "Fn::And",
-    "!Or": "Fn::Or",
-    "!Not": "Fn::Not",
-    "!FindInMap": "Fn::FindInMap",
-    "!GetAZs": "Fn::GetAZs",
-    "!Cidr": "Fn::Cidr",
-    "!Condition": "Condition",
-    "!Transform": "Fn::Transform",
-    "!Base64": "Fn::Base64",
-    "!ImportValue": "Fn::ImportValue",
-}
-
-for _yaml_tag, _cfn_key in _CFN_TAGS.items():
-    _CfnLoader.add_constructor(_yaml_tag, _multi_constructor(_cfn_key))
-
-
-def _load_cfn_template(path: Path) -> dict:
-    with open(path, encoding="utf-8") as f:
-        return yaml.load(f, Loader=_CfnLoader)
+TEMPLATES_DIR = INFRA_DIR
 
 
 # --- Helpers ---
@@ -130,7 +79,7 @@ class TestTemplateStructure:
     @pytest.mark.parametrize("template_path", _get_all_templates(), ids=lambda p: p.name)
     def test_template_has_resources(self, template_path):
         """Every template must define at least one Resource."""
-        template = _load_cfn_template(template_path)
+        template = load_intrinsics(template_path)
 
         assert "Resources" in template, f"{template_path.name} missing Resources section"
         assert len(template["Resources"]) > 0
@@ -138,6 +87,6 @@ class TestTemplateStructure:
     @pytest.mark.parametrize("template_path", _get_all_templates(), ids=lambda p: p.name)
     def test_template_has_description(self, template_path):
         """Every template should have a Description."""
-        template = _load_cfn_template(template_path)
+        template = load_intrinsics(template_path)
 
         assert "Description" in template, f"{template_path.name} missing Description"

--- a/source/tests/test_cfn_naming_limits.py
+++ b/source/tests/test_cfn_naming_limits.py
@@ -12,12 +12,9 @@ Bug this prevents:
   and the monitoring stack name is {identity_pool_name}-otel-collector (already 31+ chars)
 """
 
-from pathlib import Path
-
 import pytest
-import yaml
 
-INFRA_DIR = Path(__file__).parent.parent.parent / "deployment" / "infrastructure"
+from tests.cfn_yaml import INFRA_DIR, iter_templates, load_resolved
 
 # AWS resource types with strict naming limits
 RESOURCE_NAME_LIMITS = {
@@ -36,45 +33,11 @@ RESOURCES_NO_EXPLICIT_NAME = {
 OTEL_COLLECTOR_TEMPLATE = INFRA_DIR / "otel-collector.yaml"
 
 
-class CFLoader(yaml.SafeLoader):
-    """YAML loader that handles CloudFormation intrinsic functions."""
-
-    pass
-
-
-# Register CF intrinsic constructors
-for tag in [
-    "!Ref",
-    "!Sub",
-    "!GetAtt",
-    "!If",
-    "!Equals",
-    "!Not",
-    "!Select",
-    "!Join",
-    "!Split",
-    "!FindInMap",
-    "!Condition",
-    "!Or",
-    "!And",
-]:
-    CFLoader.add_constructor(
-        tag,
-        lambda loader, node: (
-            loader.construct_scalar(node)
-            if isinstance(node, yaml.ScalarNode)
-            else loader.construct_sequence(node)
-            if isinstance(node, yaml.SequenceNode)
-            else loader.construct_mapping(node)
-        ),
-    )
-
-
 def _get_all_cf_templates():
     """Get all CloudFormation YAML templates."""
     if not INFRA_DIR.exists():
         pytest.skip("deployment/infrastructure/ not found")
-    return list(INFRA_DIR.glob("*.yaml"))
+    return iter_templates()
 
 
 class TestCFResourceNamingLimits:
@@ -99,11 +62,7 @@ class TestCFResourceNamingLimits:
         """
         violations = []
         for template_path in templates:
-            with open(template_path, encoding="utf-8") as f:
-                try:
-                    doc = yaml.load(f, Loader=CFLoader)
-                except yaml.YAMLError:
-                    continue
+            doc = load_resolved(template_path)
 
             if not doc or "Resources" not in doc:
                 continue
@@ -120,8 +79,8 @@ class TestCFResourceNamingLimits:
 
                 name_val = props["Name"]
                 # Allow intrinsic-function-derived names (!Sub, !Join, etc.)
-                # that do NOT reference AWS::StackName. These are loaded by
-                # CFLoader as lists (sequence nodes) or dicts (mapping nodes).
+                # that do NOT reference AWS::StackName. load_resolved yields
+                # these as lists (sequence nodes) or dicts (mapping nodes).
                 # The dangerous pattern is ${AWS::StackName} which can overflow.
                 if isinstance(name_val, (list, dict)):
                     # Check the template string for StackName references
@@ -149,8 +108,7 @@ class TestCFResourceNamingLimits:
         if not OTEL_COLLECTOR_TEMPLATE.exists():
             pytest.skip("otel-collector.yaml not found")
 
-        with open(OTEL_COLLECTOR_TEMPLATE, encoding="utf-8") as f:
-            doc = yaml.load(f, Loader=CFLoader)
+        doc = load_resolved(OTEL_COLLECTOR_TEMPLATE)
 
         violations = []
         for logical_id, resource in doc["Resources"].items():

--- a/source/tests/test_cloudformation.py
+++ b/source/tests/test_cloudformation.py
@@ -3,99 +3,7 @@
 
 """Tests for CloudFormation template configuration."""
 
-from pathlib import Path
-
-import yaml
-
-
-# Custom YAML loader for CloudFormation templates
-class CloudFormationLoader(yaml.SafeLoader):
-    """Custom YAML loader that handles CloudFormation intrinsic functions."""
-
-    pass
-
-
-# Define constructors for CloudFormation intrinsic functions
-def ref_constructor(loader, node):
-    """Handle !Ref function."""
-    return {"Ref": loader.construct_scalar(node)}
-
-
-def getatt_constructor(loader, node):
-    """Handle !GetAtt function."""
-    if isinstance(node, yaml.SequenceNode):
-        return {"Fn::GetAtt": loader.construct_sequence(node)}
-    else:
-        # Handle dot notation
-        value = loader.construct_scalar(node)
-        return {"Fn::GetAtt": value.split(".", 1)}
-
-
-def sub_constructor(loader, node):
-    """Handle !Sub function (scalar or sequence form)."""
-    if node.id == "scalar":
-        return {"Fn::Sub": loader.construct_scalar(node)}
-    return {"Fn::Sub": loader.construct_sequence(node)}
-
-
-def if_constructor(loader, node):
-    """Handle !If function."""
-    return {"Fn::If": loader.construct_sequence(node)}
-
-
-def join_constructor(loader, node):
-    """Handle !Join function."""
-    return {"Fn::Join": loader.construct_sequence(node)}
-
-
-def equals_constructor(loader, node):
-    """Handle !Equals function."""
-    return {"Fn::Equals": loader.construct_sequence(node)}
-
-
-def or_constructor(loader, node):
-    """Handle !Or function."""
-    return {"Fn::Or": loader.construct_sequence(node)}
-
-
-def and_constructor(loader, node):
-    """Handle !And function."""
-    return {"Fn::And": loader.construct_sequence(node)}
-
-
-def not_constructor(loader, node):
-    """Handle !Not function."""
-    return {"Fn::Not": loader.construct_sequence(node)}
-
-
-def condition_constructor(loader, node):
-    """Handle !Condition function."""
-    return {"Condition": loader.construct_scalar(node)}
-
-
-def select_constructor(loader, node):
-    """Handle !Select function."""
-    return {"Fn::Select": loader.construct_sequence(node)}
-
-
-def split_constructor(loader, node):
-    """Handle !Split function."""
-    return {"Fn::Split": loader.construct_sequence(node)}
-
-
-# Register the constructors
-CloudFormationLoader.add_constructor("!Ref", ref_constructor)
-CloudFormationLoader.add_constructor("!GetAtt", getatt_constructor)
-CloudFormationLoader.add_constructor("!Sub", sub_constructor)
-CloudFormationLoader.add_constructor("!If", if_constructor)
-CloudFormationLoader.add_constructor("!Join", join_constructor)
-CloudFormationLoader.add_constructor("!Equals", equals_constructor)
-CloudFormationLoader.add_constructor("!Or", or_constructor)
-CloudFormationLoader.add_constructor("!And", and_constructor)
-CloudFormationLoader.add_constructor("!Not", not_constructor)
-CloudFormationLoader.add_constructor("!Condition", condition_constructor)
-CloudFormationLoader.add_constructor("!Select", select_constructor)
-CloudFormationLoader.add_constructor("!Split", split_constructor)
+from tests.cfn_yaml import INFRA_DIR, load_intrinsics
 
 
 class TestCloudFormationCrossRegion:
@@ -103,11 +11,9 @@ class TestCloudFormationCrossRegion:
 
     def get_template(self):
         """Load the CloudFormation template."""
-        template_path = (
-            Path(__file__).parent.parent.parent / "deployment" / "infrastructure" / "cognito-identity-pool.yaml"
-        )
-        with open(template_path, encoding="utf-8") as f:
-            return yaml.load(f, Loader=CloudFormationLoader)
+        # Assertions here read intrinsics in long form ({"Ref": "Foo"}), so this
+        # must be load_intrinsics rather than load_resolved.
+        return load_intrinsics(INFRA_DIR / "cognito-identity-pool.yaml")
 
     def test_allowed_bedrock_regions_default(self):
         """Test that default AllowedBedrockRegions includes all US cross-region regions."""
@@ -283,11 +189,7 @@ class TestBedrockAuthGenericTemplate:
     """
 
     def get_template(self):
-        template_path = (
-            Path(__file__).parent.parent.parent / "deployment" / "infrastructure" / "bedrock-auth-generic.yaml"
-        )
-        with open(template_path, encoding="utf-8") as f:
-            return yaml.load(f, Loader=CloudFormationLoader)
+        return load_intrinsics(INFRA_DIR / "bedrock-auth-generic.yaml")
 
     def test_template_loads(self):
         """Template must parse as valid CloudFormation YAML."""

--- a/source/tests/test_cognito_client_id_pattern.py
+++ b/source/tests/test_cognito_client_id_pattern.py
@@ -1,28 +1,8 @@
 """Regression test for issue #141: CognitoUserPoolClientId AllowedPattern too strict."""
 
 import re
-from pathlib import Path
 
-import yaml
-
-INFRA_DIR = Path(__file__).resolve().parents[2] / "deployment" / "infrastructure"
-
-
-# Custom YAML loader that handles CloudFormation intrinsic functions
-class CfnLoader(yaml.SafeLoader):
-    pass
-
-
-def _cfn_tag_constructor(loader, tag_suffix, node):
-    if isinstance(node, yaml.ScalarNode):
-        return loader.construct_scalar(node)
-    elif isinstance(node, yaml.SequenceNode):
-        return loader.construct_sequence(node)
-    elif isinstance(node, yaml.MappingNode):
-        return loader.construct_mapping(node)
-
-
-CfnLoader.add_multi_constructor("!", _cfn_tag_constructor)
+from tests.cfn_yaml import INFRA_DIR, load_resolved
 
 
 class TestCognitoClientIdPattern:
@@ -30,9 +10,7 @@ class TestCognitoClientIdPattern:
 
     def test_pattern_allows_variable_length(self):
         """AllowedPattern must not hard-code 26 chars — AWS allows 1-128."""
-        template_path = INFRA_DIR / "bedrock-auth-cognito-pool.yaml"
-        with open(template_path, encoding="utf-8") as f:
-            template = yaml.load(f, Loader=CfnLoader)
+        template = load_resolved(INFRA_DIR / "bedrock-auth-cognito-pool.yaml")
 
         param = template["Parameters"]["CognitoUserPoolClientId"]
         pattern = param["AllowedPattern"]
@@ -44,9 +22,7 @@ class TestCognitoClientIdPattern:
 
     def test_pattern_rejects_invalid_chars(self):
         """Pattern must still reject uppercase, special chars."""
-        template_path = INFRA_DIR / "bedrock-auth-cognito-pool.yaml"
-        with open(template_path, encoding="utf-8") as f:
-            template = yaml.load(f, Loader=CfnLoader)
+        template = load_resolved(INFRA_DIR / "bedrock-auth-cognito-pool.yaml")
 
         param = template["Parameters"]["CognitoUserPoolClientId"]
         pattern = param["AllowedPattern"]

--- a/source/tests/test_cost_quota_wiring.py
+++ b/source/tests/test_cost_quota_wiring.py
@@ -27,16 +27,15 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 
-import yaml
-
 # ruff: noqa: E402
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from claude_code_with_bedrock.cli.commands.init import InitCommand
 from claude_code_with_bedrock.config import Config, Profile
+from tests.cfn_yaml import INFRA_DIR, load_resolved
 
-LAMBDA_DIR = Path(__file__).resolve().parents[2] / "deployment" / "infrastructure" / "lambda-functions"
-TEMPLATE = Path(__file__).resolve().parents[2] / "deployment" / "infrastructure" / "quota-monitoring.yaml"
+LAMBDA_DIR = INFRA_DIR / "lambda-functions"
+TEMPLATE = INFRA_DIR / "quota-monitoring.yaml"
 
 
 def _load_lambda(name: str, env: dict):
@@ -136,18 +135,7 @@ class TestInitRoundTrip:
 
 
 def _load_template() -> dict:
-    class CFNLoader(yaml.SafeLoader):
-        pass
-
-    def _cfn(loader, suffix, node):  # noqa: ARG001 - yaml constructor signature
-        if isinstance(node, yaml.ScalarNode):
-            return loader.construct_scalar(node)
-        if isinstance(node, yaml.SequenceNode):
-            return loader.construct_sequence(node)
-        return loader.construct_mapping(node)
-
-    CFNLoader.add_multi_constructor("!", _cfn)
-    return yaml.load(TEMPLATE.read_text(encoding="utf-8"), Loader=CFNLoader)
+    return load_resolved(TEMPLATE)
 
 
 class TestTemplateWiring:

--- a/source/tests/test_generic_oidc_distribution.py
+++ b/source/tests/test_generic_oidc_distribution.py
@@ -11,42 +11,19 @@ ForgeRock, etc.) through the validator, config round-trip, deploy params, and CF
 from pathlib import Path
 
 import pytest
-import yaml
 
 from claude_code_with_bedrock.config import Profile
 from claude_code_with_bedrock.validators import validate_profile
+from tests.cfn_yaml import INFRA_DIR, load_resolved
 
 SOURCE_ROOT = Path(__file__).resolve().parents[1]
-REPO_ROOT = SOURCE_ROOT.parents[0]
 DEPLOY_PY = SOURCE_ROOT / "claude_code_with_bedrock" / "cli" / "commands" / "deploy.py"
 INIT_PY = SOURCE_ROOT / "claude_code_with_bedrock" / "cli" / "commands" / "init.py"
-LANDING_TEMPLATE = REPO_ROOT / "deployment" / "infrastructure" / "landing-page-distribution.yaml"
-
-
-# --- CFN-aware YAML loader (handles !Ref, !Sub, !GetAtt, etc.) ---
-
-
-class _CfnLoader(yaml.SafeLoader):
-    pass
-
-
-def _cfn_tag_constructor(loader, tag_suffix, node):
-    """Resolve any !Tag to its scalar/sequence/mapping payload (value only)."""
-    if isinstance(node, yaml.ScalarNode):
-        return loader.construct_scalar(node)
-    if isinstance(node, yaml.SequenceNode):
-        return loader.construct_sequence(node)
-    if isinstance(node, yaml.MappingNode):
-        return loader.construct_mapping(node)
-    return None
-
-
-_CfnLoader.add_multi_constructor("!", _cfn_tag_constructor)
+LANDING_TEMPLATE = INFRA_DIR / "landing-page-distribution.yaml"
 
 
 def _load_landing_template() -> dict:
-    with open(LANDING_TEMPLATE, encoding="utf-8") as f:
-        return yaml.load(f, Loader=_CfnLoader)
+    return load_resolved(LANDING_TEMPLATE)
 
 
 class TestGenericDistributionValidator:

--- a/source/tests/test_okta_domain_pattern.py
+++ b/source/tests/test_okta_domain_pattern.py
@@ -10,34 +10,14 @@ so it must be a valid FQDN with no scheme/path/port, but need not be on okta.com
 """
 
 import re
-from pathlib import Path
 
 import pytest
-import yaml
 
-INFRA_DIR = Path(__file__).resolve().parents[2] / "deployment" / "infrastructure"
-
-
-class CfnLoader(yaml.SafeLoader):
-    pass
-
-
-def _cfn_tag_constructor(loader, tag_suffix, node):
-    if isinstance(node, yaml.ScalarNode):
-        return loader.construct_scalar(node)
-    elif isinstance(node, yaml.SequenceNode):
-        return loader.construct_sequence(node)
-    elif isinstance(node, yaml.MappingNode):
-        return loader.construct_mapping(node)
-
-
-CfnLoader.add_multi_constructor("!", _cfn_tag_constructor)
+from tests.cfn_yaml import INFRA_DIR, load_resolved
 
 
 def _okta_domain_pattern() -> str:
-    template_path = INFRA_DIR / "bedrock-auth-okta.yaml"
-    with open(template_path, encoding="utf-8") as f:
-        template = yaml.load(f, Loader=CfnLoader)
+    template = load_resolved(INFRA_DIR / "bedrock-auth-okta.yaml")
     return template["Parameters"]["OktaDomain"]["AllowedPattern"]
 
 

--- a/source/tests/test_windows_buildspec_yaml.py
+++ b/source/tests/test_windows_buildspec_yaml.py
@@ -19,39 +19,19 @@ it validates the CloudFormation template, not the embedded buildspec's scalar
 semantics.
 """
 
-from pathlib import Path
-
 import pytest
 import yaml
 
-INFRA_DIR = Path(__file__).resolve().parents[2] / "deployment" / "infrastructure"
+from tests.cfn_yaml import INFRA_DIR, load_resolved
+
 TEMPLATE = INFRA_DIR / "codebuild-windows.yaml"
-
-
-# CloudFormation intrinsic tags (!Sub, !Ref, !GetAtt, ...) break a plain
-# SafeLoader. This loader treats every "!"-tag as its underlying node value,
-# which is enough to reach the BuildSpec block scalars.
-class CfnLoader(yaml.SafeLoader):
-    pass
-
-
-def _cfn_tag_constructor(loader, tag_suffix, node):
-    if isinstance(node, yaml.ScalarNode):
-        return loader.construct_scalar(node)
-    if isinstance(node, yaml.SequenceNode):
-        return loader.construct_sequence(node)
-    if isinstance(node, yaml.MappingNode):
-        return loader.construct_mapping(node)
-    return None
-
-
-CfnLoader.add_multi_constructor("!", _cfn_tag_constructor)
 
 
 def _collect_buildspecs() -> dict[str, str]:
     """Return {project logical id: BuildSpec string} for every build project."""
-    with open(TEMPLATE, encoding="utf-8") as f:
-        template = yaml.load(f, Loader=CfnLoader)
+    # load_resolved collapses the CFN tags (!Sub, !Ref, ...) that a plain
+    # SafeLoader rejects, which is all we need to reach the BuildSpec scalars.
+    template = load_resolved(TEMPLATE)
 
     specs = {}
     for logical_id, resource in template["Resources"].items():


### PR DESCRIPTION
## Why

CloudFormation templates use short-form intrinsic tags (`!Ref`, `!Sub`, `!GetAtt`) that plain `safe_load` cannot parse, so twelve test files each hand-rolled their own YAML loader. The copies had drifted into three mutually incompatible variants, and three of them registered constructors on the **global** `SafeLoader` class — leaking CFN-tag tolerance into every later `safe_load` in the same pytest session. That made those tests order-dependent and unreliable in isolation.

## What

One shared helper, `source/tests/cfn_yaml.py`, exposing the two shapes the assertions actually depend on:

| Helper | Shape | Files |
|---|---|---|
| `load_resolved` | tag collapses to its payload — `!Ref Foo` → `"Foo"` | 10 |
| `load_intrinsics` | canonical long form — `!Ref Foo` → `{"Ref": "Foo"}` | 2 |

`load_intrinsics` wraps `cfn_flip`, already a runtime dependency and already the parser the CLI itself uses for templates — so tests converge on the path production trusts. `load_resolved` uses a private `SafeLoader` subclass that adds only CFN tag constructors.

Also folds three competing repo-root path idioms into `INFRA_DIR` / `iter_templates()`, and adds `encoding="utf-8"` to the reads that omitted it (`.claude/rules/windows-platform-guards.md`).

Enables ruff `S506` so the duplication cannot grow back. Only that single rule, not the whole `S` family — the rest has a backlog tracked in `.github/workflows/bandit.yml`.

## Verification

- Full suite reports an identical **1776 passed / 28 skipped / 1 xfailed / 1 xpassed** before and after
- Same result under `-p no:randomly`, and the three highest-risk files pass **standalone** (the check that the removed global-loader leak was not load-bearing)
- All 25 templates in `deployment/infrastructure/` parse through both helpers
- `ruff check` / `ruff format --check` clean

No production code touched; net **−360 lines**.