### PR TITLE
fix(destroy): stop emptying S3 buckets marked DeletionPolicy: Retain

### DIFF
--- a/source/claude_code_with_bedrock/cli/utils/cloudformation.py
+++ b/source/claude_code_with_bedrock/cli/utils/cloudformation.py
@@ -318,6 +318,22 @@ class CloudFormationManager:
         except Exception:
             return []
 
+    def _retained_logical_ids(self, stack_name: str) -> set[str]:
+        """Logical IDs in the stack's template marked DeletionPolicy: Retain."""
+        template_resp = self.cf_client.get_template(StackName=stack_name)
+        template_body = template_resp.get("TemplateBody", {})
+        # CloudFormation returns a YAML template verbatim, short-form intrinsics
+        # (!Ref, !Sub, !GetAtt) included, so it needs the CFN-aware parser.
+        # JSON templates already come back as a dict.
+        if isinstance(template_body, str):
+            template_body = cfn_flip.load_yaml(template_body)
+        resources = template_body.get("Resources", {})
+        return {
+            logical_id
+            for logical_id, resource_def in resources.items()
+            if isinstance(resource_def, dict) and resource_def.get("DeletionPolicy") == "Retain"
+        }
+
     def pre_cleanup_stack(self, stack_name: str, on_event: Callable | None = None) -> None:
         """Pre-clean resources that block CloudFormation deletion.
 
@@ -330,21 +346,21 @@ class CloudFormationManager:
         import logging
 
         try:
-            # Read template to identify Retain resources
-            retained_logical_ids: set[str] = set()
             try:
-                template_resp = self.cf_client.get_template(StackName=stack_name)
-                import yaml
-
-                template_body = template_resp.get("TemplateBody", {})
-                if isinstance(template_body, str):
-                    template_body = yaml.safe_load(template_body)
-                resources = template_body.get("Resources", {})
-                for logical_id, resource_def in resources.items():
-                    if isinstance(resource_def, dict) and resource_def.get("DeletionPolicy") == "Retain":
-                        retained_logical_ids.add(logical_id)
+                retained_logical_ids = self._retained_logical_ids(stack_name)
             except Exception as e:
-                logging.debug(f"Could not parse template for {stack_name}: {e}")
+                # Without the retention list there is no way to tell a disposable
+                # bucket from one the operator asked to keep, so don't pre-clean
+                # at all. A stack delete that stalls on a non-empty bucket is
+                # recoverable; emptying a Retain bucket is not.
+                message = (
+                    f"Skipping pre-clean of {stack_name}: could not determine which resources "
+                    f"are retained ({e}). Empty any leftover buckets manually if the delete stalls."
+                )
+                logging.warning(message)
+                if on_event:
+                    on_event(message)
+                return
 
             response = self.cf_client.describe_stack_resources(StackName=stack_name)
             for resource in response.get("StackResources", []):

--- a/source/tests/test_cloudformation_utils.py
+++ b/source/tests/test_cloudformation_utils.py
@@ -288,3 +288,88 @@ class TestValidateTemplate:
         )
         with pytest.raises(TemplateValidationError):
             cfn_manager.validate_template(small_template)
+
+
+class TestPreCleanupStackRespectsRetain:
+    """Pre-cleaning must never empty a bucket marked DeletionPolicy: Retain.
+
+    CloudFormation hands back the template verbatim, so short-form intrinsics
+    (!Ref, !Sub) are present and a plain safe_load rejects the whole document.
+    When that parse failure was swallowed the retention list came back empty and
+    `ccwb destroy` emptied every bucket in the stack — including the CloudTrail
+    audit-log and landing-page buckets that are explicitly marked to be kept.
+    """
+
+    RETAIN_TEMPLATE = """AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  CloudTrailBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    Properties:
+      BucketName: !Sub '${AWS::StackName}-cloudtrail'
+  ScratchBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Ref ScratchBucketName
+"""
+
+    @staticmethod
+    def _stack_resources():
+        return {
+            "StackResources": [
+                {
+                    "LogicalResourceId": "CloudTrailBucket",
+                    "PhysicalResourceId": "mystack-cloudtrail",
+                    "ResourceType": "AWS::S3::Bucket",
+                },
+                {
+                    "LogicalResourceId": "ScratchBucket",
+                    "PhysicalResourceId": "mystack-scratch",
+                    "ResourceType": "AWS::S3::Bucket",
+                },
+            ]
+        }
+
+    def test_retain_survives_short_form_intrinsics(self, cfn_manager):
+        """The retention list must be readable from a template using !Sub/!Ref."""
+        cfn_manager._cf_client.get_template.return_value = {"TemplateBody": self.RETAIN_TEMPLATE}
+        assert cfn_manager._retained_logical_ids("mystack") == {"CloudTrailBucket"}
+
+    def test_retained_bucket_is_not_emptied(self, cfn_manager):
+        cfn_manager._cf_client.get_template.return_value = {"TemplateBody": self.RETAIN_TEMPLATE}
+        cfn_manager._cf_client.describe_stack_resources.return_value = self._stack_resources()
+
+        with patch.object(cfn_manager, "_empty_bucket") as empty_bucket:
+            cfn_manager.pre_cleanup_stack("mystack")
+
+        emptied = [call.args[0] for call in empty_bucket.call_args_list]
+        assert "mystack-cloudtrail" not in emptied, "emptied a DeletionPolicy: Retain bucket"
+        assert emptied == ["mystack-scratch"], "the disposable bucket should still be emptied"
+
+    def test_json_template_body_still_works(self, cfn_manager):
+        """JSON templates arrive already parsed as a dict, not a string."""
+        cfn_manager._cf_client.get_template.return_value = {
+            "TemplateBody": {
+                "Resources": {
+                    "CloudTrailBucket": {"Type": "AWS::S3::Bucket", "DeletionPolicy": "Retain"},
+                    "ScratchBucket": {"Type": "AWS::S3::Bucket"},
+                }
+            }
+        }
+        assert cfn_manager._retained_logical_ids("mystack") == {"CloudTrailBucket"}
+
+    def test_unreadable_template_skips_precleaning_entirely(self, cfn_manager):
+        """With retention unknown, empty nothing and say so.
+
+        A stack delete that stalls on a non-empty bucket is recoverable; emptying
+        a bucket the operator asked to keep is not.
+        """
+        cfn_manager._cf_client.get_template.side_effect = Exception("AccessDenied")
+        cfn_manager._cf_client.describe_stack_resources.return_value = self._stack_resources()
+        events = []
+
+        with patch.object(cfn_manager, "_empty_bucket") as empty_bucket:
+            cfn_manager.pre_cleanup_stack("mystack", on_event=events.append)
+
+        empty_bucket.assert_not_called()
+        assert events and "Skipping pre-clean" in events[0]


### PR DESCRIPTION
## Why

`ccwb destroy` pre-cleans a stack before deleting it, because CloudFormation cannot delete a non-empty bucket. It is supposed to skip resources marked `DeletionPolicy: Retain` — but it never did, so **it emptied buckets users had explicitly marked to be kept**:

| Bucket | Template | Contents |
|---|---|---|
| `CloudTrailBucket` | `cognito-identity-pool.yaml` | CloudTrail audit logs |
| `DistributionBucket` | `landing-page-distribution.yaml` | Landing-page assets |

Objects were deleted, versions and delete markers included, before the stack delete ran. The buckets themselves survived (CloudFormation honoured `Retain`); their contents did not.

**Root cause:** CloudFormation returns the template verbatim from `get_template`, short-form intrinsics and all, so the plain `safe_load` used to read it raised on the first `!Ref` or `!Sub`. Every real template hits that. The exception was swallowed into a `logging.debug`, the retained-ID set stayed empty, and pre-cleaning treated every bucket as disposable.

## What

- Parse with `cfn_flip.load_yaml` — already imported in this module and already used for templates elsewhere in it — so short-form intrinsics parse.
- If the retention list still cannot be read (e.g. `get_template` denied), **skip pre-cleaning entirely** and surface a warning rather than silently continuing. A stack delete that stalls on a non-empty bucket is recoverable; emptying a `Retain` bucket is not.

Retention detection moves into a small `_retained_logical_ids` helper so it can be tested directly.

## Verification

Four regression tests in `test_cloudformation_utils.py` cover the retained bucket surviving, the disposable one still being emptied, JSON template bodies, and the unreadable-template path.

All four fail on the previous code. The key one fails with `_empty_bucket('mystack-cloudtrail')` — the data loss itself, reproduced.

Full suite: **1780 passed / 28 skipped / 1 xfailed / 1 xpassed**. `ruff check` and `ruff format --check` clean. Templates unchanged.